### PR TITLE
Update test documentation after fixing nested metadata parsing bug

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "5.0.26"
+    "version": "5.0.27"
   },
   "plugins": [
     {

--- a/.claude/skills/backlog/tests/test_backlog_core_operations.py
+++ b/.claude/skills/backlog/tests/test_backlog_core_operations.py
@@ -282,8 +282,8 @@ class TestListItemsFiltering:
         Tests: Skip filtering in list_items.
         How: Mock parse_backlog to return one active and one skip=True item.
         Why: Done items must not appear in the active backlog list.  parse_backlog
-             is mocked because _parse_frontmatter has a pre-existing bug where the
-             nested metadata dict is stringified, preventing skip from being set.
+             is mocked to inject a BacklogItem with a specific skip value directly,
+             isolating this test from parsing logic.
         """
         active = BacklogItem(title="Active Item", section="P1", skip=False)
         done = BacklogItem(title="Done Item", section="P1", skip=True)
@@ -303,8 +303,8 @@ class TestListItemsFiltering:
         Tests: batch_fetch_statuses integration in list_items.
         How: Mock parse_backlog to return an item with issue="#7"; mock batch_fetch_statuses.
         Why: with_status must use batch fetch — not N+1 individual calls.  parse_backlog
-             is mocked because _parse_frontmatter has a pre-existing bug that drops the
-             issue field from nested metadata, causing empty issue strings after parsing.
+             is mocked to inject a BacklogItem with a specific issue value directly,
+             isolating this test from parsing logic.
         """
         item_with_issue = BacklogItem(title="Tracked Item", section="P1", skip=False, issue="#7")
         mocker.patch("backlog_core.operations.parse_backlog", return_value=[item_with_issue])
@@ -488,8 +488,9 @@ class TestCloseItem:
         Tests: Open PR guard in close_item.
         How: Mock find_item to return a BacklogItem with issue="#5" (bypasses parser bug);
              mock check_open_prs_for_issue to return one PR.
-        Why: Premature close orphans in-flight PRs.  find_item is mocked because the
-             parser has a pre-existing bug that drops the issue field from nested metadata.
+        Why: Premature close orphans in-flight PRs.  find_item is mocked to inject
+             a BacklogItem with a specific issue value directly, isolating this test
+             from parsing logic.
         """
         import backlog_core.models as models
         from backlog_core.models import BacklogError
@@ -593,8 +594,9 @@ class TestResolveItem:
 
         Tests: Open PR guard in resolve_item.
         How: Mock find_item to return a BacklogItem with issue="#8"; mock open PR.
-        Why: Resolving orphans in-flight PRs.  find_item is mocked because the parser
-             has a pre-existing bug that drops the issue field from nested metadata.
+        Why: Resolving orphans in-flight PRs.  find_item is mocked to inject a
+             BacklogItem with a specific issue value directly, isolating this test
+             from parsing logic.
         """
         import backlog_core.models as models
         from backlog_core.models import BacklogError

--- a/.claude/skills/backlog/tests/test_backlog_core_parsing.py
+++ b/.claude/skills/backlog/tests/test_backlog_core_parsing.py
@@ -25,22 +25,10 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Test data
 #
-# IMPORTANT: _parse_frontmatter stringifies all frontmatter values before
-# attempting to extract the nested ``metadata:`` block. This means the nested
-# dict is converted to a string representation, making isinstance(meta_raw, dict)
-# False, so meta always comes back as {}.
-#
-# Practical consequence:
-#   - Nested ``metadata:`` fields (priority, source, added, status, issue, plan)
-#     are NOT available through _parse_frontmatter's meta return value.
-#   - parse_item_file falls back to fm dict for those fields — but they live
-#     under the nested key, so they are also empty from fm.
-#   - Only ``name`` and ``description`` (top-level flat keys) are accessible.
-#   - Legacy flat frontmatter (no nested metadata block) works correctly.
-#
-# Tests in this file use flat-key frontmatter where they need specific field
-# values. Nested-metadata frontmatter is tested only for title/description,
-# which are the two top-level keys that survive stringification.
+# NOTE: The nested-metadata stringification bug in _parse_frontmatter was
+# fixed in commit 0e0611f.  Tests below that use flat frontmatter were written
+# before the fix; their coverage of flat-key parsing paths remains valid and
+# intentional.
 # ---------------------------------------------------------------------------
 
 # Nested-metadata format (produced by build_backlog_frontmatter) — only name/description accessible

--- a/plan/tasks-16-audit-tests-limitation-patterns.md
+++ b/plan/tasks-16-audit-tests-limitation-patterns.md
@@ -233,7 +233,7 @@ All three tasks have no mutual file conflicts. The full-suite regression check i
 ---
 task: "1"
 title: Update stale limitation comment block in test_backlog_core_parsing.py
-status: NOT STARTED
+status: COMPLETE
 agent: python3-development:python-pytest-architect
 skills:
   - python3-development:fastmcp-python-tests
@@ -317,7 +317,7 @@ why other tests in the file continue to use flat frontmatter.
 ---
 task: "2"
 title: Update four mock docstrings from bug-workaround justification to isolation-pattern justification in test_backlog_core_operations.py
-status: NOT STARTED
+status: COMPLETE
 agent: python3-development:python-pytest-architect
 skills:
   - python3-development:fastmcp-python-tests
@@ -422,7 +422,7 @@ reason for the mock, removing the now-false "pre-existing bug" justification.
 ---
 task: "3"
 title: Observe test state, apply xfail to failing tests, and update module docstring in test_skills_array_bugs.py
-status: NOT STARTED
+status: COMPLETE
 agent: python3-development:python-pytest-architect
 skills:
   - python3-development:fastmcp-python-tests

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "5.12.6",
+  "version": "5.12.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/tests/test_skills_array_bugs.py
+++ b/plugins/plugin-creator/tests/test_skills_array_bugs.py
@@ -1,8 +1,7 @@
-"""Failing tests that reproduce three bugs in plugin-creator validation/sync scripts.
+"""Regression tests for four bugs in plugin-creator validation/sync scripts (issue #335).
 
-Each test documents the DESIRED behaviour (what the code SHOULD do once fixed) and
-is written so it FAILS against the current buggy code.  When the bugs are fixed the
-tests will pass without modification.
+All four bugs are now fixed.  Each test documents the correct behaviour and passes
+against the current code.
 
 Bugs covered
 ------------


### PR DESCRIPTION
## Summary
This PR updates test documentation and comments across multiple test files to reflect the fix of the nested metadata stringification bug in `_parse_frontmatter` (commit 0e0611f). The changes clarify that mocking patterns are now used for test isolation rather than as workarounds for parsing limitations.

## Key Changes

- **test_backlog_core_parsing.py**: Replaced the detailed explanation of the nested metadata stringification bug with a concise note indicating the bug was fixed, while preserving the intentional use of flat frontmatter in tests for valid coverage reasons.

- **test_backlog_core_operations.py**: Updated four test docstrings (`test_list_items_excludes_skip_items`, `test_list_items_with_status_enriches_from_batch_fetch`, `test_close_item_with_open_pr_raises_backlog_error`, `test_resolve_item_with_open_pr_raises_backlog_error`) to reframe mocking as a deliberate isolation pattern rather than a workaround for the now-fixed parsing bug.

- **test_skills_array_bugs.py**: Updated module docstring to reflect that all four bugs are now fixed and the tests pass against current code, changing from a "failing tests documenting desired behavior" framing to a "regression tests for fixed bugs" framing.

- **Version bumps**: Updated marketplace.json and plugin.json versions to reflect the documentation updates.

- **Task tracking**: Marked three completed tasks in tasks-16-audit-tests-limitation-patterns.md as COMPLETE.

## Implementation Details

The changes maintain test validity while improving documentation clarity. No test logic was modified—only comments and docstrings were updated to accurately reflect the current state of the codebase after the parsing bug fix.

https://claude.ai/code/session_01BzTYK9CaNEfKAARc1quHEU