### PR TITLE
fix(skill): require single-line YAML description format

### DIFF
--- a/.claude/skills/agent-creator/SKILL.md
+++ b/.claude/skills/agent-creator/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: agent-creator
-description: >
-  Create high-quality Claude Code agents from scratch or by adapting existing agents as templates.
-  Use when the user wants to create a new agent, modify agent configurations, build specialized
-  subagents, or design agent architectures. Guides through requirements gathering, template
-  selection, and agent file generation following January 2026 Anthropic best practices.
+description: Create high-quality Claude Code agents from scratch or by adapting existing agents as templates. Use when the user wants to create a new agent, modify agent configurations, build specialized subagents, or design agent architectures. Guides through requirements gathering, template selection, and agent file generation following January 2026 Anthropic best practices.
 user-invocable: true
 ---
 

--- a/.claude/skills/claude-skills-overview-2026/SKILL.md
+++ b/.claude/skills/claude-skills-overview-2026/SKILL.md
@@ -51,7 +51,7 @@ Your instructions here...
 | Field                      | Required | Type         | Max Length | Description                                                                 |
 | -------------------------- | -------- | ------------ | ---------- | --------------------------------------------------------------------------- |
 | `name`                     | **Yes**  | string       | 64 chars   | Unique identifier: lowercase letters, numbers, hyphens only                 |
-| `description`              | **Yes**  | string       | 1024 chars | Claude uses this to decide when to apply the Skill                          |
+| `description`              | **Yes**  | string       | 1024 chars | Claude uses this to decide when to apply the Skill. **Must be single-line** |
 | `allowed-tools`            | No       | string/array | —          | Tools Claude can use: `Read, Grep, Glob, Bash(npm run:*)`                   |
 | `model`                    | No       | string       | —          | Override model: `claude-opus-4-5-20251101`, `claude-sonnet-4-20250514`      |
 | `context`                  | No       | string       | —          | Set to `fork` for isolated sub-agent context                                |
@@ -136,6 +136,25 @@ agent: Explore
 ---
 
 ## Description Best Practices
+
+**CRITICAL: Single-Line Format Required**
+
+Claude Code skill discovery can fail if `description` is formatted as a multi-line YAML value (including wrapped `>` or literal `|` forms). Always use a single-line string:
+
+```yaml
+# CORRECT - single line
+description: Extract text and tables from PDFs, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, extraction.
+
+# WRONG - folded block scalar (breaks discovery)
+description: >
+  Extract text and tables from PDFs, fill forms,
+  merge documents. Use when working with PDF files.
+
+# WRONG - literal block scalar (breaks discovery)
+description: |
+  Extract text and tables from PDFs, fill forms,
+  merge documents.
+```
 
 **Good**:
 

--- a/.claude/skills/rt-iac/SKILL.md
+++ b/.claude/skills/rt-iac/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: rt-iac
-description: >
-  Reverse Thinking - Information Completeness Assessment. Mandatory pre-planning checkpoint that
-  blocks planning until prerequisites are verified. Use when receiving specs, PRDs, tickets, RFCs,
-  architecture designs, or any multi-step engineering task. Integrates with CoVe-style planning
-  pipelines. Invoke BEFORE creating plans, delegating to agents, or defining acceptance criteria.
+description: Reverse Thinking - Information Completeness Assessment. Mandatory pre-planning checkpoint that blocks planning until prerequisites are verified. Use when receiving specs, PRDs, tickets, RFCs, architecture designs, or any multi-step engineering task. Integrates with CoVe-style planning pipelines. Invoke BEFORE creating plans, delegating to agents, or defining acceptance criteria.
 user-invocable: true
 ---
 

--- a/.claude/skills/subagent-contract/SKILL.md
+++ b/.claude/skills/subagent-contract/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: subagent-contract
-description: >
-  Global contract for all specialist subagents. Enforces role boundaries, scope discipline,
-  and DONE/BLOCKED status signaling. Load this skill in any agent that should operate as
-  a bounded specialist following supervisor delegation patterns.
+description: Global contract for all specialist subagents. Enforces role boundaries, scope discipline, and DONE/BLOCKED status signaling. Load this skill in any agent that should operate as a bounded specialist following supervisor delegation patterns.
 user-invocable: false
 disable-model-invocation: false
 ---


### PR DESCRIPTION
Claude Code skill discovery fails with multi-line YAML descriptions
(folded `>` or literal `|` block scalars). Updated skills reference
to document this requirement and converted non-compliant skills.

- Add critical warning to claude-skills-overview-2026 description best practices
- Update frontmatter table to note single-line requirement
- Convert rt-iac description from folded block to single line
- Convert subagent-contract description from folded block to single line
- Convert agent-creator description from folded block to single line