### PR TITLE
docs(research): add 4 research entries for Claude Code plugins and tools

### DIFF
--- a/.claude/skills/research-curator/research/README.md
+++ b/.claude/skills/research-curator/research/README.md
@@ -6,17 +6,18 @@ Resources researched for future reference in Claude Code development.
 
 ## Categories
 
-| Category            | Directory              | Description                                  |
-| ------------------- | ---------------------- | -------------------------------------------- |
-| Agent Frameworks    | `agent-frameworks/`    | Agent SDKs, multi-agent orchestration        |
-| AI Design Tools     | `ai-design-tools/`     | AI-powered UI/UX generation tools            |
-| AI Research Tools   | `ai-research-tools/`   | Document synthesis, research assistants      |
-| AI Writing Tools    | `ai-writing-tools/`    | AI-powered writing and document editors      |
-| Context Management  | `context-management/`  | Memory, RAG, context window tools            |
-| Developer Tooling   | `developer-tooling/`   | Build systems, developer tools, automation   |
-| Documentation Tools | `documentation-tools/` | AI documentation generators, README tools    |
-| LLM Infrastructure  | `llm-infrastructure/`  | LLM gateways, observability, optimization    |
-| Low-Code Platforms  | `low-code-platforms/`  | Visual app builders, internal tool platforms |
+| Category              | Directory                | Description                                  |
+| --------------------- | ------------------------ | -------------------------------------------- |
+| Agent Frameworks      | `agent-frameworks/`      | Agent SDKs, multi-agent orchestration        |
+| AI Design Tools       | `ai-design-tools/`       | AI-powered UI/UX generation tools            |
+| AI Research Tools     | `ai-research-tools/`     | Document synthesis, research assistants      |
+| AI Writing Tools      | `ai-writing-tools/`      | AI-powered writing and document editors      |
+| Context Management    | `context-management/`    | Memory, RAG, context window tools            |
+| Developer Tooling     | `developer-tooling/`     | Build systems, developer tools, automation   |
+| Documentation Tools   | `documentation-tools/`   | AI documentation generators, README tools    |
+| LLM Infrastructure    | `llm-infrastructure/`    | LLM gateways, observability, optimization    |
+| Low-Code Platforms    | `low-code-platforms/`    | Visual app builders, internal tool platforms |
+| Skill Generation Tools| `skill-generation-tools/`| Tools that create or package AI agent skills |
 
 ---
 
@@ -63,9 +64,10 @@ Resources researched for future reference in Claude Code development.
 
 ## Developer Tooling
 
-| Resource                                                      | Description                                             | Stars | Research Date |
-| ------------------------------------------------------------- | ------------------------------------------------------- | ----- | ------------- |
-| [Makefile Tutorial](./developer-tooling/makefile-tutorial.md) | Comprehensive GNU Make tutorial with practical examples | 93    | 2026-01-31    |
+| Resource                                                      | Description                                                        | Stars | Research Date |
+| ------------------------------------------------------------- | ------------------------------------------------------------------ | ----- | ------------- |
+| [Makefile Tutorial](./developer-tooling/makefile-tutorial.md) | Comprehensive GNU Make tutorial with practical examples            | 93    | 2026-01-31    |
+| [Plannotator](./developer-tooling/plannotator.md)             | Interactive plan review UI for Claude Code and OpenCode with annotations | 1,538 | 2026-01-31    |
 
 ---
 
@@ -90,6 +92,16 @@ Resources researched for future reference in Claude Code development.
 | Resource                                   | Description                                                    | Stars  | Research Date |
 | ------------------------------------------ | -------------------------------------------------------------- | ------ | ------------- |
 | [ToolJet](./low-code-platforms/tooljet.md) | Open-source low-code platform for internal tools and AI agents | 37,363 | 2026-01-31    |
+
+---
+
+## Skill Generation Tools
+
+| Resource                                                                     | Description                                                              | Stars | Research Date |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----- | ------------- |
+| [Claude Night Market](./skill-generation-tools/claude-night-market.md)       | 16-plugin marketplace with 126 skills, multi-LLM delegation, TDD hooks   | 158   | 2026-01-31    |
+| [hmohamed01/claude-code-plugins](./skill-generation-tools/hmohamed-claude-code-plugins.md) | Swift and Rust development plugins with agents, skills, and safety hooks | 4     | 2026-01-31    |
+| [Softaworks Agent Toolkit](./skill-generation-tools/softaworks-agent-toolkit.md) | Curated collection of 40+ skills for AI coding agents (Claude Code, Codex) | 378   | 2026-01-31    |
 
 ---
 

--- a/.claude/skills/research-curator/research/developer-tooling/plannotator.md
+++ b/.claude/skills/research-curator/research/developer-tooling/plannotator.md
@@ -1,0 +1,369 @@
+# Plannotator
+
+| Field         | Value                                           |
+| ------------- | ----------------------------------------------- |
+| Research Date | 2026-01-31                                      |
+| Primary URL   | <https://plannotator.ai>                        |
+| GitHub        | <https://github.com/backnotprop/plannotator>    |
+| Version       | No formal releases (monorepo, continuous dev)   |
+| License       | BSL 1.1 (Business Source License)               |
+| Created       | 2025-12-28                                      |
+
+---
+
+## Overview
+
+Plannotator is an interactive plan review tool for AI coding agents that intercepts agent plans via hooks, displays them in a visual browser-based UI for annotation, and sends structured feedback back to the agent. It supports Claude Code and OpenCode with built-in integrations for Obsidian and Bear Notes for plan archival. The tool also provides code review functionality for git diffs with inline annotations.
+
+---
+
+## Problem Addressed
+
+| Problem                                                | Solution                                                                    |
+| ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| AI agent plans are text-only, hard to review           | Visual browser-based UI with markdown rendering and syntax highlighting     |
+| No structured way to provide plan feedback             | Annotation system: delete, insert, replace, comment operations              |
+| Plans disappear after execution                        | Obsidian and Bear Notes integration for automatic plan archival             |
+| Team collaboration on agent plans difficult            | URL sharing via compressed hash for shareable annotations                   |
+| Code review feedback to agents is unstructured         | Dedicated code review mode with diff viewer and inline annotations          |
+| Remote development complicates plan review             | Environment variables for remote/devcontainer support with port forwarding  |
+| Agent proceeds without human approval                  | Hook intercepts ExitPlanMode, requires explicit approve/deny action         |
+| Feedback to agent lacks context                        | Image attachment support with pen, arrow, circle annotation tools           |
+
+---
+
+## Key Statistics
+
+| Metric           | Value                    | Date Gathered |
+| ---------------- | ------------------------ | ------------- |
+| GitHub Stars     | 1,538                    | 2026-01-31    |
+| GitHub Forks     | 97                       | 2026-01-31    |
+| Open Issues      | 30                       | 2026-01-31    |
+| Contributors     | 11                       | 2026-01-31    |
+| Primary Language | TypeScript               | 2026-01-31    |
+| Repository Size  | 25.6 MB                  | 2026-01-31    |
+| Repository Age   | 35 days (since Dec 2025) | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Plan Review System
+
+- **Hook Integration**: Intercepts Claude Code `ExitPlanMode` permission request via configurable hooks
+- **Visual Plan Display**: Markdown rendering with syntax-highlighted code blocks
+- **Annotation Types**: Deletion, insertion, replacement, comment, global comment
+- **Redline Mode**: Quick text selection creates deletion annotations
+- **Approve/Deny Flow**: Explicit user action required before agent proceeds
+
+### Code Review System (Jan 2026)
+
+- **Git Diff Viewer**: Reviews unstaged changes with multiple diff view modes
+- **Inline Annotations**: Select line numbers to add annotations
+- **View Modes**: Switch between unified, split, and raw diff views
+- **Feedback Submission**: Structured feedback sent to agent session
+
+### Image Annotations
+
+- **Image Attachment**: Attach images with feedback
+- **Drawing Tools**: Pen, arrow, circle tools for visual markup
+- **Upload Support**: Server-side image handling for agent context
+
+### Note-Taking Integration
+
+- **Obsidian Integration**: Auto-save approved plans with YAML frontmatter
+- **Bear Notes Integration**: Alternative note-taking app support
+- **Smart Tagging**: Automatic tag extraction from plan title and code languages
+- **Backlinks**: Graph connectivity via `[[Plannotator Plans]]` reference
+
+### URL Sharing
+
+- **Compression Pipeline**: JSON -> deflate-raw -> base64 -> URL-safe encoding
+- **Full State Sharing**: Shares plan content and all annotations via URL hash
+- **Position Restoration**: Finds text positions in DOM to restore highlights
+- **Team Collaboration**: Share annotated plans without server persistence
+
+### Remote Development Support
+
+- **Environment Variables**: `PLANNOTATOR_REMOTE`, `PLANNOTATOR_PORT`, `PLANNOTATOR_BROWSER`
+- **Fixed Port Mode**: Enables port forwarding for devcontainers, SSH, WSL
+- **Manual URL Mode**: Skips auto-browser-open for remote access
+
+---
+
+## Technical Architecture
+
+### Stack Components
+
+| Component          | Technology                              |
+| ------------------ | --------------------------------------- |
+| Runtime            | Bun                                     |
+| Language           | TypeScript                              |
+| UI Framework       | React                                   |
+| Syntax Highlighting| highlight.js (bundled)                  |
+| Text Highlighting  | web-highlighter library                 |
+| Build Tool         | Vite (single-file HTML output)          |
+| Compression        | CompressionStream API (deflate-raw)     |
+
+### Monorepo Structure
+
+```text
+plannotator/
+├── apps/
+│   ├── hook/                 # Claude Code plugin
+│   │   ├── .claude-plugin/   # Plugin manifest
+│   │   ├── commands/         # Slash commands (plannotator-review.md)
+│   │   ├── hooks/            # PermissionRequest hook config
+│   │   └── server/           # Entry point (plan + review subcommands)
+│   ├── opencode-plugin/      # OpenCode integration
+│   ├── review/               # Standalone review server
+│   ├── portal/               # Shared plan viewer (share.plannotator.ai)
+│   └── marketing/            # Marketing site (plannotator.ai)
+├── packages/
+│   ├── server/               # Shared server implementation
+│   ├── ui/                   # Shared React components
+│   ├── editor/               # Plan review App.tsx
+│   └── review-editor/        # Code review UI
+└── .claude-plugin/           # Marketplace registration
+```
+
+### Hook Flow
+
+```text
+Claude calls ExitPlanMode
+        |
+PermissionRequest hook fires
+        |
+Bun server reads plan from stdin JSON (tool_input.plan)
+        |
+Server starts on random port, opens browser
+        |
+User reviews plan, adds annotations
+        |
+Approve -> stdout: {"hookSpecificOutput":{"decision":{"behavior":"allow"}}}
+Deny    -> stdout: {"hookSpecificOutput":{"decision":{"behavior":"deny","message":"..."}}}
+```
+
+### Server API Endpoints
+
+**Plan Server**:
+
+| Endpoint               | Method | Purpose                                        |
+| ---------------------- | ------ | ---------------------------------------------- |
+| `/api/plan`            | GET    | Returns plan content and origin                |
+| `/api/approve`         | POST   | Approve plan with save options                 |
+| `/api/deny`            | POST   | Deny plan with structured feedback             |
+| `/api/image`           | GET    | Serve uploaded images                          |
+| `/api/upload`          | POST   | Upload image for annotation                    |
+| `/api/obsidian/vaults` | GET    | Detect available Obsidian vaults               |
+
+**Review Server**:
+
+| Endpoint       | Method | Purpose                              |
+| -------------- | ------ | ------------------------------------ |
+| `/api/diff`    | GET    | Returns raw patch and git ref        |
+| `/api/feedback`| POST   | Submit review with annotations       |
+
+### Data Types
+
+```typescript
+enum AnnotationType {
+  DELETION = "DELETION",
+  INSERTION = "INSERTION",
+  REPLACEMENT = "REPLACEMENT",
+  COMMENT = "COMMENT",
+  GLOBAL_COMMENT = "GLOBAL_COMMENT",
+}
+
+interface Annotation {
+  id: string;
+  blockId: string;
+  startOffset: number;
+  endOffset: number;
+  type: AnnotationType;
+  text?: string;
+  originalText: string;
+  createdAt: number;
+  author?: string;
+}
+
+interface Block {
+  id: string;
+  type: "paragraph" | "heading" | "blockquote" | "list-item" | "code" | "hr";
+  content: string;
+  level?: number;
+  language?: string;
+  order: number;
+  startLine: number;
+}
+```
+
+---
+
+## Installation and Usage
+
+### Prerequisites
+
+Install the `plannotator` command:
+
+```bash
+# macOS / Linux / WSL
+curl -fsSL https://plannotator.ai/install.sh | bash
+
+# Windows PowerShell
+irm https://plannotator.ai/install.ps1 | iex
+```
+
+### Claude Code Plugin Installation
+
+```text
+/plugin marketplace add backnotprop/plannotator
+/plugin install plannotator@plannotator
+```
+
+Restart Claude Code after plugin install.
+
+### Manual Hook Installation
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "plannotator",
+            "timeout": 1800
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### OpenCode Installation
+
+Add to `opencode.json`:
+
+```json
+{
+  "plugin": ["@plannotator/opencode@latest"]
+}
+```
+
+### Environment Variables
+
+| Variable             | Description                                        |
+| -------------------- | -------------------------------------------------- |
+| `PLANNOTATOR_REMOTE` | Set to `1` for remote mode (fixed port, no auto-open) |
+| `PLANNOTATOR_PORT`   | Fixed port (default: random locally, 19432 remote) |
+| `PLANNOTATOR_BROWSER`| Custom browser path                                |
+
+### Code Review Usage
+
+```text
+/plannotator-review
+```
+
+Opens diff viewer for unstaged git changes with annotation support.
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Hook System Reference**: Demonstrates production use of Claude Code's `PermissionRequest` hook system for `ExitPlanMode` interception.
+
+2. **Plugin Marketplace Pattern**: Shows complete plugin structure with marketplace.json registration, commands, and hooks configuration.
+
+3. **Plan Feedback Loop**: Establishes a pattern for structured human-in-the-loop plan review before implementation.
+
+4. **Visual Plan Review UX**: Proves value of visual annotation over text-only plan feedback.
+
+5. **Single-File HTML Deployment**: Vite build produces self-contained HTML files for easy hook integration.
+
+### Patterns Worth Adopting
+
+1. **Annotation Type System**: The DELETE/INSERT/REPLACE/COMMENT taxonomy provides structured feedback categories beyond free-text comments.
+
+2. **URL Hash State Sharing**: Compressed state in URL hash enables stateless sharing without server persistence.
+
+3. **Dual-Mode Review**: Separate plan review and code review workflows for different feedback contexts.
+
+4. **Note Integration**: Automatic archival to knowledge management tools (Obsidian) creates searchable execution history.
+
+5. **Remote Session Detection**: Environment variable flags for remote/devcontainer mode is a clean pattern for deployment flexibility.
+
+6. **Block-Based Parsing**: Markdown-to-blocks parsing enables precise annotation positioning.
+
+7. **Cookie Settings**: Using cookies instead of localStorage allows settings persistence across random ports.
+
+### Integration Opportunities
+
+1. **Native Plan Review**: Plannotator's annotation system could inform Claude Code's native plan review UX.
+
+2. **Hook Library**: The hook configuration patterns are reusable for other PermissionRequest interceptions.
+
+3. **Structured Feedback Format**: The annotation export format (`exportDiff`) could become a standard for plan feedback.
+
+4. **Knowledge Integration**: Obsidian/Bear integration pattern applicable to any execution logging.
+
+### Comparison with Native Claude Code
+
+| Aspect           | Plannotator                      | Native Claude Code            |
+| ---------------- | -------------------------------- | ----------------------------- |
+| Plan Review      | Visual browser UI with annotations | Text-based inline editing    |
+| Feedback Format  | Structured annotations           | Free-text                     |
+| Archival         | Obsidian/Bear auto-save          | Manual copy                   |
+| Collaboration    | URL sharing                      | Session-based                 |
+| Code Review      | Dedicated diff viewer            | Inline in conversation        |
+| Remote Support   | Environment variable flags       | Native terminal               |
+| Setup Required   | Plugin install + restart         | None                          |
+
+---
+
+## References
+
+| Source                 | URL                                                    | Accessed   |
+| ---------------------- | ------------------------------------------------------ | ---------- |
+| Official Website       | <https://plannotator.ai>                               | 2026-01-31 |
+| GitHub Repository      | <https://github.com/backnotprop/plannotator>           | 2026-01-31 |
+| GitHub README          | <https://github.com/backnotprop/plannotator/blob/main/README.md> | 2026-01-31 |
+| GitHub CLAUDE.md       | <https://github.com/backnotprop/plannotator/blob/main/CLAUDE.md> | 2026-01-31 |
+| Hook Installation Docs | <https://github.com/backnotprop/plannotator/blob/main/apps/hook/README.md> | 2026-01-31 |
+| GitHub API             | <https://api.github.com/repos/backnotprop/plannotator> | 2026-01-31 |
+| LICENSE File           | <https://github.com/backnotprop/plannotator/blob/main/LICENSE> | 2026-01-31 |
+| Claude Code Demo       | <https://www.youtube.com/watch?v=a_AT7cEN_9I>          | 2026-01-31 |
+| OpenCode Demo          | <https://youtu.be/_N7uo0EFI-U>                         | 2026-01-31 |
+
+**Research Method**: Information gathered from official GitHub repository via GitHub API, README and CLAUDE.md files fetched directly, LICENSE file reviewed for licensing terms. Statistics verified via direct API calls on research date.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                              |
+| ------------------ | ---------------------------------- |
+| Version Documented | No formal releases (monorepo)      |
+| Last Push          | 2026-01-29                         |
+| GitHub Stars       | 1,538 (as of 2026-01-31)           |
+| GitHub Forks       | 97 (as of 2026-01-31)              |
+| Next Review Date   | 2026-05-01                         |
+
+**Review Triggers**:
+
+- First formal version release
+- Significant star growth (5K, 10K milestones)
+- New agent platform integrations beyond Claude Code and OpenCode
+- Major annotation system changes
+- New collaboration features (real-time sync, commenting)
+- Changes to hook system or plugin structure
+- BSL license change date (2030-01-01 conversion to open source)
+- Breaking changes to API endpoints
+- Native Claude Code plan review feature release (competitive context)

--- a/.claude/skills/research-curator/research/skill-generation-tools/claude-night-market.md
+++ b/.claude/skills/research-curator/research/skill-generation-tools/claude-night-market.md
@@ -1,0 +1,264 @@
+# Claude Night Market
+
+| Field         | Value                                                      |
+| ------------- | ---------------------------------------------------------- |
+| Research Date | 2026-01-31                                                 |
+| Primary URL   | <https://github.com/athola/claude-night-market>            |
+| Homepage      | <https://athola.github.io/claude-night-market>             |
+| GitHub        | <https://github.com/athola/claude-night-market>            |
+| Installation  | `/plugin marketplace add athola/claude-night-market`       |
+| Version       | 1.3.7                                                      |
+| License       | MIT                                                        |
+| Author        | [@athola](https://github.com/athola)                       |
+
+---
+
+## Overview
+
+Claude Night Market is a comprehensive Claude Code plugin marketplace providing 16 plugins with 126 skills, 114 commands, and 41 agents for software engineering workflows. The plugins are organized in architectural layers (Foundation, Utility, Domain Specialists, Meta) covering git operations, code review, spec-driven development, issue management, multi-LLM delegation, TDD enforcement, and session management. The ecosystem adds approximately 14.8k characters to system prompts and includes cross-session state persistence via Claude Code Tasks (v2.1.16+).
+
+---
+
+## Problem Addressed
+
+| Problem                                              | Solution                                                                  |
+| ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| Claude Code lacks specialized workflow automation    | 114 slash commands for PR prep, code review, issue resolution, cleanup    |
+| No governance over AI behavior during development    | Hook-based governance (imbue TDD enforcement, pensive usage tracking)     |
+| Multi-LLM workflows require manual orchestration     | conjure plugin delegates to Gemini/Qwen while retaining strategic oversight |
+| Session context lost between conversations           | sanctum session management with checkpointing and resume strategies       |
+| No spec-driven development enforcement               | spec-kit requires written specifications before code generation           |
+| Inconsistent code review across domains              | pensive provides unified reviews (architecture, bugs, API, math, Rust, shell) |
+| Quality gates scattered across workflows             | Centralized quality gates halt execution if tests fail                    |
+| Project initialization lacks architecture awareness  | attune detects project types and scaffolds configuration files            |
+| Strategic decisions lack expert consultation         | war-room uses Type 1/2 reversibility framework with expert subagent routing |
+
+---
+
+## Key Statistics
+
+| Metric            | Value                     | Date Gathered |
+| ----------------- | ------------------------- | ------------- |
+| GitHub Stars      | 158                       | 2026-01-31    |
+| GitHub Forks      | 19                        | 2026-01-31    |
+| Open Issues       | 61                        | 2026-01-31    |
+| Contributors      | 2                         | 2026-01-31    |
+| Primary Language  | Python                    | 2026-01-31    |
+| Repository Age    | Since 2025-11-23          | 2026-01-31    |
+| Total Plugins     | 16                        | 2026-01-31    |
+| Total Skills      | 126                       | 2026-01-31    |
+| Total Commands    | 114                       | 2026-01-31    |
+| Total Agents      | 41                        | 2026-01-31    |
+| System Prompt     | ~14.8k characters         | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Plugin Architecture Layers
+
+| Layer               | Plugins                           | Purpose                                     |
+| ------------------- | --------------------------------- | ------------------------------------------- |
+| Foundation          | sanctum, leyline, imbue           | Git/sessions, auth/quotas, TDD cycles       |
+| Utility             | conserve, hookify, conjure        | Resource optimization, rules engine, delegation |
+| Domain Specialists  | pensive, spec-kit, minister, memory-palace, archetypes, parseltongue, attune, scribe, scry | Task-specific logic |
+| Meta                | abstract                          | Plugin/skill authoring, Makefile generation |
+
+### Core Plugins
+
+| Plugin          | Skills | Commands | Description                                                  |
+| --------------- | ------ | -------- | ------------------------------------------------------------ |
+| abstract        | 13     | 16       | Meta-skills infrastructure, hook development, evaluation     |
+| attune          | 13     | 11       | Full-cycle project development with war-room expert routing  |
+| archetypes      | 15     | 0        | 14 architecture paradigms from functional-core to microservices |
+| conjure         | 3      | 0        | Intelligent delegation to Gemini/Qwen with strategic oversight |
+| conserve        | 12     | 6        | Context optimization, bloat detection, token conservation    |
+| hookify         | 2      | 5        | Zero-code behavioral rule authoring via markdown             |
+| imbue           | 11     | 3        | Review scaffolding, diff analysis, TDD enforcement           |
+| leyline         | 12     | 1        | OAuth flows, storage patterns, quotas                        |
+| memory-palace   | 7      | 4        | Spatial knowledge organization, skill execution memory       |
+| minister        | 2      | 5        | GitHub issue/project alignment and status dashboards         |
+| parseltongue    | 5      | 3        | Multi-language detection, testing guidance                   |
+| pensive         | 15     | 12       | Multi-domain code review with NASA Power of 10 patterns      |
+| sanctum         | 18     | 18       | Git operations, PR prep, session management                  |
+| scribe          | 3      | 3        | Documentation with AI slop detection, style learning         |
+| scry            | 4      | 3        | Terminal recordings (VHS), browser recordings (Playwright)   |
+| spec-kit        | 3      | 2        | Spec-driven development orchestration                        |
+
+### Governance and Quality
+
+| Feature                   | Plugin/Mechanism           | Description                                       |
+| ------------------------- | -------------------------- | ------------------------------------------------- |
+| TDD Enforcement           | imbue PreToolUse hook      | Verifies test files exist before implementation   |
+| Rigorous Reasoning        | imbue:rigorous-reasoning   | Step-by-step logic checks before tool execution   |
+| Usage Tracking            | pensive                    | Tracks skill usage frequency and failure rates    |
+| Permission Checks         | conserve                   | Auto-approves safe commands, blocks risky ops     |
+| Quality Gates             | /create-skill, /create-command | Halts if project has failing tests           |
+| Expert Routing            | attune:war-room            | Type 1/2 reversibility framework for decisions    |
+
+### Installation Methods
+
+```bash
+# Plugin marketplace
+/plugin marketplace add athola/claude-night-market
+
+# Install specific plugins
+/plugin install sanctum@claude-night-market
+/plugin install pensive@claude-night-market
+/plugin install spec-kit@claude-night-market
+
+# npx (alternative)
+npx skills add athola/claude-night-market
+npx skills add athola/claude-night-market/sanctum
+```
+
+### Notable Workflows
+
+| Workflow              | Command/Skill                    | Description                                  |
+| --------------------- | -------------------------------- | -------------------------------------------- |
+| PR Preparation        | `/prepare-pr`                    | Validates branch, runs linters, verifies git state |
+| Unified Code Review   | `/full-review`                   | Multi-discipline (syntax, logic, security)   |
+| Issue Resolution      | `/do-issue`                      | Progressive GitHub issue implementation      |
+| Context Recovery      | `/catchup`                       | Reads recent git history for context         |
+| Codebase Cleanup      | `/cleanup`                       | Bloat removal, quality audit, hygiene scan   |
+| CI/CD Update          | `/update-ci`                     | Reconciles hooks/workflows with code changes |
+| Strategic Decisions   | `/attune:war-room`               | Expert routing with reversibility scoring    |
+| Spec-First Dev        | `/speckit-specify`               | Written spec required before code            |
+| Safety Review         | `Skill(pensive:safety-critical-patterns)` | NASA Power of 10 guidelines         |
+
+---
+
+## Technical Architecture
+
+### Directory Structure
+
+```text
+plugins/
+  <plugin-name>/
+    skills/
+      <skill-name>/
+        SKILL.md          # Agent-facing instructions
+    commands/
+      <command-name>.md   # Slash command definitions
+    agents/
+      <agent-name>.md     # Agent configurations
+    hooks/
+      <hook-name>.md      # Behavioral hooks
+```
+
+### Cross-Session State (Claude Code 2.1.16+)
+
+- attune, spec-kit, sanctum integrate with native Claude Code Tasks system
+- Task creation on-demand with persistence via `CLAUDE_CODE_TASK_LIST_ID`
+- `war-room-checkpoint` enables embedded escalation at decision points
+- Fallback to file-based state for versions prior to 2.1.16
+
+### LSP Integration (v2.0.74+)
+
+- Symbol search in ~50ms (faster than text search)
+- Requires `ENABLE_LSP_TOOL: "1"` in `~/.claude/settings.json`
+- Compatible with language servers like pyright
+
+### Prompt Context Management
+
+- ~14.8k character system prompt budget (limit: 15k)
+- Enforced by pre-commit hook
+- Modular designs and progressive loading to stay within limits
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Plugin Architecture Patterns**: Layered architecture (Foundation, Utility, Domain, Meta) provides clear separation of concerns for plugin ecosystem design.
+
+2. **Hook Governance**: PreToolUse hooks for TDD enforcement and rigorous reasoning demonstrate behavioral guardrails without code changes.
+
+3. **Multi-LLM Delegation**: conjure plugin patterns for routing tasks to Gemini/Qwen while retaining oversight show hybrid AI workflow design.
+
+4. **Session Management**: sanctum's checkpointing and resume strategies address context loss between conversations.
+
+5. **Expert Routing**: war-room's Type 1/2 reversibility framework provides structured approach to decision escalation.
+
+6. **Code Review Taxonomy**: pensive's domain-specific reviews (architecture, bugs, API, math, Rust, shell, Makefile) show comprehensive review coverage.
+
+### Patterns Worth Adopting
+
+1. **Layer-Based Organization**: Foundation (core utilities), Utility (resource management), Domain (task-specific), Meta (authoring tools) provides clear mental model.
+
+2. **Quality Gate Enforcement**: Halting execution on failing tests before allowing skill/command creation enforces quality.
+
+3. **Stability Metrics**: pensive's usage frequency and failure rate tracking identifies unstable workflows.
+
+4. **Progressive Depth Levels**: `/cleanup` command with configurable depth levels allows graduated thoroughness.
+
+5. **War Room Pattern**: Multi-expert consultation with reversibility scoring for high-stakes decisions.
+
+6. **Slop Detection**: scribe's AI slop detector identifies AI-generated content markers for quality control.
+
+7. **Memory Palace Technique**: Spatial knowledge organization for skill execution memory and PR review context.
+
+### Integration Opportunities
+
+1. **Skill Import**: Compatible plugin format allows cross-marketplace skill sharing.
+
+2. **Hook Patterns**: imbue's TDD enforcement hooks could inform this repository's quality gates.
+
+3. **Review Domains**: pensive's review taxonomy (15 specialized reviews) could expand coverage.
+
+4. **Delegation Framework**: conjure's delegation-core skill provides patterns for external LLM integration.
+
+5. **Session Persistence**: sanctum's cross-session state patterns address conversation continuity.
+
+### Comparison with This Repository
+
+| Aspect              | Claude Night Market                | This Repository (claude_skills)     |
+| ------------------- | ---------------------------------- | ------------------------------------ |
+| Plugins             | 16 plugins                         | Plugin marketplace                   |
+| Skills              | 126 skills                         | Skill collection                     |
+| Commands            | 114 commands                       | Command collection                   |
+| Agents              | 41 agents                          | Agent collection                     |
+| Architecture        | 4-layer (Foundation/Utility/Domain/Meta) | Category-based                 |
+| Hook Governance     | TDD enforcement, rigorous reasoning | Skill-based instructions            |
+| Multi-LLM           | Gemini/Qwen delegation             | Single-model focus                   |
+| Session State       | Cross-session persistence          | Per-session                          |
+| Primary Author      | @athola                            | Community                            |
+
+---
+
+## References
+
+| Source                    | URL                                                                        | Accessed   |
+| ------------------------- | -------------------------------------------------------------------------- | ---------- |
+| GitHub Repository         | <https://github.com/athola/claude-night-market>                            | 2026-01-31 |
+| GitHub README             | <https://raw.githubusercontent.com/athola/claude-night-market/master/README.md> | 2026-01-31 |
+| GitHub API (Metadata)     | <https://api.github.com/repos/athola/claude-night-market>                  | 2026-01-31 |
+| Marketplace JSON          | <https://raw.githubusercontent.com/athola/claude-night-market/master/.claude-plugin/marketplace.json> | 2026-01-31 |
+| Capabilities Reference    | <https://raw.githubusercontent.com/athola/claude-night-market/master/book/src/reference/capabilities-reference.md> | 2026-01-31 |
+| Homepage                  | <https://athola.github.io/claude-night-market>                             | 2026-01-31 |
+
+**Research Method**: Information gathered from GitHub repository README, GitHub API for repository metadata (stars, forks, license, dates), marketplace.json for plugin details, and capabilities reference for skill/command/agent counts. Statistics verified via direct API calls on 2026-01-31.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                               |
+| ------------------ | ----------------------------------- |
+| Version Documented | 1.3.7                               |
+| Last Pushed        | 2026-01-31                          |
+| GitHub Stars       | 158 (as of 2026-01-31)              |
+| Total Plugins      | 16 (as of 2026-01-31)               |
+| Total Skills       | 126 (as of 2026-01-31)              |
+| Next Review Date   | 2026-05-01                          |
+
+**Review Triggers**:
+
+- GitHub stars milestone (250, 500, 1K)
+- Major version bump (2.x.x release)
+- New plugin layer additions
+- Cross-session state API changes
+- War-room framework updates
+- New LLM delegation targets added
+- Significant skill additions (20+ new skills)

--- a/.claude/skills/research-curator/research/skill-generation-tools/hmohamed-claude-code-plugins.md
+++ b/.claude/skills/research-curator/research/skill-generation-tools/hmohamed-claude-code-plugins.md
@@ -1,0 +1,313 @@
+# hmohamed01/claude-code-plugins
+
+| Field         | Value                                                        |
+| ------------- | ------------------------------------------------------------ |
+| Research Date | 2026-01-31                                                   |
+| Primary URL   | <https://github.com/hmohamed01/claude-code-plugins>          |
+| GitHub        | <https://github.com/hmohamed01/claude-code-plugins>          |
+| Installation  | `claude plugin marketplace add hmohamed01/claude-code-plugins` |
+| Version       | swift-developer@0.3.0, rust-developer@0.2.0                  |
+| License       | MIT                                                          |
+| Author        | [@hmohamed01](https://github.com/hmohamed01)                 |
+
+---
+
+## Overview
+
+A collection of Claude Code plugins providing autonomous development agents for Swift and Rust programming languages. The repository implements a monorepo structure with independent plugins for iOS/macOS Swift development (SwiftUI, Swift 6 concurrency, Xcode) and comprehensive Rust development (cargo, clippy, async patterns, WebAssembly). Each plugin includes specialized agents, skills with reference documentation, pre-tool hooks for unsafe pattern detection, and utility scripts.
+
+---
+
+## Problem Addressed
+
+| Problem                                                | Solution                                                                       |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Swift development requires language-specific expertise | swift-developer plugin with SwiftUI, Swift 6 concurrency, and Xcode knowledge  |
+| Rust's ownership model creates common pitfalls         | rust-developer plugin with ownership, borrowing, and lifetime reference docs   |
+| Unsafe code patterns slip into production              | PreToolUse hooks automatically detect and warn about unsafe patterns           |
+| Apple docs not programmatically accessible             | GitHub-based documentation sources (Swift Book, Swift Evolution, Swift Testing)|
+| Manual setup for new Swift/Rust projects               | Utility scripts: `new_package.sh`, `new_project.sh` with config files          |
+| Testing requires simulator/toolchain knowledge         | Built-in xcodebuild, simctl, cargo commands and reference documentation        |
+| AI agents lack framework-specific patterns             | Skills include Axum, Actix, Rocket (Rust) and SwiftUI, @Observable (Swift)     |
+
+---
+
+## Key Statistics
+
+| Metric           | Value                            | Date Gathered |
+| ---------------- | -------------------------------- | ------------- |
+| GitHub Stars     | 4                                | 2026-01-31    |
+| GitHub Forks     | 1                                | 2026-01-31    |
+| Open Issues      | 0                                | 2026-01-31    |
+| Primary Language | Shell                            | 2026-01-31    |
+| Repository Age   | Since 2026-01-06                 | 2026-01-31    |
+| Last Updated     | 2026-01-28                       | 2026-01-31    |
+| Last Pushed      | 2026-01-13                       | 2026-01-31    |
+| Plugin Count     | 2                                | 2026-01-31    |
+| Contributors     | 1                                | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Plugin: swift-developer (v0.3.0)
+
+| Component     | Purpose                                                          |
+| ------------- | ---------------------------------------------------------------- |
+| Agent         | Autonomous Swift development for iOS/macOS apps                  |
+| Skill         | `swift-knowledge` - SwiftUI, Swift 6 concurrency, XCTest         |
+| Hooks         | PreToolUse detection of force unwraps, hardcoded secrets, unsafe patterns |
+| Command       | `/swift-developer:swift-developer <task>`                        |
+
+#### Swift Unsafe Pattern Detection
+
+| Pattern                    | Issue                     | Recommended Fix                              |
+| -------------------------- | ------------------------- | -------------------------------------------- |
+| Force unwraps (`!`)        | Runtime crashes           | `guard let`, `if let`, or `??`               |
+| Hardcoded secrets          | Security vulnerability    | Keychain or environment variables            |
+| `DispatchQueue.main.sync`  | Main thread blocking      | `.async` or async/await                      |
+| `@unchecked Sendable`      | Thread safety bypass      | Proper synchronization (NSLock, actors)      |
+| Missing `@MainActor`       | UI thread safety          | Add `@MainActor` to ObservableObject classes |
+
+#### Swift Documentation Sources
+
+| Source             | Content                                 |
+| ------------------ | --------------------------------------- |
+| Swift Book         | Language guide and reference manual     |
+| Swift Testing      | Modern testing (`@Test`, `#expect`)     |
+| Swift Evolution    | Latest language proposals               |
+| Swift Async Algos  | Async sequence operations               |
+
+### Plugin: rust-developer (v0.2.0)
+
+| Component     | Purpose                                                              |
+| ------------- | -------------------------------------------------------------------- |
+| Agent         | Comprehensive Rust development with cargo ecosystem                  |
+| Skill         | `rust-knowledge` - ownership, async Rust, error handling, frameworks |
+| Hooks         | PreToolUse detection of panics, unwraps, unsafe blocks, blocking ops |
+| Command       | `/rust-developer:rust-developer <task>`                              |
+
+#### Rust Reference Documentation
+
+| Topic           | Coverage                                      |
+| --------------- | --------------------------------------------- |
+| Ownership       | Ownership, borrowing, and lifetimes           |
+| Error Handling  | Result, Option, thiserror, anyhow             |
+| Async Rust      | Tokio, async/await, channels                  |
+| Testing         | Unit tests, integration tests, mocking        |
+| Cargo           | Cargo.toml, workspaces, features              |
+| Clippy          | Linting rules and configuration               |
+| WebAssembly     | wasm-pack, wasm-bindgen                       |
+| Frameworks      | Axum, Actix, Rocket patterns                  |
+| Troubleshooting | Common errors and solutions                   |
+
+#### Rust Unsafe Pattern Warnings
+
+| Pattern                              | Issue                           |
+| ------------------------------------ | ------------------------------- |
+| Hardcoded secrets/API keys           | Security vulnerability          |
+| `panic!` in library code             | Production instability          |
+| Multiple `.unwrap()` without context | Missing error context           |
+| `unsafe` without `// SAFETY:`        | Undocumented unsafe reasoning   |
+| Blocking operations in async         | Thread pool exhaustion          |
+
+### Utility Scripts
+
+| Plugin          | Script              | Purpose                                    |
+| --------------- | ------------------- | ------------------------------------------ |
+| swift-developer | `new_package.sh`    | Create Swift package with SwiftFormat/Lint |
+| swift-developer | `run_tests.sh`      | Run tests with common options              |
+| swift-developer | `format_and_lint.sh`| Format and lint Swift code                 |
+| swift-developer | `simulator.sh`      | Quick iOS simulator management             |
+| rust-developer  | `new_project.sh`    | Create Rust project with config files      |
+| rust-developer  | `run_tests.sh`      | Run tests with common options              |
+| rust-developer  | `format_lint.sh`    | Format and lint Rust code                  |
+
+---
+
+## Technical Architecture
+
+### Repository Structure
+
+```text
+claude-code-plugins/
+├── .claude-plugin/
+│   └── marketplace.json     # Marketplace manifest (2 plugins)
+├── CLAUDE.md                # Repo-wide AI guidance
+├── swift-developer/
+│   ├── .claude-plugin/
+│   │   └── plugin.json      # Plugin manifest
+│   ├── CLAUDE.md            # Swift-specific AI guidance
+│   ├── commands/
+│   │   └── swift-developer.md
+│   ├── agents/
+│   │   └── swift-developer.md
+│   ├── skills/
+│   │   └── swift-knowledge/
+│   │       ├── SKILL.md
+│   │       ├── references/
+│   │       ├── scripts/
+│   │       └── assets/
+│   └── hooks/
+│       ├── hooks.json
+│       └── scripts/
+└── rust-developer/
+    └── [same structure as swift-developer]
+```
+
+### Plugin Architecture Pattern
+
+Each plugin follows a consistent structure:
+
+1. **Command** - Entry point via slash command (`/plugin-name:plugin-name`)
+2. **Agent** - Autonomous task execution with tool access
+3. **Skill** - Knowledge base with SKILL.md and reference files
+4. **Hooks** - PreToolUse hooks for pattern detection and enforcement
+
+### Marketplace Configuration
+
+```json
+{
+  "name": "hmohamed-plugins",
+  "owner": { "name": "hmohamed01" },
+  "metadata": {
+    "description": "A collection of Claude Code plugins for Swift and Rust development"
+  },
+  "plugins": [
+    { "name": "swift-developer", "version": "0.3.0" },
+    { "name": "rust-developer", "version": "0.2.0" }
+  ]
+}
+```
+
+### Monorepo Design
+
+- Each plugin is an independent, self-contained project
+- Plugin-specific CLAUDE.md provides isolated AI instructions
+- No cross-plugin dependencies
+- kebab-case folder naming convention
+
+---
+
+## Installation and Usage
+
+### Installation
+
+```bash
+# Add the marketplace
+claude plugin marketplace add hmohamed01/claude-code-plugins
+
+# Browse and install plugins via /plugins command
+```
+
+### Swift Developer Usage
+
+```text
+/swift-developer:swift-developer create a SwiftUI settings screen with @Observable
+/swift-developer:swift-developer review my code for concurrency issues
+/swift-developer:swift-developer run tests on iPhone 15 simulator
+```
+
+### Rust Developer Usage
+
+```text
+/rust-developer:rust-developer create a new async HTTP client library
+/rust-developer:rust-developer review my code for ownership issues
+/rust-developer:rust-developer run clippy and fix the warnings
+```
+
+### Requirements
+
+| Plugin          | Requirements                                      |
+| --------------- | ------------------------------------------------- |
+| swift-developer | macOS, Xcode 15+ (Xcode 16+ for Swift 6), CLI tools |
+| rust-developer  | Rust toolchain via rustup, clippy, rustfmt        |
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Plugin Architecture Reference**: Demonstrates well-structured Claude Code plugin organization with command, agent, skill, and hook components working together.
+
+2. **Language-Specific Skills**: Provides templates for creating deep, domain-specific skills with comprehensive reference documentation.
+
+3. **PreToolUse Hook Patterns**: Shows how to implement safety guardrails that detect and warn about unsafe patterns before code is written.
+
+4. **Documentation Verification Pattern**: Swift plugin's approach to using GitHub-based sources when primary documentation (Apple developer docs) is JavaScript-rendered.
+
+5. **Utility Script Integration**: Demonstrates how to package helper scripts within skills for common development operations.
+
+### Patterns Worth Adopting
+
+1. **Monorepo Plugin Organization**: Independent plugins in a single repository with per-plugin CLAUDE.md enables focused AI guidance while maintaining unified distribution.
+
+2. **Hook-Based Safety Rails**: PreToolUse hooks catch dangerous patterns (force unwraps, unsafe blocks, hardcoded secrets) before they enter the codebase.
+
+3. **Structured Reference Documentation**: Skills include categorized reference files (ownership.md, error-handling.md, async-rust.md) for progressive disclosure.
+
+4. **Slash Command Entry Points**: `/plugin-name:plugin-name <task>` pattern provides clear invocation path for users.
+
+5. **Version Management**: Marketplace.json tracks plugin versions independently, allowing granular updates.
+
+6. **Dual CLAUDE.md Strategy**: Repository-level CLAUDE.md for global conventions, plugin-level CLAUDE.md for domain-specific guidance.
+
+### Integration Opportunities
+
+1. **Skill Format Compatibility**: Skills could be adapted or imported using the same structure as this repository's skill format.
+
+2. **Hook Pattern Extraction**: Unsafe pattern detection hooks could inform safety guardrails in other development plugins.
+
+3. **Reference Documentation Model**: The categorized reference file approach could be applied to other language-specific skills.
+
+4. **Swift/Rust Skills**: The plugins themselves could be installed for users needing Swift or Rust development assistance.
+
+### Comparison with This Repository
+
+| Aspect              | hmohamed01/claude-code-plugins      | This Repository (claude_skills)       |
+| ------------------- | ----------------------------------- | ------------------------------------- |
+| Plugin Count        | 2 (Swift, Rust)                     | Multiple plugins + skills             |
+| Focus               | Language-specific development       | General-purpose skill marketplace     |
+| Hook Usage          | PreToolUse safety checks            | Configurable hooks                    |
+| Skill Structure     | SKILL.md + references/ + scripts/   | SKILL.md + references/                |
+| Marketplace Support | Yes (marketplace.json)              | Yes                                   |
+| Primary Author      | @hmohamed01                         | Community                             |
+| Installation        | Plugin marketplace add              | Plugin marketplace + direct install   |
+
+---
+
+## References
+
+| Source                        | URL                                                                          | Accessed   |
+| ----------------------------- | ---------------------------------------------------------------------------- | ---------- |
+| GitHub Repository             | <https://github.com/hmohamed01/claude-code-plugins>                          | 2026-01-31 |
+| GitHub README                 | <https://github.com/hmohamed01/claude-code-plugins/blob/main/README.md>      | 2026-01-31 |
+| GitHub API (Metadata)         | <https://api.github.com/repos/hmohamed01/claude-code-plugins>                | 2026-01-31 |
+| Swift Developer README        | <https://github.com/hmohamed01/claude-code-plugins/tree/main/swift-developer>| 2026-01-31 |
+| Rust Developer README         | <https://github.com/hmohamed01/claude-code-plugins/tree/main/rust-developer> | 2026-01-31 |
+| Marketplace Configuration     | <https://github.com/hmohamed01/claude-code-plugins/blob/main/.claude-plugin/marketplace.json> | 2026-01-31 |
+| CLAUDE.md                     | <https://github.com/hmohamed01/claude-code-plugins/blob/main/CLAUDE.md>      | 2026-01-31 |
+
+**Research Method**: Information gathered from GitHub repository README files, GitHub API for repository metadata (stars, forks, dates, contributors), and raw file fetches for marketplace.json and CLAUDE.md. Statistics verified via direct API calls on 2026-01-31.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                                        |
+| ------------------ | -------------------------------------------- |
+| Version Documented | swift-developer@0.3.0, rust-developer@0.2.0  |
+| Last Pushed        | 2026-01-13                                   |
+| GitHub Stars       | 4 (as of 2026-01-31)                         |
+| Plugin Count       | 2 (as of 2026-01-31)                         |
+| Next Review Date   | 2026-05-01                                   |
+
+**Review Triggers**:
+
+- New plugins added to marketplace
+- Major version bumps (swift-developer@1.0, rust-developer@1.0)
+- GitHub stars milestone (25, 50, 100)
+- Significant new language features documented (Swift 7, Rust 2024 edition)
+- Additional language plugins added (Go, Python, TypeScript)
+- Changes to Claude Code plugin architecture

--- a/.claude/skills/research-curator/research/skill-generation-tools/softaworks-agent-toolkit.md
+++ b/.claude/skills/research-curator/research/skill-generation-tools/softaworks-agent-toolkit.md
@@ -1,0 +1,246 @@
+# Softaworks Agent Toolkit
+
+| Field         | Value                                                    |
+| ------------- | -------------------------------------------------------- |
+| Research Date | 2026-01-31                                               |
+| Primary URL   | <https://github.com/softaworks/agent-toolkit>            |
+| GitHub        | <https://github.com/softaworks/agent-toolkit>            |
+| Installation  | `npx skills add softaworks/agent-toolkit`                |
+| Version       | Active development (last pushed 2026-01-28)              |
+| License       | MIT                                                      |
+| Author        | [@leonardocouy](https://github.com/leonardocouy)         |
+| Organization  | [Softaworks](https://github.com/softaworks)              |
+
+---
+
+## Overview
+
+Softaworks Agent Toolkit is a curated collection of 40+ skills for AI coding agents that follow the Agent Skills format. Skills are packaged instructions and scripts extending agent capabilities across development, documentation, planning, and professional workflows. The toolkit works with Claude Code, OpenAI Codex, Cursor, and other AI coding assistants, offering both marketplace-based installation and direct skill copying.
+
+---
+
+## Problem Addressed
+
+| Problem                                              | Solution                                                                  |
+| ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| AI coding agents lack specialized domain knowledge   | 40+ pre-built skills covering development, docs, planning, communication  |
+| Skills scattered across repositories and formats     | Unified Agent Skills format with consistent SKILL.md structure            |
+| Installing skills requires manual copying            | Multiple install methods: npx, plugin marketplace, direct copy            |
+| Skills not portable across different AI agents       | Agent Skills format works with Claude Code, Codex, Cursor, claude.ai      |
+| No organized taxonomy for agent capabilities         | Categorized skills: AI Tools, Meta, Documentation, Design, Development    |
+| Agents and commands are separate from skills         | Unified plugin system includes skills, agents, and slash commands         |
+| Skills lack usage documentation                      | Each skill has SKILL.md (for agents) + README.md (for users)              |
+
+---
+
+## Key Statistics
+
+| Metric            | Value                     | Date Gathered |
+| ----------------- | ------------------------- | ------------- |
+| GitHub Stars      | 378                       | 2026-01-31    |
+| GitHub Forks      | 17                        | 2026-01-31    |
+| Open Issues       | 0                         | 2026-01-31    |
+| Primary Language  | Python                    | 2026-01-31    |
+| Repository Age    | Since 2026-01-19          | 2026-01-31    |
+| Total Skills      | 40+                       | 2026-01-31    |
+| Total Agents      | 6                         | 2026-01-31    |
+| Slash Commands    | 7                         | 2026-01-31    |
+
+---
+
+## Key Features
+
+### Skill Categories
+
+| Category           | Count | Examples                                             |
+| ------------------ | ----- | ---------------------------------------------------- |
+| AI Tools           | 3     | codex (GPT-5.2), gemini (200k context), perplexity   |
+| Meta               | 4     | agent-md-refactor, command-creator, plugin-forge     |
+| Documentation      | 10    | c4-architecture, mermaid-diagrams, excalidraw        |
+| Design & Frontend  | 5     | mui, react-dev, openapi-to-typescript                |
+| Development        | 5     | database-schema-designer, dependency-updater         |
+| Planning           | 4     | gepetto, requirements-clarity, game-changing-features|
+| Professional       | 4     | daily-meeting-update, feedback-mastery               |
+| Testing            | 1     | qa-test-planner                                      |
+| Git                | 1     | commit-work                                          |
+| Utilities          | 7     | humanizer, jira, web-to-markdown, meme-factory       |
+
+### Agents (Claude Code Exclusive)
+
+| Agent                           | Purpose                                        |
+| ------------------------------- | ---------------------------------------------- |
+| ascii-ui-mockup-generator       | Visualize UI concepts through ASCII mockups    |
+| codebase-pattern-finder         | Find similar implementations and patterns      |
+| communication-excellence-coach  | Email refinement, tone calibration, roleplay   |
+| general-purpose                 | Default agent for complex multi-step tasks     |
+| mermaid-diagram-specialist      | Create flowcharts, sequence diagrams, ERDs     |
+| ui-ux-designer                  | Research-backed UI/UX design feedback          |
+
+### Slash Commands (Claude Code Exclusive)
+
+| Command                        | Purpose                                    |
+| ------------------------------ | ------------------------------------------ |
+| `/codex-plan`                  | Create implementation plans using Codex    |
+| `/compose-email`               | Draft professional emails                  |
+| `/explain-changes-mental-model`| Build mental model of code changes         |
+| `/explain-pr-changes`          | Generate PR summaries                      |
+| `/sync-branch`                 | Sync feature branch with main              |
+| `/sync-skills-readme`          | Update README skills table                 |
+| `/viral-tweet`                 | Optimize tweet ideas for engagement        |
+
+### Installation Methods
+
+1. **Quick Install (Recommended)**: `npx skills add softaworks/agent-toolkit`
+2. **Plugin Marketplace**: `/plugin marketplace add softaworks/agent-toolkit`
+3. **Direct Install**: `/plugin install codex@agent-toolkit`
+4. **Manual Copy**: `cp -r skills/<skill-name> ~/.claude/skills/`
+5. **claude.ai**: Paste SKILL.md contents into conversation
+
+### Notable Skills Deep Dive
+
+#### Gepetto (Planning Skill)
+
+Multi-step planning orchestration: Research, Interview, Spec Synthesis, Plan, External Review, Sections. Creates detailed implementation plans through stakeholder interviews and multi-LLM review. Generates structured markdown files for each phase.
+
+#### Codex (AI Tools Skill)
+
+Integration with OpenAI Codex CLI for code analysis and automated editing. Supports GPT-5.2 models with configurable reasoning effort levels (xhigh, high, medium, low). Manages sandbox modes (read-only, workspace-write, danger-full-access) and session resumption.
+
+#### Humanizer (Utility Skill)
+
+Removes AI writing patterns from text to make content sound more natural and human-written.
+
+---
+
+## Technical Architecture
+
+### Skill Structure
+
+```text
+skills/
+  <skill-name>/
+    SKILL.md      # Agent-facing instructions (YAML frontmatter required)
+    README.md     # User-facing documentation
+    scripts/      # Helper automation scripts (optional)
+    references/   # Supporting documentation (optional)
+```
+
+### SKILL.md Format
+
+```yaml
+---
+name: skill-name
+description: Trigger description for when agent should activate this skill
+---
+
+# Skill Title
+
+Instructions, rules, and patterns for the agent to follow...
+```
+
+### Plugin System
+
+- Skills, agents, and commands are individual plugins
+- Marketplace support for discovery and updates
+- Auto-update capability for keeping skills current
+- Scoped installation (local/global)
+
+### Agent Skills Format Compatibility
+
+Skills follow the [Agent Skills](https://agentskills.io/) format, ensuring portability across:
+
+- Claude Code (native support)
+- OpenAI Codex (via CLI)
+- Cursor (skill import)
+- claude.ai (manual paste)
+
+---
+
+## Relevance to Claude Code Development
+
+### Direct Applications
+
+1. **Skill Library Reference**: 40+ skills provide patterns for skill design, covering diverse use cases from planning to professional communication.
+
+2. **Multi-LLM Integration Patterns**: codex, gemini, perplexity skills demonstrate patterns for integrating external AI services within Claude Code workflows.
+
+3. **Planning Methodology**: gepetto skill shows sophisticated multi-phase planning with file-based state management and resume capabilities.
+
+4. **Agent Delegation Patterns**: 6 specialized agents demonstrate effective sub-agent design with clear role boundaries.
+
+5. **Command Design**: Slash commands show patterns for reusable workflow automation.
+
+### Patterns Worth Adopting
+
+1. **Dual Documentation**: Every skill has SKILL.md (agent-facing) + README.md (user-facing), ensuring both audiences are served.
+
+2. **YAML Frontmatter Triggers**: `description` field in frontmatter acts as activation trigger, helping agents determine when to apply skills.
+
+3. **Phase-Based Planning**: gepetto's Research, Interview, Spec Synthesis, Plan, Review, Sections phases provide structured approach to complex tasks.
+
+4. **Sandbox Mode Patterns**: codex skill's read-only, workspace-write, danger-full-access modes show graduated permission levels.
+
+5. **Session Resumption**: codex skill's resume capability demonstrates stateful workflow continuation.
+
+6. **Category Organization**: Skills organized by domain (AI Tools, Documentation, Development, etc.) aids discoverability.
+
+### Integration Opportunities
+
+1. **Skill Import**: Skills could be directly imported or adapted for this repository's skill format.
+
+2. **Pattern Extraction**: gepetto's planning methodology could inform task planning improvements.
+
+3. **Cross-Repository Synergy**: agent-md-refactor skill could help maintain this repository's skill documentation.
+
+4. **Tool Patterns**: datadog-cli, jira skills show patterns for external service integration.
+
+5. **Professional Skills**: Workplace communication skills (feedback-mastery, difficult-workplace-conversations) extend agent capabilities beyond pure coding.
+
+### Comparison with This Repository
+
+| Aspect              | Softaworks Agent Toolkit          | This Repository (claude_skills)     |
+| ------------------- | --------------------------------- | ------------------------------------ |
+| Skill Format        | Agent Skills (agentskills.io)     | Claude Code native + plugins         |
+| Installation        | npx, marketplace, manual          | Plugin marketplace, symlinks         |
+| Scope               | Opinionated personal toolkit      | Marketplace-oriented collection      |
+| Agent Support       | Yes (6 agents)                    | Yes                                  |
+| Commands            | Yes (7 commands)                  | Yes                                  |
+| Auto-Update         | Yes (marketplace)                 | Yes (marketplace)                    |
+| Categories          | 10 categories                     | Category-based                       |
+| Primary Author      | @leonardocouy                     | Community                            |
+
+---
+
+## References
+
+| Source                    | URL                                                                 | Accessed   |
+| ------------------------- | ------------------------------------------------------------------- | ---------- |
+| GitHub Repository         | <https://github.com/softaworks/agent-toolkit>                       | 2026-01-31 |
+| GitHub README             | <https://github.com/softaworks/agent-toolkit/blob/main/README.md>   | 2026-01-31 |
+| GitHub API (Metadata)     | <https://api.github.com/repos/softaworks/agent-toolkit>             | 2026-01-31 |
+| Agent Skills Format       | <https://agentskills.io/>                                           | 2026-01-31 |
+| Codex Skill               | skills/codex/SKILL.md (via raw GitHub)                              | 2026-01-31 |
+| Gepetto Skill             | skills/gepetto/SKILL.md (via raw GitHub)                            | 2026-01-31 |
+
+**Research Method**: Information gathered from GitHub repository README, GitHub API for repository metadata (stars, forks, license, dates), and raw skill files for technical details. Statistics verified via direct API calls on 2026-01-31.
+
+---
+
+## Freshness Tracking
+
+| Field              | Value                               |
+| ------------------ | ----------------------------------- |
+| Version Documented | Active development                  |
+| Last Pushed        | 2026-01-28                          |
+| GitHub Stars       | 378 (as of 2026-01-31)              |
+| Total Skills       | 40+ (as of 2026-01-31)              |
+| Next Review Date   | 2026-05-01                          |
+
+**Review Triggers**:
+
+- GitHub stars milestone (500, 1K)
+- Major new skill categories added
+- Plugin marketplace format changes
+- New AI agent platform support
+- Significant skill additions (10+ new skills)
+- Changes to Agent Skills format specification


### PR DESCRIPTION
Add research entries for:
- Plannotator: Hook-based plan review UI with structured annotations
- Softaworks Agent Toolkit: 40+ skills across 10 categories with multi-platform support
- Claude Night Market: 16 plugins with TDD hooks and multi-LLM delegation
- hmohamed/claude-code-plugins: Swift and Rust developer plugins with PreToolUse safety hooks

https://claude.ai/code/session_01Tw5Siy5EuhBjpaVqKjHNxF