### PR TITLE
Enhance freshness tracking with days-old metrics and refresh reporting

### DIFF
--- a/.claude/skills/refresh-research/SKILL.md
+++ b/.claude/skills/refresh-research/SKILL.md
@@ -32,14 +32,19 @@ flowchart TD
     Start([Read entry]) --> ParseFM[Parse YAML frontmatter<br>Extract metadata.layer]
     ParseFM --> HasFreshness{Freshness Tracking section present?}
     HasFreshness -->|No| Stale1[STALE: no tracking]
-    HasFreshness -->|Yes| PastDue{Next Review Recommended < today?}
+    HasFreshness -->|Yes| ComputeDays[Compute Days Old = today minus Last Verified]
+    ComputeDays --> PastDue{Next Review Recommended < today?}
     PastDue -->|Yes| Stale2[STALE: past review date]
     PastDue -->|No| TooOld{Last Verified > 6 months ago?}
     TooOld -->|Yes| Stale3[STALE: too old]
-    TooOld -->|No| Fresh[FRESH: skip]
+    TooOld -->|No| Fresh[FRESH: N days until next review]
 ```
 
-Build inventory table: `| File | Category | Layer | Last Verified | Next Review | Stale? |`
+Build inventory table:
+`| File | Category | Layer | Last Verified | Next Review | Days Old | Stale? |`
+
+The `Days Old` column holds an integer: today's date minus the Last Verified date in days.
+If Last Verified is absent or unparseable, render as `—`.
 
 The `Layer` column holds the `metadata.layer` value or `—` if absent.
 
@@ -56,6 +61,18 @@ Apply filters sequentially. Filters combine with AND logic — each filter narro
 5. **Dry-run check**: `--dry-run` — display the filtered target list and stop without spawning agents.
 
 If zero entries remain after all filters: report "No entries match the applied filters." and stop. When `--layer` was specified and zero entries match, additionally report: "No entries found for layer {N}. Entries need `metadata.layer` in their YAML frontmatter to be targeted by `--layer`."
+
+When the `--stale` filter excludes entries because they are FRESH, list each excluded entry
+before continuing to Step 3:
+
+```text
+Skipped (fresh):
+  ./research/{category}/{name}.md — N days until next review (last: YYYY-MM-DD, vX.Y.Z)
+  ./research/{category}/{name}.md — N days until next review (last: YYYY-MM-DD, vX.Y.Z)
+```
+
+This listing appears regardless of whether `--dry-run` is active. Under `--all` (no staleness
+filter), no entries are excluded by staleness, so this block does not appear.
 
 ### Step 3: RT-ICA Pre-Flight
 
@@ -109,15 +126,19 @@ After all waves complete, update `./research/README.md`:
 
 **Date**: {YYYY-MM-DD}
 **Scope**: {--all | --stale | --category X | --layer N}
-**Total scanned**: {N} | **Targeted**: {M} | **Skipped (fresh)**: {K}
+**Total scanned**: {N} | **Targeted**: {M} | **Skipped (fresh)**: {K} ({min}–{max} days until next review)
 
 ## Results
 
-| Outcome | Count |
-|---------|-------|
-| Updated | {N} |
-| Unchanged | {N} |
-| Failed | {N} |
+| Outcome | Count | Notes |
+|---------|-------|-------|
+| Updated | {N} | |
+| Unchanged | {N} | |
+| Failed | {N} | |
+| Skipped (fresh) | {K} | {min}–{max} days until next review |
+
+When K = 0, omit the Skipped (fresh) row. When K = 1, Notes column: `{N} days until next review`.
+When K = 0 in the header: `**Skipped (fresh)**: 0`. When K = 1: `**Skipped (fresh)**: 1 ({N} days until next review)`.
 
 ## Updates
 

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -163,7 +163,17 @@ Spawn up to 5 `@research-curator` agents per wave via Agent tool. Wait for all a
 
 ### Duplicate Detection
 
-Before spawning, check if `./research/` already contains an entry for the URL's resource. If found, skip with info message suggesting `--rerun` instead.
+Before spawning, check if `./research/` already contains an entry for the URL's resource.
+If found:
+
+1. Read the entry's Freshness Tracking section.
+2. Compute days since Last Verified (integer: today minus Last Verified date).
+3. Emit: `Entry is N days old (last verified: YYYY-MM-DD, vX.Y.Z). Proceeding with refresh.`
+4. Pass `--rerun ./research/{category}/{name}.md` to the agent instead of skipping.
+
+If the Freshness Tracking section is absent or Last Verified is unreadable, emit:
+`Entry exists but freshness data unavailable. Proceeding with refresh.`
+and pass `--rerun ./research/{category}/{name}.md` to the agent.
 
 ### Progress Reporting
 
@@ -171,9 +181,9 @@ After each wave, relay exact counts and exact failure reasons from agent output:
 
 ```text
 Wave N complete: M/N succeeded
-  created -- category/resource-name.md
-  created -- category/resource-name.md
-  failed  -- https://url.com -- {exact reason from agent}
+  created    -- category/resource-name.md
+  refreshed  -- category/resource-name.md (was N days old)
+  failed     -- https://url.com -- {exact reason from agent}
 ```
 
 After all waves:
@@ -393,12 +403,15 @@ YYYY-MM-DD
 ## Batch Research Complete
 
 **Total**: X URLs processed
-**Succeeded**: Y entries created
-**Failed**: Z
+**Created**: Y new entries
+**Refreshed**: Z existing entries
+**Failed**: W
 
 ### Entries Created
 - ./research/{category}/{name}.md
-- ./research/{category}/{name}.md
+
+### Entries Refreshed
+- ./research/{category}/{name}.md (was N days old, last: YYYY-MM-DD, vX.Y.Z)
 
 ### Failures
 - {URL} -- {exact reason from agent output}

--- a/.claude/skills/research-curator/references/entry-template.md
+++ b/.claude/skills/research-curator/references/entry-template.md
@@ -174,10 +174,20 @@ How the resource works internally. Include diagrams if helpful.
 | Next Review Recommended | YYYY-MM-DD |
 ````
 
+> **Note**: "Next Review Recommended" is a suggestion, not a gate. When a user or
+> orchestrator explicitly requests re-research for this entry — via `--rerun`, via
+> `--batch` URL resubmission, or via `--all` — the refresh proceeds regardless of this
+> date. This field provides context ("how stale is this?") and informs scheduling
+> decisions. It does not block operations.
+
 ---
 
 ## Freshness Schedule
 
-- **Next Review**: Set to 3 months from research date
+- **Next Review**: Set to 3 months from research date. This is a conservative baseline
+  appropriate for stable or slow-moving projects. High-activity repositories — those with
+  frequent major or minor releases, rapidly growing star or fork counts, or active breaking
+  API changes — benefit from shorter intervals (4–6 weeks). The agent setting this date
+  should calibrate to the observed activity level of the resource at time of research.
 - **Stale threshold**: 6 months without verification
 - **Review required**: Version change, significant star/fork growth, breaking API changes


### PR DESCRIPTION
## Summary
This PR enhances the research entry freshness tracking system by adding explicit "days old" calculations and improving visibility into refresh operations. The changes provide better context for staleness decisions and clearer reporting of which entries are being refreshed versus created.

## Key Changes

**Freshness Tracking Enhancements:**
- Added `Days Old` column to inventory table, computed as today's date minus Last Verified date
- Updated flowchart to explicitly show the computation step before staleness checks
- Modified FRESH status message to show "N days until next review" instead of generic "skip"
- Added handling for missing or unparseable Last Verified dates (rendered as `—`)

**Filtering & Reporting:**
- Added new "Skipped (fresh)" listing when `--stale` filter excludes FRESH entries, showing days until next review for each skipped entry
- Enhanced summary statistics to include min–max range of days until next review for skipped entries
- Updated results table to include a Notes column with freshness context

**Duplicate Detection & Refresh Workflow:**
- Changed duplicate detection behavior: instead of skipping existing entries, now reads their freshness data and proceeds with refresh via `--rerun`
- Added freshness context emission (e.g., "Entry is N days old") when refreshing existing entries
- Gracefully handles missing freshness data with fallback message

**Progress & Completion Reporting:**
- Updated wave completion output to distinguish between `created` and `refreshed` outcomes
- Enhanced final summary to separately report Created, Refreshed, and Failed counts
- Added "Entries Refreshed" section in completion report showing age and last verification details

**Documentation:**
- Clarified that "Next Review Recommended" is advisory, not a gate—explicit refresh requests bypass this date
- Enhanced freshness schedule guidance to recommend shorter intervals (4–6 weeks) for high-activity repositories versus the conservative 3-month baseline
- Added note explaining the relationship between Next Review date and actual refresh behavior

## Implementation Details
- Days old calculations use integer arithmetic (today minus Last Verified date)
- Freshness context is consistently formatted as `(last: YYYY-MM-DD, vX.Y.Z)` across reports
- Skipped entries listing and summary statistics only appear when entries are actually excluded by staleness filters
- The changes maintain backward compatibility while providing richer operational visibility

https://claude.ai/code/session_011iBfbWNQ61AEpMofYuHj9a