### PR TITLE
docs(research): add research entries for AI tools and frameworks

### DIFF
--- a/.claude/skills/research-curator/research/README.md
+++ b/.claude/skills/research-curator/research/README.md
@@ -1,0 +1,108 @@
+# Research Directory
+
+Resources researched for future reference in Claude Code development.
+
+---
+
+## Categories
+
+| Category            | Directory              | Description                                  |
+| ------------------- | ---------------------- | -------------------------------------------- |
+| Agent Frameworks    | `agent-frameworks/`    | Agent SDKs, multi-agent orchestration        |
+| AI Design Tools     | `ai-design-tools/`     | AI-powered UI/UX generation tools            |
+| AI Research Tools   | `ai-research-tools/`   | Document synthesis, research assistants      |
+| AI Writing Tools    | `ai-writing-tools/`    | AI-powered writing and document editors      |
+| Context Management  | `context-management/`  | Memory, RAG, context window tools            |
+| Developer Tooling   | `developer-tooling/`   | Build systems, developer tools, automation   |
+| Documentation Tools | `documentation-tools/` | AI documentation generators, README tools    |
+| LLM Infrastructure  | `llm-infrastructure/`  | LLM gateways, observability, optimization    |
+| Low-Code Platforms  | `low-code-platforms/`  | Visual app builders, internal tool platforms |
+
+---
+
+## Agent Frameworks
+
+| Resource                               | Description                                                           | Stars  | Research Date |
+| -------------------------------------- | --------------------------------------------------------------------- | ------ | ------------- |
+| [Agno](./agent-frameworks/agno.md)     | Multi-agent framework with learning, 40+ models, MCP support          | 37,379 | 2026-01-31    |
+| [RA.Aid](./agent-frameworks/ra-aid.md) | Autonomous software dev assistant with Research-Plan-Implement stages | 2,204  | 2026-01-31    |
+
+---
+
+## AI Design Tools
+
+| Resource                                            | Description                                                   | AI Model   | Research Date |
+| --------------------------------------------------- | ------------------------------------------------------------- | ---------- | ------------- |
+| [Google Stitch](./ai-design-tools/google-stitch.md) | AI-powered UI generation for mobile and web apps using Gemini | Gemini 2.5 | 2026-01-31    |
+
+---
+
+## AI Research Tools
+
+| Resource                                        | Description                                                            | AI Model | Research Date |
+| ----------------------------------------------- | ---------------------------------------------------------------------- | -------- | ------------- |
+| [NotebookLM](./ai-research-tools/notebooklm.md) | Google's virtual research assistant with Audio/Video Overviews and Q&A | Gemini   | 2026-01-31    |
+
+---
+
+## AI Writing Tools
+
+| Resource                                 | Description                                                    | Users | Research Date |
+| ---------------------------------------- | -------------------------------------------------------------- | ----- | ------------- |
+| [Type.ai](./ai-writing-tools/type-ai.md) | AI-first document editor for long-form writing (GPT-5, Claude) | 200k+ | 2026-01-31    |
+
+---
+
+## Context Management
+
+| Resource                                                         | Description                                                              | Stars  | Research Date |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------ | ------ | ------------- |
+| [Microsoft GraphRAG](./context-management/microsoft-graphrag.md) | Graph-based RAG system for cross-document reasoning and thematic queries | 30,637 | 2026-01-31    |
+
+---
+
+## Developer Tooling
+
+| Resource                                                      | Description                                             | Stars | Research Date |
+| ------------------------------------------------------------- | ------------------------------------------------------- | ----- | ------------- |
+| [Makefile Tutorial](./developer-tooling/makefile-tutorial.md) | Comprehensive GNU Make tutorial with practical examples | 93    | 2026-01-31    |
+
+---
+
+## Documentation Tools
+
+| Resource                                        | Description                                          | Pricing  | Research Date |
+| ----------------------------------------------- | ---------------------------------------------------- | -------- | ------------- |
+| [GitDocify](./documentation-tools/gitdocify.md) | AI-powered README generation for GitHub repositories | Freemium | 2026-01-31    |
+
+---
+
+## LLM Infrastructure
+
+| Resource                                         | Description                                                           | Stars  | Research Date |
+| ------------------------------------------------ | --------------------------------------------------------------------- | ------ | ------------- |
+| [TensorZero](./llm-infrastructure/tensorzero.md) | Open-source LLMOps stack: gateway, observability, optimization, evals | 10,886 | 2026-01-31    |
+
+---
+
+## Low-Code Platforms
+
+| Resource                                   | Description                                                    | Stars  | Research Date |
+| ------------------------------------------ | -------------------------------------------------------------- | ------ | ------------- |
+| [ToolJet](./low-code-platforms/tooljet.md) | Open-source low-code platform for internal tools and AI agents | 37,363 | 2026-01-31    |
+
+---
+
+## Adding New Entries
+
+Use the research-curator skill to add new resources:
+
+```text
+Skill(command: "research-curator") [url-or-resource]
+```
+
+All entries must include:
+
+- Verified information from primary sources
+- Access dates for all references
+- Freshness tracking with next review date

--- a/.claude/skills/research-curator/research/agent-frameworks/agno.md
+++ b/.claude/skills/research-curator/research/agent-frameworks/agno.md
@@ -1,0 +1,329 @@
+# Agno
+
+| Field         | Value                                                    |
+| ------------- | -------------------------------------------------------- |
+| Research Date | 2026-01-31                                               |
+| Primary URL   | <https://docs.agno.com>                                  |
+| GitHub        | <https://github.com/agno-agi/agno>                       |
+| PyPI          | <https://pypi.org/project/agno/>                         |
+| Version       | v2.4.7 (released 2026-01-28)                             |
+| License       | Apache-2.0                                               |
+| Discord       | <https://www.agno.com/discord>                           |
+| Community     | <https://community.agno.com/>                            |
+
+---
+
+## Overview
+
+Agno is a Python framework for building multi-agent systems that learn and improve with every interaction. Unlike stateless agents that forget after each session, Agno agents persist user profiles across sessions, accumulate knowledge across conversations, and transfer learned insights across users. The framework provides model-agnostic support for 40+ providers, built-in toolkits, vector store integrations, and a production runtime called AgentOS.
+
+---
+
+## Problem Addressed
+
+| Problem                                           | Solution                                                                |
+| ------------------------------------------------- | ----------------------------------------------------------------------- |
+| Agents are stateless and forget between sessions  | Learning system persists user profiles and memories across sessions     |
+| Knowledge doesn't transfer between users          | Learned knowledge transfers across users, improving system over time    |
+| Building multi-agent systems is complex           | Teams and workflows abstractions coordinate multiple agents             |
+| RAG integration requires custom implementation    | Built-in agentic RAG with 20+ vector stores, hybrid search, reranking   |
+| Production deployment is separate concern         | AgentOS runtime + control plane UI for monitoring and management        |
+| Tool integration varies across frameworks         | 100+ built-in toolkits, first-class MCP and A2A protocol support        |
+| Model lock-in limits flexibility                  | Model-agnostic: OpenAI, Anthropic, Google, local models, 40+ providers  |
+
+---
+
+## Key Statistics
+
+| Metric            | Value                     | Date Gathered |
+| ----------------- | ------------------------- | ------------- |
+| GitHub Stars      | 37,379                    | 2026-01-31    |
+| GitHub Forks      | 4,954                     | 2026-01-31    |
+| Open Issues       | 489                       | 2026-01-31    |
+| Contributors      | ~385                      | 2026-01-31    |
+| PyPI Monthly DL   | 1,158,777                 | 2026-01-31    |
+| PyPI Weekly DL    | 294,556                   | 2026-01-31    |
+| Primary Language  | Python                    | 2026-01-31    |
+| Repository Age    | Since May 2022            | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Learning System
+
+- **User profiles**: Persist across sessions, accumulate user-specific context
+- **User memories**: Store insights and facts about users across conversations
+- **Learned knowledge**: Transfers across users, improving system globally
+- **Learning modes**: Always-on or agentic (agent decides when to learn)
+- **Decision logging**: Track and analyze agent decisions for improvement
+
+### Core Framework
+
+- **Model-agnostic**: 40+ providers (OpenAI, Anthropic, Google, Llama, Mistral, DeepSeek, Groq, Ollama, vLLM)
+- **Type-safe I/O**: `input_schema` and `output_schema` for structured data
+- **Async-first**: Built for long-running tasks and concurrent execution
+- **Natively multimodal**: Text, images, audio, video, files
+- **Guardrails**: Validation and security constraints for agent behavior
+
+### Multi-Agent Orchestration
+
+- **Teams**: Coordinate multiple agents with shared memory and distributed RAG
+- **Workflows**: Chain agents, teams, and functions into automated pipelines
+- **Human-in-the-loop**: Confirmations, approvals, overrides at decision points
+- **A2A protocol**: Agent-to-agent communication standard support
+- **MCP support**: First-class Model Context Protocol integration
+
+### Knowledge and RAG
+
+- **Agentic RAG**: Intelligent retrieval with agent-guided search
+- **20+ vector stores**: Comprehensive vector database support
+- **Hybrid search**: Combine dense and sparse retrieval
+- **Reranking**: Improve retrieval quality with reranking models
+- **Multiple sources**: URLs, S3, GCS, YouTube, PDFs, and more
+
+### Reasoning Capabilities
+
+- **Reasoning models**: Support for o1, o3, and other reasoning-trained models
+- **Reasoning tools**: Give agents tools that enable reasoning (think, analyze)
+- **Reasoning harness**: `reasoning=True` for chain-of-thought with tool use
+
+### Storage
+
+- **Session history**: Persistent conversation storage
+- **State management**: Agent state persistence across sessions
+- **Supported backends**: Postgres, SQLite, DynamoDB, Firestore, MongoDB, Redis, SingleStore, SurrealDB
+
+### Production Infrastructure
+
+- **AgentOS runtime**: Ready-to-use FastAPI-based deployment
+- **Control plane UI**: Monitor and manage agents via <https://os.agno.com>
+- **Evals**: Accuracy (LLM-as-judge), performance (latency, memory), reliability metrics
+- **100+ toolkits**: Web search, SQL, email, APIs, Discord, Slack, Docker, custom tools
+
+---
+
+## Technical Architecture
+
+### Stack Components
+
+| Component       | Technology                                          |
+| --------------- | --------------------------------------------------- |
+| Core Framework  | Python (async-first design)                         |
+| Runtime         | AgentOS (FastAPI-based)                             |
+| Storage         | Pluggable (Postgres, SQLite, DynamoDB, etc.)        |
+| Vector Stores   | 20+ integrations (Pinecone, Weaviate, Chroma, etc.) |
+| Model Providers | 40+ (OpenAI, Anthropic, Google, local, etc.)        |
+| Control Plane   | AgentOS UI (os.agno.com)                            |
+
+### Agent Abstraction Layers
+
+```text
+Workflows (complex orchestration)
+    |
+Teams (multi-agent coordination)
+    |
+Agents (single agent with tools, knowledge, learning)
+    |
+Models (40+ provider implementations)
+```
+
+### Data Flow
+
+1. User input received by agent
+2. Agent retrieves relevant knowledge (RAG)
+3. Agent reasons with model and available tools
+4. Learning system captures insights (if enabled)
+5. Response generated with structured output
+6. Session state persisted to storage
+7. Metrics logged for evals
+
+---
+
+## Installation and Usage
+
+### Installation
+
+```bash
+# Using pip
+pip install agno
+
+# Using uv (recommended)
+uv pip install agno
+```
+
+### Basic Agent (with Learning)
+
+```python
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-4o"),
+    db=SqliteDb(db_file="tmp/agents.db"),
+    learning=True,  # Enable learning across sessions
+)
+
+# Agent now remembers users and improves over time
+response = agent.run("What can you help me with?")
+```
+
+### Agent with Tools
+
+```python
+from agno.agent import Agent
+from agno.models.anthropic import Claude
+from agno.tools.web_search import WebSearchTools
+
+agent = Agent(
+    model=Claude(id="claude-sonnet-4-20250514"),
+    tools=[WebSearchTools()],
+    instructions="You are a helpful research assistant.",
+)
+```
+
+### Multi-Agent Team
+
+```python
+from agno.agent import Agent
+from agno.team import Team
+
+researcher = Agent(name="researcher", role="Research topics")
+writer = Agent(name="writer", role="Write content")
+
+team = Team(
+    agents=[researcher, writer],
+    workflow="sequential",  # or "parallel", "routing"
+)
+```
+
+### Agent with Knowledge (RAG)
+
+```python
+from agno.agent import Agent
+from agno.knowledge.pdf import PDFKnowledge
+from agno.vectordb.pgvector import PgVector
+
+knowledge = PDFKnowledge(
+    path="./documents/",
+    vector_db=PgVector(table_name="documents"),
+)
+
+agent = Agent(
+    knowledge=knowledge,
+    search_knowledge=True,
+)
+```
+
+---
+
+## Cookbook Examples
+
+The [cookbook](https://github.com/agno-agi/agno/tree/main/cookbook) provides hundreds of examples:
+
+| Directory           | Content                                           |
+| ------------------- | ------------------------------------------------- |
+| `00_quickstart/`    | Fundamentals, building on previous examples       |
+| `01_showcase/`      | Advanced real-world use cases                     |
+| `02_agents/`        | Tools, RAG, structured outputs, multimodal        |
+| `03_teams/`         | Multi-agent coordination, async flows             |
+| `04_workflows/`     | Complex process orchestration                     |
+| `05_agent_os/`      | Deployment to APIs, Slack, WhatsApp               |
+| `06_storage/`       | Postgres, SQLite, DynamoDB, MongoDB               |
+| `07_knowledge/`     | Chunking, embedders, vector databases             |
+| `08_learning/`      | Decision logging, preference tracking             |
+| `09_evals/`         | Accuracy, performance, reliability testing        |
+| `10_reasoning/`     | Chain-of-thought, reasoning tools                 |
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Multi-Agent Orchestration Patterns**: Teams and workflows abstractions provide reference architecture for coordinating Claude Code sub-agents.
+
+2. **Learning System Design**: User profile persistence and knowledge transfer patterns could inform session-aware skill development.
+
+3. **MCP Integration Patterns**: First-class MCP support demonstrates integration approaches for Model Context Protocol tools.
+
+4. **Tool Architecture**: 100+ built-in toolkits show patterns for tool organization and discoverability.
+
+5. **RAG Implementation**: Agentic RAG with hybrid search provides reference for knowledge-augmented agent design.
+
+### Patterns Worth Adopting
+
+1. **Learning Modes**: "Always" vs "agentic" learning modes allow agents to decide when knowledge capture is valuable.
+
+2. **Type-Safe I/O**: `input_schema` and `output_schema` ensure structured data contracts between agents.
+
+3. **Reasoning Harness**: `reasoning=True` flag for enabling chain-of-thought is a clean abstraction.
+
+4. **Human-in-the-Loop**: Explicit confirmation/approval points in workflows prevent autonomous runaway.
+
+5. **Eval Categories**: Separating accuracy, performance, and reliability metrics provides clear measurement framework.
+
+### Integration Opportunities
+
+1. **MCP Server**: Agno agents could be exposed as MCP tools for Claude Code workflows.
+
+2. **A2A Protocol**: Agent-to-agent communication standard could enable Agno-Claude Code interop.
+
+3. **Tool Reuse**: 100+ toolkits could inspire or directly inform Claude Code tool implementations.
+
+4. **Knowledge Pipeline**: Document loading from URLs, S3, GCS patterns applicable to skill reference ingestion.
+
+5. **Eval Framework**: Agno's eval patterns could inform Claude Code skill testing approaches.
+
+### Comparison with Claude Code
+
+| Aspect              | Agno                           | Claude Code                    |
+| ------------------- | ------------------------------ | ------------------------------ |
+| Primary Use         | Multi-agent systems            | Developer workflow automation  |
+| Learning            | Built-in persistence           | Session-based (skills persist) |
+| Orchestration       | Teams, workflows, A2A          | Agent delegation, Task tool    |
+| Tool Integration    | 100+ toolkits, MCP, A2A        | MCP, custom tools              |
+| Model Support       | 40+ providers                  | Claude models (Anthropic)      |
+| Runtime             | AgentOS (FastAPI)              | CLI + IDE integration          |
+| Knowledge           | Agentic RAG, vector stores     | Skills, references             |
+
+---
+
+## References
+
+| Source                    | URL                                                      | Accessed   |
+| ------------------------- | -------------------------------------------------------- | ---------- |
+| Official Documentation    | <https://docs.agno.com/introduction>                     | 2026-01-31 |
+| GitHub Repository         | <https://github.com/agno-agi/agno>                       | 2026-01-31 |
+| GitHub README             | <https://github.com/agno-agi/agno/blob/main/README.md>   | 2026-01-31 |
+| Cookbook                  | <https://github.com/agno-agi/agno/tree/main/cookbook>    | 2026-01-31 |
+| PyPI Package              | <https://pypi.org/project/agno/>                         | 2026-01-31 |
+| PyPI Stats                | <https://pypistats.org/packages/agno>                    | 2026-01-31 |
+| AgentOS Control Plane     | <https://os.agno.com>                                    | 2026-01-31 |
+| Community Forum           | <https://community.agno.com/>                            | 2026-01-31 |
+| LLM Documentation         | <https://docs.agno.com/llms-full.txt>                    | 2026-01-31 |
+
+**Research Method**: Information gathered from official GitHub repository README, GitHub API (stars, forks, issues, releases), PyPI statistics API, and cookbook README. Statistics verified via direct API calls.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                               |
+| ------------------ | ----------------------------------- |
+| Version Documented | v2.4.7                              |
+| Release Date       | 2026-01-28                          |
+| GitHub Stars       | 37,379 (as of 2026-01-31)           |
+| Monthly Downloads  | 1,158,777 (as of 2026-01-31)        |
+| Next Review Date   | 2026-05-01                          |
+
+**Review Triggers**:
+
+- Major version release (v3.x)
+- Significant new feature (new learning modes, orchestration patterns)
+- GitHub stars milestone (40K, 50K)
+- PyPI downloads milestone (2M monthly)
+- New production runtime capabilities
+- Breaking changes to Teams/Workflows API
+- New model provider integrations of note

--- a/.claude/skills/research-curator/research/agent-frameworks/ra-aid.md
+++ b/.claude/skills/research-curator/research/agent-frameworks/ra-aid.md
@@ -1,0 +1,332 @@
+# RA.Aid
+
+| Field         | Value                                               |
+| ------------- | --------------------------------------------------- |
+| Research Date | 2026-01-31                                          |
+| Primary URL   | <https://ra-aid.ai/>                                |
+| Documentation | <https://docs.ra-aid.ai>                            |
+| GitHub        | <https://github.com/ai-christianson/RA.Aid>         |
+| PyPI          | <https://pypi.org/project/ra-aid/>                  |
+| Version       | v0.30.2 (released 2025-05-07)                       |
+| License       | Apache-2.0                                          |
+| Discord       | <https://discord.gg/f6wYbzHYxV>                     |
+
+---
+
+## Overview
+
+RA.Aid (pronounced "raid") is a standalone autonomous software development assistant built on LangGraph's agent-based task execution framework. It implements a three-stage architecture (Research, Planning, Implementation) to handle complex multi-step development tasks. The tool can optionally integrate with aider for specialized code editing and supports multiple LLM providers including Anthropic, OpenAI, OpenRouter, Makehub, Gemini, and DeepSeek.
+
+---
+
+## Problem Addressed
+
+| Problem                                                | Solution                                                                    |
+| ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Complex tasks require manual breakdown                 | Three-stage architecture automatically researches, plans, and implements    |
+| Single-shot code edits insufficient for complex work   | Multi-step task planning executes discrete steps sequentially               |
+| Need for human oversight in autonomous execution       | Human-in-the-loop mode allows agent questions during execution              |
+| Context gathering is manual and time-consuming         | Automated web research via Tavily API gathers real-world context            |
+| Expert reasoning needed for complex debugging          | Dedicated expert provider supports o1/o3 reasoning models when needed       |
+| Code editing requires specialized tools                | Optional aider integration leverages specialized code editing capabilities  |
+| Autonomous execution can be dangerous                  | Shell command approval prompts by default, cowboy mode optional             |
+| Model lock-in limits flexibility                       | Multi-provider support: Anthropic, OpenAI, OpenRouter, Makehub, Gemini, DeepSeek |
+
+---
+
+## Key Statistics
+
+| Metric           | Value                    | Date Gathered |
+| ---------------- | ------------------------ | ------------- |
+| GitHub Stars     | 2,204                    | 2026-01-31    |
+| GitHub Forks     | 218                      | 2026-01-31    |
+| Open Issues      | 60                       | 2026-01-31    |
+| Primary Language | Python                   | 2026-01-31    |
+| PyPI Monthly DL  | 933                      | 2026-01-31    |
+| PyPI Weekly DL   | 106                      | 2026-01-31    |
+| Repository Age   | Since December 2024      | 2026-01-31    |
+| Python Required  | >=3.10                   | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Three-Stage Architecture
+
+- **Research Stage**: Gathers information, analyzes codebases, identifies components and dependencies
+- **Planning Stage**: Develops detailed implementation plans, breaks down tasks into steps, identifies challenges
+- **Implementation Stage**: Executes planned tasks sequentially, generates code, performs system operations
+
+### Multi-Provider LLM Support
+
+- **Anthropic**: Default provider with Claude 3.7 Sonnet (`claude-3-7-sonnet-20250219`)
+- **OpenAI**: GPT-4o and o1/o3 reasoning models for expert queries
+- **OpenRouter**: Access to Mistral, Llama, and other models
+- **Makehub**: Price-performance optimization with configurable ratio
+- **Gemini**: Google's Gemini models including thinking variants
+- **DeepSeek**: DeepSeek Reasoner for complex reasoning tasks
+- **OpenAI-compatible**: Custom endpoints via `OPENAI_API_BASE`
+
+### Expert Reasoning System
+
+- Dedicated expert provider configuration separate from main agent
+- Supports reasoning models (o1, o3, DeepSeek Reasoner, Gemini Thinking)
+- Used for complex debugging and architectural decisions
+- Independent API key configuration per provider
+
+### Web Research Integration
+
+- Autonomous web research powered by Tavily API
+- Automatic context gathering when agent determines it valuable
+- Searches for best practices, documentation, security recommendations
+- No explicit configuration required - happens automatically
+
+### Execution Modes
+
+- **Standard Mode**: Interactive approval prompts for shell commands
+- **Cowboy Mode**: Automated execution without confirmation (for CI/CD, batch processing)
+- **Human-in-the-Loop (HIL)**: Agent can ask questions during execution
+- **Chat Mode**: Interactive assistant for collaborative problem-solving
+- **Research-Only Mode**: Analysis without implementation
+
+### Aider Integration
+
+- Optional integration via `--use-aider` flag
+- Leverages aider's specialized code editing capabilities
+- Automatic model selection based on available API keys
+- Configurable via `AIDER_FLAGS` environment variable
+
+### Cost and Token Management
+
+- `--show-cost`: Display cost information during execution
+- `--track-cost`: Track token usage and costs
+- `--max-cost`: Set maximum cost threshold in USD
+- `--max-tokens`: Set maximum token threshold
+- `--exit-at-limit`: Auto-exit when limits reached
+
+### Server and Web Interface (Alpha)
+
+- Modern dark-themed chat interface
+- Real-time streaming of agent trajectory
+- Responsive design for all devices
+- Configurable host and port
+
+---
+
+## Technical Architecture
+
+### Stack Components
+
+| Component        | Technology                                    |
+| ---------------- | --------------------------------------------- |
+| Core Framework   | Python (>=3.10)                               |
+| Agent Framework  | LangGraph (graph-based workflow management)   |
+| LLM Integration  | LangChain (langchain-anthropic)               |
+| Web Research     | Tavily API (tavily-python)                    |
+| Git Operations   | GitPython 3.1.41                              |
+| Terminal Output  | Rich >=13.0.0                                 |
+| String Matching  | FuzzyWuzzy, python-Levenshtein                |
+
+### Core Modules
+
+```text
+ra_aid/
+├── console/     # Console output formatting, user interaction
+├── proc/        # Interactive processing, workflow control
+├── text/        # Text processing utilities
+└── tools/       # File operations, search, shell execution
+```
+
+### Workflow
+
+```text
+User Input → Research Stage → Planning Stage → Implementation Stage → Output
+                  ↓                  ↓                  ↓
+            Analyze codebase   Break into steps   Execute with tools
+            Gather context     Identify risks     Generate code
+            Web research       Create plan        System operations
+```
+
+### Tool Categories
+
+- **Shell Execution**: Run commands with optional approval
+- **Expert Querying**: Access reasoning models for complex problems
+- **File Operations**: Read, write, modify files
+- **Memory Management**: Persistent context across execution
+- **Research Tools**: Web search, codebase analysis
+- **Code Analysis**: AST parsing, dependency identification
+
+---
+
+## Installation and Usage
+
+### Installation
+
+```bash
+# Using pip
+pip install ra-aid
+
+# Using Homebrew (macOS)
+brew tap ai-christianson/homebrew-ra-aid
+brew install ra-aid
+```
+
+### Environment Setup
+
+```bash
+# Required for default Anthropic provider
+export ANTHROPIC_API_KEY=your_key
+
+# Optional providers
+export OPENAI_API_KEY=your_key
+export OPENROUTER_API_KEY=your_key
+export GEMINI_API_KEY=your_key
+export DEEPSEEK_API_KEY=your_key
+export MAKEHUB_API_KEY=your_key
+
+# Web research
+export TAVILY_API_KEY=your_key
+```
+
+### Basic Usage
+
+```bash
+# Basic task
+ra-aid -m "Your task or query here"
+
+# Research only (no implementation)
+ra-aid -m "Explain the authentication flow" --research-only
+
+# Automated execution
+ra-aid -m "Update deprecated API calls" --cowboy-mode
+
+# Human-in-the-loop
+ra-aid -m "Implement new feature" --hil
+
+# Chat mode
+ra-aid --chat
+
+# With aider integration
+ra-aid -m "Refactor database code" --use-aider
+```
+
+### Provider Configuration
+
+```bash
+# OpenAI
+ra-aid -m "Task" --provider openai --model gpt-4o
+
+# OpenRouter
+ra-aid -m "Task" --provider openrouter --model mistralai/mistral-large-2411
+
+# Expert provider (for complex reasoning)
+ra-aid -m "Task" --expert-provider openai --expert-model o1
+
+# Makehub with price-performance optimization
+ra-aid -m "Task" --provider makehub --model anthropic/claude-4-sonnet --price-performance-ratio 0.7
+```
+
+### Server Mode
+
+```bash
+# Start web interface
+ra-aid --server
+
+# Custom host/port
+ra-aid --server --server-host 127.0.0.1 --server-port 3000
+```
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Three-Stage Architecture Reference**: The Research-Planning-Implementation pattern provides a clear model for structuring complex autonomous tasks with distinct phases.
+
+2. **Multi-Provider Abstraction**: RA.Aid's provider configuration pattern (separate expert provider, research provider, planner provider) demonstrates how to route different task types to appropriate models.
+
+3. **Human-in-the-Loop Patterns**: The HIL mode implementation shows how to pause autonomous execution for human input and resume with new context.
+
+4. **Cost Control Mechanisms**: Token and cost tracking with configurable limits demonstrates patterns for responsible autonomous execution.
+
+5. **Aider Integration Model**: The optional aider integration shows how to compose specialized tools within an agent framework.
+
+### Patterns Worth Adopting
+
+1. **Staged Execution**: Explicit separation of research, planning, and implementation phases improves task quality and debuggability.
+
+2. **Expert Escalation**: Routing complex problems to reasoning models (o1, DeepSeek Reasoner) only when needed optimizes cost while maintaining capability.
+
+3. **Cowboy Mode Toggle**: Having a dedicated flag for unattended execution vs interactive approval is a clean safety pattern.
+
+4. **Command Interruption**: Ctrl-C pauses for feedback rather than immediate exit, allowing course correction.
+
+5. **Per-Stage Provider Configuration**: Allowing different models for research vs planning vs implementation enables cost/quality optimization.
+
+6. **Test Integration**: `--test-cmd` and `--auto-test` flags for automatic test execution after code changes.
+
+### Integration Opportunities
+
+1. **LangGraph Compatibility**: Both use graph-based agent execution, potential for shared tooling or patterns.
+
+2. **Aider Bridge**: RA.Aid's aider integration patterns could inform Claude Code's approach to external tool composition.
+
+3. **Tavily Integration**: Web research patterns applicable to Claude Code context gathering.
+
+4. **Expert Tool Pattern**: Delegating complex reasoning to specialized models is directly applicable to sub-agent design.
+
+### Comparison with Claude Code
+
+| Aspect              | RA.Aid                                  | Claude Code                           |
+| ------------------- | --------------------------------------- | ------------------------------------- |
+| Primary Use         | Autonomous software development         | Developer workflow automation         |
+| Architecture        | Three-stage (Research/Plan/Implement)   | Agent delegation, Task tool           |
+| Execution Model     | Sequential stage execution              | Tool-based, iterative                 |
+| Human Interaction   | HIL mode, chat mode, interruption       | Interactive by default                |
+| Code Editing        | Native + optional aider                 | Native Edit tool                      |
+| Model Support       | Multi-provider (6+ providers)           | Claude models (Anthropic)             |
+| Cost Controls       | Token/cost limits, exit-at-limit        | Session-based                         |
+| Web Research        | Tavily integration                      | MCP tools, WebSearch                  |
+| Deployment          | CLI + web server (alpha)                | CLI + IDE integration                 |
+
+---
+
+## References
+
+| Source                       | URL                                                       | Accessed   |
+| ---------------------------- | --------------------------------------------------------- | ---------- |
+| Official Website             | <https://ra-aid.ai/>                                      | 2026-01-31 |
+| Official Documentation       | <https://docs.ra-aid.ai>                                  | 2026-01-31 |
+| GitHub Repository            | <https://github.com/ai-christianson/RA.Aid>               | 2026-01-31 |
+| GitHub README                | <https://github.com/ai-christianson/RA.Aid/blob/master/README.md> | 2026-01-31 |
+| PyPI Package                 | <https://pypi.org/project/ra-aid/>                        | 2026-01-31 |
+| PyPI Stats                   | <https://pypistats.org/packages/ra-aid>                   | 2026-01-31 |
+| Installation Guide           | <https://docs.ra-aid.ai/quickstart/installation>          | 2026-01-31 |
+| Open Models Setup            | <https://docs.ra-aid.ai/quickstart/open-models>           | 2026-01-31 |
+| Contributing Guide           | <https://docs.ra-aid.ai/contributing>                     | 2026-01-31 |
+
+**Research Method**: Information gathered from official GitHub repository README (via GitHub API), PyPI package metadata, PyPI download statistics API, and official website metadata. Statistics verified via direct API calls on research date.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                              |
+| ------------------ | ---------------------------------- |
+| Version Documented | v0.30.2                            |
+| Release Date       | 2025-05-07                         |
+| GitHub Stars       | 2,204 (as of 2026-01-31)           |
+| Monthly Downloads  | 933 (as of 2026-01-31)             |
+| Next Review Date   | 2026-05-01                         |
+
+**Review Triggers**:
+
+- Major version release (v1.x)
+- Significant star growth (5K, 10K milestones)
+- New stage architecture (additional stages beyond R-P-I)
+- Production-ready server/web interface release
+- New provider integrations of note
+- Breaking changes to CLI or configuration
+- Aider integration changes or removal
+- New execution modes

--- a/.claude/skills/research-curator/research/ai-design-tools/google-stitch.md
+++ b/.claude/skills/research-curator/research/ai-design-tools/google-stitch.md
@@ -1,0 +1,228 @@
+# Google Stitch
+
+| Field         | Value                                                  |
+| ------------- | ------------------------------------------------------ |
+| Research Date | 2026-01-31                                             |
+| Primary URL   | <https://stitch.withgoogle.com>                        |
+| Announced     | Google I/O 2025 (May 20, 2025)                         |
+| Version       | Beta (SaaS)                                            |
+| License       | Proprietary (Google product)                           |
+| Twitter       | [@stitchbygoogle](https://twitter.com/stitchbygoogle)  |
+
+---
+
+## Overview
+
+Google Stitch is an AI-powered design tool that generates UI elements and code for mobile and web applications. Launched at Google I/O 2025, Stitch uses Google's Gemini 2.5 models to create app frontends from text prompts or images, outputting HTML and CSS markup. The tool is positioned for rapid design ideation rather than as a full-fledged design platform like Figma or Adobe XD.
+
+---
+
+## Problem Addressed
+
+| Problem                                      | Solution                                                         |
+| -------------------------------------------- | ---------------------------------------------------------------- |
+| UI design requires specialized skills        | AI generates professional UI from natural language descriptions  |
+| Iteration from concept to prototype is slow  | Rapid generation of initial UI iterations in seconds             |
+| Design-to-code handoff creates friction      | Direct code output (HTML/CSS) eliminates translation step        |
+| Designers/developers use different tools     | Export to Figma + IDE-ready code bridges both workflows          |
+| Communicating design changes is difficult    | Annotated screenshot feature (upcoming) enables visual feedback  |
+
+---
+
+## Key Statistics
+
+| Metric               | Value                           | Date Gathered |
+| -------------------- | ------------------------------- | ------------- |
+| Public GitHub Repo   | Not available (closed source)   | 2026-01-31    |
+| Launch Date          | May 20, 2025 (Google I/O 2025)  | 2026-01-31    |
+| Hosting Platform     | Google Cloud (App Engine)       | 2026-01-31    |
+| AI Models Available  | Gemini 2.5 Pro, Gemini 2.5 Flash| 2026-01-31    |
+| Pricing              | Free (beta)                     | 2026-01-31    |
+
+Note: Google Stitch is a closed-source Google product. No public GitHub repository, npm package, or open-source components are available.
+
+---
+
+## Key Features
+
+### AI-Powered UI Generation
+
+- Text-to-UI: Describe desired interface in natural language
+- Image-to-UI: Upload reference images to generate similar designs
+- HTML/CSS output: Production-ready markup from AI generation
+- Model selection: Choose between Gemini 2.5 Pro (higher quality) or Gemini 2.5 Flash (faster)
+
+### Design Workflow Integration
+
+- Figma export: Direct export of generated designs to Figma
+- IDE compatibility: Expose code for refinement in development environments
+- Element fine-tuning: Adjust individual UI components after generation
+- Responsive design: Support for mobile and web layouts
+
+### Input Methods
+
+- Text prompts: Describe UI requirements in natural language
+- Image prompts: Upload reference designs or mockups
+- Screenshot annotation (upcoming): Mark changes on captured screens
+
+### Example Use Cases (from Google demos)
+
+- Mobile app UI for a bookworm/reading application
+- Web dashboard for beekeeping data visualization
+- Responsive layouts for various screen sizes
+
+---
+
+## Technical Architecture
+
+### Stack Components (observed from production)
+
+| Component      | Technology                              |
+| -------------- | --------------------------------------- |
+| Frontend       | Angular SPA (appcompanion-root)         |
+| Backend        | Google App Engine (app-companion)       |
+| AI Models      | Gemini 2.5 Pro, Gemini 2.5 Flash        |
+| Authentication | Google Account OAuth                    |
+| Analytics      | Google Tag Manager (G-1CD1CPGEYF)       |
+| CDN            | Google Static (gstatic.com)             |
+
+### Internal Codename
+
+- Project codename: "Nemo" (observed in production JavaScript)
+
+### Workflow
+
+1. User authenticates via Google Account
+2. User provides prompt (text description or image)
+3. User selects AI model (Gemini 2.5 Pro or Flash)
+4. Stitch generates UI preview and code
+5. User refines elements or adjusts prompt
+6. User exports to Figma or copies code for IDE
+
+---
+
+## Installation and Usage
+
+Google Stitch is a web-based SaaS product. No local installation required.
+
+### Getting Started
+
+1. Visit <https://stitch.withgoogle.com>
+2. Sign in with Google Account
+3. Describe desired UI or upload reference image
+4. Select Gemini model (Pro for quality, Flash for speed)
+5. Generate and iterate on designs
+6. Export to Figma or copy code
+
+### No CLI or Local Tool
+
+There is no command-line interface, API, or self-hosted option. The service operates entirely through the web interface.
+
+### Requirements
+
+- Google Account for authentication
+- Modern web browser
+- Active internet connection
+
+---
+
+## Comparison with Similar Tools
+
+| Feature                  | Google Stitch  | v0 (Vercel) | Bolt.new  | Cursor    |
+| ------------------------ | -------------- | ----------- | --------- | --------- |
+| UI Generation            | Yes            | Yes         | Yes       | Limited   |
+| Code Output              | HTML/CSS       | React/Next  | Multiple  | Multiple  |
+| Image Input              | Yes            | Yes         | Yes       | No        |
+| Figma Export             | Yes            | No          | No        | No        |
+| Full App Development     | No             | Limited     | Yes       | Yes       |
+| Model Selection          | Yes (Gemini)   | No          | No        | Yes       |
+| Self-Hosted Option       | No             | No          | No        | Yes       |
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **UI Prototyping Reference**: Demonstrates text-to-UI patterns that could inform Claude Code skill development for frontend generation tasks.
+
+2. **Design Workflow Patterns**: Export-to-Figma workflow shows integration patterns between AI generation and professional design tools.
+
+3. **Prompt Engineering Insights**: Text and image prompt handling for UI generation provides reference for multimodal prompt design.
+
+### Patterns Worth Studying
+
+1. **Model Selection UX**: Letting users choose between speed (Flash) and quality (Pro) models is a pattern applicable to agent tool selection.
+
+2. **Iterative Refinement**: The fine-tune-after-generation workflow supports rapid iteration without starting over.
+
+3. **Dual Output Formats**: Simultaneous visual preview and code output addresses both designer and developer needs.
+
+4. **Screenshot Annotation** (upcoming): Visual feedback mechanism for modifications could inspire similar approaches in agentic workflows.
+
+### Limitations for Claude Code
+
+1. **Closed Source**: No codebase or API to study implementation details.
+
+2. **Web-Only**: Cannot be integrated as a CLI tool, library, or MCP server.
+
+3. **Narrow Scope**: Focused on UI generation only; not a general coding assistant.
+
+4. **Google Account Required**: Authentication dependency limits automation.
+
+### Integration Opportunities
+
+1. **Workflow Inspiration**: "Describe UI, generate, refine, export" workflow is a clean pattern for agentic design tools.
+
+2. **Competitive Benchmarking**: Compare UI generation quality when building similar capabilities.
+
+3. **Figma Integration Pattern**: Export-to-Figma feature suggests integration patterns worth emulating.
+
+---
+
+## Related Google Tools
+
+### Jules (AI Coding Agent)
+
+Announced alongside Stitch at Google I/O 2025, Jules is Google's AI agent for code maintenance tasks:
+
+- Bug fixing and code understanding
+- Pull request creation on GitHub
+- Node.js version upgrades and similar maintenance
+- Currently in public beta
+- Uses Gemini 2.5 Pro (multi-model support planned)
+
+Jules complements Stitch by handling backend/infrastructure while Stitch focuses on frontend UI.
+
+---
+
+## References
+
+| Source                        | URL                                                                                      | Accessed   |
+| ----------------------------- | ---------------------------------------------------------------------------------------- | ---------- |
+| Google Stitch Homepage        | <https://stitch.withgoogle.com>                                                          | 2026-01-31 |
+| TechCrunch Article            | <https://techcrunch.com/2025/05/20/google-launches-stitch-an-ai-powered-tool-to-help-design-apps/> | 2026-01-31 |
+| Stitch Web Manifest           | <https://stitch.withgoogle.com/_/Nemo/manifest.json>                                     | 2026-01-31 |
+| Twitter Account               | <https://twitter.com/stitchbygoogle>                                                     | 2026-01-31 |
+
+**Research Method**: Information gathered from official homepage meta tags, TechCrunch exclusive coverage from Google I/O 2025, and production JavaScript bundle analysis. The site is an Angular SPA requiring authentication for full access.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                               |
+| ------------------ | ----------------------------------- |
+| Version Documented | Beta (as of 2026-01-31)             |
+| Launch Date        | May 20, 2025 (Google I/O 2025)      |
+| Product Manager    | Kathy Korevec (Google)              |
+| Next Review Date   | 2026-05-01                          |
+
+**Review Triggers**:
+
+- Exit from beta to general availability
+- Public API or SDK release
+- Addition of screenshot annotation feature
+- New export format support (beyond Figma)
+- Integration with other Google Workspace tools
+- Pricing model announcement

--- a/.claude/skills/research-curator/research/ai-research-tools/notebooklm.md
+++ b/.claude/skills/research-curator/research/ai-research-tools/notebooklm.md
@@ -1,0 +1,256 @@
+# NotebookLM
+
+| Field         | Value                                                                                 |
+| ------------- | ------------------------------------------------------------------------------------- |
+| Research Date | 2026-01-31                                                                            |
+| Primary URL   | <https://notebooklm.google>                                                           |
+| Support       | <https://support.google.com/notebooklm>                                               |
+| Android App   | <https://play.google.com/store/apps/details?id=com.google.android.apps.labs.tailwind> |
+| iOS App       | App Store (Google NotebookLM)                                                         |
+| Version       | Android 2026.01.06 / iOS 1.21.0                                                       |
+| License       | Proprietary (Google)                                                                  |
+
+---
+
+## Overview
+
+NotebookLM (Google NotebookLM; LM = "Language Model") is a research and note-taking online tool developed by Google Labs that uses Google Gemini to assist users in interacting with their documents. Google describes it as a "virtual research assistant" that generates summaries, explanations, and answers based on user-uploaded content. Its distinctive "Audio Overviews" feature converts documents into podcast-style conversations between two AI hosts.
+
+---
+
+## Problem Addressed
+
+| Problem                                             | Solution                                                                            |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Long documents are time-consuming to read           | Generates summaries and key insights from uploaded sources                          |
+| Complex topics are hard to understand               | Creates explanations in simplified, structured format                               |
+| Traditional notes are passive and static            | Q&A interface allows interactive exploration of document content                    |
+| Text-heavy content doesn't suit all learning styles | Audio Overviews create podcast discussions; Video Overviews create visual summaries |
+| Research requires manual synthesis across sources   | AI analyzes multiple documents to extract and connect key ideas                     |
+| Knowledge is siloed in individual documents         | Notebook structure organizes related sources for cross-document reasoning           |
+
+---
+
+## Key Statistics
+
+| Metric           | Value                          | Date Gathered |
+| ---------------- | ------------------------------ | ------------- |
+| Initial Release  | May 2023 (as Project Tailwind) | 2026-01-31    |
+| Stable Release   | October 17, 2024               | 2026-01-31    |
+| Android Version  | 2026.01.06 (Build 853388154)   | 2026-01-31    |
+| iOS Version      | 1.21.0                         | 2026-01-31    |
+| Platform Support | Web, Android 10+, iOS 17+      | 2026-01-31    |
+| AI Model         | Google Gemini                  | 2026-01-31    |
+| Language Support | 80+ languages (Audio/Video)    | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Document Processing
+
+- **Multi-format support**: PDFs, Google Docs, Google Slides, websites
+- **Video transcripts**: Processes videos with subtitles/transcripts (no auto-extraction)
+- **Source organization**: Notebooks group related documents for cross-document analysis
+- **Key idea extraction**: Identifies and structures main concepts from uploaded content
+
+### AI-Powered Analysis
+
+- **Summarization**: Condenses long documents into digestible summaries
+- **Q&A interface**: Interactive question-answering based on source content
+- **Explanation generation**: Simplifies complex topics with structured explanations
+- **Cross-document reasoning**: Connects ideas across multiple uploaded sources
+
+### Audio Overviews
+
+- **Podcast generation**: Converts documents into conversational discussions between two AI hosts
+- **Interactive mode**: Users can "Join" the conversation and ask questions directly (December 2024)
+- **Language support**: Available in 80+ languages
+- **Accessibility**: Makes complex content accessible through audio format
+
+### Video Overviews (May 2025)
+
+- **Visual summaries**: Transforms documents into slide-style videos
+- **AI narration**: Combines spoken explanations with visual elements
+- **Diagrams and images**: Includes generated visuals, diagrams, and structured layouts
+- **Multi-language**: Supports 80+ languages
+
+### Visualization Features (November 2025)
+
+- **Infographics**: Generates visual infographics from source material
+- **Slide Decks**: Creates presentation-ready slides
+- **Nano Banana Pro**: Powered by Google's image generation model
+
+### NotebookLM Plus (Premium Tier)
+
+- **Higher usage limits**: Extended quotas for power users
+- **Longer documents**: Support for larger document uploads
+- **Collaborative notebooks**: Shared workspaces for teams
+- **Enhanced controls**: Additional output customization options
+
+---
+
+## Technical Architecture
+
+### Stack Components
+
+| Component        | Technology                                |
+| ---------------- | ----------------------------------------- |
+| AI Model         | Google Gemini (multimodal, long-context)  |
+| Audio Generation | Google AI voice synthesis                 |
+| Image Generation | Nano Banana Pro (for infographics/slides) |
+| Platform         | Google Labs infrastructure                |
+| Integration      | Google Workspace, Google Cloud            |
+
+### Processing Flow
+
+```text
+User uploads sources (PDFs, Docs, Slides, URLs)
+    |
+Gemini processes and indexes content
+    |
+User interacts via Q&A, summary requests, or overview generation
+    |
+AI generates responses grounded in source material
+    |
+Output: Text summaries, Audio Overviews, Video Overviews, Infographics
+```
+
+### Source Grounding
+
+NotebookLM responses are grounded in user-uploaded content, reducing hallucination risk by limiting AI responses to information present in the provided sources. This differs from general-purpose chatbots that draw from training data.
+
+---
+
+## Pricing and Availability
+
+### Free Tier
+
+- Basic access to NotebookLM features
+- Standard usage limits
+- Available via Google account
+
+### NotebookLM Plus
+
+- **Individual**: Via Google One AI Premium subscription
+- **Enterprise**: Via Google Workspace and Google Cloud (December 2024)
+- **Features**: Higher limits, longer documents, collaboration, enhanced controls
+
+### Platform Availability
+
+| Platform | Requirement        | App               |
+| -------- | ------------------ | ----------------- |
+| Web      | Any modern browser | notebooklm.google |
+| Android  | Android 10+        | Google Play Store |
+| iOS      | iOS 17+            | App Store         |
+| iPadOS   | iPadOS 17+         | App Store         |
+
+---
+
+## Timeline
+
+| Date              | Milestone                                                          |
+| ----------------- | ------------------------------------------------------------------ |
+| May 2023          | Introduced as "Project Tailwind" at Google I/O                     |
+| 2024              | Rebranded to NotebookLM, broader rollout                           |
+| September 2024    | Audio Overviews feature released                                   |
+| October 17, 2024  | "Experimental" status removed, becomes stable product              |
+| December 2024     | NotebookLM Plus launched (enterprise); Interactive Audio Overviews |
+| February 10, 2025 | NotebookLM Plus available to individuals via Google One AI Premium |
+| May 2025          | Video Overviews feature launched                                   |
+| 2025              | Audio/Video Overviews expanded to 80+ languages                    |
+| November 2025     | Infographics and Slide Deck features (Nano Banana Pro)             |
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Research Workflow**: NotebookLM demonstrates effective document synthesis patterns - grounding AI responses in provided sources to reduce hallucination.
+
+2. **Multi-Modal Output**: The progression from text to audio to video overviews shows how to make AI-generated content accessible across different consumption preferences.
+
+3. **Interactive AI Sessions**: The "Join" feature for Audio Overviews demonstrates real-time user participation in AI-generated content - a pattern applicable to interactive coding sessions.
+
+4. **Source Grounding Pattern**: NotebookLM's approach of limiting responses to uploaded content is a strong anti-hallucination pattern worth studying for skill-based systems.
+
+### Patterns Worth Adopting
+
+1. **Notebook Organization**: Grouping related sources into notebooks enables cross-document reasoning - similar to how skills could group related references.
+
+2. **Format Flexibility**: Same content delivered as text, audio, video, or infographics - Claude Code could offer multiple output formats for documentation.
+
+3. **Interactive Overviews**: Users joining AI discussions could inspire interactive code review or pair programming patterns.
+
+4. **Progressive Disclosure**: NotebookLM starts with summaries and allows drilling into details - relevant for skill documentation structure.
+
+### Integration Opportunities
+
+1. **Research Phase Tool**: Use NotebookLM to synthesize technical documentation before creating skills.
+
+2. **Audio Learning**: Generate audio overviews of complex codebases for auditory learners.
+
+3. **Documentation Synthesis**: Process multiple API docs/READMEs into unified understanding.
+
+4. **Competitive Analysis**: Compare how NotebookLM's source grounding differs from Claude Code's skill-based approach.
+
+### Comparison with Claude Code
+
+| Aspect            | NotebookLM                       | Claude Code                          |
+| ----------------- | -------------------------------- | ------------------------------------ |
+| Primary Use       | Document research and synthesis  | Developer workflow automation        |
+| Source Grounding  | User-uploaded documents          | Skills, references, codebase context |
+| Output Formats    | Text, Audio, Video, Infographics | Text, code, structured outputs       |
+| Interaction Model | Q&A, overview generation         | Agentic task execution               |
+| Knowledge Scope   | Limited to uploaded sources      | Skills + codebase + reasoning        |
+| Collaboration     | Shared notebooks (Plus)          | Shared skills, git workflows         |
+| Platform          | Web, mobile apps                 | CLI, IDE integration                 |
+
+---
+
+## Notable Adoption
+
+- **Spotify Wrapped 2024**: Used NotebookLM's Audio Overview feature to generate personalized podcast-style summaries of individual listening habits.
+- **Enterprise Research**: Adopted by companies and students for document synthesis and research workflows.
+- **Academic Use**: Students use it for studying complex topics and preparing for exams.
+
+---
+
+## References
+
+| Source                        | URL                                                                                     | Accessed   |
+| ----------------------------- | --------------------------------------------------------------------------------------- | ---------- |
+| Official Website              | <https://notebooklm.google>                                                             | 2026-01-31 |
+| Google Support                | <https://support.google.com/notebooklm>                                                 | 2026-01-31 |
+| Wikipedia Article             | <https://en.wikipedia.org/wiki/NotebookLM>                                              | 2026-01-31 |
+| Google Blog: Introduction     | <https://blog.google/technology/ai/notebooklm-google-ai/>                               | 2026-01-31 |
+| Google Blog: Audio Overviews  | <https://blog.google/technology/ai/notebooklm-audio-overviews/>                         | 2026-01-31 |
+| Google Play Store             | <https://play.google.com/store/apps/details?id=com.google.android.apps.labs.tailwind>   | 2026-01-31 |
+| TechCrunch: Enterprise Launch | <https://techcrunch.com/2024/12/13/google-debuts-notebooklm-for-enterprises/>           | 2026-01-31 |
+| TechCrunch: Individual Plus   | <https://techcrunch.com/2025/02/10/google-expands-notebooklm-plus-to-individual-users/> | 2026-01-31 |
+| Ars Technica: Audio Overviews | <https://arstechnica.com/ai/2024/09/fake-ai-podcasters-are-reviewing-my-book/>          | 2026-01-31 |
+| The Verge: Project Tailwind   | <https://www.theverge.com/2023/5/10/23719866/google-project-tailwind-ai-notebook>       | 2026-01-31 |
+
+**Research Method**: Information gathered from Wikipedia article (citing multiple primary sources), Google official blog posts, official NotebookLM website, and Google Play Store listing. Feature timeline and version numbers verified via Wikipedia citations to TechCrunch, The Verge, 9to5Google, and official Google announcements.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                                   |
+| ------------------ | --------------------------------------- |
+| Version Documented | Android 2026.01.06 / iOS 1.21.0         |
+| Last Major Feature | Infographics and Slide Decks (Nov 2025) |
+| AI Model           | Google Gemini                           |
+| Next Review Date   | 2026-05-01                              |
+
+**Review Triggers**:
+
+- New major feature release (beyond current Video/Infographic capabilities)
+- Significant pricing changes to NotebookLM Plus
+- New platform support (desktop apps, API access)
+- Integration with additional Google services
+- Changes to AI model (Gemini version updates)
+- Enterprise-specific feature announcements
+- API or developer access announcements

--- a/.claude/skills/research-curator/research/ai-writing-tools/type-ai.md
+++ b/.claude/skills/research-curator/research/ai-writing-tools/type-ai.md
@@ -1,0 +1,258 @@
+# Type.ai
+
+| Field         | Value                                                        |
+| ------------- | ------------------------------------------------------------ |
+| Research Date | 2026-01-31                                                   |
+| Primary URL   | <https://type.ai>                                            |
+| Blog          | <https://blog.type.ai>                                       |
+| YCombinator   | <https://www.ycombinator.com/companies/type>                 |
+| LinkedIn      | <https://www.linkedin.com/company/type-ai/>                  |
+| Twitter/X     | <https://x.com/typedotai>                                    |
+| YouTube       | <https://www.youtube.com/@typedotai>                         |
+| License       | Proprietary (SaaS)                                           |
+| Contact       | hello@type.ai                                                |
+
+---
+
+## Overview
+
+Type.ai is an AI-first document editor designed for long-form professional writing. Unlike chat-based AI tools (ChatGPT, Claude), Type.ai embeds AI capabilities directly into a feature-rich document editor, making it an alternative for writing tasks that require an involved editing process. Trusted by 200k+ writers, it supports documents up to 130,000 words and provides deeply integrated AI features for generating, revising, and reviewing books, essays, novels, screenplays, and other long-form documents.
+
+---
+
+## Problem Addressed
+
+| Problem                                              | Solution                                                          |
+| ---------------------------------------------------- | ----------------------------------------------------------------- |
+| Chat-based AI tools lack integrated editing workflow | Document editor with embedded AI commands via Cmd+K               |
+| Prompt engineering required to use LLMs effectively  | Context-aware AI that understands document intent as you write    |
+| Template-based AI writing tools constrain creativity | Flexible commands that adapt to any writing task                  |
+| Difficult to edit long documents in AI chat tools    | Purpose-built editor supporting documents up to 130,000 words     |
+| Multiple tools needed for writing workflow           | Unified platform: generate, rewrite, review, and organize         |
+| AI tools don't maintain document context             | AI improves suggestions based on document context over time       |
+
+---
+
+## Key Statistics
+
+| Metric            | Value                         | Date Gathered |
+| ----------------- | ----------------------------- | ------------- |
+| Active Writers    | 200,000+                      | 2026-01-31    |
+| Max Document Size | 130,000 words                 | 2026-01-31    |
+| Pricing (Annual)  | $12/month ($144/year)         | 2026-01-31    |
+| Pricing (Monthly) | $29/month                     | 2026-01-31    |
+| First Year Disc.  | 48% off                       | 2026-01-31    |
+| YC Batch          | Y Combinator company          | 2026-01-31    |
+
+---
+
+## Key Features
+
+### AI Writing Capabilities
+
+- **Cmd+K Commands**: Instant AI access while writing to generate or transform text
+- **Context Awareness**: AI understands document context and improves with usage
+- **Draft Generation**: Generate complete drafts from prompts or outlines
+- **Rewriting**: Sentence and paragraph rewriting with multiple style options
+- **Review Features**: AI-powered document review and feedback
+
+### Document Editor
+
+- **Long-Form Support**: Documents up to 130,000 words (full novels/books)
+- **Dark Mode**: Full dark mode interface for extended writing sessions
+- **Word/PDF Import**: Import existing Word documents and PDFs
+- **Export Options**: Export to Word, PDF, and other formats
+- **Document Organization**: Tools for organizing multiple documents
+
+### AI Models
+
+- **GPT-5**: Access to OpenAI's latest model
+- **Claude 4.5 Sonnet**: Access to Anthropic's Claude models
+- **Speed Mode**: GPT-3.5 for faster responses
+- **Power Mode**: GPT-4o+ for more accurate and creative outputs
+
+### Free AI Writing Tools
+
+- **AI Email Writer**: Generate polished professional emails
+- **Paragraph Rewriter**: Rewrite and polish paragraphs
+- **Sentence Rewriter**: Rewrite individual sentences
+- **Writing Templates**: Pre-built templates for various content types
+
+### Privacy and Data
+
+- **No Model Training**: Does not train AI models on user data
+- **Private Documents**: User uploads and documents remain private
+- **Money-Back Guarantee**: Satisfaction guarantee on subscriptions
+
+---
+
+## Technical Architecture
+
+### Product Stack
+
+| Component        | Technology                              |
+| ---------------- | --------------------------------------- |
+| Platform         | Web-based SaaS                          |
+| Editor           | Custom document editor                  |
+| AI Integration   | OpenAI (GPT-3.5, GPT-4o, GPT-5)         |
+| AI Integration   | Anthropic (Claude 4.5 Sonnet)           |
+| Analytics        | Amplitude, Google Analytics             |
+| Infrastructure   | Webflow (marketing), Custom app         |
+
+### User Experience Flow
+
+```text
+User Input
+    |
+Document Context Analysis
+    |
+Cmd+K Command Invocation
+    |
+AI Model Selection (Speed/Power)
+    |
+Context-Aware Generation/Transformation
+    |
+In-Place Document Update
+```
+
+### Key Differentiator
+
+Unlike chat interfaces (ChatGPT, Claude), Type.ai integrates AI directly into the writing workflow:
+
+1. Write in a full-featured document editor
+2. Invoke AI commands inline with Cmd+K
+3. AI uses document context for better suggestions
+4. Results appear directly in document
+5. Continue editing seamlessly
+
+---
+
+## Founders and Company
+
+| Role | Name         | Background                                   |
+| ---- | ------------ | -------------------------------------------- |
+| CEO  | Stew Fortier | Entrepreneur with lifelong passion for writing |
+| CTO  | Stefan Li    | Software engineer, advanced document editors   |
+
+**Company**: Y Combinator backed startup focused on AI-powered writing tools.
+
+**Mission**: Make it effortless to access the most powerful capabilities of today's large language models while maintaining the flexibility and fun of a great document editor.
+
+---
+
+## Use Cases
+
+### Primary Audiences
+
+- **Book Authors**: Write and edit full-length books and novels
+- **Content Marketers**: Create marketing copy, blog posts, articles
+- **Screenwriters**: Draft screenplays and scripts
+- **Essayists**: Academic and creative essay writing
+- **Business Writers**: Proposals, reports, documentation
+
+### Content Types
+
+- Books and novels (up to 130k words)
+- Essays and articles
+- Marketing content
+- Screenplays
+- Blog posts
+- Professional emails
+- Long-form documents
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **AI-Integrated Editor Patterns**: Type.ai demonstrates how to embed AI capabilities directly into an editing workflow rather than using a chat interface. This pattern could inform how Claude Code integrates AI assistance into coding workflows.
+
+2. **Context-Aware Assistance**: The document context awareness pattern (AI improving suggestions based on surrounding content) parallels how Claude Code should use codebase context for better suggestions.
+
+3. **Command Invocation UX**: The Cmd+K command interface is similar to command palette patterns. Type.ai shows how to make AI commands discoverable and accessible inline.
+
+4. **Long-Form Content Handling**: Supporting 130k word documents demonstrates patterns for handling large context windows, relevant for Claude Code's work with large codebases.
+
+### Patterns Worth Adopting
+
+1. **Inline AI Commands**: Rather than switching to a chat interface, invoke AI inline within the work context.
+
+2. **Mode Selection**: Speed Mode vs Power Mode pattern allows users to trade off between response time and quality - applicable to code generation.
+
+3. **Context Accumulation**: AI improving with usage as it learns document context - could inform session-aware skill development.
+
+4. **Privacy-First Design**: Clear communication about data not being used for training builds user trust.
+
+5. **Template Library**: Pre-built templates for common tasks reduce friction - applicable to code templates and snippets.
+
+### Integration Opportunities
+
+1. **Writing Skills**: Type.ai's approach to AI-powered writing could inform Claude Code skills for documentation, README generation, and technical writing.
+
+2. **Editor Integration Patterns**: How Type.ai handles inline suggestions and transformations could inform VSCode/IDE integrations.
+
+3. **Model Switching**: The Speed/Power mode pattern for model selection is directly applicable to Claude Code's model selection for different task types.
+
+### Comparison with Claude Code
+
+| Aspect             | Type.ai                        | Claude Code                   |
+| ------------------ | ------------------------------ | ----------------------------- |
+| Primary Use        | Long-form writing              | Code development              |
+| Interface          | Document editor with AI        | CLI with AI                   |
+| Context Handling   | Document-aware                 | Codebase-aware                |
+| AI Invocation      | Cmd+K inline commands          | Natural language prompts      |
+| Output             | Text transformations           | Code and explanations         |
+| Model Options      | GPT + Claude                   | Claude models                 |
+| Target Users       | Writers, marketers             | Developers                    |
+
+---
+
+## Competitive Landscape
+
+| Competitor     | Positioning                        | Type.ai Advantage                   |
+| -------------- | ---------------------------------- | ----------------------------------- |
+| ChatGPT        | General-purpose chat AI            | Integrated document editor          |
+| Claude.ai      | General-purpose chat AI            | Purpose-built for writing workflow  |
+| Grammarly      | Grammar and style checking         | Full AI generation + editing        |
+| Jasper         | Marketing content generation       | Flexible for any writing type       |
+| Rytr           | Short-form content templates       | Long-form document support          |
+| Copy.ai        | Marketing copy templates           | Document-first editing experience   |
+
+---
+
+## References
+
+| Source                  | URL                                                    | Accessed   |
+| ----------------------- | ------------------------------------------------------ | ---------- |
+| Type.ai Homepage        | <https://type.ai>                                      | 2026-01-31 |
+| Type.ai Pricing         | <https://type.ai/pricing>                              | 2026-01-31 |
+| Type.ai Writing Tools   | <https://type.ai/ai-writing-tools>                     | 2026-01-31 |
+| Type.ai Blog            | <https://blog.type.ai>                                 | 2026-01-31 |
+| YCombinator Profile     | <https://www.ycombinator.com/companies/type>           | 2026-01-31 |
+| Type.ai Privacy Policy  | <https://type.ai/privacy-policy>                       | 2026-01-31 |
+| Type.ai FAQ             | <https://blog.type.ai/faqs>                            | 2026-01-31 |
+
+**Research Method**: Information gathered from Type.ai official website, YCombinator company profile, blog content, and FAQ. Statistics verified through direct observation of marketing materials and pricing pages.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                             |
+| ------------------ | --------------------------------- |
+| Product Type       | SaaS (continuously updated)       |
+| Active Writers     | 200,000+ (as of 2026-01-31)       |
+| AI Models          | GPT-5, Claude 4.5 Sonnet          |
+| Annual Pricing     | $12/month (as of 2026-01-31)      |
+| Next Review Date   | 2026-05-01                        |
+
+**Review Triggers**:
+
+- New AI model integration announcements
+- Major feature releases (especially collaborative or API features)
+- Pricing changes
+- User milestone announcements (500k users, etc.)
+- New free tool additions
+- Mobile app release
+- API availability for developers

--- a/.claude/skills/research-curator/research/context-management/microsoft-graphrag.md
+++ b/.claude/skills/research-curator/research/context-management/microsoft-graphrag.md
@@ -1,0 +1,309 @@
+# Microsoft GraphRAG
+
+| Field         | Value                                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| Research Date | 2026-01-31                                                                                                  |
+| Primary URL   | <https://microsoft.github.io/graphrag/>                                                                     |
+| GitHub        | <https://github.com/microsoft/graphrag>                                                                     |
+| PyPI          | <https://pypi.org/project/graphrag/>                                                                        |
+| arXiv Paper   | <https://arxiv.org/pdf/2404.16130>                                                                          |
+| Version       | v3.0.1 (released 2026-01-28)                                                                                |
+| License       | MIT                                                                                                         |
+| Blog Post     | <https://www.microsoft.com/en-us/research/blog/graphrag-unlocking-llm-discovery-on-narrative-private-data/> |
+
+---
+
+## Overview
+
+GraphRAG is a modular graph-based Retrieval-Augmented Generation (RAG) system developed by Microsoft Research. It extracts meaningful, structured data from unstructured text using LLMs to create a knowledge graph, then uses these connections to answer questions that span many documents or require thematic understanding. Unlike traditional vector-based RAG, GraphRAG excels at answering abstract questions like "What are the top themes in this dataset?" by leveraging community detection and hierarchical summarization.
+
+---
+
+## Problem Addressed
+
+| Problem                                                 | Solution                                                                      |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Vector/keyword search fails on cross-document questions | Knowledge graph connects information across large volumes of documents        |
+| Thematic questions unanswerable with traditional RAG    | Community detection and hierarchical summarization enable abstract reasoning  |
+| RAG limited to local context around retrieved chunks    | Global search via map-reduce over community reports provides dataset overview |
+| Noisy data with conflicting information                 | Graph structure surfaces relationships and identifies authoritative entities  |
+| Single retrieval strategy limits flexibility            | Multiple search modes: Local, Global, DRIFT, Basic for different query types  |
+| LLM costs high for re-indexing on errors                | Built-in LLM caching prevents redundant API calls during indexing             |
+| Lock-in to specific storage or model providers          | Factory pattern allows custom implementations for all subsystems              |
+
+---
+
+## Key Statistics
+
+| Metric           | Value            | Date Gathered |
+| ---------------- | ---------------- | ------------- |
+| GitHub Stars     | 30,637           | 2026-01-31    |
+| GitHub Forks     | 3,229            | 2026-01-31    |
+| Open Issues      | 95               | 2026-01-31    |
+| PyPI Monthly DL  | 60,312           | 2026-01-31    |
+| PyPI Weekly DL   | 19,803           | 2026-01-31    |
+| PyPI Daily DL    | 4,051            | 2026-01-31    |
+| Primary Language | Python           | 2026-01-31    |
+| Repository Age   | Since March 2024 | 2026-01-31    |
+| Python Required  | >=3.11, <3.14    | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Indexing Pipeline
+
+- **Entity extraction**: LLM-powered extraction of entities, relationships, and claims from raw text
+- **Community detection**: Graph-based clustering to identify related entity communities
+- **Hierarchical summarization**: Community reports generated at multiple levels of granularity
+- **Chunk embedding**: Text chunks embedded for vector similarity search
+- **Entity embedding**: Entities embedded for semantic retrieval
+- **LLM caching**: Cached completions for idempotent, resilient indexing
+- **Configurable workflows**: Modular pipeline with customizable steps and prompts
+
+### Query Mechanisms
+
+- **Local Search**: Combines AI-extracted knowledge graph with text chunks for entity-specific questions
+- **Global Search**: Map-reduce over community reports for dataset-wide thematic questions
+- **DRIFT Search**: Expands local search breadth using community insights for comprehensive answers
+- **Basic Search**: Vector RAG baseline for comparison (top-k chunk retrieval)
+- **Question Generation**: Generates follow-up questions for deeper investigation
+
+### Architecture
+
+- **Monorepo structure**: Modular packages (graphrag-cache, graphrag-chunking, graphrag-common, graphrag-input, graphrag-llm, graphrag-storage, graphrag-vectors)
+- **Factory pattern**: Extensible providers for models, storage, cache, vectors, input readers
+- **Parquet outputs**: Indexes stored as Parquet tables for efficient querying
+- **CLI and Python API**: Multiple interfaces for indexing and querying
+
+### Model Support
+
+- **OpenAI**: Direct API integration
+- **Azure OpenAI**: Full support with managed identity authentication
+- **LiteLLM wrapper**: Extensible to additional providers
+- **Prompt tuning**: Guidance for domain-specific prompt optimization
+
+### Storage Backends
+
+- **File storage**: Local filesystem for development
+- **Azure Blob Storage**: Cloud storage integration
+- **CosmosDB**: Distributed database support
+- **Vector stores**: LanceDB, Azure AI Search, CosmosDB vector search
+
+---
+
+## Technical Architecture
+
+### Pipeline Flow
+
+```text
+Load Documents
+    |
+Chunk Documents
+    |
+    +-- Extract Graph --> Detect Communities --> Generate Reports --> Embed Reports
+    |
+    +-- Extract Claims
+    |
+    +-- Embed Chunks
+    |
+    +-- Embed Entities
+```
+
+### Knowledge Model
+
+| Component         | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| Documents         | Source text files (txt, CSV, JSON)                   |
+| Text Units        | Chunked document segments                            |
+| Entities          | Extracted named entities (people, places, things)    |
+| Relationships     | Connections between entities                         |
+| Claims            | Factual assertions extracted from text               |
+| Communities       | Clusters of related entities from graph analysis     |
+| Community Reports | LLM-generated summaries at multiple hierarchy levels |
+| Embeddings        | Vector representations for semantic search           |
+
+### Factory Extensions
+
+| Subsystem      | Purpose                         | Built-in Options                      |
+| -------------- | ------------------------------- | ------------------------------------- |
+| Language Model | Chat and embed methods          | LiteLLM wrapper (OpenAI, Azure, etc.) |
+| Input Reader   | Document ingestion              | Text, CSV, JSON                       |
+| Cache          | LLM response caching            | File, Blob, CosmosDB                  |
+| Storage        | Index persistence               | File, Blob, CosmosDB                  |
+| Vector Store   | Embedding storage and retrieval | LanceDB, Azure AI Search, CosmosDB    |
+| Workflows      | Pipeline step customization     | Default GraphRAG pipeline             |
+
+---
+
+## Installation and Usage
+
+### Installation
+
+```bash
+# Using pip
+pip install graphrag
+
+# Using uv
+uv pip install graphrag
+```
+
+### Quick Start
+
+```bash
+# Initialize workspace
+mkdir graphrag_project && cd graphrag_project
+graphrag init
+
+# Configure API key in .env
+# GRAPHRAG_API_KEY=<your-api-key>
+
+# Add documents to ./input directory
+curl https://www.gutenberg.org/cache/epub/24022/pg24022.txt -o ./input/book.txt
+
+# Run indexing
+graphrag index
+
+# Query with Global Search (thematic questions)
+graphrag query "What are the top themes in this story?"
+
+# Query with Local Search (entity-specific questions)
+graphrag query "Who is Scrooge and what are his main relationships?" --method local
+```
+
+### Python API
+
+```python
+from graphrag.api import build_index, local_search, global_search
+
+# Index documents
+await build_index(root="./graphrag_project")
+
+# Local search for entity questions
+result = await local_search(
+    root="./graphrag_project",
+    query="What are the healing properties of chamomile?"
+)
+
+# Global search for thematic questions
+result = await global_search(
+    root="./graphrag_project",
+    query="What are the main themes across all documents?"
+)
+```
+
+### Azure OpenAI Configuration
+
+```yaml
+# settings.yaml
+models:
+  default_chat_model:
+    type: chat
+    model_provider: azure
+    model: gpt-4.1
+    deployment_name: <AZURE_DEPLOYMENT_NAME>
+    api_base: https://<instance>.openai.azure.com
+    api_version: 2024-02-15-preview
+    auth_type: azure_managed_identity  # Optional: for managed auth
+```
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Knowledge-Augmented Skills**: GraphRAG patterns could inform how Claude Code skills organize and retrieve reference documentation, using graph structure instead of flat files.
+
+2. **Cross-Document Reasoning**: The community detection and hierarchical summarization approach provides a model for answering questions that span multiple skill reference files.
+
+3. **Thematic Query Support**: Global search mechanism could inspire how Claude Code answers abstract questions about a codebase ("What patterns does this project follow?").
+
+4. **Context Window Optimization**: Community reports provide compressed summaries that could reduce token usage while maintaining comprehensive coverage.
+
+5. **Caching Patterns**: LLM caching strategy applicable to Claude Code for expensive operations.
+
+### Patterns Worth Adopting
+
+1. **Multiple Search Strategies**: Local vs Global vs DRIFT search demonstrates value of query-type-specific retrieval strategies.
+
+2. **Community Detection**: Graph clustering to identify related concepts could improve skill organization and cross-referencing.
+
+3. **Hierarchical Summarization**: Multi-level community reports enable both detailed and overview queries on same index.
+
+4. **Factory Pattern**: Extensible providers for all subsystems enable customization without core changes.
+
+5. **Parquet Outputs**: Columnar format for index storage enables efficient analytical queries.
+
+### Integration Opportunities
+
+1. **MCP Server**: GraphRAG could be exposed as an MCP tool for Claude Code to query indexed knowledge bases.
+
+2. **Skill Indexing**: Index skill reference documentation with GraphRAG for enhanced retrieval in complex multi-skill queries.
+
+3. **Codebase Understanding**: Index codebase documentation/comments to answer architectural questions.
+
+4. **Research Aggregation**: Index research entries (like this one) for cross-resource thematic queries.
+
+### Comparison: GraphRAG vs Traditional RAG
+
+| Aspect                    | GraphRAG                              | Traditional Vector RAG        |
+| ------------------------- | ------------------------------------- | ----------------------------- |
+| Cross-document reasoning  | Strong (graph connections)            | Weak (isolated chunks)        |
+| Thematic/abstract queries | Strong (community reports)            | Weak (no global context)      |
+| Entity-specific queries   | Strong (local search + graph)         | Moderate (chunk retrieval)    |
+| Indexing cost             | High (LLM-intensive extraction)       | Low (embedding only)          |
+| Query latency             | Higher (map-reduce for global)        | Lower (single retrieval)      |
+| Storage requirements      | Higher (graph + reports + embeddings) | Lower (embeddings only)       |
+| Update complexity         | Higher (re-extraction)                | Lower (re-embed changed docs) |
+
+### Cost Considerations
+
+The README explicitly warns: "GraphRAG indexing can be an expensive operation." Best practices:
+
+- Start with small test datasets
+- Use inexpensive/fast models for initial experimentation
+- Leverage LLM caching to avoid redundant API calls
+- Consider update strategies before large indexing jobs
+
+---
+
+## References
+
+| Source                     | URL                                                                                                         | Accessed   |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------- |
+| GitHub Repository          | <https://github.com/microsoft/graphrag>                                                                     | 2026-01-31 |
+| Official Documentation     | <https://microsoft.github.io/graphrag/>                                                                     | 2026-01-31 |
+| arXiv Paper                | <https://arxiv.org/pdf/2404.16130>                                                                          | 2026-01-31 |
+| Microsoft Research Blog    | <https://www.microsoft.com/en-us/research/blog/graphrag-unlocking-llm-discovery-on-narrative-private-data/> | 2026-01-31 |
+| PyPI Package               | <https://pypi.org/project/graphrag/>                                                                        | 2026-01-31 |
+| PyPI Stats                 | <https://pypistats.org/packages/graphrag>                                                                   | 2026-01-31 |
+| RAI Transparency Document  | <https://github.com/microsoft/graphrag/blob/main/RAI_TRANSPARENCY.md>                                       | 2026-01-31 |
+| Query Engine Documentation | <https://microsoft.github.io/graphrag/query/overview/>                                                      | 2026-01-31 |
+| Indexing Documentation     | <https://microsoft.github.io/graphrag/index/overview/>                                                      | 2026-01-31 |
+| Architecture Documentation | <https://microsoft.github.io/graphrag/index/architecture/>                                                  | 2026-01-31 |
+
+**Research Method**: Information gathered from official GitHub repository README, RAI transparency document, documentation pages (query overview, index overview, architecture), GitHub API for statistics, PyPI API for package info and download statistics. All claims verified against primary sources.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                     |
+| ------------------ | ------------------------- |
+| Version Documented | v3.0.1                    |
+| Release Date       | 2026-01-28                |
+| GitHub Stars       | 30,637 (as of 2026-01-31) |
+| Monthly Downloads  | 60,312 (as of 2026-01-31) |
+| Next Review Date   | 2026-05-01                |
+
+**Review Triggers**:
+
+- Major version release (v4.x)
+- Significant new query mechanisms
+- New storage or model provider integrations
+- GitHub stars milestone (40K, 50K)
+- PyPI downloads milestone (100K monthly)
+- New community detection algorithms
+- Breaking changes to knowledge model or API
+- Integration with Claude/Anthropic models

--- a/.claude/skills/research-curator/research/developer-tooling/makefile-tutorial.md
+++ b/.claude/skills/research-curator/research/developer-tooling/makefile-tutorial.md
@@ -1,0 +1,184 @@
+# Makefile Tutorial (vampy/Makefile)
+
+| Field          | Value                                   |
+| -------------- | --------------------------------------- |
+| Research Date  | 2026-01-31                              |
+| GitHub URL     | https://github.com/vampy/Makefile       |
+| Version        | N/A (reference documentation)           |
+| License        | MIT                                     |
+| Primary Author | vampy                                   |
+
+---
+
+## Overview
+
+A comprehensive Makefile tutorial that teaches GNU Make through practical examples. The repository consolidates Makefile syntax, patterns, and best practices into a single markdown document, referencing sections from the GNU Make manual. It provides runnable examples covering variables, targets, pattern rules, functions, and implicit rules.
+
+---
+
+## Problem Addressed
+
+| Problem                                    | Solution                                                     |
+| ------------------------------------------ | ------------------------------------------------------------ |
+| Make syntax is complex and poorly understood | Step-by-step examples with clear explanations                |
+| GNU Make manual is dense and hard to navigate | Curated subset with practical examples organized by topic    |
+| Learning curve for build automation        | Progressive examples from simple to complex patterns         |
+| Understanding implicit rules and magic behavior | Explicit documentation of GCC coupling and automatic variables |
+
+---
+
+## Key Statistics
+
+| Metric        | Value | Date Gathered |
+| ------------- | ----- | ------------- |
+| GitHub Stars  | 93    | 2026-01-31    |
+| Forks         | 25    | 2026-01-31    |
+| Contributors  | 1     | 2026-01-31    |
+| Open Issues   | 0     | 2026-01-31    |
+| Watchers      | 2     | 2026-01-31    |
+| Created       | 2020-11-17 | 2026-01-31 |
+| Last Push     | 2021-01-10 | 2026-01-31 |
+
+---
+
+## Key Features
+
+### Syntax Fundamentals
+
+- Target, prerequisite, and command structure
+- Tab vs space requirements for commands
+- Line continuation with backslash
+- Alternative single-line syntax
+
+### Variable System
+
+- Recursive (`=`) vs simply expanded (`:=`) variables
+- Conditional assignment (`?=`)
+- Variable appending (`+=`)
+- Text replacement patterns (`$(var:a=b)`)
+- Target-specific and pattern-specific variables
+- Automatic variables (`$@`, `$^`, `$?`, `$<`)
+
+### Target Patterns
+
+- Default target selection
+- `.PHONY` targets for non-file operations
+- Multiple targets with wildcards (`%`)
+- Static pattern rules
+- Double-colon rules for multiple command sets
+- `all` target convention
+
+### Functions
+
+- Text processing: `subst`, `patsubst`
+- Control flow: `if`, `foreach`, `call`
+- File operations: `wildcard`
+- Shell integration: `shell`
+- String searching: `findstring`, `filter`
+
+### Build Control
+
+- Command echoing/silencing (`@`)
+- Error handling (`-`, `-k`, `-i`)
+- `.DELETE_ON_ERROR` for cleanup
+- Recursive make with `$(MAKE)`
+- Variable export for sub-makes
+- `vpath` for source file discovery
+
+### Implicit Rules
+
+- C/C++ compilation rules
+- Automatic linking
+- Standard variables: `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS`
+
+---
+
+## Technical Architecture
+
+The tutorial is structured as a single README.md file organized by GNU Make manual sections. Each concept includes:
+
+1. Explanation of the feature
+2. Syntax description
+3. Complete runnable Makefile example
+4. Expected output or behavior
+
+The examples are designed to be copy-pasted into a file named `Makefile` and executed with `make`. Most examples include a `clean` target for cleanup.
+
+---
+
+## Installation and Usage
+
+No installation required. The repository is reference documentation.
+
+To use the examples:
+
+```bash
+# Clone or view the repository
+git clone https://github.com/vampy/Makefile.git
+
+# Or read directly on GitHub
+# Copy any example into a file named "Makefile"
+# Run with:
+make
+
+# Clean up generated files:
+make clean
+```
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Build System Understanding**: Claude Code frequently works with projects using Makefiles. Understanding Make syntax enables accurate modification and generation of build rules.
+
+2. **Task Automation Patterns**: Makefile patterns (targets, dependencies, phony targets) map well to task automation in any context.
+
+3. **Variable Scoping**: Understanding recursive vs immediate expansion informs variable handling in other templating systems.
+
+### Patterns Worth Adopting
+
+1. **Dependency Declaration**: Explicit prerequisite declaration ensures correct execution order.
+
+2. **Phony Targets**: Using `.PHONY` for command aliases (clean, test, build) prevents conflicts with filesystem.
+
+3. **Static Pattern Rules**: Compact syntax for applying transformations to file sets.
+
+4. **Automatic Variables**: Using `$@`, `$<`, `$^` reduces repetition in rules.
+
+### Integration Opportunities
+
+1. **Makefile Generation**: Claude Code can generate Makefiles following these documented patterns.
+
+2. **Build System Migration**: Understanding both Make and modern tools (just, task, etc.) enables accurate migrations.
+
+3. **Cross-Platform Scripts**: Makefiles remain common in open-source projects; understanding them is essential for contribution.
+
+---
+
+## References
+
+| Source | URL | Accessed |
+| ------ | --- | -------- |
+| vampy/Makefile Repository | https://github.com/vampy/Makefile | 2026-01-31 |
+| theicfire/makefiletutorial (original source) | https://github.com/theicfire/makefiletutorial | 2026-01-31 |
+| GNU Make Manual (HTML) | https://www.gnu.org/software/make/manual/make.html | 2026-01-31 |
+| GNU Make Book (PDF) | https://www.cl.cam.ac.uk/teaching/0910/UnixTools/make.pdf | 2026-01-31 |
+
+---
+
+## Freshness Tracking
+
+| Field               | Value                    |
+| ------------------- | ------------------------ |
+| Version Documented  | master branch (2021-01-10) |
+| Stars at Research   | 93                       |
+| Last Commit         | 2021-01-10               |
+| Next Review Date    | 2026-05-01               |
+
+**Review Triggers**:
+
+- Significant star growth (>50% increase)
+- New commits after 4+ year dormancy
+- Changes to referenced GNU Make manual

--- a/.claude/skills/research-curator/research/documentation-tools/gitdocify.md
+++ b/.claude/skills/research-curator/research/documentation-tools/gitdocify.md
@@ -1,0 +1,201 @@
+# GitDocify
+
+| Field         | Value                                  |
+| ------------- | -------------------------------------- |
+| Research Date | 2026-01-31                             |
+| Primary URL   | <https://gitdocify.com>                |
+| Backend URL   | <https://api.gitdocify.com>            |
+| Version       | Production (SaaS)                      |
+| License       | Proprietary (commercial SaaS)          |
+| Hosting       | Vercel (frontend), Supabase (database) |
+
+---
+
+## Overview
+
+GitDocify is a commercial SaaS tool that generates README documentation for GitHub repositories using AI. Users connect their GitHub account, select a repository (public or private depending on plan), and receive professionally formatted README files in seconds. The service launched in early 2025 and operates on a freemium model with one-time purchase and subscription options.
+
+---
+
+## Problem Addressed
+
+| Problem                                   | Solution                                                     |
+| ----------------------------------------- | ------------------------------------------------------------ |
+| Writing README files is time-consuming    | AI-powered generation produces complete README in seconds    |
+| Developers neglect documentation          | Low-friction process (connect GitHub, select repo, generate) |
+| Inconsistent documentation quality        | Standardized AI output ensures professional formatting       |
+| Private repo documentation requires setup | GitHub App integration handles authentication automatically  |
+| Documentation maintenance burden          | Regenerate as project evolves (with paid plans)              |
+
+---
+
+## Key Statistics
+
+| Metric                   | Value      | Date Gathered |
+| ------------------------ | ---------- | ------------- |
+| Public GitHub Repo       | Not found  | 2026-01-31    |
+| Supabase Project Created | 2025-01-16 | 2026-01-31    |
+| Last Site Update         | 2025-12-06 | 2026-01-31    |
+| Hosting Platform         | Vercel     | 2026-01-31    |
+
+Note: GitDocify is a closed-source commercial product. No public GitHub repository or open-source components were found.
+
+---
+
+## Key Features
+
+### GitHub Integration
+
+- OAuth-based GitHub App authentication
+- Support for public repositories (all plans)
+- Support for private repositories (paid plans)
+- Repository browser for easy selection
+- Automatic code analysis across repository
+
+### AI Documentation Generation
+
+- README generation in seconds
+- Professional markdown formatting
+- Project analysis for context-aware content
+- "Basic AI agent" (free tier)
+- "Most Advanced AI Agent" (paid tiers)
+
+### Output Options
+
+- Markdown export
+- Customization via add-ons
+- Full project analysis (paid)
+
+### Pricing Tiers (as of 2026-01-31)
+
+| Tier         | Price         | Generations | Features                                       |
+| ------------ | ------------- | ----------- | ---------------------------------------------- |
+| Free Trial   | $0            | 1           | Public repos, basic AI, no credit card         |
+| Starter Pack | $3.99 (once)  | 10          | Public/private repos, add-ons, markdown export |
+| Monthly      | $14.99/mo     | 50/month    | Advanced AI, full analysis, all features       |
+| Lifetime     | $54.99 (once) | Unlimited   | All features, permanent access                 |
+
+### Announced/Coming Soon
+
+- "Full Documentation Coming Soon" - complete code documentation features beyond README
+
+---
+
+## Technical Architecture
+
+### Stack Components (extracted from production JavaScript)
+
+| Component      | Technology                            |
+| -------------- | ------------------------------------- |
+| Frontend       | React (SPA), hosted on Vercel         |
+| Backend API    | api.gitdocify.com (unknown framework) |
+| Database       | Supabase (PostgreSQL)                 |
+| Payments       | Stripe (checkout and customer portal) |
+| Analytics      | PostHog, Google Tag Manager           |
+| Authentication | GitHub OAuth via Supabase             |
+
+### API Endpoints (observed)
+
+```text
+/api/github/install-url    # GitHub App installation
+/api/github/repositories   # List connected repos
+/api/github/link           # Link repo for generation
+```
+
+### Workflow
+
+1. User authenticates via GitHub OAuth
+2. User selects repository from connected repos
+3. Backend analyzes repository code
+4. AI generates README based on analysis
+5. User downloads/copies markdown output
+
+---
+
+## Installation and Usage
+
+GitDocify is a web-based SaaS product. No local installation required.
+
+### Getting Started
+
+1. Visit <https://gitdocify.com>
+2. Click "Get Started" or similar CTA
+3. Authenticate with GitHub account
+4. Select a public repository (free tier)
+5. Generate README
+6. Export markdown
+
+### No CLI or Local Tool
+
+There is no command-line interface or self-hosted option. The service operates entirely through the web interface.
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Documentation Workflow Comparison**: Provides a reference point for AI-assisted documentation generation patterns. Useful for comparing approaches when building documentation skills for Claude Code.
+
+2. **SaaS Architecture Reference**: Demonstrates production patterns for GitHub-integrated AI services (OAuth, Supabase, Stripe, Vercel).
+
+3. **Pricing Model Insights**: Offers a case study in monetizing AI documentation services with tiered offerings.
+
+### Patterns Worth Studying
+
+1. **GitHub App Integration**: OAuth flow + repository access pattern is reusable for skills that need GitHub integration.
+
+2. **Freemium AI Services**: One-time purchase credits model as alternative to pure subscription.
+
+3. **AI Agent Tiering**: Marketing distinction between "basic" and "advanced" AI agents.
+
+### Limitations for Claude Code
+
+1. **Closed Source**: No codebase to study for implementation details.
+
+2. **Web-Only**: Cannot be integrated as a CLI tool or library.
+
+3. **Narrow Scope**: Currently limited to README generation (full docs "coming soon").
+
+4. **No API Access**: No documented public API for programmatic access.
+
+### Integration Opportunities
+
+1. **Competitive Analysis**: When building documentation generation skills, compare output quality.
+
+2. **Feature Parity Goals**: Target similar or better README quality with local skill.
+
+3. **Workflow Inspiration**: "Connect repo, select, generate, export" is a smooth UX to emulate.
+
+---
+
+## References
+
+| Source                         | URL                                                 | Accessed   |
+| ------------------------------ | --------------------------------------------------- | ---------- |
+| GitDocify Homepage             | <https://gitdocify.com>                             | 2026-01-31 |
+| GitDocify Sitemap              | <https://gitdocify.com/sitemap.xml>                 | 2026-01-31 |
+| Features JS Bundle (extracted) | <https://gitdocify.com/assets/Features-DLif5GYB.js> | 2026-01-31 |
+| Pricing JS Bundle (extracted)  | <https://gitdocify.com/assets/Pricing-B9ZMlUbY.js>  | 2026-01-31 |
+| Main JS Bundle (config)        | <https://gitdocify.com/assets/index-DPVmzviH.js>    | 2026-01-31 |
+
+**Research Method**: Information extracted from client-side JavaScript bundles as the site is a React SPA without server-rendered content. No public documentation, GitHub repository, or press coverage was found.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                                   |
+| ------------------ | --------------------------------------- |
+| Version Documented | Production SaaS (2026-01-31)            |
+| Site Last Modified | 2025-12-06                              |
+| Service Launch     | ~2025-01-16 (Supabase project creation) |
+| Next Review Date   | 2026-05-01                              |
+
+**Review Triggers**:
+
+- Launch of "Full Documentation" feature (currently announced as "coming soon")
+- Public API release
+- Open-source components released
+- Significant pricing changes
+- Product Hunt launch or major press coverage

--- a/.claude/skills/research-curator/research/llm-infrastructure/tensorzero.md
+++ b/.claude/skills/research-curator/research/llm-infrastructure/tensorzero.md
@@ -1,0 +1,352 @@
+# TensorZero
+
+| Field         | Value                                      |
+| ------------- | ------------------------------------------ |
+| Research Date | 2026-01-31                                 |
+| Primary URL   | <https://tensorzero.com>                   |
+| GitHub        | <https://github.com/tensorzero/tensorzero> |
+| Documentation | <https://www.tensorzero.com/docs>          |
+| PyPI          | <https://pypi.org/project/tensorzero/>     |
+| Version       | 2026.1.8 (released 2026-01-30)             |
+| License       | Apache-2.0                                 |
+| Slack         | <https://www.tensorzero.com/slack>         |
+| Discord       | <https://www.tensorzero.com/discord>       |
+
+---
+
+## Overview
+
+TensorZero is an open-source stack for industrial-grade LLM applications, written in Rust for extreme performance (<1ms p99 latency). It unifies five core capabilities: a multi-provider LLM gateway, observability with feedback collection, prompt/model optimization, evaluation with LLM judges, and experimentation with A/B testing. The platform enables a data and learning flywheel where production metrics and human feedback continuously improve prompts, models, and inference strategies.
+
+---
+
+## Problem Addressed
+
+| Problem                                     | Solution                                                              |
+| ------------------------------------------- | --------------------------------------------------------------------- |
+| LLM provider lock-in and fragmented APIs    | Unified gateway supporting 20+ providers through single API           |
+| High latency overhead from LLM proxies      | Rust-based gateway with <1ms p99 latency at 10k+ QPS                  |
+| No feedback loop for production LLMs        | Metrics and human feedback collection powers continuous optimization  |
+| Prompt engineering is manual and ad-hoc     | Automated prompt engineering with GEPA algorithm and MIPROv2          |
+| Fine-tuning requires complex data pipelines | Direct fine-tuning from production feedback (SFT, RLHF)               |
+| A/B testing LLMs is complex                 | Built-in adaptive A/B testing with multi-armed bandits                |
+| LLM evaluations lack standardization        | Inference and workflow evaluations with heuristics and LLM judges     |
+| Observability scattered across tools        | Unified data store with UI, programmatic access, OpenTelemetry export |
+| Type safety lacking in LLM interfaces       | Prompt templates with schemas enforce typed interface contracts       |
+
+---
+
+## Key Statistics
+
+| Metric           | Value           | Date Gathered |
+| ---------------- | --------------- | ------------- |
+| GitHub Stars     | 10,886          | 2026-01-31    |
+| GitHub Forks     | 763             | 2026-01-31    |
+| Open Issues      | 368             | 2026-01-31    |
+| Contributors     | ~105            | 2026-01-31    |
+| PyPI Monthly DL  | 45,236          | 2026-01-31    |
+| PyPI Weekly DL   | 12,957          | 2026-01-31    |
+| Primary Language | Rust            | 2026-01-31    |
+| Repository Age   | Since July 2024 | 2026-01-31    |
+| Rust Version     | 1.88.0          | 2026-01-31    |
+
+---
+
+## Key Features
+
+### LLM Gateway
+
+- **Unified API**: Access 20+ LLM providers through single interface
+- **Performance**: <1ms p99 latency overhead at 10k+ QPS (Rust-based)
+- **Inference modes**: Streaming, tool use, structured outputs (JSON), batch, embeddings, multimodal (images, files), caching
+- **Prompt templates**: Type-safe schemas enforce consistent interface between application and LLMs
+- **High availability**: Routing, retries, fallbacks, load balancing, granular timeouts
+- **Rate limiting**: Custom rate limits with granular scopes (user-defined tags)
+- **Auth**: Clients access models without sharing provider API keys
+
+### Supported Providers
+
+Anthropic, AWS Bedrock, AWS SageMaker, Azure, DeepSeek, Fireworks, GCP Vertex AI (Anthropic), GCP Vertex AI (Gemini), Google AI Studio (Gemini), Groq, Hyperbolic, Mistral, OpenAI, OpenRouter, SGLang, TGI, Together AI, vLLM, xAI (Grok), and any OpenAI-compatible API (e.g., Ollama).
+
+### Observability
+
+- **Data storage**: Inferences and feedback stored in your own database
+- **TensorZero UI**: Debug individual API calls or monitor aggregate metrics
+- **Datasets**: Build datasets for optimization, evaluation, and workflows
+- **Replay**: Replay historical inferences with new prompts/models/strategies
+- **Export**: OpenTelemetry traces (OTLP) and Prometheus metrics export
+- **Programmatic access**: Query inferences with filters, compound filters, search, pagination
+
+### Optimization
+
+- **Fine-tuning**: Supervised fine-tuning (SFT) and RLHF from production feedback
+- **Prompt engineering**: Automated optimization with GEPA and MIPROv2 algorithms
+- **Inference strategies**: Dynamic in-context learning (DICL), best-of-N sampling, mixture-of-N
+- **Data flywheel**: Production data continuously improves models (better variants -> better data -> better variants)
+
+### Evaluation
+
+- **Inference evaluations**: Evaluate individual LLM calls with heuristics or LLM judges (unit tests for LLMs)
+- **Workflow evaluations**: Evaluate end-to-end workflows with complete flexibility (integration tests for LLMs)
+- **Judge optimization**: Optimize LLM judges like any TensorZero function to align with human preferences
+- **CLI and UI**: Run evaluations from command line or through the TensorZero UI
+
+### Experimentation
+
+- **Adaptive A/B testing**: Multi-armed bandits for efficient variant selection
+- **Principled experiments**: Support for multi-turn systems and sequential testing
+- **Confidence**: Ship with statistical confidence in prompt/model changes
+
+---
+
+## Technical Architecture
+
+### Stack Components
+
+| Component     | Technology                                  |
+| ------------- | ------------------------------------------- |
+| Core Gateway  | Rust (tensorzero-core)                      |
+| Python Client | tensorzero PyPI package                     |
+| Rust Client   | clients/rust workspace member               |
+| Evaluations   | evaluations workspace member                |
+| Optimizers    | tensorzero-optimizers workspace member      |
+| Database      | User-owned (Postgres, ClickHouse supported) |
+| UI            | TensorZero UI (open-source)                 |
+| Deployment    | Docker (tensorzero/gateway image)           |
+
+### Workspace Structure
+
+```text
+tensorzero/
+├── tensorzero-core/          # Core gateway logic
+├── gateway/                  # Gateway service
+├── clients/
+│   ├── rust/                 # Rust client
+│   └── python/               # Python client (PyPI: tensorzero)
+├── evaluations/              # Evaluation framework
+├── tensorzero-optimizers/    # Optimization algorithms
+├── provider-proxy/           # Provider proxy layer
+└── internal/                 # Internal utilities
+    ├── tensorzero-types/     # Type definitions
+    ├── tensorzero-auth/      # Authentication
+    └── autopilot-*/          # Autopilot components
+```
+
+### Data Flow
+
+1. Application sends inference request to TensorZero gateway
+2. Gateway routes to configured provider(s) with fallback/retry logic
+3. Inference logged to database with request/response data
+4. Application sends feedback (metrics, human edits) via feedback API
+5. Feedback linked to inference for training data collection
+6. Optimization jobs consume feedback to improve prompts/models
+7. New variants deployed via A/B testing framework
+8. Cycle repeats: better variants -> better data -> better variants
+
+### Configuration Model
+
+TensorZero uses TOML configuration with GitOps-friendly structure:
+
+```toml
+# tensorzero.toml
+[functions.my_function]
+type = "chat"
+
+[functions.my_function.variants.gpt4o]
+type = "chat_completion"
+model = "gpt-4o"
+
+[functions.my_function.variants.claude]
+type = "chat_completion"
+model = "claude-sonnet-4-20250514"
+weight = 0.5  # A/B test allocation
+```
+
+---
+
+## Installation and Usage
+
+### Installation
+
+```bash
+# Python client
+pip install tensorzero
+
+# Using uv (recommended)
+uv pip install tensorzero
+```
+
+### Gateway Deployment
+
+```bash
+# Docker deployment
+docker run -p 3000:3000 tensorzero/gateway
+
+# With configuration
+docker run -p 3000:3000 -v $(pwd)/config:/app/config tensorzero/gateway
+```
+
+### Basic Inference (TensorZero SDK)
+
+```python
+from tensorzero import TensorZeroGateway  # or AsyncTensorZeroGateway
+
+with TensorZeroGateway.build_embedded(...) as t0:
+    response = t0.inference(
+        model_name="openai::gpt-4o-mini",
+        # Switch providers easily: "anthropic::claude-sonnet-4-5"
+        input={
+            "messages": [
+                {"role": "user", "content": "Write a haiku about TensorZero."}
+            ]
+        },
+    )
+```
+
+### Using with OpenAI SDK
+
+```python
+from openai import OpenAI
+from tensorzero import patch_openai_client
+
+client = OpenAI()
+patch_openai_client(client, ...)
+
+response = client.chat.completions.create(
+    model="tensorzero::model_name::openai::gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+```
+
+### Feedback Collection
+
+```python
+# Record feedback for optimization
+t0.feedback(
+    inference_id=response.inference_id,
+    metric_name="user_rating",
+    value=5,
+)
+```
+
+### Running Evaluations (CLI)
+
+```bash
+docker compose run --rm evaluations \
+  --evaluation-name extract_data \
+  --dataset-name hard_test_cases \
+  --variant-name gpt_4o \
+  --concurrency 5
+```
+
+---
+
+## Example Use Cases
+
+The repository includes complete runnable examples:
+
+| Example                       | Description                                             |
+| ----------------------------- | ------------------------------------------------------- |
+| Data Extraction (NER)         | Optimize extraction pipeline with fine-tuning and DICL  |
+| Agentic RAG                   | Multi-hop retrieval agent searching Wikipedia           |
+| Haiku with Hidden Preferences | Fine-tune GPT-4o Mini for specific taste using feedback |
+| Multimodal Vision Fine-tuning | Fine-tune VLMs for document image categorization        |
+| Chess Puzzles with Best-of-N  | Improve LLM chess ability with best-of-N sampling       |
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **LLM Gateway Patterns**: Unified API with fallbacks, retries, and rate limiting provides reference architecture for resilient LLM integrations.
+
+2. **Feedback Loop Design**: Metrics and human feedback collection enabling continuous improvement could inform Claude Code skill refinement workflows.
+
+3. **Evaluation Framework**: Inference-level and workflow-level evaluations with LLM judges offer testing patterns for skill quality assurance.
+
+4. **Observability Patterns**: Structured logging with programmatic query access provides model for tracking Claude Code operations.
+
+5. **Configuration-as-Code**: TOML-based prompt templates and variant management demonstrate GitOps approach for LLM configurations.
+
+### Patterns Worth Adopting
+
+1. **Dynamic In-Context Learning (DICL)**: Automatically selecting relevant examples from historical data improves LLM performance without fine-tuning.
+
+2. **Adaptive A/B Testing**: Multi-armed bandits efficiently identify best prompts/models with statistical confidence.
+
+3. **Type-Safe LLM Interfaces**: Schema enforcement on prompts creates contracts between application and LLM.
+
+4. **Feedback-to-Training Pipeline**: Direct path from production feedback to fine-tuning enables continuous improvement.
+
+5. **Evaluation Categories**: Separating inference evaluations (unit tests) from workflow evaluations (integration tests) provides clear testing taxonomy.
+
+### Integration Opportunities
+
+1. **Gateway for Multi-Provider Access**: TensorZero could serve as backend for Claude Code operations requiring multiple LLM providers.
+
+2. **Feedback Collection**: Integrate TensorZero feedback API to collect metrics on Claude Code skill effectiveness.
+
+3. **Prompt Optimization**: Use GEPA/MIPROv2 algorithms to optimize Claude Code prompts and instructions.
+
+4. **Evaluation Infrastructure**: Leverage evaluation framework to test skill quality with LLM judges.
+
+5. **Observability Export**: Export Claude Code operations to TensorZero for unified LLM observability.
+
+### Comparison with Claude Code
+
+| Aspect            | TensorZero                    | Claude Code                   |
+| ----------------- | ----------------------------- | ----------------------------- |
+| Primary Use       | LLMOps platform               | Developer workflow automation |
+| Model Support     | 20+ providers                 | Claude models (Anthropic)     |
+| Optimization      | Fine-tuning, prompt eng, DICL | Manual skill iteration        |
+| Evaluation        | Built-in with LLM judges      | Manual testing                |
+| Feedback          | Structured collection & use   | Session-based                 |
+| Configuration     | TOML with GitOps              | Skills, CLAUDE.md             |
+| Performance Focus | <1ms latency, 10k+ QPS        | Developer experience          |
+| Deployment        | Self-hosted Docker            | CLI + IDE integration         |
+
+---
+
+## References
+
+| Source                   | URL                                                                                              | Accessed   |
+| ------------------------ | ------------------------------------------------------------------------------------------------ | ---------- |
+| GitHub Repository        | <https://github.com/tensorzero/tensorzero>                                                       | 2026-01-31 |
+| GitHub README            | <https://github.com/tensorzero/tensorzero/blob/main/README.md>                                   | 2026-01-31 |
+| Official Documentation   | <https://www.tensorzero.com/docs>                                                                | 2026-01-31 |
+| Quick Start Guide        | <https://www.tensorzero.com/docs/quickstart>                                                     | 2026-01-31 |
+| PyPI Package             | <https://pypi.org/project/tensorzero/>                                                           | 2026-01-31 |
+| PyPI Stats               | <https://pypistats.org/packages/tensorzero>                                                      | 2026-01-31 |
+| GitHub API               | <https://api.github.com/repos/tensorzero/tensorzero>                                             | 2026-01-31 |
+| Seed Round Announcement  | <https://www.tensorzero.com/blog/tensorzero-raises-7-3m-seed-round>                              | 2026-01-31 |
+| VentureBeat Coverage     | <https://venturebeat.com/ai/tensorzero-nabs-7-3m-seed>                                           | 2026-01-31 |
+| GEPA Algorithm           | <https://www.tensorzero.com/docs/optimization/gepa>                                              | 2026-01-31 |
+| DICL Documentation       | <https://www.tensorzero.com/docs/gateway/guides/inference-time-optimizations>                    | 2026-01-31 |
+| Example: Data Extraction | <https://github.com/tensorzero/tensorzero/tree/main/examples/data-extraction-ner>                | 2026-01-31 |
+| Example: Agentic RAG     | <https://github.com/tensorzero/tensorzero/tree/main/examples/rag-retrieval-augmented-generation> | 2026-01-31 |
+
+**Research Method**: Information gathered from official GitHub repository README, GitHub API (stars, forks, issues, contributors, releases), PyPI package metadata, PyPI download statistics API, and Cargo.toml workspace configuration. Statistics verified via direct API calls on 2026-01-31.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                     |
+| ------------------ | ------------------------- |
+| Version Documented | 2026.1.8                  |
+| Release Date       | 2026-01-30                |
+| GitHub Stars       | 10,886 (as of 2026-01-31) |
+| Monthly Downloads  | 45,236 (as of 2026-01-31) |
+| Next Review Date   | 2026-05-01                |
+
+**Review Triggers**:
+
+- Major version release
+- Significant new optimization algorithm
+- GitHub stars milestone (15K, 20K)
+- PyPI downloads milestone (100K monthly)
+- TensorZero Autopilot general availability
+- New model provider integrations of note
+- Breaking changes to gateway API or configuration format
+- Significant updates to evaluation framework

--- a/.claude/skills/research-curator/research/low-code-platforms/tooljet.md
+++ b/.claude/skills/research-curator/research/low-code-platforms/tooljet.md
@@ -1,0 +1,321 @@
+# ToolJet
+
+| Field         | Value                                                    |
+| ------------- | -------------------------------------------------------- |
+| Research Date | 2026-01-31                                               |
+| Primary URL   | <https://tooljet.com>                                    |
+| GitHub        | <https://github.com/ToolJet/ToolJet>                     |
+| Documentation | <https://docs.tooljet.com>                               |
+| Version       | v3.20.82-lts (released 2026-01-30)                       |
+| License       | AGPL-3.0                                                 |
+| Docker Hub    | <https://hub.docker.com/r/tooljet/tooljet-ce>            |
+
+---
+
+## Overview
+
+ToolJet is an open-source low-code platform for building internal tools, dashboards, business applications, workflows, and AI agents. The platform provides a visual drag-and-drop builder with 60+ components, connects to 75+ data sources including databases, APIs, and cloud storage, and offers an integrated no-code database. ToolJet AI (enterprise) adds AI-powered app generation, query building, debugging, and an Agent Builder for workflow automation.
+
+---
+
+## Problem Addressed
+
+| Problem                                              | Solution                                                         |
+| ---------------------------------------------------- | ---------------------------------------------------------------- |
+| Building internal tools requires significant dev time | Visual drag-and-drop builder with 60+ responsive components      |
+| Connecting to multiple data sources is complex       | 75+ pre-built integrations for databases, APIs, SaaS, storage    |
+| Teams need quick data management without SQL         | Built-in ToolJet Database (no-code relational database)          |
+| Collaboration on app development is difficult        | Multiplayer editing, inline comments, mentions, version control  |
+| Self-hosting internal tools is operationally heavy   | Docker, Kubernetes, cloud marketplace deployment options         |
+| Non-developers cannot build business applications    | No-code interface with JavaScript/Python extensibility           |
+| Creating AI-powered workflows is complex             | Agent Builder for intelligent automation (enterprise)            |
+
+---
+
+## Key Statistics
+
+| Metric             | Value                     | Date Gathered |
+| ------------------ | ------------------------- | ------------- |
+| GitHub Stars       | 37,363                    | 2026-01-31    |
+| GitHub Forks       | 4,936                     | 2026-01-31    |
+| Open Issues        | 967                       | 2026-01-31    |
+| Contributors       | ~419                      | 2026-01-31    |
+| Docker Pulls       | 2,184,706                 | 2026-01-31    |
+| Primary Language   | JavaScript/TypeScript     | 2026-01-31    |
+| Repository Age     | Since March 2021          | 2026-01-31    |
+| Watchers           | 195                       | 2026-01-31    |
+| Repository Size    | ~1.5 GB                   | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Visual App Builder (Community Edition)
+
+- **60+ Components**: Tables, Charts, Forms, Lists, Progress Bars, Maps, and more
+- **Responsive Design**: Components adapt to different screen sizes
+- **Multi-page Apps**: Build complex applications with navigation
+- **Multiplayer Editing**: Collaborative real-time development
+- **Code Execution**: Run JavaScript and Python within apps
+- **Theming**: Customize appearance with themes
+
+### Data Sources
+
+- **75+ Integrations**: Databases, REST/GraphQL APIs, cloud storage, SaaS tools
+- **ToolJet Database**: Built-in no-code relational database
+- **Default Sources**: ToolJet DB, REST API, JavaScript queries, Python queries
+- **Plugin System**: Create custom data source connectors via CLI
+- **Workspace-level Connections**: Share data sources across applications
+
+Supported data sources include:
+
+- Databases: PostgreSQL, MySQL, MongoDB, Firestore, DynamoDB, Redis, etc.
+- APIs: REST API, GraphQL, Stripe, Twilio, SendGrid, Slack, etc.
+- Cloud Storage: AWS S3, Google Cloud Storage, Azure Blob, MinIO
+- SaaS: Airtable, Google Sheets, Notion, Baserow, NocoDB
+
+### ToolJet AI (Enterprise)
+
+- **AI App Generation**: Create apps from natural language prompts
+- **AI Query Builder**: Generate and transform database queries with AI
+- **AI Debugging**: One-click issue identification and fixes
+- **Agent Builder**: Create intelligent agents to automate workflows
+
+### Security and Compliance (Enterprise)
+
+- **Encryption**: AES-256-GCM encryption at rest
+- **SSO Support**: SAML, OAuth 2.0, OpenID Connect
+- **Audit Logs**: Track user actions and changes
+- **RBAC**: Role-based access control with custom groups
+- **Row-Level Security**: Fine-grained data access control
+- **SOC 2 / GDPR**: Enterprise compliance readiness
+
+### Deployment Options
+
+- **Cloud Hosted**: ToolJet Cloud (managed service)
+- **Self-Hosted**: Docker, Kubernetes, Helm
+- **Cloud Platforms**: AWS EC2/ECS/EKS, GCP GKE/Cloud Run, Azure AKS/Container
+- **Marketplaces**: AWS Marketplace, Azure Marketplace
+- **Platform Support**: Digital Ocean, OpenShift
+
+---
+
+## Technical Architecture
+
+### Stack Components
+
+| Component       | Technology                                        |
+| --------------- | ------------------------------------------------- |
+| Backend         | NestJS (Node.js framework)                        |
+| Frontend        | React.js                                          |
+| Database        | PostgreSQL (primary), ToolJet DB (built-in)       |
+| Realtime        | Socket.IO                                         |
+| Job Queue       | Bull (Redis-based)                                |
+| ORM             | TypeORM                                           |
+| Authentication  | Passport.js                                       |
+| Containerization| Docker                                            |
+| Orchestration   | Kubernetes, Helm                                  |
+
+### Application Architecture
+
+```text
+User Interface (React + Drag-and-Drop Builder)
+           |
+    Application Layer (NestJS)
+           |
+    +------+------+
+    |             |
+Data Sources   ToolJet DB
+(75+ connectors) (PostgreSQL)
+           |
+    Deployment Layer
+(Docker/K8s/Cloud)
+```
+
+### Data Flow
+
+1. User builds app using visual drag-and-drop interface
+2. Components bind to data sources via queries
+3. Queries execute against connected databases/APIs
+4. Results render in UI components
+5. User actions trigger JavaScript/Python handlers
+6. Real-time updates via WebSocket connections
+7. Changes persisted to ToolJet application database
+
+---
+
+## Installation and Usage
+
+### Quick Start with Docker
+
+```bash
+docker run \
+  --name tooljet \
+  --restart unless-stopped \
+  -p 80:80 \
+  --platform linux/amd64 \
+  -v tooljet_data:/var/lib/postgresql/13/main \
+  tooljet/try:ee-lts-latest
+```
+
+### Docker Compose (Production)
+
+```yaml
+version: "3"
+services:
+  tooljet:
+    image: tooljet/tooljet-ce:ce-lts-latest
+    restart: always
+    ports:
+      - "80:80"
+    environment:
+      - TOOLJET_HOST=https://your-domain.com
+      - PG_HOST=postgres
+      - PG_DB=tooljet
+      - PG_USER=postgres
+      - PG_PASS=password
+      - SECRET_KEY_BASE=your-secret-key
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:13
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=tooljet
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:
+```
+
+### Creating a Data Source Connection
+
+1. Navigate to Data Sources page from dashboard sidebar
+2. Select category (Databases, APIs, Cloud Storage, Plugins)
+3. Click + Add on desired data source
+4. Enter connection configuration
+5. Data source available across workspace applications
+
+### Building an Application
+
+1. Create new app from dashboard
+2. Drag components from component library
+3. Add queries to connect data sources
+4. Bind query results to component properties
+5. Add JavaScript event handlers for interactivity
+6. Deploy application
+
+---
+
+## CLI Tool
+
+The ToolJet CLI enables custom plugin development:
+
+```bash
+# Install CLI
+npm install -g @tooljet/cli
+
+# Create new plugin
+tooljet plugin create my-data-source
+
+# Build plugin
+tooljet plugin build
+
+# Publish to marketplace
+tooljet plugin publish
+```
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Internal Tool Building**: Rapid prototyping of dashboards and admin interfaces that could complement Claude Code workflows.
+
+2. **Agent Builder Patterns**: ToolJet's AI Agent Builder demonstrates visual approaches to workflow automation that could inform skill design.
+
+3. **Data Source Integration**: The 75+ connector patterns provide reference implementations for database and API integrations.
+
+4. **Plugin Architecture**: The CLI-based plugin creation workflow offers patterns for extensible tool ecosystems.
+
+5. **Multi-Tenant Security**: RBAC, row-level security, and audit logging patterns applicable to enterprise Claude Code deployments.
+
+### Patterns Worth Adopting
+
+1. **Visual Query Building**: Natural language to SQL/query translation reduces barrier for non-developers.
+
+2. **Component Library**: Well-organized, discoverable component system with consistent APIs.
+
+3. **Workspace Scoping**: Data sources shared at workspace level, similar to skill sharing patterns.
+
+4. **Multi-environment Support**: Dev/staging/production environment management for controlled deployments.
+
+5. **Plugin Marketplace**: Extensibility through community-contributed connectors.
+
+### Integration Opportunities
+
+1. **MCP Server for ToolJet**: Expose ToolJet applications as MCP tools for Claude Code workflows.
+
+2. **Claude-Powered Agents**: Use Claude models within ToolJet Agent Builder for intelligent automation.
+
+3. **Data Pipeline Integration**: ToolJet as data visualization layer for Claude Code analysis outputs.
+
+4. **Admin Interface Generation**: Generate ToolJet admin UIs for Claude Code project management.
+
+5. **Workflow Handoff**: ToolJet workflows could trigger or be triggered by Claude Code processes.
+
+### Comparison with Claude Code
+
+| Aspect              | ToolJet                        | Claude Code                    |
+| ------------------- | ------------------------------ | ------------------------------ |
+| Primary Use         | Internal tool building         | Developer workflow automation  |
+| Interface           | Visual drag-and-drop           | CLI + natural language         |
+| Data Access         | 75+ connectors, built-in DB    | MCP, file system, tools        |
+| Code Execution      | JavaScript, Python in browser  | Full development environment   |
+| Target Users        | Business users, developers     | Developers                     |
+| AI Features         | App generation, query building | Code generation, analysis      |
+| Deployment          | Self-hosted, cloud             | Local CLI, IDE integration     |
+| Extensibility       | Plugin marketplace, CLI        | Skills, MCP servers            |
+
+---
+
+## References
+
+| Source                    | URL                                                      | Accessed   |
+| ------------------------- | -------------------------------------------------------- | ---------- |
+| GitHub Repository         | <https://github.com/ToolJet/ToolJet>                     | 2026-01-31 |
+| GitHub README             | <https://github.com/ToolJet/ToolJet/blob/develop/README.md> | 2026-01-31 |
+| Official Documentation    | <https://docs.tooljet.com>                               | 2026-01-31 |
+| Data Sources Overview     | <https://docs.tooljet.com/docs/data-sources/overview>    | 2026-01-31 |
+| Docker Hub                | <https://hub.docker.com/r/tooljet/tooljet-ce>            | 2026-01-31 |
+| AWS Marketplace           | <https://aws.amazon.com/marketplace/pp/prodview-fxjto27jkpqfg> | 2026-01-31 |
+| Azure Marketplace         | <https://azuremarketplace.microsoft.com/en-us/marketplace/apps/tooljetsolutioninc1679496832216.tooljet> | 2026-01-31 |
+| ToolJet CLI (npm)         | <https://www.npmjs.com/package/@tooljet/cli>             | 2026-01-31 |
+| Contributing Guide        | <https://github.com/ToolJet/ToolJet/blob/develop/CONTRIBUTING.md> | 2026-01-31 |
+| Project Roadmap           | <https://github.com/orgs/ToolJet/projects/15>            | 2026-01-31 |
+
+**Research Method**: Information gathered from official GitHub repository README, GitHub API (stars, forks, issues, releases, contributors), Docker Hub API (pull counts), and official documentation. Statistics verified via direct API calls on 2026-01-31.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                               |
+| ------------------ | ----------------------------------- |
+| Version Documented | v3.20.82-lts                        |
+| Release Date       | 2026-01-30                          |
+| GitHub Stars       | 37,363 (as of 2026-01-31)           |
+| Docker Pulls       | 2,184,706 (as of 2026-01-31)        |
+| Next Review Date   | 2026-05-01                          |
+
+**Review Triggers**:
+
+- Major version release (v4.x)
+- Significant AI feature additions
+- GitHub stars milestone (40K, 50K)
+- Docker pulls milestone (3M, 5M)
+- New Agent Builder capabilities
+- MCP or Claude integration announcements
+- Changes to open-source licensing

--- a/research/README.md
+++ b/research/README.md
@@ -20,6 +20,7 @@ research/
 ├── coding-agents/                     # Autonomous AI coding agent platforms
 │   └── openhands.md                   # Open platform for cloud coding agents (67K+ stars)
 ├── developer-tools/                   # Developer productivity and workflow tools
+│   ├── animejs.md                     # Lightweight JavaScript animation engine (66K+ stars)
 │   └── git-cliff.md                   # Customizable changelog generator from Git history
 ├── mcp-ecosystem/                     # MCP servers and integrations
 │   ├── docs-mcp-server.md             # Local documentation index (Grounded Docs)
@@ -152,7 +153,7 @@ Agent SDKs, orchestration frameworks, and comparative studies of multi-agent arc
 
 | Document                                                              | Description                                                                                                                            | Last Updated |
 | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| [ai-agents-frameworks.md](./agent-frameworks/ai-agents-frameworks.md) | Comparative learning repository for 10 AI agent frameworks with benchmarks for response time, memory, tokens, RAG, and API integration | 2026-01-26   |
+| [ai-agents-frameworks.md](./agent-frameworks/ai-agents-frameworks.md) | Comparative learning repository for 10 AI agent frameworks with benchmarks for response time, memory, tokens, RAG, and API integration | 2026-01-31   |
 
 **Key Topics**:
 
@@ -194,10 +195,13 @@ Developer productivity tools and workflow automation for software engineering wi
 
 | Document                                       | Description                                                                                                         | Last Updated |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------ |
+| [animejs.md](./developer-tools/animejs.md)     | Lightweight JavaScript animation engine with declarative API, timelines, staggering, and 30+ easing functions       | 2026-01-31   |
 | [git-cliff.md](./developer-tools/git-cliff.md) | Customizable changelog generator using conventional commits and regex parsers with GitHub/GitLab remote integration | 2026-01-26   |
 
 **Key Topics**:
 
+- Declarative animation APIs for frontend code generation
+- Composable building blocks pattern (animate, stagger, timeline)
 - Conventional commits specification and parsing
 - Customizable Tera templates for changelog output
 - GitHub/GitLab/Gitea/Bitbucket remote metadata integration

--- a/research/agent-frameworks/ai-agents-frameworks.md
+++ b/research/agent-frameworks/ai-agents-frameworks.md
@@ -1,9 +1,9 @@
 # AI Agents Frameworks - Comparative Learning Repository
 
-**Research Date**: 2026-01-26
+**Research Date**: 2026-01-31
 **Source URL**: <https://github.com/martimfasantos/ai-agents-frameworks>
 **GitHub Repository**: <https://github.com/martimfasantos/ai-agents-frameworks>
-**Version at Research**: Main branch (commit 1fba6c9, 2026-01-02)
+**Version at Research**: Main branch (pushed 2026-01-24)
 **License**: Not specified (no LICENSE file)
 
 ---
@@ -28,19 +28,19 @@ AI Agents Frameworks is a hands-on learning repository that provides practical i
 
 ---
 
-## Key Statistics (as of 2026-01-26)
+## Key Statistics (as of 2026-01-31)
 
 | Metric             | Value            |
 | ------------------ | ---------------- |
-| GitHub Stars       | 348              |
+| GitHub Stars       | 354              |
 | Forks              | 43               |
 | Contributors       | 1                |
-| Open Issues        | 2                |
-| Open Pull Requests | 2                |
+| Open Issues        | 4                |
+| Open Pull Requests | 0                |
 | Primary Language   | Jupyter Notebook |
 | Frameworks Covered | 10               |
 | Created            | 2025-01-21       |
-| Last Updated       | 2026-01-21       |
+| Last Updated       | 2026-01-31       |
 
 ---
 
@@ -284,7 +284,7 @@ streamlit run agent-ui.py
 
 ## References
 
-1. **GitHub Repository**: <https://github.com/martimfasantos/ai-agents-frameworks> (accessed 2026-01-26)
+1. **GitHub Repository**: <https://github.com/martimfasantos/ai-agents-frameworks> (accessed 2026-01-31)
 2. **Study Methodology**: study-agents-differences/README.md (accessed 2026-01-26)
 3. **Author Profile**: Martim Santos, daredata.ai - <https://martimfasantos.github.io>
 
@@ -305,13 +305,13 @@ streamlit run agent-ui.py
 
 ## Freshness Tracking
 
-| Field                        | Value                                        |
-| ---------------------------- | -------------------------------------------- |
-| Last Verified                | 2026-01-26                                   |
-| Commit at Verification       | 1fba6c9 (refactor: added UV package manager) |
-| GitHub Stars at Verification | 348                                          |
-| Forks at Verification        | 43                                           |
-| Next Review Recommended      | 2026-04-26 (3 months)                        |
+| Field                        | Value                 |
+| ---------------------------- | --------------------- |
+| Last Verified                | 2026-01-31            |
+| Last Push at Verification    | 2026-01-24            |
+| GitHub Stars at Verification | 354                   |
+| Forks at Verification        | 43                    |
+| Next Review Recommended      | 2026-04-30 (3 months) |
 
 **Change Detection Indicators**:
 

--- a/research/developer-tools/animejs.md
+++ b/research/developer-tools/animejs.md
@@ -1,0 +1,328 @@
+# Anime.js - JavaScript Animation Engine
+
+**Research Date**: January 31, 2026
+**Source URL**: <https://animejs.com>
+**GitHub Repository**: <https://github.com/juliangarnier/anime>
+**Documentation**: <https://animejs.com/documentation>
+**npm Package**: <https://www.npmjs.com/package/animejs>
+**Version at Research**: v4.3.5
+**License**: MIT
+
+---
+
+## Overview
+
+Anime.js is a fast, multipurpose, and lightweight JavaScript animation library with a simple yet powerful API. It works with CSS properties, SVG, DOM attributes, and JavaScript Objects. Version 4 introduces a complete API redesign with ES module imports, improved timeline controls, and enhanced performance.
+
+**Core Value Proposition**: Enable declarative, chainable animations with minimal code while supporting complex staggering, timelines, and easing functions across any animatable web property.
+
+---
+
+## Problem Addressed
+
+| Problem                                                     | How Anime.js Solves It                                                        |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| CSS animations lack programmatic control                    | Full JavaScript API with play, pause, reverse, seek controls                  |
+| Complex sequenced animations are hard to manage             | Timeline API with sequential and parallel composition                         |
+| Staggered animations require manual delay calculations      | Built-in stagger utility with grid, from-center, and easing options           |
+| SVG animations require specialized knowledge                | Native SVG property support including path morphing and motion paths          |
+| Animation libraries are often heavyweight                   | ~17KB minified, zero dependencies, tree-shakeable ES modules                  |
+| Coordinating animations across multiple elements is complex | Target-based approach with CSS selectors, NodeLists, or JavaScript objects    |
+| Easing functions are limited in CSS                         | 30+ built-in easing functions plus custom cubic-bezier and spring physics     |
+
+---
+
+## Key Statistics (as of January 31, 2026)
+
+| Metric              | Value                        |
+| ------------------- | ---------------------------- |
+| GitHub Stars        | 66,288                       |
+| Forks               | 4,435                        |
+| Open Issues         | 86                           |
+| Primary Language    | JavaScript                   |
+| Created             | March 2016                   |
+| Latest Release      | v4.3.5 (January 25, 2026)    |
+| npm Weekly Downloads| 487,588                      |
+| npm Monthly Downloads| 1,477,792                   |
+| License             | MIT                          |
+
+---
+
+## Key Features
+
+### 1. ES Module Architecture (v4)
+
+- **Tree-shakeable Imports**: Import only what you need (`animate`, `stagger`, `createTimeline`)
+- **Named Exports**: Clean API surface with explicit function imports
+- **TypeScript Support**: Full type declarations included
+
+```javascript
+import { animate, stagger, createTimeline } from 'animejs';
+```
+
+### 2. Target-Based Animation
+
+- **CSS Selectors**: Animate elements matching any valid selector
+- **DOM Elements**: Direct element or NodeList references
+- **JavaScript Objects**: Animate any numeric object properties
+- **Mixed Targets**: Combine different target types in single animation
+
+### 3. Property Animation
+
+- **CSS Properties**: All animatable CSS including transforms, colors, dimensions
+- **SVG Attributes**: Native SVG property support (path d, stroke-dasharray, etc.)
+- **DOM Attributes**: Any numeric DOM attribute
+- **Object Properties**: Arbitrary JavaScript object values
+
+### 4. Stagger System
+
+- **Linear Stagger**: Incremental delays across targets
+- **Grid Stagger**: 2D staggering for grid layouts
+- **From Options**: Start from first, last, center, or specific index
+- **Easing Integration**: Apply easing curves to stagger distribution
+
+```javascript
+animate('.item', {
+  translateX: 250,
+  delay: stagger(100, { from: 'center', ease: 'outQuad' })
+});
+```
+
+### 5. Timeline API
+
+- **Sequential Composition**: Chain animations with `add()`
+- **Parallel Composition**: Overlap animations with offset parameters
+- **Nested Timelines**: Compose complex sequences from simpler ones
+- **Default Parameters**: Shared properties across all timeline children
+
+```javascript
+const tl = createTimeline({ defaults: { duration: 400, ease: 'outQuad' }});
+tl.add('.el1', { translateX: 250 })
+  .add('.el2', { translateY: 100 }, '-=200');
+```
+
+### 6. Playback Controls
+
+- **play() / pause() / resume()**: Standard playback control
+- **reverse()**: Play animation backwards
+- **seek(time)**: Jump to specific time position
+- **restart()**: Reset and play from beginning
+- **Playback Rate**: Speed up or slow down animations
+
+### 7. Easing Functions
+
+- **Built-in Easings**: 30+ named easings (linear, quad, cubic, quart, quint, sine, expo, circ, back, elastic, bounce)
+- **Directional Variants**: in, out, inOut for each easing type
+- **Custom Bezier**: Define custom cubic-bezier curves
+- **Spring Physics**: Physics-based spring animations
+- **Stepped Easing**: Discrete step transitions
+
+### 8. Callbacks and Promises
+
+- **Event Callbacks**: onBegin, onUpdate, onLoop, onComplete
+- **Promise-based**: Async/await support for animation completion
+- **Progress Values**: Access current progress in callbacks
+
+---
+
+## Technical Architecture
+
+```text
+Application Code
+      |
+      v
++------------------------------------------+
+|           Anime.js Engine                 |
+|  +------------------------------------+  |
+|  |         Target Resolution          |  |
+|  |  - CSS selector parsing            |  |
+|  |  - NodeList handling               |  |
+|  |  - Object property mapping         |  |
+|  +------------------------------------+  |
+|                   |                       |
+|                   v                       |
+|  +------------------------------------+  |
+|  |         Property Parser            |  |
+|  |  - CSS value parsing               |  |
+|  |  - Unit conversion                 |  |
+|  |  - Color interpolation (RGB/HSL)   |  |
+|  |  - Transform decomposition         |  |
+|  +------------------------------------+  |
+|                   |                       |
+|                   v                       |
+|  +------------------------------------+  |
+|  |         Animation Scheduler        |  |
+|  |  - requestAnimationFrame loop      |  |
+|  |  - Easing calculation              |  |
+|  |  - Progress interpolation          |  |
+|  |  - Stagger delay management        |  |
+|  +------------------------------------+  |
+|                   |                       |
+|                   v                       |
+|  +------------------------------------+  |
+|  |         Value Renderer             |  |
+|  |  - Style application               |  |
+|  |  - SVG attribute updates           |  |
+|  |  - Object mutation                 |  |
+|  |  - DOM batch updates               |  |
+|  +------------------------------------+  |
++------------------------------------------+
+      |
+      v
+Animated DOM / Objects
+```
+
+---
+
+## Installation & Usage
+
+### Installation Options
+
+```bash
+# npm
+npm install animejs
+
+# yarn
+yarn add animejs
+
+# pnpm
+pnpm add animejs
+
+# CDN (UMD)
+<script src="https://cdn.jsdelivr.net/npm/animejs@4/lib/anime.umd.min.js"></script>
+```
+
+### Basic Usage (v4)
+
+```javascript
+import { animate } from 'animejs';
+
+// Simple animation
+animate('.box', {
+  translateX: 250,
+  rotate: '1turn',
+  backgroundColor: '#FF0000',
+  duration: 800,
+  ease: 'outQuad'
+});
+
+// With keyframes
+animate('.box', {
+  translateX: [
+    { to: 100, duration: 500 },
+    { to: 250, duration: 500 }
+  ],
+  rotate: { from: -180, to: 180 },
+  ease: 'inOutSine'
+});
+```
+
+### Stagger Example
+
+```javascript
+import { animate, stagger } from 'animejs';
+
+animate('.grid-item', {
+  scale: [0, 1],
+  opacity: [0, 1],
+  delay: stagger(50, { grid: [10, 10], from: 'center' }),
+  ease: 'outBack'
+});
+```
+
+### Timeline Example
+
+```javascript
+import { createTimeline } from 'animejs';
+
+const tl = createTimeline({
+  defaults: { duration: 750, ease: 'outQuint' }
+});
+
+tl.add('.header', { translateY: [-50, 0], opacity: [0, 1] })
+  .add('.content', { translateY: [30, 0], opacity: [0, 1] }, '-=500')
+  .add('.footer', { translateY: [20, 0], opacity: [0, 1] }, '-=500');
+```
+
+### v3 to v4 Migration Key Changes
+
+| v3 Syntax | v4 Syntax |
+| --------- | --------- |
+| `anime({ targets: 'div', ... })` | `animate('div', { ... })` |
+| `easing: 'easeOutQuad'` | `ease: 'outQuad'` |
+| `direction: 'alternate'` | `alternate: true` |
+| `direction: 'reverse'` | `reversed: true` |
+| `anime.timeline()` | `createTimeline()` |
+| `endDelay: 1000` | `loopDelay: 1000` |
+| `value: 100` | `to: 100` |
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **AI-Generated Web Applications**: When Claude generates frontend code with animations, anime.js provides a well-documented, declarative API that produces reliable results
+2. **Code Example Generation**: The consistent API patterns make it predictable for AI code generation with fewer hallucinations
+3. **Documentation-to-Code Pattern**: Anime.js demonstrates excellent API documentation that translates cleanly to working code
+
+### Patterns Worth Adopting
+
+1. **Declarative Configuration**: The object-based parameter pattern (`{ duration: 800, ease: 'outQuad' }`) is highly readable and self-documenting
+2. **Composable Building Blocks**: `animate()`, `stagger()`, `createTimeline()` compose naturally - similar to skill composition patterns
+3. **Named Easing Functions**: Semantic names like 'outQuad' vs numeric cubic-bezier values improve code readability
+4. **From/To Explicit Syntax**: `{ from: 0, to: 100 }` pattern eliminates ambiguity about animation direction
+5. **Tree-Shakeable Exports**: ES module pattern that imports only needed functions reduces bundle size
+
+### Integration Opportunities
+
+1. **Frontend Skills**: Could inform a skill for generating animated web components
+2. **Code Generation Patterns**: The declarative API style can inspire how Claude structures generated animation code
+3. **Documentation Standards**: Anime.js documentation exemplifies API docs that work well for both human and AI consumption
+
+### Key Insight
+
+Anime.js demonstrates that declarative, composable APIs with semantic naming conventions are both human-readable and AI-friendly. The explicit `{ from, to }` pattern and named easings reduce ambiguity, making generated code more reliable. This principle applies to skill and agent API design: explicit, declarative configurations outperform imperative approaches for AI comprehension.
+
+---
+
+## References
+
+1. **Official Website**: <https://animejs.com> (accessed 2026-01-31)
+2. **GitHub Repository**: <https://github.com/juliangarnier/anime> (accessed 2026-01-31)
+3. **Documentation**: <https://animejs.com/documentation> (accessed 2026-01-31)
+4. **npm Package**: <https://www.npmjs.com/package/animejs> (accessed 2026-01-31)
+5. **v3 to v4 Migration Guide**: <https://github.com/juliangarnier/anime/wiki/Migrating-from-v3-to-v4> (accessed 2026-01-31)
+6. **CodePen Examples**: <https://codepen.io/collection/b392d3a52d6abf5b8d9fda4e4cab61ab/> (accessed 2026-01-31)
+
+---
+
+## Related Tools
+
+| Tool                                                          | Relationship                                           |
+| ------------------------------------------------------------- | ------------------------------------------------------ |
+| [GSAP](https://greensock.com/gsap/)                           | More feature-rich animation platform (commercial)      |
+| [Motion One](https://motion.dev/)                             | Modern alternative with Web Animations API             |
+| [Framer Motion](https://www.framer.com/motion/)               | React-specific animation library                       |
+| [Popmotion](https://popmotion.io/)                            | Functional animation library                           |
+| [Lottie](https://airbnb.design/lottie/)                       | After Effects animation player for web                 |
+
+---
+
+## Freshness Tracking
+
+| Field                        | Value                 |
+| ---------------------------- | --------------------- |
+| Last Verified                | 2026-01-31            |
+| Version at Verification      | v4.3.5                |
+| GitHub Stars at Verification | 66,288                |
+| npm Weekly Downloads         | 487,588               |
+| Next Review Recommended      | 2026-04-30 (3 months) |
+
+**Change Detection Indicators**:
+
+- Monitor npm for new version releases (v4.x active development)
+- Check GitHub releases for changelog updates
+- Watch for new easing functions or timeline features
+- Track browser compatibility updates
+- Review documentation for API additions


### PR DESCRIPTION
Add research documentation for:
- Agent frameworks: Agno, RA.Aid, AI Agents Frameworks (updated)
- Developer tools: Anime.js, Makefile Tutorial
- AI tools: Google Stitch, Type.ai, NotebookLM, GitDocify
- Infrastructure: TensorZero, Microsoft GraphRAG, ToolJet

Each entry includes key findings and relevance to Claude Code development.

https://claude.ai/code/session_01Ui465Gox2pkXSQTZkKRiPx