### PR TITLE
fix(scripts): migrate validate-glfm.py from requests to httpx

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "2.7.1"
+    "version": "2.7.2"
   },
   "plugins": [
     {

--- a/.claude/BACKLOG.md
+++ b/.claude/BACKLOG.md
@@ -1,8 +1,8 @@
 ---
-last-updated: 2026-02-05
+last-updated: 2026-02-06
 p0-count: 0
-p1-count: 7
-p2-count: 9
+p1-count: 6
+p2-count: 6
 ideas-count: 10
 ---
 
@@ -60,18 +60,6 @@ _(Empty)_
 **Research first**: How does GSD plan-checker detect deviation? What diff/comparison techniques exist? How do code review tools detect scope creep in PRs?
 **Suggested location**: `methodology_development/stateless-software-engineering-framework.md` (section 3.6 Forensic Review)
 
-### Replace requests with httpx in all scripts
-
-**Source**: CI/pre-commit inconsistency discovery (2026-02-05)
-**Added**: 2026-02-05
-**Description**: Migrate all scripts from `requests` to `httpx`. The `requests` library requires `types-requests` stubs for mypy, adding friction. `httpx` has built-in type annotations and is already the project standard (see python3-development skill modern-modules reference). Add ruff rule to ban `requests` imports.
-**Tasks**:
-- Audit all scripts for `requests` usage (currently: `validate-glfm.py`)
-- Replace with `httpx` equivalents
-- Add ruff ban rule: `"requests" = ["banned-api"]` or similar
-- Update any PEP 723 inline dependencies
-**Suggested location**: Scripts in `plugins/**/scripts/`
-
 ### Extract claude-plugin-lint to standalone PyPI package
 
 **Source**: Gap analysis - no existing Claude Code plugin linters exist
@@ -91,30 +79,6 @@ _(Empty)_
 ---
 
 ## P2 - Could Have
-
-### Enhance swarm-task-planner with multi-source synthesis
-
-**Source**: [external-pattern-integration-2026-02-01.md](.claude/external-pattern-integration-2026-02-01.md)
-**Added**: 2026-02-01
-**Description**: Add pattern for synthesizing outputs from multiple parallel research agents into unified summary documents.
-**Patterns from**: gsd-research-synthesizer.md
-**Suggested location**: `plugins/python3-development/agents/swarm-task-planner.md`
-
-### Add context compliance checking
-
-**Source**: [external-pattern-integration-2026-02-01.md](.claude/external-pattern-integration-2026-02-01.md)
-**Added**: 2026-02-01
-**Description**: Verify plans comply with user decisions (Decisions/Discretion/Deferred format). Requires adopting GSD CONTEXT.md artifact format.
-**Patterns from**: gsd-plan-checker.md (context compliance dimension)
-**Suggested location**: `plugins/python3-development/agents/plan-validator.md` or new CONTEXT.md format
-
-### SAM: Artifact Versioning Strategy
-
-**Source**: Gap analysis of SAM framework
-**Added**: 2026-02-01
-**Description**: Define versioning strategy for artifacts. How to track artifact evolution? How to reference specific versions? Git-based vs embedded version fields?
-**Research first**: How do GSD STATE.md and CONTEXT.md handle versioning? How does git-based versioning work in document-heavy workflows? What patterns exist in event sourcing?
-**Suggested location**: `methodology_development/stateless-software-engineering-framework.md` (section 2.1.2)
 
 ### SAM: Parallel Execution Details
 
@@ -266,6 +230,34 @@ _(Empty)_
 ---
 
 ## Completed
+
+### Replace requests with httpx in all scripts
+
+**Source**: CI/pre-commit inconsistency discovery (2026-02-05)
+**Completed**: 2026-02-06
+**Description**: Migrated `validate-glfm.py` from `requests` to `httpx`. Added TID251 ruff ban rule for `requests` imports. Removed `types-requests` from dev dependencies. `sync-gitlab-docs.py` was already using httpx.
+**Location**: `plugins/gitlab-skill/skills/gitlab-skill/scripts/validate-glfm.py`, `pyproject.toml`
+
+### Enhance swarm-task-planner with multi-source synthesis
+
+**Source**: [external-pattern-integration-2026-02-01.md](.claude/external-pattern-integration-2026-02-01.md)
+**Completed**: 2026-02-06
+**Description**: Multi-source synthesis implemented via CLEAR+CoVe standard and Project Awareness section with investigation commands for searching documentation, assessing project structure, and identifying progress.
+**Location**: `plugins/python3-development/agents/swarm-task-planner.md`
+
+### Add context compliance checking
+
+**Source**: [external-pattern-integration-2026-02-01.md](.claude/external-pattern-integration-2026-02-01.md)
+**Completed**: 2026-02-06
+**Description**: Complete plan-validator agent implements 8 validation dimensions including Requirement Coverage, Task Completeness, Dependency Correctness, Agent Capability Match, Input/Output Validity, Artifact Wiring, Testability, and Scope Sanity.
+**Location**: `plugins/python3-development/agents/plan-validator.md`
+
+### SAM: Artifact Versioning Strategy
+
+**Source**: Gap analysis of SAM framework
+**Completed**: 2026-02-06
+**Description**: Implemented storage-agnostic semantic tokens using pattern `ARTIFACT:{TYPE}({SCOPE_OR_ID})` with disambiguators (CTX, PREREQ, EXEC, VERIFY). Provides both filesystem-backed and SQL-backed example implementations.
+**Location**: `methodology_development/stateless-software-engineering-framework.md` (section 2.1.2)
 
 ### Create ecosystem-researcher agent
 

--- a/plugins/gitlab-skill/.claude-plugin/plugin.json
+++ b/plugins/gitlab-skill/.claude-plugin/plugin.json
@@ -1,11 +1,15 @@
 {
   "name": "gitlab-skill",
   "description": "The model must apply when tasks involve .gitlab-ci.yml configuration, GitLab Flavored Markdown (GLFM) syntax, gitlab-ci-local testing, CI/CD pipeline optimization, GitLab CI Steps composition, Docker-in-Docker workflows, or GitLab documentation creation. Triggers include modifying pipelines, writing GitLab README/Wiki content, debugging CI jobs locally, implementing caching strategies, or configuring release workflows.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"
   },
-  "skills": ["./skills/gitlab-skill"],
-  "commands": ["./commands"]
+  "skills": [
+    "./skills/gitlab-skill"
+  ],
+  "commands": [
+    "./commands"
+  ]
 }

--- a/plugins/gitlab-skill/skills/gitlab-skill/scripts/validate-glfm.py
+++ b/plugins/gitlab-skill/skills/gitlab-skill/scripts/validate-glfm.py
@@ -2,8 +2,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "requests>=2.31.0",
-#     "types-requests>=2.31.0",
+#     "httpx>=0.28.1",
 # ]
 # ///
 """GitLab Flavored Markdown Validation Script.
@@ -22,7 +21,7 @@ import os
 import sys
 from pathlib import Path
 
-import requests
+import httpx
 
 
 def get_gitlab_token() -> str | None:
@@ -75,38 +74,37 @@ def validate_markdown(
         print(f"API URL: {api_url}", file=sys.stderr)
         print(f"Request payload: {json.dumps(payload, indent=2)}", file=sys.stderr)
 
-    response: requests.Response | None = None
     try:
-        response = requests.post(api_url, headers=headers, json=payload, timeout=30)
+        response = httpx.post(api_url, headers=headers, json=payload, timeout=30)
+    except httpx.RequestError as e:
+        print(f"Request Error: {e}", file=sys.stderr)
+        return None
 
-        if verbose:
-            print(f"Response status: {response.status_code}", file=sys.stderr)
+    if verbose:
+        print(f"Response status: {response.status_code}", file=sys.stderr)
 
+    try:
         response.raise_for_status()
-
-        result = response.json()
-
-    except requests.exceptions.HTTPError as e:
+    except httpx.HTTPStatusError as e:
         print(
             f"HTTP Error {e.response.status_code}: {e.response.text}", file=sys.stderr
         )
         return None
-    except requests.exceptions.RequestException as e:
-        print(f"Request Error: {e}", file=sys.stderr)
-        return None
+
+    try:
+        result = response.json()
     except json.JSONDecodeError as e:
         print(f"JSON Error: {e}", file=sys.stderr)
-        if response is not None:
-            print(f"Response text: {response.text}", file=sys.stderr)
+        print(f"Response text: {response.text}", file=sys.stderr)
         return None
-    else:
-        if "html" in result:
-            return str(result["html"])
-        if "error" in result:
-            print(f"API Error: {result['error']}", file=sys.stderr)
-            return None
-        print(f"Unexpected response: {result}", file=sys.stderr)
+
+    if "html" in result:
+        return str(result["html"])
+    if "error" in result:
+        print(f"API Error: {result['error']}", file=sys.stderr)
         return None
+    print(f"Unexpected response: {result}", file=sys.stderr)
+    return None
 
 
 def main() -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ extend-select = [
 	"T10",   # see: https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
 	"T20",   # see: https://docs.astral.sh/ruff/rules/#flake8-typing-t20
 	"TC",    # see: https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc
+	"TID",   # see: https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
 	"TRY",   # see: https://docs.astral.sh/ruff/rules/#tryceratops-try
 	"UP",    # see: https://docs.astral.sh/ruff/rules/#pyupgrade-up
 	"W",     # see: https://docs.astral.sh/ruff/rules/#warning-w
@@ -111,6 +112,9 @@ unfixable = ["F401"]
 "**/assets/nested-typer-exceptions/*.py" = ["DOC", "ANN"]
 # Lazy imports for optional dependency detection (hatchling may not be installed)
 "**/assets/version.py" = ["PLC0415"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"requests".msg = "Use httpx instead. httpx has built-in type annotations and is the project standard."
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120
@@ -224,5 +228,4 @@ dev = [
 	"tiktoken>=0.12.0",
 	"typer>=0.20.0",
 	"types-pyyaml>=6.0.12.20250915",
-	"types-requests>=2.32.0",
 ]


### PR DESCRIPTION
- Replace requests with httpx for built-in type annotations and project consistency
- Add TID251 ruff ban rule to prevent future requests usage
- Remove types-requests from dev dependencies
- Restructure error handling for cleaner type narrowing
- Update backlog: mark 4 items as completed (httpx migration, swarm-task-planner
  multi-source synthesis, context compliance checking, artifact versioning strategy)

https://claude.ai/code/session_01DNFxbcFphwDwP4NwZpMCau