### PR TITLE
fix: resolve DTZ lint issues and add MCP backlog for 10 plugins

### DIFF
--- a/.claude/BACKLOG.md
+++ b/.claude/BACKLOG.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-02-22
+last-updated: 2026-02-23
 last-completed: 2026-02-22
 p0-count: 0
 p1-count: 22
 p2-count: 26
-ideas-count: 11
+ideas-count: 21
 ---
 
 # Backlog
@@ -637,6 +637,83 @@ be applied to both scripts (as seen when reversing the name-field bug workaround
 - Test text extraction: Can we pipe output or capture rendered text?
 - Compare JS rendering quality with other tools
 **Blocked on 2026-02-05**: Needs TTY (Inappropriate ioctl for device), DNS also blocked
+
+---
+
+## Ideas — MCP Servers for Plugins
+
+Each plugin with scripts or external tooling should expose a universal MCP interface. The `agentskill-kaizen` plugin is the reference example (two MCP servers: `kaizen-duckdb` via mcp-server-motherduck, `kaizen-analysis` via FastMCP `server.py`). Below are MCP server ideas for every plugin that would benefit.
+
+### plugin-creator: Plugin Validation & Scaffolding MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap `plugin_validator.py`, `auto_sync_manifests.py`, `create_plugin.py`, and `normalize_frontmatter.py` as MCP tools. Agents could validate plugins, scaffold new ones, sync manifests, and normalize frontmatter without shell invocations. Tools: `validate_plugin`, `create_plugin`, `sync_manifests`, `normalize_frontmatter`, `list_validation_errors`.
+**Suggested location**: `plugins/plugin-creator/mcp/server.py`
+
+### hallucination-detector: Hallucination Audit MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Expose `hallucination-audit-stop.js` logic as an MCP tool. Currently only runs as a Stop hook — an MCP server would let any agent or workflow request on-demand hallucination scanning of arbitrary text. Tools: `audit_text`, `audit_file`.
+**Suggested location**: `plugins/hallucination-detector/mcp/server.py` (reimplement core logic in Python) or `plugins/hallucination-detector/mcp/server.js` (wrap existing JS)
+
+### gitlab-skill: GitLab CI & GLFM Validation MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap `validate_glfm.py` and `sync_gitlab_docs.py` as MCP tools. Agents could validate GitLab Flavored Markdown compliance and sync documentation without shell access. Tools: `validate_glfm`, `sync_docs`, `list_glfm_errors`.
+**Suggested location**: `plugins/gitlab-skill/mcp/server.py`
+
+### holistic-linting: Linting Orchestration MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap `holistic_lint.py` as an MCP tool. Currently agents must invoke linting via shell. An MCP server would expose structured linting results (errors, warnings, fixes applied) as tool outputs. Tools: `lint_files`, `list_lint_errors`, `auto_fix`.
+**Suggested location**: `plugins/holistic-linting/mcp/server.py`
+
+### development-harness: Task Status MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap `implementation_manager.py` CLI as MCP tools. Agents could query task status, list pending tasks, and update task state programmatically. Tools: `query_tasks`, `list_pending`, `update_task_status`, `parse_task_file`.
+**Suggested location**: `plugins/development-harness/mcp/server.py`
+
+### summarizer: File Metrics & Summarization MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap `file_metrics.py` as MCP tools. Agents could request file complexity analysis, token counts, and structured summaries. Tools: `count_tokens`, `scan_files`, `summarize_file`.
+**Suggested location**: `plugins/summarizer/mcp/server.py`
+
+### the-rewrite-room: Document Analysis MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap `file_metrics.py` (count/scan commands with `--json` support) as MCP tools. Provides structured document analysis for the rewriting workflow router. Tools: `count_document_metrics`, `scan_documents`, `compare_versions`.
+**Suggested location**: `plugins/the-rewrite-room/mcp/server.py`
+
+### fastmcp-creator: MCP Meta-Tooling MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap `connections.py`, `evaluation.py`, and `get_environment.py` as MCP tools. An MCP server that helps build MCP servers — agents could test connections, run evaluations, and inspect environments. Tools: `test_mcp_connection`, `run_evaluation`, `get_mcp_environment`, `validate_mcp_config`.
+**Suggested location**: `plugins/fastmcp-creator/mcp/server.py`
+
+### python3-development: Python Development Toolchain MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap the various scripts under python3-development (mkdocs sync, uv release sync) as MCP tools. Agents could manage Python project tooling without shell access. Tools: `sync_mkdocs`, `sync_uv_releases`, `check_python_environment`.
+**Suggested location**: `plugins/python3-development/mcp/server.py`
+
+### dasel: Structured Data Query MCP
+
+**Source**: MCP backlog audit 2026-02-23
+**Added**: 2026-02-23
+**Description**: Wrap dasel CLI operations as MCP tools. Agents could query, transform, and convert structured data (JSON, YAML, TOML, XML, CSV) without shell piping. Tools: `query_data`, `transform_data`, `convert_format`, `install_dasel`.
+**Research first**: Evaluate whether wrapping the dasel binary (subprocess) or reimplementing core operations in Python is better for MCP transport.
+**Suggested location**: `plugins/dasel/mcp/server.py`
 
 ---
 

--- a/research/knowledge-explorer.py
+++ b/research/knowledge-explorer.py
@@ -25,7 +25,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from io import StringIO
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
@@ -272,7 +272,7 @@ class KBEntry:
 
     def __post_init__(self) -> None:
         """Compute derived fields."""
-        self.is_overdue = self.next_review < date.today()
+        self.is_overdue = self.next_review < datetime.now(tz=UTC).date()
 
 
 @dataclass
@@ -448,7 +448,7 @@ def _build_readme_row(entry: KBEntry) -> str:
     Returns:
         Markdown table row string.
     """
-    today_iso = date.today().isoformat()
+    today_iso = datetime.now(tz=UTC).date().isoformat()
     summary = _extract_first_paragraph(entry.body) or entry.name
     if len(summary) > _README_SUMMARY_MAX_LEN:
         summary = summary[: _README_SUMMARY_MAX_LEN - 1] + "\u2026"
@@ -649,7 +649,7 @@ def _parse_research_date(value: str) -> date:
     except ValueError:
         pass
     try:
-        return datetime.strptime(value, "%B %d, %Y").date()
+        return datetime.strptime(value, "%B %d, %Y").replace(tzinfo=UTC).date()
     except ValueError:
         pass
     raise ParseError(
@@ -1231,7 +1231,7 @@ def build_draft(repo_slug: str, meta: GitHubMetadata, category: str) -> KBEntry:
         Draft KBEntry with the provided category.
     """
     topic_slug = re.sub(r"[^a-z0-9-]", "-", meta.name.lower()).strip("-")
-    today = date.today()
+    today = datetime.now(tz=UTC).date()
 
     # Build description from GitHub repo description (max 1024 chars)
     desc_max = 1024
@@ -1609,7 +1609,7 @@ def list_kb() -> None:
 @app.command("show-template")
 def show_template() -> None:
     """Print the skill-spec compatible frontmatter template with body structure."""
-    today = date.today()
+    today = datetime.now(tz=UTC).date()
     next_review = today + timedelta(days=_DEFAULT_REVIEW_DAYS)
     cats_comment = f"# one of: {', '.join(sorted(VALID_CATEGORIES))}"
     template = (
@@ -1783,7 +1783,7 @@ def update_append(
             console.print("[yellow]No update content provided. Aborted.[/yellow]")
             raise typer.Exit(code=0)
 
-        today = date.today()
+        today = datetime.now(tz=UTC).date()
         update_block = format_update_block(update_content, today)
 
         # Update frontmatter dates


### PR DESCRIPTION
## Summary

Two changes in this PR:

### 1. Fix 6 ruff DTZ lint issues in `research/knowledge-explorer.py`

All 6 were timezone-naive datetime usage flagged by ruff's `DTZ` rules:
- **5x DTZ011**: `date.today()` → `datetime.now(tz=UTC).date()` (lines 275, 451, 1234, 1612, 1786)
- **1x DTZ007**: `datetime.strptime(value, fmt).date()` → `datetime.strptime(value, fmt).replace(tzinfo=UTC).date()` (line 652)

After this change, `uv run ruff check .` passes with zero errors.

### 2. Add "Ideas — MCP Servers for Plugins" section to `.claude/BACKLOG.md`

Audited all 25 plugins. Currently only `agentskill-kaizen` has MCP servers (used as the reference example). Added 10 MCP server ideas for plugins that have existing scripts/tooling that would benefit from a universal MCP interface:

| Plugin | MCP Idea | Key Tools |
|--------|----------|-----------|
| plugin-creator | Plugin Validation & Scaffolding | `validate_plugin`, `create_plugin`, `sync_manifests` |
| hallucination-detector | Hallucination Audit | `audit_text`, `audit_file` |
| gitlab-skill | GitLab CI & GLFM Validation | `validate_glfm`, `sync_docs` |
| holistic-linting | Linting Orchestration | `lint_files`, `auto_fix` |
| development-harness | Task Status | `query_tasks`, `update_task_status` |
| summarizer | File Metrics & Summarization | `count_tokens`, `scan_files` |
| the-rewrite-room | Document Analysis | `count_document_metrics`, `scan_documents` |
| fastmcp-creator | MCP Meta-Tooling | `test_mcp_connection`, `run_evaluation` |
| python3-development | Python Toolchain | `sync_mkdocs`, `sync_uv_releases` |
| dasel | Structured Data Query | `query_data`, `transform_data` |

Updated `ideas-count` from 11 to 21.

_This PR was generated with [Warp](https://www.warp.dev/)._
