### PR TITLE
feat(backlog): state_handler.py — 8-state lifecycle DAG and atomic GitHub label management

### DIFF
--- a/.claude/skills/backlog/references/state-machine.md
+++ b/.claude/skills/backlog/references/state-machine.md
@@ -159,7 +159,7 @@ This is the only transition into `closed`. No other skill sets this status.
 
 ## GitHub Label Taxonomy
 
-Labels correspond to states 1:1. The backlog script manages label transitions — do not set labels with `gh label` directly.
+Labels correspond to states 1:1. The backlog script manages label transitions — do not set labels with `gh label` directly. Use `state_handler.apply_github_transition()` for all label changes.
 
 ```
 status:needs-grooming   — item created, awaiting grooming
@@ -171,6 +171,12 @@ status:done             — implementation complete, AC verified
 status:resolved         — closed without full implementation
 status:closed           — terminal: milestone archived by complete-milestone
 ```
+
+### Reconciliation: `status:needs-review`
+
+`status:needs-review` exists in `labels.md` and `github_project_setup.py` but is **not** part of the 8-state lifecycle above. It has no defined entry or exit transitions in this document.
+
+**Decision**: Retained in the label taxonomy for backwards compatibility (PRs may use it for code review workflows), but backlog commands MUST NOT set it during state transitions. It is not a backlog lifecycle state. Do not add it to the state machine DAG.
 
 Priority labels (orthogonal to status):
 

--- a/.claude/skills/backlog/scripts/backlog.py
+++ b/.claude/skills/backlog/scripts/backlog.py
@@ -27,6 +27,7 @@ Usage:
     backlog update <selector> [--plan PATH] [--status in-progress] [--create-issue]
     backlog groom <selector> [--groomed-content "..." | --groomed-file PATH | --section X --content "..." | stdin]
     backlog normalize  # one-off: rewrite per-item files to research-style metadata, remove body duplication
+    backlog migrate-status [--dry-run]  # migrate items with 'open' status to valid state-machine states
     backlog pull [--dry-run] [--force]  # pull issue bodies from GitHub into local files
 
 Environment:
@@ -65,12 +66,14 @@ from rich.table import Table
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _SCRIPT_DIR.parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "plugins" / "plugin-creator" / "scripts"))
+sys.path.insert(0, str(_SCRIPT_DIR))
 
 import operator
 
 import frontmatter
 
 from frontmatter_utils import dump_frontmatter, loads_frontmatter
+from state_handler import BacklogState, StateTransitionError, apply_github_transition
 
 if TYPE_CHECKING:
     from github.Issue import Issue
@@ -1221,9 +1224,13 @@ def _close_github_issue(issue_ref: str, reason: str, reference: str, comment: st
         if comment:
             parts.append(f"\n{comment}")
         issue.create_comment(" ".join(parts))
+        current_status = next(
+            (lbl.name.removeprefix("status:") for lbl in issue.labels if lbl.name.startswith("status:")), None
+        )
+        apply_github_transition(repository, issue, current_status, BacklogState.CLOSED.value)
         issue.edit(state="closed")
         typer.echo(f"  GitHub issue #{num} closed ({reason}).")
-    except GithubException as e:
+    except (GithubException, StateTransitionError) as e:
         typer.echo(f"  WARNING: Could not close issue: {e}", err=True)
 
 
@@ -1328,9 +1335,13 @@ def _resolve_github_issue(
         if findings:
             body_parts.append(f"\n### Findings\n\n{findings}")
         issue.create_comment("\n".join(body_parts))
+        current_status = next(
+            (lbl.name.removeprefix("status:") for lbl in issue.labels if lbl.name.startswith("status:")), None
+        )
+        apply_github_transition(repository, issue, current_status, BacklogState.DONE.value)
         issue.edit(state="closed")
         typer.echo(f"  GitHub issue #{num} resolved.")
-    except GithubException as e:
+    except (GithubException, StateTransitionError) as e:
         typer.echo(f"  WARNING: Could not close issue: {e}", err=True)
 
 
@@ -1605,6 +1616,7 @@ def _write_groomed_to_item_file(filepath: Path, groomed_content: str, section_na
         if isinstance(meta_block, dict):
             updated = dict(meta_block)
             updated["groomed"] = today
+            updated["status"] = BacklogState.GROOMED.value
             post.metadata["metadata"] = updated
         else:
             post.metadata["groomed"] = today
@@ -1743,9 +1755,8 @@ def _write_groomed_to_github(issue_ref: str, content: str, section_name: str | N
             typer.echo(f"  Synced to GitHub issue {issue_ref}")
             try:
                 issue = repository.get_issue(num)
-                if any(label.name == "status:needs-grooming" for label in issue.labels):
-                    issue.remove_from_labels("status:needs-grooming")
-            except GithubException as e:
+                apply_github_transition(repository, issue, "needs-grooming", "groomed")
+            except (GithubException, StateTransitionError) as e:
                 typer.echo(f"  WARNING: Could not update grooming label: {e}", err=True)
         else:
             typer.echo(f"  No changes to sync to GitHub issue {issue_ref}")
@@ -1753,20 +1764,17 @@ def _write_groomed_to_github(issue_ref: str, content: str, section_name: str | N
 
 
 def _apply_status_in_progress(item: dict, repo: str) -> None:
-    """Set GitHub issue label to status:in-progress."""
+    """Set GitHub issue label to status:in-progress via state handler."""
     try:
         repository = _get_github(repo)
         num = item.get("_issue", "").lstrip("#")
         issue = repository.get_issue(int(num))
-        labels = [label.name for label in issue.labels]
-        if "status:in-progress" not in labels:
-            lbl = repository.get_label("status:in-progress")
-            issue.add_to_labels(lbl)
-            if "status:needs-grooming" in labels:
-                ng = repository.get_label("status:needs-grooming")
-                issue.remove_from_labels(ng)
+        current_status = next(
+            (lbl.name.removeprefix("status:") for lbl in issue.labels if lbl.name.startswith("status:")), None
+        )
+        apply_github_transition(repository, issue, current_status, BacklogState.IN_PROGRESS.value)
         typer.echo("  Status: in-progress")
-    except GithubException as e:
+    except (GithubException, StateTransitionError) as e:
         typer.echo(f"  WARNING: Could not set status: {e}", err=True)
 
 
@@ -2099,6 +2107,92 @@ def _normalize_item_file(filepath: Path, dry_run: bool) -> bool:
     if not dry_run:
         filepath.write_text(content, encoding="utf-8")
     return True
+
+
+def _infer_correct_status(filepath: Path) -> str:
+    """Infer the correct state-machine status for a backlog item whose local status is 'open'.
+
+    Decision rules (applied in priority order):
+    1. If metadata.status is already a valid state-machine value — return it unchanged.
+    2. If metadata.groomed is set (non-empty) — item has been groomed → 'groomed'.
+    3. Otherwise — item not yet groomed → 'needs-grooming'.
+
+    Returns:
+        A valid BacklogState value string.
+    """
+    valid_states = {s.value for s in BacklogState}
+    try:
+        text = filepath.read_text(encoding="utf-8")
+        post = loads_frontmatter(text)
+        fm = post.metadata or {}
+        meta_raw = fm.get("metadata", {})
+        meta: dict = dict(meta_raw) if isinstance(meta_raw, dict) else {}
+        status = str(meta.get("status") or fm.get("status") or "open").strip()
+        if status in valid_states:
+            return status
+        # 'open' or any other legacy value — derive from groomed field
+        groomed = str(meta.get("groomed") or fm.get("groomed") or "").strip()
+        if groomed:
+            return BacklogState.GROOMED.value
+    except (OSError, ValueError, KeyError, TypeError):
+        pass
+    return BacklogState.NEEDS_GROOMING.value
+
+
+@app.command(name="migrate-status")
+def migrate_status(
+    dry_run: Annotated[bool, typer.Option("--dry-run")] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
+) -> None:
+    """Migrate local per-item files with status 'open' to valid state-machine states.
+
+    Rule: items with a groomed date → 'groomed'; items without → 'needs-grooming'.
+
+    Does not touch GitHub labels (run 'backlog sync' afterwards to sync labels).
+    Use --dry-run to preview changes without writing files.
+    """
+    if not BACKLOG_DIR.exists():
+        typer.echo(f"ERROR: {BACKLOG_DIR} not found", err=True)
+        raise typer.Exit(1)
+
+    valid_states = {s.value for s in BacklogState}
+    pattern = re.compile(r"^(p0|p1|p2|idea|ideas|completed)-[a-z0-9-]+\.md$", re.IGNORECASE)
+    files = sorted(f for f in BACKLOG_DIR.glob("*.md") if pattern.match(f.name))
+
+    migrated = skipped = already_valid = 0
+    for filepath in files:
+        try:
+            text = filepath.read_text(encoding="utf-8")
+            if not text.startswith("---"):
+                continue
+            post = loads_frontmatter(text)
+            fm = post.metadata or {}
+            meta_raw = fm.get("metadata", {})
+            meta: dict = dict(meta_raw) if isinstance(meta_raw, dict) else {}
+            current = str(meta.get("status") or fm.get("status") or "open").strip()
+            if current in valid_states:
+                already_valid += 1
+                if verbose:
+                    typer.echo(f"  {filepath.name}: already {current!r}")
+                continue
+            # 'open' or other unknown value — needs migration
+            new_status = _infer_correct_status(filepath)
+            if dry_run:
+                typer.echo(f"  [dry-run] {filepath.name}: {current!r} → {new_status!r}")
+            else:
+                _update_item_metadata(filepath, {"metadata": {"status": new_status}})
+                typer.echo(f"  {filepath.name}: {current!r} → {new_status!r}")
+            migrated += 1
+        except (OSError, ValueError, KeyError, TypeError) as e:
+            typer.echo(f"  Skip {filepath.name}: {e}", err=True)
+            skipped += 1
+
+    action = "Would migrate" if dry_run else "Migrated"
+    typer.echo(f"\n{action} {migrated} item(s) to valid states. Already valid: {already_valid}. Skipped: {skipped}.")
+    if dry_run and migrated:
+        typer.echo("Re-run without --dry-run to apply changes.")
+    if migrated and not dry_run:
+        typer.echo("Run 'backlog sync' to push updated labels to GitHub.")
 
 
 @app.command()

--- a/.claude/skills/backlog/scripts/state_handler.py
+++ b/.claude/skills/backlog/scripts/state_handler.py
@@ -1,0 +1,177 @@
+"""Backlog item state machine — transition validation and atomic GitHub label updates.
+
+Implements the 8-state lifecycle defined in
+.claude/skills/backlog/references/state-machine.md.
+
+Valid states: needs-grooming, groomed, blocked, in-milestone, in-progress,
+              done, resolved, closed
+
+Usage
+-----
+Validation only (no I/O):
+
+    from state_handler import validate_transition, StateTransitionError
+
+    try:
+        validate_transition("needs-grooming", "groomed")
+    except StateTransitionError as e:
+        print(f"Invalid: {e}")
+
+GitHub label update (requires PyGithub repo + issue objects):
+
+    from state_handler import apply_github_transition
+
+    apply_github_transition(repo, issue, from_state="needs-grooming", to_state="groomed")
+
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+try:
+    from github import GithubException  # type: ignore[import-untyped]
+except ImportError:
+    GithubException = Exception  # type: ignore[misc,assignment]
+
+
+class BacklogState(StrEnum):
+    """The 8 canonical backlog item lifecycle states."""
+
+    NEEDS_GROOMING = "needs-grooming"
+    GROOMED = "groomed"
+    BLOCKED = "blocked"
+    IN_MILESTONE = "in-milestone"
+    IN_PROGRESS = "in-progress"
+    DONE = "done"
+    RESOLVED = "resolved"
+    CLOSED = "closed"
+
+
+# Valid transitions as a DAG: {from_state: frozenset(valid_to_states)}
+# Source: .claude/skills/backlog/references/state-machine.md
+VALID_TRANSITIONS: dict[BacklogState, frozenset[BacklogState]] = {
+    BacklogState.NEEDS_GROOMING: frozenset({BacklogState.GROOMED, BacklogState.BLOCKED, BacklogState.RESOLVED}),
+    BacklogState.GROOMED: frozenset({BacklogState.IN_MILESTONE, BacklogState.RESOLVED}),
+    BacklogState.BLOCKED: frozenset({BacklogState.NEEDS_GROOMING, BacklogState.RESOLVED}),
+    BacklogState.IN_MILESTONE: frozenset({BacklogState.IN_PROGRESS, BacklogState.GROOMED, BacklogState.RESOLVED}),
+    BacklogState.IN_PROGRESS: frozenset({BacklogState.DONE, BacklogState.RESOLVED, BacklogState.BLOCKED}),
+    BacklogState.DONE: frozenset({BacklogState.CLOSED}),
+    BacklogState.RESOLVED: frozenset({BacklogState.CLOSED}),
+    BacklogState.CLOSED: frozenset(),  # terminal state
+}
+
+# Color palette for auto-creating missing GitHub labels.
+# Hex without leading '#'.
+_STATE_LABEL_COLORS: dict[str, str] = {
+    "needs-grooming": "FEF2C0",
+    "groomed": "C2E0C6",
+    "blocked": "B60205",
+    "in-milestone": "BFD4F2",
+    "in-progress": "1D76DB",
+    "done": "0E8A16",
+    "resolved": "6B737B",
+    "closed": "EDEDED",
+}
+
+
+class StateTransitionError(Exception):
+    """Raised when an invalid state transition is attempted."""
+
+
+def validate_transition(from_state: str, to_state: str) -> None:
+    """Validate a state transition against the DAG.
+
+    Args:
+        from_state: Current state value (e.g., "needs-grooming").
+        to_state: Target state value (e.g., "groomed").
+
+    Raises:
+        StateTransitionError: If from_state or to_state are unknown, or if
+            the transition from_state → to_state is not in the DAG.
+
+    Note:
+        This function is pure (no I/O). It never touches GitHub or the filesystem.
+    """
+    valid_values = [s.value for s in BacklogState]
+
+    try:
+        from_s = BacklogState(from_state)
+    except ValueError:
+        raise StateTransitionError(f"Unknown source state: {from_state!r}. Valid states: {valid_values}") from None
+
+    try:
+        to_s = BacklogState(to_state)
+    except ValueError:
+        raise StateTransitionError(f"Unknown target state: {to_state!r}. Valid states: {valid_values}") from None
+
+    allowed = VALID_TRANSITIONS.get(from_s, frozenset())
+    if to_s not in allowed:
+        valid_targets = sorted(s.value for s in allowed) if allowed else []
+        raise StateTransitionError(
+            f"Invalid transition: {from_state!r} \u2192 {to_state!r}. "
+            f"Allowed targets from {from_state!r}: "
+            f"{valid_targets or ['none (terminal state)']}"
+        )
+
+
+def _ensure_label_exists(repo: Any, label_name: str) -> Any:  # noqa: ANN401
+    """Fetch a GitHub label, creating it with a default color if absent.
+
+    Args:
+        repo: PyGithub Repository object.
+        label_name: Full label name, e.g., ``"status:groomed"``.
+
+    Returns:
+        PyGithub Label object.
+    """
+    try:
+        return repo.get_label(label_name)
+    except GithubException:
+        state_name = label_name.removeprefix("status:")
+        color = _STATE_LABEL_COLORS.get(state_name, "EDEDED")
+        description = f"Backlog item state: {state_name}"
+        return repo.create_label(name=label_name, color=color, description=description)
+
+
+def apply_github_transition(repo: Any, issue: Any, from_state: str | None, to_state: str) -> None:  # noqa: ANN401
+    """Remove the old ``status:*`` label and add the new one on a GitHub issue.
+
+    The new label is auto-created on the repo if it does not yet exist.
+
+    Args:
+        repo: PyGithub Repository object.
+        issue: PyGithub Issue object.
+        from_state: State to remove (``"needs-grooming"`` → removes
+            ``"status:needs-grooming"``). Pass ``None`` to remove ALL
+            existing ``status:*`` labels (use when prior state is unknown).
+        to_state: Target state to add (``"groomed"`` → adds ``"status:groomed"``).
+
+    Raises:
+        StateTransitionError: On GitHub API failure.
+    """
+    try:
+        current_labels = [lbl.name for lbl in issue.labels]
+
+        # Remove old status label(s)
+        if from_state:
+            old_label_name = f"status:{from_state}"
+            if old_label_name in current_labels:
+                issue.remove_from_labels(old_label_name)
+        else:
+            # Prior state unknown — remove ALL status: labels to avoid orphaned labels
+            for lbl_name in current_labels:
+                if lbl_name.startswith("status:"):
+                    issue.remove_from_labels(lbl_name)
+
+        # Add new status label (auto-create if missing)
+        new_label_name = f"status:{to_state}"
+        # Re-fetch current labels after removal
+        refreshed_labels = [lbl.name for lbl in issue.labels]
+        if new_label_name not in refreshed_labels:
+            lbl = _ensure_label_exists(repo, new_label_name)
+            issue.add_to_labels(lbl)
+
+    except GithubException as exc:
+        raise StateTransitionError(f"Could not update GitHub labels for issue #{issue.number}: {exc}") from exc

--- a/.claude/skills/gh/references/labels.md
+++ b/.claude/skills/gh/references/labels.md
@@ -35,12 +35,22 @@ Three axes: **priority**, **type**, **status**.
 
 ### Status Labels
 
+All 8 lifecycle states from the backlog state machine (`.claude/skills/backlog/references/state-machine.md`) have corresponding labels.
+
 | Label | Color | Description |
 |-------|-------|-------------|
-| `status:in-progress` | `#1D76DB` | Actively being worked |
-| `status:blocked` | `#B60205` | Waiting on external dependency |
 | `status:needs-grooming` | `#FEF2C0` | Captured but not yet groomed |
-| `status:needs-review` | `#D876E3` | Implementation done, needs review |
+| `status:groomed` | `#C2E0C6` | Grooming complete, RT-ICA APPROVED |
+| `status:blocked` | `#B60205` | RT-ICA BLOCKED or AC verification FAIL |
+| `status:in-milestone` | `#BFD4F2` | Assigned to an active milestone |
+| `status:in-progress` | `#1D76DB` | Actively being worked |
+| `status:done` | `#0E8A16` | Implementation complete, AC verified PASS |
+| `status:resolved` | `#6B737B` | Closed without full implementation (obsolete/superseded) |
+| `status:closed` | `#EDEDED` | Terminal — milestone archived by complete-milestone |
+
+> Note: `status:needs-review` was previously in this taxonomy but is not part of the
+> state machine lifecycle. It has been retained in `github_project_setup.py` for
+> backwards compatibility but should not be applied by backlog commands.
 
 ---
 

--- a/.claude/skills/gh/scripts/github_project_setup.py
+++ b/.claude/skills/gh/scripts/github_project_setup.py
@@ -67,11 +67,16 @@ LABELS: list[dict[str, str]] = [
     {"name": "type:refactor", "color": "5319E7", "description": "Internal improvement, no behavior change"},
     {"name": "type:docs", "color": "0075CA", "description": "Documentation only"},
     {"name": "type:chore", "color": "EDEDED", "description": "Maintenance, tooling, CI"},
-    # Status
-    {"name": "status:in-progress", "color": "1D76DB", "description": "Actively being worked on"},
-    {"name": "status:done", "color": "0E8A16", "description": "Work complete, milestone closing"},
-    {"name": "status:blocked", "color": "B60205", "description": "Waiting on external dependency"},
+    # Status (all 8 state-machine states + legacy needs-review)
     {"name": "status:needs-grooming", "color": "FEF2C0", "description": "Captured but not yet groomed"},
+    {"name": "status:groomed", "color": "C2E0C6", "description": "Grooming complete, RT-ICA APPROVED"},
+    {"name": "status:blocked", "color": "B60205", "description": "RT-ICA BLOCKED or AC verification FAIL"},
+    {"name": "status:in-milestone", "color": "BFD4F2", "description": "Assigned to an active milestone"},
+    {"name": "status:in-progress", "color": "1D76DB", "description": "Actively being worked on"},
+    {"name": "status:done", "color": "0E8A16", "description": "Implementation complete, AC verified PASS"},
+    {"name": "status:resolved", "color": "6B737B", "description": "Closed without full implementation"},
+    {"name": "status:closed", "color": "EDEDED", "description": "Terminal — milestone archived"},
+    # Legacy label retained for backwards compatibility — not part of state machine
     {"name": "status:needs-review", "color": "D876E3", "description": "Implementation done, needs review"},
 ]
 


### PR DESCRIPTION
## Summary

- Adds `state_handler.py`: `BacklogState(StrEnum)` enum, `VALID_TRANSITIONS` DAG, `validate_transition()`, `_ensure_label_exists()`, and `apply_github_transition()` for atomic `status:*` label swaps
- Integrates `state_handler` into `backlog.py`: grooming, in-progress, close, and resolve paths all route through `apply_github_transition`
- Adds `migrate-status` CLI command to migrate legacy `open` status → `groomed` or `needs-grooming` based on groomed-date heuristic
- Expands `labels.md` and `github_project_setup.py` to declare all 8 lifecycle status labels
- Documents `status:needs-review` reconciliation in `state-machine.md` (retained for PR workflow, not a backlog lifecycle state)

## Test plan

- [ ] `uv run prek run --files .claude/skills/backlog/scripts/state_handler.py .claude/skills/backlog/scripts/backlog.py` passes all checks
- [ ] `validate_transition("needs-grooming", "groomed")` succeeds; `validate_transition("done", "in-progress")` raises `StateTransitionError`
- [ ] `apply_github_transition` removes old `status:*` label and adds new one on a real issue
- [ ] `uv run .claude/skills/backlog/scripts/backlog.py migrate-status --dry-run` lists items with legacy status without modifying files

Fixes #426

https://claude.ai/code/session_01EfKrzFY6gmxpnNhAZi3fpW