### PR TITLE
chore: disable sessions_enforce.js hook temporarily

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,15 +27,6 @@
             "command": "node $CLAUDE_PROJECT_DIR/sessions/hooks/subagent_hooks.js"
           }
         ]
-      },
-      {
-        "matcher": "Write|Edit|Task|Bash|TodoWrite|NotebookEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/sessions/hooks/sessions_enforce.js"
-          }
-        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
Remove the DAIC enforcement hook from PreToolUse to allow subagent
execution. Other hooks (UserPromptSubmit, Task, PostToolUse,
SessionStart) remain active.