### PR TITLE
chore: symlink fastmcp skills into local project skills directory

### DIFF
--- a/.claude/skills/fastmcp-creator
+++ b/.claude/skills/fastmcp-creator
@@ -1,0 +1,1 @@
+../../plugins/fastmcp-creator/skills/fastmcp-creator

--- a/.claude/skills/fastmcp-python-tests
+++ b/.claude/skills/fastmcp-python-tests
@@ -1,0 +1,1 @@
+../../plugins/fastmcp-creator/skills/fastmcp-python-tests


### PR DESCRIPTION
Adds symlinks for fastmcp-creator and fastmcp-python-tests from the
fastmcp-creator plugin to .claude/skills/ for direct skill invocation.

https://claude.ai/code/session_01KjxEziQrFE6WcBrLvGHWLc