### PR TITLE
Migrate backlog CLI commands to MCP tool invocations

### DIFF
--- a/.claude/rules/local-workflow.md
+++ b/.claude/rules/local-workflow.md
@@ -261,9 +261,9 @@ Final:   commit + push          -> Stage and commit all remaining modified files
 If Phase 1 (code review) creates follow-up task files (naming: `plan/tasks-{N}-{slug}-followup-{k}.md`), each follow-up is routed through a backlog-linking step before any recursion decision:
 
 1. Follow-up files are detected from the code-reviewer's ARTIFACTS `Task files:` output. If the list is empty or absent, a confirmatory glob for `plan/tasks-*-{slug}-followup-*.md` is run as fallback.
-2. For each follow-up, a search title is derived from the filename (strip prefix/suffix, convert hyphens to spaces) and searched against existing backlog items via `backlog.py list --format json`.
-3. If a matching backlog item is found, the follow-up is attached as its plan via `backlog update --plan`.
-4. If no match is found, a new backlog item is created via `create-backlog-item --auto`, then the follow-up is attached via `backlog update --plan`.
+2. For each follow-up, a search title is derived from the filename (strip prefix/suffix, convert hyphens to spaces) and searched against existing backlog items via `mcp__backlog__backlog_list`.
+3. If a matching backlog item is found, the follow-up is attached as its plan via `mcp__backlog__backlog_update` with `plan=` parameter.
+4. If no match is found, a new backlog item is created via `create-backlog-item --auto`, then the follow-up is attached via `mcp__backlog__backlog_update` with `plan=` parameter.
 5. Recursion proceeds only when BOTH conditions are true: the follow-up file's feature slug matches the parent task file's slug (same session scope), AND the follow-up's `## Priority` section contains `High`.
 6. Otherwise, the follow-up is deferred to backlog with no recursion. The follow-up path, backlog item title, priority, and scope match result are logged.
 
@@ -370,8 +370,8 @@ User
   ├─ [If follow-up task files created by code-reviewer]
   │    ├─ Route each follow-up:
   │    │    ├─ Search backlog by title keywords from filename
-  │    │    ├─ Match found: backlog update --plan {followup_path}
-  │    │    └─ No match: create-backlog-item --auto, then backlog update --plan
+  │    │    ├─ Match found: backlog_update(selector=..., plan={followup_path})
+  │    │    └─ No match: create-backlog-item --auto, then backlog_update(selector=..., plan=...)
   │    └─ Gate: same slug AND High priority -> Recurse: /implement-feature + /complete-implementation
   │             otherwise -> Deferred to backlog (no recursion)
   │

--- a/plan/tasks-20-backlog-mcp-migration-followup-1.md
+++ b/plan/tasks-20-backlog-mcp-migration-followup-1.md
@@ -1,7 +1,7 @@
 ---
 tasks:
   - task: "Migrate complete-implementation/SKILL.md and local-workflow.md CLI invocations to MCP"
-    status: pending
+    status: complete
     parent_task: "plan/tasks-17-backlog-mcp-migration.md"
 ---
 
@@ -14,7 +14,7 @@ tasks:
 
 ## Status
 
-- [ ] Pending
+- [x] Complete
 
 ## Priority
 


### PR DESCRIPTION
## Summary
Updated local workflow documentation and task tracking to reflect the migration of backlog CLI commands to MCP (Model Context Protocol) tool invocations, replacing direct command-line calls with structured MCP function calls.

## Key Changes
- **Documentation updates** (`local-workflow.md`):
  - Replaced `backlog.py list --format json` with `mcp__backlog__backlog_list` MCP tool invocation
  - Replaced `backlog update --plan` with `mcp__backlog__backlog_update` MCP tool invocation with explicit `plan=` parameter
  - Updated workflow diagram to show MCP function call syntax: `backlog_update(selector=..., plan=...)` instead of CLI command syntax
  - Clarified parameter passing in both the procedural steps and visual workflow representation

- **Task status update** (`plan/tasks-20-backlog-mcp-migration-followup-1.md`):
  - Marked migration task as complete (status: pending → complete)
  - Updated task checklist to reflect completion

## Implementation Details
The changes standardize the workflow to use MCP tool invocations instead of direct CLI commands, improving consistency with the broader MCP integration strategy. The `backlog_update` calls now explicitly show the `selector` and `plan` parameters in the function call syntax, making the interface clearer and more maintainable.

https://claude.ai/code/session_01HvEzyfhoJLuir7GvHmhpRD