### PR TITLE
fix(brainstorming-skill): remove orphaned bibliography entry and cross-reference headings

### DIFF
--- a/plugins/brainstorming-skill/.claude-plugin/plugin.json
+++ b/plugins/brainstorming-skill/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brainstorming-skill",
   "description": "This skill should be used when users need to generate ideas, explore creative solutions, or systematically brainstorm approaches to problems. Use when users request help with ideation, content planning, product features, marketing campaigns, strategic planning, creative writing, or any task requiring structured idea generation. The skill provides 30+ research-validated prompt patterns across 14 categories with exact templates, success metrics, and domain-specific applications.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/brainstorming-skill/skills/brainstorming-skill/SKILL.md
+++ b/plugins/brainstorming-skill/skills/brainstorming-skill/SKILL.md
@@ -6,7 +6,7 @@ description: This skill should be used when users need to generate ideas, explor
 
 ## Overview
 
-This skill provides comprehensive, research-validated brainstorming patterns and prompt templates to help generate high-quality ideas across any domain. It contains 30+ documented patterns from 14 primary sources, organized into systematic categories with exact prompt wording, output format specifications, and proven success metrics.
+This skill provides comprehensive, research-validated brainstorming patterns and prompt templates to help generate high-quality ideas across any domain. It contains 30+ documented patterns from 13 primary sources, organized into systematic categories with exact prompt wording, output format specifications, and proven success metrics.
 
 ## When to Use This Skill
 

--- a/plugins/brainstorming-skill/skills/brainstorming-skill/references/better-creator.md
+++ b/plugins/brainstorming-skill/skills/brainstorming-skill/references/better-creator.md
@@ -474,11 +474,3 @@ From BetterCreator's approach:
 4. **Constraint-Based Creativity**: Specific constraints (SCAMPER operations, hat perspectives) unlock creative thinking
 5. **Context Matters**: Providing complete context to ChatGPT significantly improves output relevance
 
----
-
-## See Also
-
-- SCAMPER Method for content format innovation
-- Six Thinking Hats for stakeholder-inclusive decision making
-- Mind Mapping for visual content organization
-- SWOT Analysis for competitive positioning

--- a/plugins/brainstorming-skill/skills/brainstorming-skill/references/bibliography-and-source-documentation.md
+++ b/plugins/brainstorming-skill/skills/brainstorming-skill/references/bibliography-and-source-documentation.md
@@ -79,18 +79,3 @@
     - QA and testing-specific pattern adaptations
     - Edge case discovery methodologies
 
-14. **NotionAI & Various Prompt Marketplaces** (PromptBase, Gumroad)
-    - Practitioner-created prompts with reported success metrics
-    - Real-world usage data and effectiveness reports
-
----
-
-## Verification Note
-
-**Evidence Strength Assessment:**
-
-- **Strong (3+ independent sources)**: Perspective multiplication patterns, SCAMPER framework, constraint-based ideation, Six Thinking Hats, time travel scenarios, fill-in-the-blank templates
-- **Moderate (2 sources)**: Morphological matrix, analogical transfer, chain-of-thought reasoning, assumption challenge
-- **Emerging (1-2 sources but consistent language)**: Devil's advocate patterns, worst possible idea inversion, stakeholder perspective grids
-
-All 30+ patterns documented appear in at least one authoritative source with exact prompt wording. Most common patterns appear in 3-5+ independent sources, validating cross-domain applicability.

--- a/plugins/brainstorming-skill/skills/brainstorming-skill/references/itonics-innovation-platform.md
+++ b/plugins/brainstorming-skill/skills/brainstorming-skill/references/itonics-innovation-platform.md
@@ -580,14 +580,3 @@ All 79 prompts use bracketed placeholders to enable customization:
 
 5. **Stakeholder Inclusivity**: Several prompts explicitly introduce diverse perspectives (ages, cultures, roles, industries) to reduce groupthink and cognitive bias.
 
----
-
-## Related Brainstorming Frameworks
-
-While not documented in this source, these prompts align with established brainstorming methodologies:
-
-- **SCAMPER** (Substitute, Combine, Adapt, Modify, Put to another use, Eliminate, Reverse) - aspects appear in Categories 1, 4
-- **Blue Ocean Strategy** (Value innovation, uncontested market space) - aspects appear in Categories 1, 6
-- **Futures Thinking** (Scenario planning, weak signals, trends) - Categories 7 and 8
-- **Design Thinking** (Empathy, ideation, prototyping) - Categories 3, 5, 10
-- **Divergent Thinking** (Multiple solutions, perspective diversity) - Categories 4, 7

--- a/plugins/brainstorming-skill/skills/brainstorming-skill/references/linkedin-ruben-hassid.md
+++ b/plugins/brainstorming-skill/skills/brainstorming-skill/references/linkedin-ruben-hassid.md
@@ -443,13 +443,3 @@ Rather than pure volume, Hassid emphasizes:
 
 **Confidence Level**: High for core methodology and scaling principles; Medium-High for specific prompt wording (framework structure verified, some variations based on documented examples).
 
----
-
-## Related Resources
-
-For deeper exploration of related methodologies:
-
-- **Prompt Engineering Fundamentals**: 26 Prompt Hacks for ChatGPT (science-backed techniques)
-- **Advanced Brainstorming**: Five Whys Technique, TRIZ (Theory of Inventive Problem Solving), Job-To-Be-Done Framework
-- **AI Integration**: System architecture for scaling content production across teams
-- **Platform-Specific**: LinkedIn-optimized hooks, carousel structures, engagement patterns

--- a/plugins/brainstorming-skill/skills/brainstorming-skill/references/verification-note.md
+++ b/plugins/brainstorming-skill/skills/brainstorming-skill/references/verification-note.md
@@ -10,4 +10,4 @@ All 30+ patterns documented appear in at least one authoritative source with exa
 
 ---
 
-**Document Version:** 1.0 **Research Completed:** 2025-11-04 **Total Patterns Documented:** 30+ **Primary Sources:** 14 **Evidence Quality:** Strong (peer-reviewed + practitioner-validated)
+**Document Version:** 1.0 **Research Completed:** 2025-11-04 **Total Patterns Documented:** 30+ **Primary Sources:** 13 **Evidence Quality:** Strong (peer-reviewed + practitioner-validated)


### PR DESCRIPTION
## Summary

- Removed orphaned bibliography entry 14 (NotionAI & Various Prompt Marketplaces) — no URL, no reference file, not cited anywhere
- Removed duplicated `## Verification Note` section from bibliography file (standalone `verification-note.md` already exists)
- Removed 3 unlinked cross-reference sections (`## See Also`, `## Related Resources`, `## Related Brainstorming Frameworks`) from reference files that listed concepts without any file links
- Updated source count from 14 to 13 in SKILL.md and verification-note.md

## Test plan

- [x] Verify all remaining bibliography entries (1-13) still have corresponding reference files or are cited elsewhere
- [x] Verify `## See Also` sections with valid links (prompthub-role-prompting.md, learn-prompting.md) are preserved
- [x] Pre-commit linting passes on all modified files
- [x] No broken links introduced

Fixes #100

https://claude.ai/code/session_01VvCiRoHvGPtCzsApMcmixo