### PR TITLE
fix(ci): resolve Biome lint errors blocking PR #423

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "5.0.38"
+    "version": "5.0.39"
   },
   "plugins": [
     {

--- a/.claude/hooks/run-commands-try-all.cjs
+++ b/.claude/hooks/run-commands-try-all.cjs
@@ -54,7 +54,9 @@ function runCommand(cmd, index) {
 
 const commands = getCommands();
 if (commands.length === 0) {
-  process.stderr.write('run-commands-try-all: no commands (pass as argv or stdin {"commands": [...]})\n');
+  process.stderr.write(
+    'run-commands-try-all: no commands (pass as argv or stdin {"commands": [...]})\n',
+  );
   process.exit(0);
 }
 

--- a/plugins/orchestrator-discipline/.claude-plugin/plugin.json
+++ b/plugins/orchestrator-discipline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrator-discipline",
   "description": "Enforces orchestrator context window discipline via PreToolUse hooks and rules. Prevents the orchestrator from reading source files it will not edit, running diagnostic commands that should be delegated, and bypassing delegation with 'small change' rationalizations. Install to structurally prevent investigation escalation anti-patterns.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/orchestrator-discipline/hooks/pre-tool-orchestrator-read-warning.cjs
+++ b/plugins/orchestrator-discipline/hooks/pre-tool-orchestrator-read-warning.cjs
@@ -83,9 +83,8 @@ process.stdin.on('end', () => {
     shouldWarn = isSourceOrConfigFile(targetPath);
   } else if (toolName === 'Grep') {
     targetPath = toolInput.path || '';
-    shouldWarn = isSourceOrConfigFile(targetPath)
-              || isDirectory(targetPath)
-              || looksLikeDirectory(targetPath);
+    shouldWarn =
+      isSourceOrConfigFile(targetPath) || isDirectory(targetPath) || looksLikeDirectory(targetPath);
   } else {
     process.stdout.write(JSON.stringify({}));
     process.exit(0);

--- a/plugins/orchestrator-discipline/hooks/prevent-bash-tool-misuse.cjs
+++ b/plugins/orchestrator-discipline/hooks/prevent-bash-tool-misuse.cjs
@@ -35,49 +35,56 @@ const VIOLATIONS = [
     // Standalone grep at start of command — not as pipeline step
     pattern: /^\s*grep\b/,
     redirect: 'Grep',
-    message: 'Use the Grep tool instead of Bash grep. Reason: built-in tools handle encoding and permissions correctly.',
+    message:
+      'Use the Grep tool instead of Bash grep. Reason: built-in tools handle encoding and permissions correctly.',
     example: 'Grep(pattern="...", path="...")',
   },
   {
     // find with -name
     pattern: /\bfind\b\s+\S+\s+-name\b/,
     redirect: 'Glob',
-    message: 'Use the Glob tool instead of Bash find. Reason: built-in tools handle gitignore and permissions correctly.',
+    message:
+      'Use the Glob tool instead of Bash find. Reason: built-in tools handle gitignore and permissions correctly.',
     example: 'Glob(pattern="**/*.ts")',
   },
   {
     // ls at start of command (not in pipeline, not ls -la for human consumption)
     pattern: /^\s*ls\b(?!\s+-la\s*$)/,
     redirect: 'Glob',
-    message: 'Use the Glob tool instead of Bash ls. Reason: built-in tools handle encoding and permissions correctly.',
+    message:
+      'Use the Glob tool instead of Bash ls. Reason: built-in tools handle encoding and permissions correctly.',
     example: 'Glob(pattern="*", path="/some/dir")',
   },
   {
     // cat a file (not cat /dev/stdin, not cat | something)
-    pattern: /^\s*cat\s+[^\|]+\.\w+\s*$/,
+    pattern: /^\s*cat\s+[^|]+\.\w+\s*$/,
     redirect: 'Read',
-    message: 'Use the Read tool instead of Bash cat. Reason: built-in tools handle encoding, large files, and binary detection.',
+    message:
+      'Use the Read tool instead of Bash cat. Reason: built-in tools handle encoding, large files, and binary detection.',
     example: 'Read(file_path="/path/to/file")',
   },
   {
     // sed -n 'N,Mp' for reading a range — use Read with offset/limit
     pattern: /^\s*sed\s+-n\s+['"]?\d+,\d+p['"]?/,
     redirect: 'Read',
-    message: 'Use the Read tool with offset and limit instead of sed -n. Reason: Read handles encoding correctly and is more expressive.',
+    message:
+      'Use the Read tool with offset and limit instead of sed -n. Reason: Read handles encoding correctly and is more expressive.',
     example: 'Read(file_path="/path/to/file", offset=10, limit=20)',
   },
   {
     // head -N (reading first N lines)
     pattern: /^\s*head\s+-\d+/,
     redirect: 'Read',
-    message: 'Use the Read tool with limit instead of head. Reason: built-in tools handle encoding and large files correctly.',
+    message:
+      'Use the Read tool with limit instead of head. Reason: built-in tools handle encoding and large files correctly.',
     example: 'Read(file_path="/path/to/file", limit=20)',
   },
   {
     // tail -N (reading last N lines) — use Read with offset
     pattern: /^\s*tail\s+-\d+\s+\S+\.\w+\s*$/,
     redirect: 'Read',
-    message: 'Use the Read tool with offset instead of tail. Reason: built-in tools handle encoding and large files correctly.',
+    message:
+      'Use the Read tool with offset instead of tail. Reason: built-in tools handle encoding and large files correctly.',
     example: 'Read(file_path="/path/to/file", offset=-20)',
   },
 ];
@@ -87,15 +94,15 @@ const VIOLATIONS = [
  * These are pipeline contexts where the bash command is necessary.
  */
 const LEGITIMATE_PATTERNS = [
-  /git\s.*\|\s*grep/,          // git log | grep, git diff | grep
-  /\|\s*grep/,                  // any pipeline ... | grep
-  /grep.*\|\s/,                 // grep as pipeline source with another step
-  /uv run.*\|\s*(head|tail)/,   // uv run output piped to head/tail
-  /gh\s.*\|\s*(grep|head)/,     // gh CLI output piped
-  /npm\s.*\|\s*(grep|head)/,    // npm output piped
-  /cat\s+\/dev\/(stdin|null)/,  // cat /dev/stdin or /dev/null
-  /cat\s+-/,                    // cat - (stdin)
-  /ls\s+-la\s*$/,               // ls -la for human-readable directory listing
+  /git\s.*\|\s*grep/, // git log | grep, git diff | grep
+  /\|\s*grep/, // any pipeline ... | grep
+  /grep.*\|\s/, // grep as pipeline source with another step
+  /uv run.*\|\s*(head|tail)/, // uv run output piped to head/tail
+  /gh\s.*\|\s*(grep|head)/, // gh CLI output piped
+  /npm\s.*\|\s*(grep|head)/, // npm output piped
+  /cat\s+\/dev\/(stdin|null)/, // cat /dev/stdin or /dev/null
+  /cat\s+-/, // cat - (stdin)
+  /ls\s+-la\s*$/, // ls -la for human-readable directory listing
 ];
 
 function main() {
@@ -132,7 +139,7 @@ function main() {
   for (const v of VIOLATIONS) {
     if (v.pattern.test(cmd)) {
       process.stderr.write(
-        [
+        `${[
           '--- Bash Tool Misuse Prevented ---',
           '',
           `Command: ${cmd.trim()}`,
@@ -143,7 +150,7 @@ function main() {
           '',
           'Rule source: orchestrator-discipline plugin — Bash Built-In Tool Enforcement',
           '--- End ---',
-        ].join('\n') + '\n'
+        ].join('\n')}\n`,
       );
       process.exit(2);
     }

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/skills/agent-capability-analyzer/scripts/populate-agent-descriptions.mjs
+++ b/plugins/plugin-creator/skills/agent-capability-analyzer/scripts/populate-agent-descriptions.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * populate-agent-descriptions.mjs
  *
@@ -9,9 +10,9 @@
  *   node populate-agent-descriptions.mjs
  */
 
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve, dirname } from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -192,9 +193,7 @@ function resolveLatestVersion(pluginDir) {
   if (hasSemver) {
     // Filter to only semver entries, then pick highest
     const semverEntries = entries.filter((e) => semverRe.test(e));
-    return semverEntries.reduce((best, cur) =>
-      compareVersions(cur, best) > 0 ? cur : best,
-    );
+    return semverEntries.reduce((best, cur) => (compareVersions(cur, best) > 0 ? cur : best));
   }
 
   // Hash-based: pick by most recent mtime
@@ -271,46 +270,46 @@ function buildAgentList() {
   // ── User agents ─────────────────────────────────────────────────────────────
   /** @type {Array<{ key: string, file: string }>} */
   const userAgents = [
-    { key: 'c-systems-programmer',       file: 'c-systems-programmer.md' },
-    { key: 'code-refactorer-agent',       file: 'refactor-agent.md' },
-    { key: 'code-review',                 file: 'code-review.md' },
-    { key: 'comprehensive-researcher',    file: 'comprehensive-researcher.md' },
-    { key: 'context-gathering',           file: 'context-gathering.md' },
-    { key: 'context-refinement',          file: 'context-refinement.md' },
-    { key: 'doc-drift-auditor',           file: 'doc-drift-auditor.md' },
-    { key: 'doc-freshness-guardian',      file: 'doc-freshness-guardian.md' },
-    { key: 'documentation-expert',        file: 'documentation-expert.md' },
-    { key: 'embedded-dev-specialist',     file: 'embedded-dev-specialist.md' },
-    { key: 'github-project-manager',      file: 'github-project-manager.md' },
-    { key: 'gitlab-docs-expert',          file: 'gitlab-docs-expert.md' },
-    { key: 'gsd-codebase-mapper',         file: 'gsd-codebase-mapper.md' },
-    { key: 'gsd-debugger',                file: 'gsd-debugger.md' },
-    { key: 'gsd-executor',                file: 'gsd-executor.md' },
-    { key: 'gsd-integration-checker',     file: 'gsd-integration-checker.md' },
-    { key: 'gsd-phase-researcher',        file: 'gsd-phase-researcher.md' },
-    { key: 'gsd-plan-checker',            file: 'gsd-plan-checker.md' },
-    { key: 'gsd-planner',                 file: 'gsd-planner.md' },
-    { key: 'gsd-project-researcher',      file: 'gsd-project-researcher.md' },
-    { key: 'gsd-research-synthesizer',    file: 'gsd-research-synthesizer.md' },
-    { key: 'gsd-roadmapper',              file: 'gsd-roadmapper.md' },
-    { key: 'gsd-verifier',                file: 'gsd-verifier.md' },
+    { key: 'c-systems-programmer', file: 'c-systems-programmer.md' },
+    { key: 'code-refactorer-agent', file: 'refactor-agent.md' },
+    { key: 'code-review', file: 'code-review.md' },
+    { key: 'comprehensive-researcher', file: 'comprehensive-researcher.md' },
+    { key: 'context-gathering', file: 'context-gathering.md' },
+    { key: 'context-refinement', file: 'context-refinement.md' },
+    { key: 'doc-drift-auditor', file: 'doc-drift-auditor.md' },
+    { key: 'doc-freshness-guardian', file: 'doc-freshness-guardian.md' },
+    { key: 'documentation-expert', file: 'documentation-expert.md' },
+    { key: 'embedded-dev-specialist', file: 'embedded-dev-specialist.md' },
+    { key: 'github-project-manager', file: 'github-project-manager.md' },
+    { key: 'gitlab-docs-expert', file: 'gitlab-docs-expert.md' },
+    { key: 'gsd-codebase-mapper', file: 'gsd-codebase-mapper.md' },
+    { key: 'gsd-debugger', file: 'gsd-debugger.md' },
+    { key: 'gsd-executor', file: 'gsd-executor.md' },
+    { key: 'gsd-integration-checker', file: 'gsd-integration-checker.md' },
+    { key: 'gsd-phase-researcher', file: 'gsd-phase-researcher.md' },
+    { key: 'gsd-plan-checker', file: 'gsd-plan-checker.md' },
+    { key: 'gsd-planner', file: 'gsd-planner.md' },
+    { key: 'gsd-project-researcher', file: 'gsd-project-researcher.md' },
+    { key: 'gsd-research-synthesizer', file: 'gsd-research-synthesizer.md' },
+    { key: 'gsd-roadmapper', file: 'gsd-roadmapper.md' },
+    { key: 'gsd-verifier', file: 'gsd-verifier.md' },
     { key: 'live-api-integration-tester', file: 'live-api-integration-tester.md' },
-    { key: 'logging',                     file: 'logging.md' },
-    { key: 'metadata-vault-manager',      file: 'metadata-vault-manager.md' },
-    { key: 'qa-devops-lead',              file: 'qa-devops-lead.md' },
-    { key: 'service-documentation',       file: 'service-documentation.md' },
-    { key: 'spec-analyst',                file: 'spec-analyst.md' },
-    { key: 'spec-developer',              file: 'spec-developer.md' },
-    { key: 'spec-orchestrator',           file: 'spec-orchestrator.md' },
-    { key: 'spec-reviewer',               file: 'spec-reviewer.md' },
-    { key: 'spec-tester',                 file: 'spec-tester.md' },
-    { key: 'spec-validator',              file: 'spec-validator.md' },
-    { key: 'subagent-generator',          file: 'subagent-generator.md' },
-    { key: 'subagent-refactorer',         file: 'subagent-refactorer.md' },
-    { key: 'system-architect',            file: 'system-architect.md' },
-    { key: 'technical-researcher',        file: 'technical-researcher.md' },
-    { key: 'test-architect',              file: 'test-architect.md' },
-    { key: 'test-quality-auditor',        file: 'test-quality-auditor.md' },
+    { key: 'logging', file: 'logging.md' },
+    { key: 'metadata-vault-manager', file: 'metadata-vault-manager.md' },
+    { key: 'qa-devops-lead', file: 'qa-devops-lead.md' },
+    { key: 'service-documentation', file: 'service-documentation.md' },
+    { key: 'spec-analyst', file: 'spec-analyst.md' },
+    { key: 'spec-developer', file: 'spec-developer.md' },
+    { key: 'spec-orchestrator', file: 'spec-orchestrator.md' },
+    { key: 'spec-reviewer', file: 'spec-reviewer.md' },
+    { key: 'spec-tester', file: 'spec-tester.md' },
+    { key: 'spec-validator', file: 'spec-validator.md' },
+    { key: 'subagent-generator', file: 'subagent-generator.md' },
+    { key: 'subagent-refactorer', file: 'subagent-refactorer.md' },
+    { key: 'system-architect', file: 'system-architect.md' },
+    { key: 'technical-researcher', file: 'technical-researcher.md' },
+    { key: 'test-architect', file: 'test-architect.md' },
+    { key: 'test-quality-auditor', file: 'test-quality-auditor.md' },
     { key: 'trace-protocol-investigator', file: 'trace-protocol-investigator.md' },
   ];
 
@@ -321,20 +320,20 @@ function buildAgentList() {
   // ── Project agents (shadow user agents with same key) ───────────────────────
   /** @type {Array<{ key: string, file: string }>} */
   const projectAgents = [
-    { key: 'backlog-item-groomer',  file: 'backlog-item-groomer.md' },
-    { key: 'c-systems-programmer',  file: 'c-systems-programmer.md' },
-    { key: 'code-review',           file: 'code-review.md' },
-    { key: 'context-gathering',     file: 'context-gathering.md' },
-    { key: 'context-refinement',    file: 'context-refinement.md' },
-    { key: 'fact-checker',          file: 'fact-checker.md' },
-    { key: 'javascript-pro',        file: 'javascript-pro.md' },
-    { key: 'logging',               file: 'logging.md' },
-    { key: 'plugin-docs-writer',    file: 'plugin-docs-writer.md' },
-    { key: 'process-siren',         file: 'process-siren.md' },
+    { key: 'backlog-item-groomer', file: 'backlog-item-groomer.md' },
+    { key: 'c-systems-programmer', file: 'c-systems-programmer.md' },
+    { key: 'code-review', file: 'code-review.md' },
+    { key: 'context-gathering', file: 'context-gathering.md' },
+    { key: 'context-refinement', file: 'context-refinement.md' },
+    { key: 'fact-checker', file: 'fact-checker.md' },
+    { key: 'javascript-pro', file: 'javascript-pro.md' },
+    { key: 'logging', file: 'logging.md' },
+    { key: 'plugin-docs-writer', file: 'plugin-docs-writer.md' },
+    { key: 'process-siren', file: 'process-siren.md' },
     { key: 'research-context-agent', file: 'research-context-agent.md' },
-    { key: 'research-curator',      file: 'research-curator.md' },
-    { key: 'topic-specialist',      file: 'topic-specialist.md' },
-    { key: 'typescript-pro',        file: 'typescript-pro.md' },
+    { key: 'research-curator', file: 'research-curator.md' },
+    { key: 'topic-specialist', file: 'topic-specialist.md' },
+    { key: 'typescript-pro', file: 'typescript-pro.md' },
   ];
 
   for (const { key, file } of projectAgents) {
@@ -686,9 +685,7 @@ for (const { key, filePath } of agents) {
   const description = readDescription(filePath);
 
   if (description === null || description === '') {
-    process.stderr.write(
-      `WARN: Skipping "${key}" — no description found in ${filePath}\n`,
-    );
+    process.stderr.write(`WARN: Skipping "${key}" — no description found in ${filePath}\n`);
     skipped++;
     continue;
   }
@@ -698,9 +695,7 @@ for (const { key, filePath } of agents) {
     process.stdout.write(`OK  ${key}\n`);
     populated++;
   } catch (err) {
-    process.stderr.write(
-      `WARN: Skipping "${key}" — update-agent-map failed: ${err.message}\n`,
-    );
+    process.stderr.write(`WARN: Skipping "${key}" — update-agent-map failed: ${err.message}\n`);
     skipped++;
   }
 }

--- a/plugins/plugin-creator/skills/agent-capability-analyzer/scripts/update-agent-map.mjs
+++ b/plugins/plugin-creator/skills/agent-capability-analyzer/scripts/update-agent-map.mjs
@@ -98,8 +98,12 @@ async function runWrite(parsed) {
     // raw === undefined means key is absent — keep defaults
 
     const merged = {
-      capabilities: flags.has('capabilities') ? (flags.get('capabilities') ?? null) : existing.capabilities,
-      description: flags.has('description') ? (flags.get('description') ?? null) : existing.description,
+      capabilities: flags.has('capabilities')
+        ? (flags.get('capabilities') ?? null)
+        : existing.capabilities,
+      description: flags.has('description')
+        ? (flags.get('description') ?? null)
+        : existing.description,
     };
 
     await db.put(name, JSON.stringify(merged));
@@ -165,7 +169,7 @@ async function runDump(parsed) {
   const merged = { ...existingJson, ...dbEntries };
   const entryCount = Object.keys(dbEntries).length;
 
-  writeFileSync(resolvedPath, JSON.stringify(merged, null, 2) + '\n', 'utf8');
+  writeFileSync(resolvedPath, `${JSON.stringify(merged, null, 2)}\n`, 'utf8');
   process.stdout.write(`Dumped agent-map.db to ${resolvedPath} (${entryCount} entries)\n`);
 }
 


### PR DESCRIPTION
## Summary
- Fix `lint/style/useTemplate` errors in `prevent-bash-tool-misuse.cjs` and `update-agent-map.mjs` — replaced string concatenation (`+ '\n'`) with template literals
- Apply Biome auto-formatting fixes (trailing commas, quote consistency) across 3 additional JS/CJS/MJS files that were also failing the Biome check

These were pre-existing lint issues on `main` that caused the Biome CI check (and therefore Quality Gate) to fail on PR #423.

## Files changed
- `.claude/hooks/run-commands-try-all.cjs` — formatting
- `plugins/orchestrator-discipline/hooks/pre-tool-orchestrator-read-warning.cjs` — formatting
- `plugins/orchestrator-discipline/hooks/prevent-bash-tool-misuse.cjs` — useTemplate fix + formatting
- `plugins/plugin-creator/skills/agent-capability-analyzer/scripts/populate-agent-descriptions.mjs` — formatting
- `plugins/plugin-creator/skills/agent-capability-analyzer/scripts/update-agent-map.mjs` — useTemplate fix

## Test plan
- [x] `uv run prek run biome-check --all-files` passes
- [x] Full `uv run prek run --all-files` passes (all 24 hooks)

https://claude.ai/code/session_01Lq6vv4eE7jXmPCdHVRtVKR