### PR TITLE
Add fact-checking step to backlog grooming workflow

### DIFF
--- a/.claude/skills/groom-backlog-item/SKILL.md
+++ b/.claude/skills/groom-backlog-item/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: groom-backlog-item
-description: Groom backlog items — trigger /groom-backlog-item <title|section|all> — runs RT-ICA per item then spawns @backlog-item-groomer agents to discover research, skills, agents, prior work, and dependencies. Produces context manifests and grooming report. Use when preparing backlog items for planning or execution.
+description: Groom backlog items — trigger /groom-backlog-item <title|section|all> — fact-checks item claims against primary sources, runs RT-ICA per item, then spawns @backlog-item-groomer agents to discover research, skills, agents, prior work, and dependencies. Produces context manifests and grooming report. Use when preparing backlog items for planning or execution.
 argument-hint: <item-title-or-section-or-all>
 user-invocable: true
 ---
@@ -26,9 +26,34 @@ Read `.claude/BACKLOG.md`. Identify target items based on argument type above.
 
 For each target item, extract: title, description, research-first questions (if present), source, suggested location.
 
-### Step 3: RT-ICA Assessment Per Item
+### Step 3: Fact-Check Item Claims
 
-Perform Reverse Thinking — Information Completeness Assessment before spawning groomer agents. This directs the groomer's discovery toward filling gaps rather than broad search.
+Invoke the `fact-check` skill on each target item to verify factual claims against primary sources **before** running RT-ICA or spawning groomer agents. This prevents unverified or refuted assertions from entering the planning context.
+
+```text
+Skill(command: "fact-check", args: "{item title}")
+```
+
+The `fact-check` skill spawns `@fact-checker` agents that MUST retrieve evidence via `WebFetch`, `WebSearch`, or `gh`. Training data recall is not accepted as evidence.
+
+After each run, collect the verdict summary:
+
+```text
+Fact-Check Summary: {item title}
+Claims checked: {N}
+VERIFIED: {N} | REFUTED: {N} | INCONCLUSIVE: {N}
+Refuted claims:      [{list of claim texts — each becomes a MISSING condition in Step 4}]
+Inconclusive claims: [{list of claim texts — flag as unverified DERIVABLE in Step 4}]
+Citations:           [{VERIFIED claims cite their primary sources}]
+```
+
+**Multiple items** — invoke `fact-check` for each item sequentially (respect the wave-of-5 concurrency limit inside `fact-check` itself). Do not batch items into a single `fact-check` call.
+
+Pass the fact-check summary forward to Step 4.
+
+### Step 4: RT-ICA Assessment Per Item
+
+Perform Reverse Thinking — Information Completeness Assessment using both the item details **and** the fact-check verdicts from Step 3. This directs the groomer's discovery toward filling gaps rather than broad search.
 
 For each item, produce:
 
@@ -42,27 +67,29 @@ Decision: {APPROVED|BLOCKED}
 Missing: {list of missing inputs, or "None"}
 ```
 
-- **AVAILABLE**: Explicitly stated in item description or research questions
-- **DERIVABLE**: Safely inferable from codebase context (state basis)
-- **MISSING**: Not present, not safely inferable — groomer must find it
+- **AVAILABLE**: Explicitly stated in item description or research questions AND fact-check verdict is VERIFIED or not applicable
+- **DERIVABLE**: Safely inferable from codebase context (state basis); fact-check verdict is INCONCLUSIVE
+- **MISSING**: Not present, not safely inferable — OR fact-check verdict is REFUTED (the stated condition is false and the correct state is unknown)
 
-Pass the RT-ICA summary to the groomer alongside item details.
+REFUTED claims from Step 3 MUST be listed as MISSING conditions. A REFUTED claim is not a valid basis for any AVAILABLE or DERIVABLE status.
 
-### Step 4: Spawn Groomer Agents
+Pass the RT-ICA summary and fact-check summary to the groomer alongside item details.
 
-**Single item** — invoke `@backlog-item-groomer` directly, passing item details and RT-ICA summary.
+### Step 5: Spawn Groomer Agents
+
+**Single item** — invoke `@backlog-item-groomer` directly, passing item details, RT-ICA summary, and fact-check summary.
 
 **Multiple items** — spawn parallel Task agents (max 5 concurrent; batch in waves if more):
 
 ```text
 Task(
   subagent_type: "general-purpose",
-  prompt: "Act as @backlog-item-groomer. Groom this item:\n{item details}\n\nRT-ICA Assessment:\n{rt-ica summary}",
+  prompt: "Act as @backlog-item-groomer. Groom this item:\n{item details}\n\nRT-ICA Assessment:\n{rt-ica summary}\n\nFact-Check Verdicts:\n{fact-check summary}",
   model: "haiku"
 )
 ```
 
-### Step 5: Collect and Report
+### Step 6: Collect and Report
 
 Gather context manifests. Produce grooming report:
 
@@ -75,19 +102,30 @@ Gather context manifests. Produce grooming report:
 
 ## Summary
 
-| Item | RT-ICA | Research Found | Skills | Agents | Blockers |
-|------|--------|----------------|--------|--------|----------|
-| {title} | {APPROVED/BLOCKED} | {count} | {count} | {count} | {count} |
+| Item | Fact-Check | RT-ICA | Research Found | Skills | Agents | Blockers |
+|------|------------|--------|----------------|--------|--------|----------|
+| {title} | {V}/{R}/{I} | {APPROVED/BLOCKED} | {count} | {count} | {count} | {count} |
 
 ## Individual Manifests
 
 ### {Item title}
 {manifest from agent}
 
+## Fact-Check Results
+
+### Refuted Claims
+- {item title}: {claim text} — REFUTED by {source URL}
+
+### Inconclusive Claims
+- {item title}: {claim text} — INCONCLUSIVE: {what additional verification is needed}
+
+### Verified Claims
+- {item title}: {count} claims verified against primary sources
+
 ## RT-ICA Results
 
 ### BLOCKED Items
-- {item title}: {list of missing inputs}
+- {item title}: {list of missing inputs, including any from refuted claims}
 
 ### APPROVED Items
 - {item title}: {count} conditions verified
@@ -116,7 +154,9 @@ If grooming multiple items, offer to save report to `.claude/grooming-reports/gr
 
 ## Completion Criteria
 
+- Fact-check run for each item before RT-ICA (training data not used as evidence)
+- Fact-check verdicts passed into RT-ICA conditions (REFUTED → MISSING)
 - RT-ICA summary included for each item
-- Groomer agent(s) received RT-ICA context
-- Report contains RT-ICA Results section
+- Groomer agent(s) received RT-ICA context and fact-check verdicts
+- Report contains Fact-Check Results section and RT-ICA Results section
 - Cross-item findings present (if multiple items groomed)


### PR DESCRIPTION
## Summary

Enhanced the backlog grooming skill to include a fact-checking phase that verifies item claims against primary sources before running RT-ICA assessment and spawning groomer agents. This prevents unverified or refuted assertions from entering the planning context.

## Key Changes

- **New Step 3: Fact-Check Item Claims** — Invokes the `fact-check` skill on each target item to verify factual claims against primary sources (via WebFetch, WebSearch, or gh) before proceeding with RT-ICA or grooming
  - Collects verdict summaries categorizing claims as VERIFIED, REFUTED, or INCONCLUSIVE
  - Processes items sequentially while respecting concurrency limits
  - Passes fact-check results forward to RT-ICA assessment

- **Updated RT-ICA Assessment (now Step 4)** — Incorporates fact-check verdicts into condition evaluation:
  - VERIFIED claims support AVAILABLE status
  - INCONCLUSIVE claims map to DERIVABLE status
  - REFUTED claims are treated as MISSING conditions (the stated condition is false, correct state unknown)
  - Ensures refuted claims are explicitly listed in missing inputs

- **Enhanced Groomer Agent Invocation (now Step 5)** — Passes both RT-ICA summary and fact-check summary to groomer agents for context-aware discovery

- **Expanded Reporting (now Step 6)** — Added dedicated Fact-Check Results section showing:
  - Refuted claims with source citations
  - Inconclusive claims flagged for additional verification
  - Count of verified claims per item
  - Updated summary table to include fact-check verdict column (V/R/I counts)

- **Updated Completion Criteria** — Added verification that fact-checking runs before RT-ICA and that verdicts are properly integrated into the assessment workflow

## Implementation Details

- Fact-check skill is invoked per-item sequentially (not batched) to maintain clarity and traceability
- Training data recall is explicitly rejected as evidence; only primary sources via WebFetch, WebSearch, or gh are accepted
- Refuted claims create a clear audit trail by becoming MISSING conditions in RT-ICA, making blockers transparent
- Report structure now provides visibility into claim verification status alongside research and dependency discovery

https://claude.ai/code/session_013TKWkcvG2GioZkrjzUL8nF