### PR TITLE
Add octocode MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -31,6 +31,10 @@
     "backlog": {
       "command": "uv",
       "args": ["run", "python", "-m", "backlog_core.server"]
+    },
+    "octocode": {
+      "command": "npx",
+      "args": ["-y", "octocode-mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
## Summary
Added configuration for the octocode MCP (Model Context Protocol) server to the MCP tools configuration file.

## Changes
- Added a new `octocode` server entry to the MCP configuration
- Configured to run via `npx` with the `octocode-mcp@latest` package
- Uses the `-y` flag to automatically confirm prompts during execution

## Details
This enables the octocode MCP server as an available tool alongside the existing backlog server, allowing it to be invoked through the MCP framework.

https://claude.ai/code/session_01LRq2LM2i9sR8ZoYW68kQFD