### PR TITLE
Add final commit+push step to complete-implementation workflow

### DIFF
--- a/.claude/rules/local-workflow.md
+++ b/.claude/rules/local-workflow.md
@@ -238,6 +238,7 @@ Phase 3: integration-checker    -> Integration check
 Phase 4: doc-drift-auditor      -> Documentation drift audit (read-only)
 Phase 5: service-docs-maintainer -> Documentation update (if drift found)
 Phase 6: context-refinement     -> Update task file Context Manifest + plan artifact freshness check
+Final:   commit + push          -> Stage and commit all remaining modified files
 ```
 
 ### Agent File Locations
@@ -373,6 +374,10 @@ User
   │    │    └─ No match: create-backlog-item --auto, then backlog update --plan
   │    └─ Gate: same slug AND High priority -> Recurse: /implement-feature + /complete-implementation
   │             otherwise -> Deferred to backlog (no recursion)
+  │
+  ├─ [Final Step: Commit and push remaining changes]
+  │    └─ Stage modified files (task file, backlog items, plan annotations)
+  │       ──> single commit + push
   │
   ▼
 Done

--- a/.claude/skills/complete-implementation/SKILL.md
+++ b/.claude/skills/complete-implementation/SKILL.md
@@ -166,3 +166,15 @@ Log: `Follow-up {followup_path} linked to backlog item "{title}" -- deferred (pr
 Do not recurse. The follow-up is tracked in the backlog and can be picked up later via `/work-backlog-item`.
 
 **Error handling**: If the follow-up file has no `## Priority` section, default to `Medium` (defer). Log: `No priority found in {followup_path}, defaulting to Medium (deferred).`
+
+---
+
+## Final Step: Commit and Push Remaining Changes
+
+After all phases and follow-up routing are complete, check for uncommitted changes. Phases 1-6 and the Recursive Follow-up Handling steps modify files (task file context manifests, backlog item files, plan annotations). Commit any remaining modifications in a single commit and push to the current branch.
+
+```bash
+git status
+```
+
+If there are staged or unstaged changes: stage the modified files, commit with a message summarizing the quality gate results, and push. If the working tree is clean, skip this step.


### PR DESCRIPTION
## Summary

- Added a **Final Step: Commit and Push Remaining Changes** section to the `complete-implementation` SKILL.md so that file modifications from Phase 6 (context refinement) and Recursive Follow-up Handling (backlog item updates) are committed before the workflow exits
- Updated the Phase Sequence and Data Flow Diagram in `local-workflow.md` to reflect this final step

## Problem

After `/complete-implementation` finished, one extra modified file (typically a backlog item file from `backlog.py update --plan`) was left uncommitted in the working tree. The workflow had no explicit final commit step — it relied on ad-hoc commits during intermediate phases.

## Test plan

- [ ] Run `/complete-implementation` on a feature with follow-up task files and verify no uncommitted changes remain after the workflow completes
- [ ] Run `/complete-implementation` on a feature with no follow-ups and verify the final step is a no-op (clean tree, no empty commit)

https://claude.ai/code/session_011dPDR5ciBPcYvbVKbnUBty