### PR TITLE
docs: fix plugin installation instructions across all READMEs

### DIFF
--- a/.claude/agents/plugin-docs-writer.md
+++ b/.claude/agents/plugin-docs-writer.md
@@ -153,8 +153,16 @@ When you encounter unfamiliar tools, libraries, or concepts in the plugin:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 \`\`\`bash
-/plugin install {plugin-name}
+/plugin marketplace add {owner}/{repo}
+\`\`\`
+
+Then install the plugin:
+
+\`\`\`bash
+/plugin install {plugin-name}@{marketplace-name}
 \`\`\`
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -5,19 +5,11 @@ A collection of Claude Code plugins that make Claude better at specific developm
 ## Installation
 
 ```bash
-# Add the marketplace
+# Add the marketplace (one-time setup)
 /plugin marketplace add Jamie-BitFlight/claude_skills
 
 # Install a plugin
-/plugin install plugin-name
-```
-
-Or install locally:
-
-```bash
-git clone https://github.com/Jamie-BitFlight/claude_skills.git
-cd claude_skills
-./install.py
+/plugin install plugin-name@jamie-bitflight-skills
 ```
 
 ## Available Plugins
@@ -91,20 +83,16 @@ plugins/plugin-name/
 └── README.md             # Documentation
 ```
 
-## Creating Plugins
-
-Ask Claude to create a new skill, then run:
-
-```bash
-./install.py
-```
-
 ## Contributing
 
 1. Fork the repository
 2. Create your feature branch
 3. Add or modify plugins
-4. Test locally with `./install.py`
+4. Test locally:
+   ```bash
+   ./install.py
+   ```
+   This creates symlinks from plugin components (skills, commands, agents) to `~/.claude/` for local testing.
 5. Submit a pull request
 
 ## License

--- a/plugins/agent-orchestration/README.md
+++ b/plugins/agent-orchestration/README.md
@@ -43,8 +43,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install agent-orchestration
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install agent-orchestration@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/async-python-patterns/README.md
+++ b/plugins/async-python-patterns/README.md
@@ -25,8 +25,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install async-python-patterns
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install async-python-patterns@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/brainstorming-skill/README.md
+++ b/plugins/brainstorming-skill/README.md
@@ -23,8 +23,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install brainstorming-skill
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install brainstorming-skill@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/clang-format/README.md
+++ b/plugins/clang-format/README.md
@@ -24,8 +24,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install clang-format
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install clang-format@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/commitlint/README.md
+++ b/plugins/commitlint/README.md
@@ -26,8 +26,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install commitlint
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install commitlint@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/conventional-commits/README.md
+++ b/plugins/conventional-commits/README.md
@@ -23,8 +23,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install conventional-commits
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install conventional-commits@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/fastmcp-creator/README.md
+++ b/plugins/fastmcp-creator/README.md
@@ -27,8 +27,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install fastmcp-creator
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install fastmcp-creator@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/gitlab-skill/README.md
+++ b/plugins/gitlab-skill/README.md
@@ -23,8 +23,16 @@ Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install gitlab-skill
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install gitlab-skill@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/hatchling/README.md
+++ b/plugins/hatchling/README.md
@@ -24,8 +24,16 @@ With this plugin installed, Claude can:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install hatchling
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install hatchling@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/holistic-linting/README.md
+++ b/plugins/holistic-linting/README.md
@@ -23,8 +23,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install holistic-linting
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install holistic-linting@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/litellm/README.md
+++ b/plugins/litellm/README.md
@@ -28,8 +28,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install litellm
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install litellm@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/llamafile/README.md
+++ b/plugins/llamafile/README.md
@@ -30,8 +30,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install llamafile
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install llamafile@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/mkdocs/README.md
+++ b/plugins/mkdocs/README.md
@@ -23,8 +23,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install mkdocs
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install mkdocs@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/pre-commit/README.md
+++ b/plugins/pre-commit/README.md
@@ -24,8 +24,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install pre-commit
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install pre-commit@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/prompt-optimization-claude-45/README.md
+++ b/plugins/prompt-optimization-claude-45/README.md
@@ -32,8 +32,16 @@ With this plugin installed, when you ask Claude to review or improve your CLAUDE
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install prompt-optimization-claude-45
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install prompt-optimization-claude-45@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/pypi-readme-creator/README.md
+++ b/plugins/pypi-readme-creator/README.md
@@ -26,8 +26,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install pypi-readme-creator
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install pypi-readme-creator@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/python3-development/README.md
+++ b/plugins/python3-development/README.md
@@ -23,8 +23,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install python3-development
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install python3-development@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/story-based-framing/README.md
+++ b/plugins/story-based-framing/README.md
@@ -24,8 +24,16 @@ Works across any domain: code reviews, security audits, business process analysi
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install story-based-framing
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install story-based-framing@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/toml-python/README.md
+++ b/plugins/toml-python/README.md
@@ -26,8 +26,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install toml-python
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install toml-python@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/uv/README.md
+++ b/plugins/uv/README.md
@@ -26,8 +26,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install uv
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install uv@jamie-bitflight-skills
 ```
 
 ## What You'll Experience

--- a/plugins/verification-gate/README.md
+++ b/plugins/verification-gate/README.md
@@ -23,8 +23,16 @@ This makes Claude slower to execute but much more accurate.
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install verification-gate
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install verification-gate@jamie-bitflight-skills
 ```
 
 ## Usage

--- a/plugins/xdg-base-directory/README.md
+++ b/plugins/xdg-base-directory/README.md
@@ -25,8 +25,16 @@ With this plugin installed, Claude will:
 
 ## Installation
 
+First, add the marketplace (one-time setup):
+
 ```bash
-/plugin install xdg-base-directory
+/plugin marketplace add Jamie-BitFlight/claude_skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install xdg-base-directory@jamie-bitflight-skills
 ```
 
 ## Usage


### PR DESCRIPTION
Updated installation documentation to match official Claude Code plugin
marketplace documentation:

1. plugin-docs-writer agent:
   - Added marketplace setup step to README template
   - Uses plugin@marketplace format per official docs

2. Main README.md:
   - Fixed installation to use plugin@marketplace format
   - Clarified that install.py is for local development testing only
   - install.py creates symlinks to ~/.claude/ for testing during
     development, not for general plugin installation

3. All 22 plugin READMEs:
   - Added marketplace setup step: /plugin marketplace add owner/repo
   - Changed install command to use @jamie-bitflight-skills suffix
   - Example: /plugin install uv@jamie-bitflight-skills

This ensures users understand they must first add the marketplace before
installing plugins, matching the official Anthropic documentation at
code.claude.com/docs/en/plugin-marketplaces