### PR TITLE
Add claim-task command to atomically transition tasks to in-progress

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "5.3.6"
+    "version": "5.3.7"
   },
   "plugins": [
     {

--- a/.claude/docs/TASK_FILE_FORMAT.md
+++ b/.claude/docs/TASK_FILE_FORMAT.md
@@ -174,16 +174,61 @@ Report:
 
 ## Authorized Writers
 
-Only designated scripts should write or update task data files. Direct edits by agents or
-humans should be confined to the markdown body — never the YAML frontmatter — unless performing
-a deliberate manual migration.
+Task metadata fields are owned by specific components. Only the designated component for
+a field may write that field. No other component (including LLM agents acting via Edit
+tool calls) may write lifecycle fields (`status`, `started`, `completed`, `last_activity`) except
+through the designated path.
 
-| Script | Purpose | Path |
-|--------|---------|------|
-| `implementation_manager.py` | Read-only status queries, ready-tasks, and task file parsing | `plugins/python3-development/skills/implementation-manager/scripts/implementation_manager.py` |
-| `task_status_hook.py` | Timestamp and status updates from hooks | `plugins/python3-development/skills/implementation-manager/scripts/task_status_hook.py` |
-| `split_task_file.py` | Splits monolithic task files into per-task files | `plugins/python3-development/scripts/split_task_file.py` |
-| `migrate_task_format.py` | Converts legacy markdown to YAML frontmatter | `plugins/python3-development/scripts/migrate_task_format.py` |
+This prevents the following observed failure modes:
+
+- Dual-dispatch (two agents claiming the same task)
+- Overwritten `started` timestamps on agent retry
+- `last_activity` updates written to completed tasks
+
+The table below lists every writeable field, its authorized writer, and the trigger that
+fires the write.
+
+| Field | Authorized Writer | Trigger | Guard | Notes |
+|-------|-----------------|---------|-------|-------|
+| `status: not-started` | `swarm-task-planner` agent (file creation) | Task file generation | N/A — initial write only | Set once at file creation. Never written again by any component. |
+| `status: in-progress` | `implementation_manager.py claim-task` | `start-task` skill step 3 (agent invokes CLI) | Read-check-write: refuses if current status is not `not-started` | Agent must NOT write this field directly via Edit tool. |
+| `status: complete` | `task_status_hook.py` SubagentStop handler | Claude Code `SubagentStop` hook event | None — SubagentStop fires once per sub-agent | May also be written by `start-task` `--complete` path; hook overwrites with later timestamp. |
+| `status: blocked` | Human operator or `start-task` agent | Manual intervention or acceptance criteria failure | None | Agent may set this when blocked on external dependency. |
+| `started` | `implementation_manager.py claim-task` | Same as `status: in-progress` | Conditional: written only if field is absent. Existing value preserved on retry. | Preserving the original timestamp maintains accurate audit trail on agent retry. |
+| `completed` | `task_status_hook.py` SubagentStop handler | Claude Code `SubagentStop` hook event | None | Also writable by `start-task --complete` path; hook overwrites. |
+| `last_activity` | `task_status_hook.py` PostToolUse handler | Claude Code `PostToolUse` hook (Write, Edit, Bash tools) | Added guard: skip write if task status is `complete` | Prevents stale activity stamps on completed tasks (Gap 4). |
+| `divergence-notes` (count) | `start-task` skill (agent direct write via Edit) | Agent detects implementation divergence from architect spec | None | Appended integer count. Body content (`## Divergence Notes`) is also agent-written. |
+| `task`, `title`, `agent`, `dependencies`, `priority`, `complexity`, `created`, `skills`, `issue-classification`, `scenario-target`, `analysis-method` | `swarm-task-planner` agent (file creation) | Task file generation | N/A — set at creation | These fields describe task intent and scheduling. No lifecycle component writes them after creation. |
+
+### Field Ownership Rules
+
+1. `status: in-progress` and `started` are written ONLY by `implementation_manager.py claim-task`.
+   LLM agents in the `start-task` skill must invoke `claim-task` via `uv run` and check exit code.
+   Direct Edit of these fields by agents is an architectural violation.
+
+2. `status: complete` and `completed` are written ONLY by `task_status_hook.py` SubagentStop handler.
+   The `start-task --complete` path also writes these fields as a convenience, but the hook
+   always overwrites them at SubagentStop time. If both paths fire, the hook timestamp wins.
+
+3. `last_activity` is written ONLY by `task_status_hook.py` PostToolUse handler, and only when
+   the task status is not `complete`. Writing `last_activity` to a completed task is a no-op.
+
+4. `divergence-notes` (count) and the `## Divergence Notes` body section are written ONLY by the
+   executing agent via the `start-task` skill. These are not lifecycle fields.
+
+5. All other fields (`task`, `title`, `agent`, `dependencies`, `priority`, `complexity`, `created`, `skills`,
+   and analytical metadata fields) are written ONCE at task file creation by `swarm-task-planner`.
+   No component modifies them after creation.
+
+### Scripts
+
+| Script | Role | Writes |
+|--------|------|--------|
+| `implementation_manager.py` | CLI for status queries AND `claim-task` | `status: in-progress`, `started` (via `claim-task` only) |
+| `task_status_hook.py` | Hook handler for Claude Code events | `status: complete`, `completed`, `last_activity` |
+| `swarm-task-planner` (agent) | Task file generator | All fields at creation |
+| `split_task_file.py` | Structural: splits monolithic task files into per-task files | Full frontmatter (preserved from source, not lifecycle transition) |
+| `migrate_task_format.py` | Structural: converts legacy markdown to YAML frontmatter | Full frontmatter (format migration, not lifecycle transition) |
 
 Task data files MUST contain raw YAML frontmatter starting with `---`. Agents generating task
 files SHOULD produce content matching this format directly. When the generator is an LLM agent

--- a/.claude/plan/test-coverage-gaps.md
+++ b/.claude/plan/test-coverage-gaps.md
@@ -1,5 +1,17 @@
 # Test Coverage Gaps
 
+## Gap: implementation_manager.py — claim-task command and helpers
+
+**Files**: `plugins/python3-development/skills/implementation-manager/scripts/implementation_manager.py`, `plugins/python3-development/skills/implementation-manager/scripts/task_format.py`
+**Behavior to cover**:
+- `claim_task` command: success path (not-started → in-progress), already-in-progress rejection, task-not-found rejection, write-error path
+- `_try_claim_part`: single-frontmatter file (part starts with `---`), multi-frontmatter file (part without leading `---`), non-matching task ID
+- `_apply_claim_to_content`: single-frontmatter file, multi-frontmatter file, task-not-found returns None, preserves existing `started` field
+- `_find_task_section_in_file`: single-frontmatter file, multi-frontmatter file, task-not-found returns None
+- `_resolve_task_status`: parse-error path, task-not-found for multi-frontmatter
+- `normalize_status` in `task_format.py`: already-normalized inputs (in-progress, not-started) pass through without mapping to not-started
+**Reason not written**: Scope constraint — task T1.1 covers implementation only; test authoring is a separate task in the SAM plan.
+
 ## Gap: plugin_validator.py — PR005 command-is-skill-directory check
 
 **Files**: `plugins/plugin-creator/scripts/plugin_validator.py`

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -78,15 +78,46 @@ For monolithic files (multiple tasks), find the specific task section.
    - **Redundancy note**: The orchestrator (`/implement-feature`) may also include skill-loading instructions in the delegation prompt. This direct reading from task metadata is intentional redundancy -- it ensures skills are loaded even when `/start-task` is invoked manually or by an older orchestrator that does not pass skill-loading instructions. Loading a skill twice is a no-op.
    - Task-level skills are **additive** to any skills already declared in the agent definition's frontmatter. They supplement, not replace, agent-level skills.
 
-3. Update the task status:
+3. Claim the task (prevents duplicate dispatch):
 
-   **If YAML frontmatter format:**
-   - Edit the `status:` field in frontmatter to `in-progress`
-   - Add `started: {ISO timestamp}` field to frontmatter
+   Run the claim-task command. This is the ONLY permitted way to mark a task in-progress.
+   Do NOT edit status or started fields directly with the Edit tool.
 
-   **If inline markdown format:**
-   - Set `**Status**: 🔄 IN PROGRESS`
-   - Add `**Started**: {ISO timestamp}`
+   Resolve the implementation_manager.py script path:
+
+   ```bash
+   IMPL_MGR="plugins/python3-development/skills/implementation-manager/scripts/implementation_manager.py"
+   ```
+
+   Run claim-task:
+
+   ```bash
+   CLAIM_RESULT=$(uv run "$IMPL_MGR" claim-task "{task_file_path}" "{task_id}")
+   CLAIM_EXIT=$?
+   ```
+
+   Print the result:
+
+   ```bash
+   echo "$CLAIM_RESULT"
+   ```
+
+   If exit code is non-zero (`CLAIM_EXIT != 0`):
+
+   - The task was already claimed by another agent, or is complete, or could not be found.
+   - Output the full JSON result for the orchestrator.
+   - STOP. Do not proceed with implementation. Do not write the context file.
+   - The orchestrator's hook will detect the stop and the task remains in its current state.
+
+   If exit code is 0 (`CLAIM_EXIT == 0`):
+
+   - The task is claimed. `status: in-progress` and `started:` are written on disk.
+   - Proceed to step 4 (write context file) and step 5 (implement).
+
+   If the task file uses legacy inline markdown format (not YAML frontmatter):
+
+   - Emit a warning: `Task {id} is in legacy markdown format. Run migrate_task_format.py before executing.`
+   - STOP. Do not proceed with implementation.
 
 4. Write the active-task context file (required for hook-driven updates):
 

--- a/plan/tasks-24-enforce-single-authority-task-state.md
+++ b/plan/tasks-24-enforce-single-authority-task-state.md
@@ -23,7 +23,7 @@ tasks:
 
 task: "1.1"
 title: "Add claim-task command and update get_ready_tasks docstring in implementation_manager.py"
-status: not-started
+status: complete
 agent: python3-development:python-cli-architect
 dependencies: []
 priority: 1
@@ -35,6 +35,8 @@ parallelize-with: ["1.2"]
 reason: "Task 1.2 writes only task_status_hook.py; task 1.1 writes only implementation_manager.py. No file conflict."
 handoff: "Report: diff of implementation_manager.py showing new claim_task function and updated get_ready_tasks docstring; output of `uv run implementation_manager.py claim-task --help`; any blocking issues."
 
+started: "2026-03-06T05:50:30Z"
+completed: "2026-03-06T05:51:00Z"
 ---
 
 ## Context
@@ -170,7 +172,7 @@ Add `claim-task` as a new Typer command to `implementation_manager.py` and updat
 
 task: "1.2"
 title: "Add last_activity guard to task_status_hook.py handle_activity_update"
-status: not-started
+status: complete
 agent: python3-development:python-cli-architect
 dependencies: []
 priority: 1
@@ -182,6 +184,8 @@ parallelize-with: ["1.1"]
 reason: "Task 1.1 writes only implementation_manager.py; task 1.2 writes only task_status_hook.py. No file conflict."
 handoff: "Report: exact lines changed in task_status_hook.py; confirmation that handle_subagent_stop is unchanged; linting result."
 
+started: "2026-03-06T05:50:46Z"
+completed: "2026-03-06T05:51:00Z"
 ---
 
 ## Context
@@ -258,7 +262,7 @@ Add a status check in `handle_activity_update()` that skips writing `last_activi
 
 task: "2.1"
 title: "Replace step 3 in start-task SKILL.md with claim-task invocation"
-status: not-started
+status: complete
 agent: general-purpose
 dependencies: ["1.1"]
 priority: 2
@@ -269,6 +273,8 @@ parallelize-with: ["2.2"]
 reason: "Task 2.1 writes only .claude/skills/start-task/SKILL.md; task 2.2 writes only .claude/docs/TASK_FILE_FORMAT.md. No file conflict. Both depend on 1.1 being complete (claim-task must exist before the skill references it)."
 handoff: "Report: diff of SKILL.md showing step 3 replacement; confirmation that all other steps are unchanged; linting result."
 
+started: "2026-03-06T05:55:20Z"
+completed: "2026-03-06T05:55:20Z"
 ---
 
 ## Context
@@ -396,7 +402,7 @@ Replace the current step 3 in `.claude/skills/start-task/SKILL.md` with the `cla
 
 task: "2.2"
 title: "Replace Authorized Writers section in TASK_FILE_FORMAT.md"
-status: not-started
+status: complete
 agent: general-purpose
 dependencies: ["1.1"]
 priority: 2
@@ -407,6 +413,8 @@ parallelize-with: ["2.1"]
 reason: "Task 2.2 writes only .claude/docs/TASK_FILE_FORMAT.md; task 2.1 writes only .claude/skills/start-task/SKILL.md. No file conflict. Both depend on 1.1 being complete (claim-task must exist before it is documented as a writer)."
 handoff: "Report: confirmation that Authorized Writers section is replaced and all other sections unchanged; linting result."
 
+started: "2026-03-06T05:55:20Z"
+completed: "2026-03-06T05:55:20Z"
 ---
 
 ## Context
@@ -471,7 +479,7 @@ Replace the entire "Authorized Writers" section in `.claude/docs/TASK_FILE_FORMA
 
 task: "3.1"
 title: "Verification — smoke-test claim-task command end-to-end"
-status: not-started
+status: complete
 agent: python3-development:python-cli-architect
 dependencies: ["1.1", "1.2", "2.1", "2.2"]
 priority: 3
@@ -483,6 +491,8 @@ parallelize-with: []
 reason: "Terminal verification task; no parallelization."
 handoff: "Report: output of each verification command; pass/fail per acceptance criterion; any failures with exact error text."
 
+started: "2026-03-06T05:58:34Z"
+completed: "2026-03-06T05:58:34Z"
 ---
 
 ## Context

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/skills/implementation-manager/scripts/implementation_manager.py
+++ b/plugins/python3-development/skills/implementation-manager/scripts/implementation_manager.py
@@ -23,9 +23,10 @@ import json
 import re
 import sys
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import IntEnum, StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, TypedDict
+from typing import Annotated, TypedDict
 
 import typer
 from rich.console import Console
@@ -34,10 +35,13 @@ from rich.console import Console
 # Ensure the script directory is on sys.path for direct execution.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from task_format import VALID_STATUSES, has_yaml_frontmatter, normalize_status, parse_yaml_frontmatter
-
-if TYPE_CHECKING:
-    import datetime
+from task_format import (
+    VALID_STATUSES,
+    has_yaml_frontmatter,
+    normalize_status,
+    parse_yaml_frontmatter,
+    update_yaml_field,
+)
 
 app = typer.Typer(
     name="implementation-manager", help="Query and manage feature implementation task status.", no_args_is_help=True
@@ -298,7 +302,7 @@ def _parse_yaml_status(raw_status: str) -> TaskStatus:
     return TaskStatus.NOT_STARTED
 
 
-def _coerce_timestamp(value: str | datetime.datetime | None) -> str | None:
+def _coerce_timestamp(value: str | datetime | None) -> str | None:
     """Coerce a YAML timestamp value to an ISO 8601 string or None.
 
     PyYAML automatically parses ISO 8601 timestamps into datetime objects.
@@ -727,6 +731,12 @@ def find_task_file_by_slug(project_path: Path, slug: str) -> Path | None:
 def get_ready_tasks(tasks: list[Task]) -> list[Task]:
     """Get tasks that are ready for execution.
 
+    Returns tasks whose status is NOT_STARTED at the time of the snapshot.
+    This list is advisory: status may change between this query and task dispatch.
+    Callers MUST invoke claim-task before beginning task execution to atomically
+    mark the task in-progress. If claim-task returns claimed=false, discard the
+    task from the dispatch queue without error.
+
     A task is ready when:
     1. Status is NOT_STARTED
     2. All dependencies are terminal (COMPLETE, DEFERRED, or SKIPPED)
@@ -921,6 +931,268 @@ def validate(project_path: ProjectPath, feature_slug: FeatureSlug) -> None:
 
     if errors:
         raise typer.Exit(1)
+
+
+def _find_task_section_in_file(content: str, task_id: str) -> tuple[int, int] | None:
+    r"""Locate the byte offsets of the frontmatter block for a given task_id.
+
+    Splits content on ``\\n---\\n`` boundaries and searches each candidate
+    section for a frontmatter block that contains ``task: {task_id}``.
+
+    Args:
+        content: Full file content, potentially containing multiple frontmatter blocks.
+        task_id: Task ID to find (e.g., "T1", "1.1").
+
+    Returns:
+        Tuple of (start, end) character offsets for the entire section
+        (including its ``---\\n`` prefix and ``\\n---\\n`` suffix), or None
+        if no matching section is found.
+    """
+    # Split on "\n---\n" to get candidate sections.
+    # The file starts with "---\n" so parts[0] is empty.
+    separator = "\n---\n"
+    parts = content.split(separator)
+
+    # Reconstruct offsets for each part.
+    offset = 0
+    for part in parts:
+        # The part content is everything between separators.
+        # Reconstruct what the original slice looks like.
+        part_start = offset
+        part_end = offset + len(part)
+
+        # Only consider sections that look like standalone YAML blocks
+        # (i.e., start with a key: value line, not a comment or blank line).
+        stripped = part.strip()
+        if stripped and not stripped.startswith("#") and not stripped.startswith("<!--"):
+            # If the part already starts with "---" it is a self-contained
+            # frontmatter block (first section of a standard single-frontmatter
+            # file).  Wrap only parts that lack their own opening delimiter.
+            if part.startswith(("---\n", "---\r\n")):
+                candidate_content = part if part.endswith("\n---\n") else f"{part}\n---\n"
+            else:
+                candidate_content = f"---\n{part}\n---\n"
+            if has_yaml_frontmatter(candidate_content):
+                try:
+                    fm, _ = parse_yaml_frontmatter(candidate_content)
+                    raw_task_id = fm.get("task")
+                    if raw_task_id is not None and str(raw_task_id) == task_id:
+                        return (part_start, part_end)
+                except (ValueError, TypeError):
+                    pass
+
+        # Advance offset past this part + the separator.
+        offset = part_end + len(separator)
+
+    return None
+
+
+def _resolve_write_target(task_file_path: Path, task_id: str) -> tuple[Path, str] | None:
+    """Resolve the write target file and its content for a given task_id.
+
+    For directory-based task files, locates the individual ``.md`` file
+    containing the task. For single-file task files with multiple frontmatter
+    blocks, returns the single file.
+
+    Args:
+        task_file_path: Path to the task file or directory.
+        task_id: Task ID to locate.
+
+    Returns:
+        Tuple of (write_target_path, file_content) if the task is found,
+        or None if no file containing the task is found.
+    """
+    if task_file_path.is_dir():
+        # Directory: scan individual .md files for the matching task.
+        for md_file in sorted(task_file_path.glob("*.md")):
+            if not md_file.is_file():
+                continue
+            file_content = md_file.read_text(encoding="utf-8")
+            parsed = parse_task_content(file_content)
+            for task in parsed:
+                if task.id == task_id:
+                    return (md_file, file_content)
+        return None
+
+    # Single file: read once, locate the section containing task_id.
+    file_content = task_file_path.read_text(encoding="utf-8")
+    return (task_file_path, file_content)
+
+
+def _try_claim_part(part: str, task_id: str, timestamp: str) -> str | None:
+    r"""Try to claim task_id in a single frontmatter part.
+
+    Args:
+        part: One section split from the file on ``\\n---\\n``.
+        task_id: Task ID to match.
+        timestamp: UTC ISO 8601 timestamp for the ``started`` field.
+
+    Returns:
+        Updated part string if task_id matched, else None.
+    """
+    if part.startswith(("---\n", "---\r\n")):
+        candidate = part if part.endswith("\n---\n") else f"{part}\n---\n"
+        prefix_len = 0
+    else:
+        candidate = f"---\n{part}\n---\n"
+        prefix_len = len("---\n")
+    if not has_yaml_frontmatter(candidate):
+        return None
+    try:
+        fm, _ = parse_yaml_frontmatter(candidate)
+    except (ValueError, TypeError):
+        return None
+    if fm.get("task") is None or str(fm["task"]) != task_id:
+        return None
+    updated = update_yaml_field(candidate, "status", "in-progress")
+    if fm.get("started") is None:
+        updated = update_yaml_field(updated, "started", timestamp)
+    return updated[prefix_len : -len("\n---\n")]
+
+
+def _apply_claim_to_content(content: str, task_id: str, timestamp: str) -> str | None:
+    """Apply status and started fields to the section matching task_id.
+
+    For a single-task file (one frontmatter block), updates the block in place.
+    For a multi-task file (multiple frontmatter blocks), locates and updates
+    only the block matching task_id.
+
+    Args:
+        content: Full file content.
+        task_id: Task ID whose frontmatter should be updated.
+        timestamp: UTC ISO 8601 timestamp for the ``started`` field.
+
+    Returns:
+        Updated file content string, or None if task_id was not found.
+    """
+    separator = "\n---\n"
+    parts = content.split(separator)
+    updated_parts: list[str] = []
+    found = False
+
+    for part in parts:
+        stripped = part.strip()
+        if not found and stripped and not stripped.startswith("#") and not stripped.startswith("<!--"):
+            claimed = _try_claim_part(part, task_id, timestamp)
+            if claimed is not None:
+                updated_parts.append(claimed)
+                found = True
+                continue
+        updated_parts.append(part)
+
+    if not found:
+        return None
+
+    return separator.join(updated_parts)
+
+
+def _claim_fail(payload: dict[str, object], exc: BaseException | None = None) -> None:
+    """Emit JSON error to stdout and stderr then exit 1.
+
+    Args:
+        payload: Dict to serialize as JSON.
+        exc: Optional chained exception for ``raise ... from``.
+    """
+    msg = json.dumps(payload)
+    print(msg)
+    sys.stderr.write(msg + "\n")
+    raise typer.Exit(1) from exc
+
+
+def _resolve_task_status(file_content: str, task_id: str, task_file_str: str) -> Task:
+    """Parse the task matching task_id and return it, or exit 1.
+
+    Args:
+        file_content: Full text of the task file.
+        task_id: Task ID to locate.
+        task_file_str: File path string for error payloads.
+
+    Returns:
+        Matching Task object with ``status`` populated.
+    """
+    try:
+        tasks = parse_task_content(file_content)
+        if not tasks:
+            section_result = _find_task_section_in_file(file_content, task_id)
+            if section_result is None:
+                _claim_fail({
+                    "claimed": False,
+                    "task_id": task_id,
+                    "reason": "task-not-found",
+                    "task_file": task_file_str,
+                })
+            start_idx, end_idx = section_result  # type: ignore[misc]
+            tasks = parse_task_content(f"---\n{file_content[start_idx:end_idx]}\n---\n")
+        matching_task = next((t for t in tasks if t.id == task_id), None)
+    except (ValueError, TypeError) as exc:
+        _claim_fail(
+            {
+                "claimed": False,
+                "task_id": task_id,
+                "reason": "parse-error",
+                "error": str(exc),
+                "task_file": task_file_str,
+            },
+            exc,
+        )
+        return None  # type: ignore[return-value]  # unreachable
+
+    if matching_task is None:
+        _claim_fail({"claimed": False, "task_id": task_id, "reason": "task-not-found", "task_file": task_file_str})
+    return matching_task  # type: ignore[return-value]
+
+
+@app.command(name="claim-task")
+def claim_task(
+    task_file_path: Annotated[
+        Path, typer.Argument(help="Path to the task file or directory.", exists=True, resolve_path=True)
+    ],
+    task_id: Annotated[str, typer.Argument(help="Task ID to claim (e.g., T1, 1.1).")],
+) -> None:
+    """Claim a task by atomically transitioning it from not-started to in-progress.
+
+    Performs a read-check-write sequence: reads the task file, verifies the
+    task status is ``not-started``, writes ``status: in-progress`` and
+    ``started: <timestamp>``, then exits 0 with JSON output on success.
+
+    Exits 1 with ``claimed: false`` JSON when the task is not found, already
+    claimed, or the file cannot be parsed or written.
+
+    Args:
+        task_file_path: Path to the task file (``.md``) or task directory.
+        task_id: Task identifier to claim (e.g., ``T1``, ``1.1``).
+    """
+    task_file_str = str(task_file_path)
+    timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    resolved = _resolve_write_target(task_file_path, task_id)
+    if resolved is None:
+        _claim_fail({"claimed": False, "task_id": task_id, "reason": "task-not-found", "task_file": task_file_str})
+
+    write_target, file_content = resolved  # type: ignore[misc]
+    matching_task = _resolve_task_status(file_content, task_id, task_file_str)
+
+    if matching_task.status != TaskStatus.NOT_STARTED:
+        current_status_str = normalize_status(matching_task.status.value)
+        _claim_fail({
+            "claimed": False,
+            "task_id": task_id,
+            "reason": f"already-{current_status_str}",
+            "current_status": current_status_str,
+            "task_file": task_file_str,
+        })
+
+    updated_content = _apply_claim_to_content(file_content, task_id, timestamp)
+    if updated_content is None:
+        _claim_fail({"claimed": False, "task_id": task_id, "reason": "task-not-found", "task_file": task_file_str})
+
+    try:
+        write_target.write_text(updated_content, encoding="utf-8")  # type: ignore[union-attr]
+    except OSError as exc:
+        _claim_fail({"claimed": False, "reason": "write-error", "error": str(exc), "task_file": task_file_str}, exc)
+
+    print(json.dumps({"claimed": True, "task_id": task_id, "started": timestamp, "task_file": task_file_str}))
+    raise typer.Exit(0)
 
 
 if __name__ == "__main__":

--- a/plugins/python3-development/skills/implementation-manager/scripts/task_format.py
+++ b/plugins/python3-development/skills/implementation-manager/scripts/task_format.py
@@ -262,6 +262,10 @@ def normalize_status(old_status: str) -> str:
     """
     status_clean = old_status.strip()
 
+    # Fast path: already a valid normalized status (e.g. "in-progress", "not-started")
+    if status_clean in VALID_STATUSES:
+        return status_clean
+
     # Remove common Unicode emoji characters
     status_clean = (
         status_clean

--- a/plugins/python3-development/skills/implementation-manager/scripts/task_status_hook.py
+++ b/plugins/python3-development/skills/implementation-manager/scripts/task_status_hook.py
@@ -477,6 +477,17 @@ def handle_activity_update(hook_input: dict[str, Any]) -> None:
         sys.exit(0)
 
     resolved_path, content = resolved
+
+    # Guard: skip silently if task is already complete
+    if has_yaml_frontmatter(content):
+        try:
+            frontmatter, _ = parse_yaml_frontmatter(content)
+            current_status = normalize_status(str(frontmatter.get("status", "")))
+            if current_status == "complete":
+                return
+        except (ValueError, TypeError):
+            pass
+
     timestamp = get_iso_timestamp()
 
     try:


### PR DESCRIPTION
## Summary

Implements the `claim-task` command in `implementation_manager.py` to enforce single-authority task state transitions. This command atomically marks a task as `in-progress` and records the `started` timestamp, preventing duplicate task dispatch and ensuring accurate audit trails.

## Key Changes

- **New `claim-task` CLI command** in `implementation_manager.py`:
  - Performs read-check-write sequence to atomically transition task status from `not-started` to `in-progress`
  - Records UTC ISO 8601 `started` timestamp on first claim
  - Preserves existing `started` value on retry (maintains original timestamp)
  - Returns JSON output with claim result and task metadata
  - Exits with code 0 on success, 1 on failure (already claimed, not found, parse error, write error)

- **Helper functions for claim operation**:
  - `_find_task_section_in_file()`: Locates frontmatter block for a task ID in multi-frontmatter files
  - `_resolve_write_target()`: Resolves write target file and content for directory-based or single-file task layouts
  - `_try_claim_part()`: Attempts to claim a task within a single frontmatter section
  - `_apply_claim_to_content()`: Applies status and started field updates to file content
  - `_resolve_task_status()`: Parses and validates task status before claiming
  - `_claim_fail()`: Emits structured JSON error output and exits

- **Updated `get_ready_tasks()` docstring**: Added advisory note that callers MUST invoke `claim-task` before task execution to atomically mark tasks in-progress

- **Import changes**:
  - Removed `TYPE_CHECKING` guard for `datetime`; now imports `datetime` and `UTC` directly
  - Added `update_yaml_field` to imports from `task_format`

- **Documentation updates**:
  - `TASK_FILE_FORMAT.md`: Added comprehensive field ownership table and rules for authorized writers
  - `start-task/SKILL.md`: Replaced step 3 (manual status edit) with `claim-task` invocation via CLI
  - `test-coverage-gaps.md`: Added gap entry for claim-task test coverage

- **Guard in `task_status_hook.py`**: Added check to skip `last_activity` updates if task status is already `complete`

- **Optimization in `task_format.py`**: Added fast path in `normalize_status()` to return already-normalized statuses without mapping

## Implementation Details

The `claim-task` command supports both single-file and directory-based task layouts:
- For directories: scans individual `.md` files to locate the matching task
- For single files: handles both single-frontmatter and multi-frontmatter formats by splitting on `\n---\n` boundaries

The command enforces strict field ownership: only `claim-task` may write `status: in-progress` and `started` fields. LLM agents must invoke this command via CLI rather than editing these fields directly with the Edit tool.

Error responses include structured JSON with `claimed: false`, reason codes (e.g., `already-in-progress`, `task-not-found`, `parse-error`), and relevant context for orchestrator handling.

https://claude.ai/code/session_01JPARDBiKFMHJkcgA39Dhsj