### PR TITLE
Refactor close_item and resolve_item APIs with validation changes

### DIFF
--- a/.claude/hooks/validate-delegation.cjs
+++ b/.claude/hooks/validate-delegation.cjs
@@ -66,9 +66,7 @@ function validatePrompt(prompt) {
 
   // Rule 1: must start with the role declaration
   if (!prompt.trimStart().startsWith('Your ROLE_TYPE is sub-agent.')) {
-    violations.push(
-      'Rule 1: Prompt must start with "Your ROLE_TYPE is sub-agent."'
-    );
+    violations.push('Rule 1: Prompt must start with "Your ROLE_TYPE is sub-agent."');
   }
 
   // Rule 2: must contain DEFINITION OF SUCCESS section
@@ -85,10 +83,14 @@ function validatePrompt(prompt) {
   // that look like implementation code (assignments, function calls, imports),
   // flag it as prescribing HOW.
   const fencedBlockPattern = /```[^\n]*\n([\s\S]*?)```/g;
-  let fenceMatch;
-  const implementationLinePattern = /^\s*(const |let |var |import |export |function |class |return |if \(|for \(|\w+\s*=\s*|\w+\.\w+\()/m;
+  const implementationLinePattern =
+    /^\s*(const |let |var |import |export |function |class |return |if \(|for \(|\w+\s*=\s*|\w+\.\w+\()/m;
 
-  while ((fenceMatch = fencedBlockPattern.exec(prompt)) !== null) {
+  for (
+    let fenceMatch = fencedBlockPattern.exec(prompt);
+    fenceMatch !== null;
+    fenceMatch = fencedBlockPattern.exec(prompt)
+  ) {
     const blockBody = fenceMatch[1] ?? '';
     const lines = blockBody.split('\n').filter((l) => l.trim().length > 0);
     const implLines = lines.filter((l) => implementationLinePattern.test(l));
@@ -97,7 +99,7 @@ function validatePrompt(prompt) {
     if (lines.length >= 3 && implLines.length >= Math.ceil(lines.length / 2)) {
       violations.push(
         'Rule 3: Prompt contains implementation code block (prescribes HOW). ' +
-          'Use OBSERVATIONS/CONTEXT constraints instead of code snippets.'
+          'Use OBSERVATIONS/CONTEXT constraints instead of code snippets.',
       );
       break; // one violation is enough
     }
@@ -161,7 +163,7 @@ function main() {
 
   // Exit code 2 blocks the tool call and shows stderr as feedback to Claude
   process.stderr.write(
-    [
+    `${[
       '--- Delegation Template Validation Failed ---',
       '',
       `Agent type: ${subagentType || '(not specified)'}`,
@@ -197,7 +199,7 @@ function main() {
       '',
       'Fix the prompt and retry.',
       '--- End Validation ---',
-    ].join('\n') + '\n'
+    ].join('\n')}\n`,
   );
 
   process.exit(2);

--- a/.claude/skills/backlog/tests/test_backlog_core_operations.py
+++ b/.claude/skills/backlog/tests/test_backlog_core_operations.py
@@ -440,32 +440,32 @@ class TestViewItem:
 
 
 class TestCloseItem:
-    """close_item requires checklist_pass and optionally checks for open PRs."""
+    """close_item requires a valid categorized reason and optionally checks for open PRs."""
 
-    def test_close_item_without_checklist_pass_raises_validation_error(self, mocker: MockerFixture) -> None:
-        """Verify close_item raises ValidationError when checklist_pass=False.
+    def test_close_item_invalid_reason_raises_validation_error(self, mocker: MockerFixture) -> None:
+        """Verify close_item raises ValidationError when reason is not in VALID_CLOSE_REASONS.
 
-        Tests: Checklist gate in close_item.
-        How: Call close_item with checklist_pass=False.
-        Why: Closing without checklist bypasses quality assurance — must be blocked.
+        Tests: Reason validation gate in close_item.
+        How: Call close_item with an invalid reason string.
+        Why: Closing without a categorized reason loses context permanently.
         """
-        with pytest.raises(ValidationError, match="checklist_pass required"):
-            close_item(selector="anything", plan="plan/test.md", checklist_pass=False)
+        with pytest.raises(ValidationError, match="Invalid close reason"):
+            close_item(selector="anything", reason="not-a-valid-reason")
 
     def test_close_item_unknown_selector_raises_item_not_found_error(self, mocker: MockerFixture) -> None:
         """Verify close_item raises ItemNotFoundError when selector matches nothing.
 
         Tests: close_item selector resolution error path.
-        How: Empty backlog; call close_item with checklist_pass=True.
+        How: Empty backlog; call close_item with a valid reason.
         Why: Callers must catch ItemNotFoundError to surface actionable feedback.
         """
         mocker.patch("backlog_core.operations.check_open_prs_for_issue", return_value=[])
 
         with pytest.raises(ItemNotFoundError):
-            close_item(selector="Nonexistent Item", plan="plan/test.md", checklist_pass=True)
+            close_item(selector="Nonexistent Item", reason="superseded")
 
     def test_close_item_happy_path_returns_closed_true(self, mocker: MockerFixture) -> None:
-        """Verify close_item returns closed=True for a valid item with checklist_pass=True.
+        """Verify close_item returns closed=True for a valid item with a valid reason.
 
         Tests: close_item success path.
         How: Write a local item with no issue; call close_item; check closed=True.
@@ -478,7 +478,7 @@ class TestCloseItem:
         mocker.patch("backlog_core.operations.check_open_prs_for_issue", return_value=[])
         mocker.patch("backlog_core.operations.close_github_issue")
 
-        result = close_item(selector="Closeable Item", plan="plan/done.md", checklist_pass=True)
+        result = close_item(selector="Closeable Item", reason="superseded")
 
         assert result["closed"] is True
 
@@ -505,7 +505,7 @@ class TestCloseItem:
         )
 
         with pytest.raises(BacklogError, match="Open PRs"):
-            close_item(selector="PR Blocked Close", plan="plan/done.md", checklist_pass=True, force=False)
+            close_item(selector="PR Blocked Close", reason="superseded", force=False)
 
     def test_close_item_force_bypasses_open_pr_guard(self, mocker: MockerFixture) -> None:
         """Verify close_item with force=True succeeds despite open PRs.
@@ -526,7 +526,7 @@ class TestCloseItem:
         )
         mocker.patch("backlog_core.operations.close_github_issue")
 
-        result = close_item(selector="Force Close Item", plan="plan/done.md", checklist_pass=True, force=True)
+        result = close_item(selector="Force Close Item", reason="superseded", force=True)
 
         assert result["closed"] is True
 
@@ -537,39 +537,39 @@ class TestCloseItem:
 
 
 class TestResolveItem:
-    """resolve_item requires a non-empty reason and validates the selector."""
+    """resolve_item requires a non-empty summary and validates the selector."""
 
-    def test_resolve_item_empty_reason_raises_validation_error(self, mocker: MockerFixture) -> None:
-        """Verify resolve_item raises ValidationError when reason is empty string.
+    def test_resolve_item_empty_summary_raises_validation_error(self, mocker: MockerFixture) -> None:
+        """Verify resolve_item raises ValidationError when summary is empty string.
 
-        Tests: Empty reason guard in resolve_item.
-        How: Call resolve_item with reason="".
-        Why: Resolving without a reason loses context permanently.
+        Tests: Empty summary guard in resolve_item.
+        How: Call resolve_item with summary="".
+        Why: Resolving without a summary loses context permanently.
         """
-        with pytest.raises(ValidationError, match="reason is required"):
-            resolve_item(selector="anything", reason="")
+        with pytest.raises(ValidationError, match="summary is required"):
+            resolve_item(selector="anything", summary="")
 
-    def test_resolve_item_whitespace_reason_raises_validation_error(self, mocker: MockerFixture) -> None:
-        """Verify resolve_item raises ValidationError when reason is whitespace-only.
+    def test_resolve_item_whitespace_summary_raises_validation_error(self, mocker: MockerFixture) -> None:
+        """Verify resolve_item raises ValidationError when summary is whitespace-only.
 
-        Tests: Whitespace reason guard in resolve_item.
-        How: Call resolve_item with reason="   ".
-        Why: Whitespace-only reason is semantically empty — must be rejected.
+        Tests: Whitespace summary guard in resolve_item.
+        How: Call resolve_item with summary="   ".
+        Why: Whitespace-only summary is semantically empty — must be rejected.
         """
-        with pytest.raises(ValidationError, match="reason is required"):
-            resolve_item(selector="anything", reason="   ")
+        with pytest.raises(ValidationError, match="summary is required"):
+            resolve_item(selector="anything", summary="   ")
 
     def test_resolve_item_unknown_selector_raises_item_not_found_error(self, mocker: MockerFixture) -> None:
         """Verify resolve_item raises ItemNotFoundError when selector matches nothing.
 
         Tests: resolve_item selector resolution error path.
-        How: Empty backlog; call resolve_item with a valid reason.
+        How: Empty backlog; call resolve_item with a valid summary.
         Why: Callers must distinguish missing items from validation errors.
         """
         mocker.patch("backlog_core.operations.check_open_prs_for_issue", return_value=[])
 
         with pytest.raises(ItemNotFoundError):
-            resolve_item(selector="Missing Item", reason="No longer needed")
+            resolve_item(selector="Missing Item", summary="No longer needed")
 
     def test_resolve_item_happy_path_returns_resolved_true(self, mocker: MockerFixture) -> None:
         """Verify resolve_item returns resolved=True for a valid item with a reason.
@@ -585,7 +585,7 @@ class TestResolveItem:
         mocker.patch("backlog_core.operations.check_open_prs_for_issue", return_value=[])
         mocker.patch("backlog_core.operations.resolve_github_issue")
 
-        result = resolve_item(selector="Resolvable Item", reason="Superseded by new approach")
+        result = resolve_item(selector="Resolvable Item", summary="Superseded by new approach")
 
         assert result["resolved"] is True
 
@@ -611,7 +611,7 @@ class TestResolveItem:
         )
 
         with pytest.raises(BacklogError, match="Open PRs"):
-            resolve_item(selector="PR Blocked Resolve", reason="Superseded", force=False)
+            resolve_item(selector="PR Blocked Resolve", summary="Superseded", force=False)
 
     def test_resolve_item_force_bypasses_open_pr_guard(self, mocker: MockerFixture) -> None:
         """Verify resolve_item with force=True succeeds despite open PRs.
@@ -632,7 +632,7 @@ class TestResolveItem:
         )
         mocker.patch("backlog_core.operations.resolve_github_issue")
 
-        result = resolve_item(selector="Force Resolve Item", reason="Superseded by different effort", force=True)
+        result = resolve_item(selector="Force Resolve Item", summary="Superseded by different effort", force=True)
 
         assert result["resolved"] is True
 

--- a/plugins/dasel/.claude-plugin/plugin.json
+++ b/plugins/dasel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dasel",
-  "version": "1.64.4",
+  "version": "1.64.5",
   "description": "Query, transform, and convert structured data files (JSON, YAML, TOML, XML, CSV, HCL, INI) using dasel v3. Provides reference syntax, exploration workflows, transformation patterns, and cross-platform installation.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/dasel/hooks/session-start-dasel-check.cjs
+++ b/plugins/dasel/hooks/session-start-dasel-check.cjs
@@ -36,9 +36,11 @@ function checkDasel() {
   }
 }
 
-let input = '';
+let _input = '';
 process.stdin.setEncoding('utf8');
-process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('data', (chunk) => {
+  _input += chunk;
+});
 process.stdin.on('end', () => {
   const result = checkDasel();
   process.stdout.write(


### PR DESCRIPTION
## Summary
This PR updates the `close_item` and `resolve_item` function signatures and their corresponding test suite to use more semantically appropriate parameters and validation logic.

## Key Changes

### API Signature Updates
- **close_item**: Replaced `checklist_pass` boolean parameter with `reason` parameter that validates against `VALID_CLOSE_REASONS`
  - Removes the plan parameter from function calls
  - Changes validation from a simple boolean gate to categorical reason validation
  
- **resolve_item**: Renamed `reason` parameter to `summary` for clarity
  - Better reflects the semantic purpose of capturing resolution context

### Test Suite Updates
- Updated `TestCloseItem` class:
  - Renamed `test_close_item_without_checklist_pass_raises_validation_error` to `test_close_item_invalid_reason_raises_validation_error`
  - Updated test logic to validate against `VALID_CLOSE_REASONS` instead of boolean flag
  - Updated all test calls to use `reason="superseded"` instead of `checklist_pass=True` and plan parameter
  - Updated docstrings to reflect reason-based validation

- Updated `TestResolveItem` class:
  - Renamed all references from `reason` to `summary` parameter
  - Updated test names and docstrings accordingly
  - Updated all function calls to use `summary=` instead of `reason=`

### Code Quality Improvements
- Fixed formatting in `.claude/hooks/validate-delegation.cjs`:
  - Converted `while` loop to `for` loop for better readability
  - Improved string concatenation formatting
  - Fixed template literal formatting

- Fixed variable naming in `plugins/dasel/hooks/session-start-dasel-check.cjs`:
  - Renamed unused `input` variable to `_input` to indicate intentional non-use

- Bumped dasel plugin version from 1.64.4 to 1.64.5

## Notable Details
The changes improve API clarity by using domain-specific parameter names (`reason` for close reasons, `summary` for resolution summaries) and enforce stricter validation through categorical reason checking rather than simple boolean gates.

https://claude.ai/code/session_01CCaT5KZgxWYvvU9z95xgnU