### PR TITLE
Add format-specific extraction patterns for non-Markdown docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "5.3.18"
+    "version": "5.3.19"
   },
   "plugins": [
     {

--- a/plugins/the-rewrite-room/.claude-plugin/plugin.json
+++ b/plugins/the-rewrite-room/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rwr",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Documentation and authoring workflow router: audit docs vs code drift, sync docs after changes, optimize prompts and SKILL.md files, validate GLFM and Markdown formatting, summarize files/URLs/images with fidelity enforcement. Use when: docs are out of date, CLAUDE.md needs improving, SKILL.md needs optimizing, checking if documentation matches code, summarizing files or URLs.",
   "author": {
     "name": "Jamie Nelson",
@@ -24,5 +24,13 @@
     "./agents/rewrite-room-doc-converter.md",
     "./agents/rewrite-room-cite.md"
   ],
-  "commands": []
+  "commands": [],
+  "mcpServers": {
+    "file-reader": {
+      "command": "uvx",
+      "args": [
+        "mcp-file-contents-reader"
+      ]
+    }
+  }
 }

--- a/plugins/the-rewrite-room/skills/user-docs-to-ai-skill/SKILL.md
+++ b/plugins/the-rewrite-room/skills/user-docs-to-ai-skill/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: user-docs-to-ai-skill
-description: Converts user-facing documentation (how-to guides, tutorials, API references, examples) into Claude Code skill directories — SKILL.md with valid frontmatter plus thematically grouped references/*.md files. Use when given a docs directory to transform into an AI skill, when building expert-level Claude knowledge from library or tool documentation, or when the user asks to create a skill from existing docs. Produces output equivalent in quality to fastmcp-creator.
+description: Converts user-facing documentation (how-to guides, tutorials, API references, examples) in any format — Markdown, PDF, DOCX, PPTX, XLSX, AsciiDoc, RST, HTML, Jupyter notebooks, man pages, TOML/YAML/JSON configs, and plain text — into Claude Code skill directories with SKILL.md plus thematically grouped references/*.md files. Use when given a docs directory or mixed-format documentation to transform into an AI skill. Uses MCP file-reader server for binary formats.
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit, Task
 argument-hint: "<docs_path> <output_plugin> [output_skill]"
 ---
 
 # User Docs to AI Skill
 
-Converts human-readable documentation into a Claude Code skill directory. The output is consumed by Claude, not humans — every word must serve AI comprehension, not user readability.
+Converts human-readable documentation in any text or binary format into a Claude Code skill directory. Supports Markdown, PDF, DOCX, PPTX, XLSX, AsciiDoc, RST, HTML, Jupyter notebooks, man pages, config files, and plain text. Uses the MCP `file-reader` server for binary document formats. The output is consumed by Claude, not humans — every word must serve AI comprehension, not user readability.
 
 ## Inputs
 
@@ -40,7 +40,7 @@ flowchart TD
     Q_docs -->|Yes| UseDocs[Set docs_path = docs_root/docs/]
     Q_docs -->|No| ScanAll["Task: Explore agent\nGlob all .md files across docs_root\nReturn list of markdown and inline doc files"]
     UseDocs --> Inv
-    ScanAll --> Inv[Glob all files in docs_path\nCount by type .md .html .rst .txt\nIdentify top-level sections and index files]
+    ScanAll --> Inv[Glob all files in docs_path\nCount by format category — see input-resolution.md\nIdentify top-level sections and index files\nFlag MCP-dependent formats]
     Inv --> Phase1[Phase 1 — Extraction]
     Phase1 --> Extract[Apply extraction patterns per doc type\nSee extraction-patterns.md]
     Extract --> Phase15[Phase 1.5 — Workflow Identification]
@@ -89,16 +89,19 @@ If `output_skill` was not passed as input, derive it from `project-name` (the la
 ### Step 0d — Inventory
 
 1. `Glob("**/*", docs_path)` — list all files
-2. Group by extension: `.md`, `.html`, `.rst`, `.txt`, other
-3. Read the index file (`index.md`, `README.md`, `index.html`, or equivalent) to understand top-level structure
-4. List all section headings from the index — these hint at reference file themes
-5. Note total file count and estimated reading volume
+2. Group by format category (see [input-resolution.md](./references/input-resolution.md) File Format Categories table)
+3. Flag files requiring the MCP `file-reader` server (PDF, DOCX, PPTX, XLSX) — these need the `file-reader` MCP tool during extraction
+4. Read the index file (`index.md`, `README.md`, `index.html`, or equivalent) to understand top-level structure
+5. List all section headings from the index — these hint at reference file themes
+6. Note total file count and estimated reading volume
 
 Report the inventory before proceeding to Phase 1.
 
 ## Phase 1 — Extraction
 
 Apply extraction patterns from [extraction-patterns.md](./references/extraction-patterns.md).
+
+For non-markdown formats (PDF, DOCX, PPTX, XLSX, AsciiDoc, RST, HTML, Jupyter, man pages, config files), apply the format-specific extraction patterns from the Format-Specific Extraction section of [extraction-patterns.md](./references/extraction-patterns.md). Use the MCP `file-reader` server tools for binary formats that the Read tool cannot parse.
 
 Extraction produces a structured list of knowledge atoms:
 

--- a/plugins/the-rewrite-room/skills/user-docs-to-ai-skill/references/extraction-patterns.md
+++ b/plugins/the-rewrite-room/skills/user-docs-to-ai-skill/references/extraction-patterns.md
@@ -10,9 +10,21 @@ How to extract AI-usable knowledge atoms from each user-facing documentation typ
 4. [Tutorials](#tutorials)
 5. [Conceptual Explanations](#conceptual-explanations)
 6. [Examples and Code Samples](#examples-and-code-samples)
-7. [What to Preserve Verbatim](#what-to-preserve-verbatim)
-8. [What to Abstract](#what-to-abstract)
-9. [Anti-Patterns](#anti-patterns)
+7. [Format-Specific Extraction](#format-specific-extraction)
+   - [PDF Documents](#pdf-documents)
+   - [Word Documents](#word-documents)
+   - [Excel and Spreadsheet Files](#excel-and-spreadsheet-files)
+   - [PowerPoint Presentations](#powerpoint-presentations)
+   - [AsciiDoc](#asciidoc)
+   - [reStructuredText](#restructuredtext)
+   - [Jupyter Notebooks](#jupyter-notebooks)
+   - [HTML Documentation](#html-documentation)
+   - [Man Pages](#man-pages)
+   - [TOML, YAML, and JSON Config Files](#toml-yaml-and-json-config-files)
+   - [Plain Text](#plain-text)
+8. [What to Preserve Verbatim](#what-to-preserve-verbatim)
+9. [What to Abstract](#what-to-abstract)
+10. [Anti-Patterns](#anti-patterns)
 
 ---
 
@@ -191,6 +203,551 @@ Code examples are the highest-fidelity source. They show exact invocation patter
 - If the example demonstrates a constraint ("notice that X must come before Y"), extract that as a separate `TYPE: constraint` atom
 
 **Preserve verbatim:** All code. Never paraphrase code examples — rewriting introduces subtle errors. If the original code has a bug, copy it exactly and add a note in the atom description.
+
+---
+
+## Format-Specific Extraction
+
+Apply these patterns when the source document is not plain markdown. Each format has a preferred read tool, extraction targets, and items to skip.
+
+---
+
+### PDF Documents
+
+**Tool:** Use `Read` (Claude supports `.pdf` natively with `pages` parameter) for standard PDFs. Use MCP server `mcp-file-contents-reader` (tool: `file-reader`) when the Read tool returns empty content.
+
+**Extract:**
+
+- Headings and section structure as atom context
+- Body paragraphs as `TYPE: pattern` or `TYPE: constraint` atoms — one claim per atom
+- Code blocks or monospaced text as `TYPE: example` atoms — copy verbatim
+- Tables as `TYPE: parameter` atoms — one row per atom with column headers as field names
+
+**Skip:**
+
+- Page headers, footers, and page numbers
+- Table of contents entries (use the referenced sections instead)
+- Watermarks and legal boilerplate
+
+**Note:** Scanned PDFs without OCR yield empty text. If Read returns no content, try `mcp-file-contents-reader`. If both fail, report the file as unreadable and skip it.
+
+**Example — source PDF section:**
+
+```text
+## Rate Limits
+
+Requests are capped at 100 per minute per API key.
+Exceeding the limit returns HTTP 429.
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: API requests are capped at 100 per minute per API key
+TYPE: constraint
+SOURCE: api-guide.pdf:Rate Limits
+
+ATOM: exceeding the rate limit returns HTTP 429
+TYPE: error
+SOURCE: api-guide.pdf:Rate Limits
+```
+
+---
+
+### Word Documents
+
+**Tool:** Use `mcp-file-contents-reader` (tool: `file-reader`) for `.docx` and `.doc` files. The Read tool does not support Word format.
+
+**Extract:**
+
+- Heading hierarchy — map Heading 1/2/3 to `#`/`##`/`###` for atom SOURCE fields
+- Tables — each data row becomes a `TYPE: parameter` atom; column headers name the fields
+- Numbered and bulleted lists — each item as a separate atom
+- Callout boxes and "Note:" paragraphs as `TYPE: constraint` atoms
+
+**Skip:**
+
+- Bold, italic, color, and font formatting — extract text content only
+- Track-changes markup and comments
+- Document metadata (author, revision date) unless operationally relevant
+
+**Example — source Word table:**
+
+```text
+| Parameter     | Type    | Default | Required |
+|---------------|---------|---------|----------|
+| timeout       | integer | 30      | No       |
+| retry_count   | integer | 3       | No       |
+| api_key       | string  | —       | Yes      |
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: timeout parameter is type integer, default 30, optional
+TYPE: parameter
+SOURCE: setup-guide.docx:Configuration Parameters
+
+ATOM: retry_count parameter is type integer, default 3, optional
+TYPE: parameter
+SOURCE: setup-guide.docx:Configuration Parameters
+
+ATOM: api_key parameter is type string, required, no default
+TYPE: parameter
+SOURCE: setup-guide.docx:Configuration Parameters
+```
+
+---
+
+### Excel and Spreadsheet Files
+
+**Tool:** Use `mcp-file-contents-reader` for `.xlsx` and `.xls`. Read `.csv` directly with the Read tool.
+
+**Extract:**
+
+- Column headers as field names for `TYPE: parameter` atoms
+- Each data row as a separate atom — include all non-empty field values
+- Configuration sheets where each row defines a setting — extract as `TYPE: parameter` atoms with name, type, default, and description
+- Lookup tables (e.g., error codes → descriptions) as `TYPE: error` atoms
+
+**Skip:**
+
+- Empty rows and formatting-only rows
+- Chart objects and pivot table metadata
+- Summary/total rows that duplicate computed values
+
+**Example — source CSV:**
+
+```text
+setting,type,default,description
+log_level,string,INFO,Logging verbosity (DEBUG|INFO|WARN|ERROR)
+max_connections,integer,10,Maximum concurrent database connections
+cache_ttl,integer,300,Cache entry lifetime in seconds
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: log_level setting is type string, default INFO, accepts DEBUG|INFO|WARN|ERROR
+TYPE: parameter
+SOURCE: config-reference.csv:sheet1
+
+ATOM: max_connections setting is type integer, default 10
+TYPE: parameter
+SOURCE: config-reference.csv:sheet1
+
+ATOM: cache_ttl setting is type integer, default 300 seconds
+TYPE: parameter
+SOURCE: config-reference.csv:sheet1
+```
+
+---
+
+### PowerPoint Presentations
+
+**Tool:** Use `mcp-file-contents-reader` (tool: `file-reader`) for `.pptx` and `.ppt`. The Read tool does not support PowerPoint format.
+
+**Extract:**
+
+- Slide titles as section headings for atom SOURCE fields
+- Bullet points as individual atoms — one bullet per atom
+- Code or command text on slides as `TYPE: example` or `TYPE: command` atoms — copy verbatim
+- Speaker notes as supplementary `TYPE: constraint` atoms when they add detail absent from slide content
+
+**Skip:**
+
+- Decorative text, theme placeholders, and footer text
+- Slide numbers
+- Repeated header/footer content present on every slide
+- Transition and animation metadata
+
+**Example — source slide:**
+
+```text
+Slide title: Authentication Flow
+
+Bullets:
+- Client sends POST /auth with credentials
+- Server returns JWT valid for 24 hours
+- Token must be sent as Bearer in Authorization header
+
+Speaker notes:
+Tokens are not refreshable — clients must re-authenticate after expiry.
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: client authenticates by sending POST /auth with credentials
+TYPE: pattern
+SOURCE: architecture-overview.pptx:Authentication Flow
+
+ATOM: server returns JWT valid for 24 hours
+TYPE: constraint
+SOURCE: architecture-overview.pptx:Authentication Flow
+
+ATOM: JWT token must be sent as Bearer in Authorization header
+TYPE: constraint
+SOURCE: architecture-overview.pptx:Authentication Flow
+
+ATOM: JWT tokens are not refreshable; clients must re-authenticate after expiry
+TYPE: constraint
+SOURCE: architecture-overview.pptx:Authentication Flow
+```
+
+---
+
+### AsciiDoc
+
+**Tool:** Read directly with the Read tool. `.adoc` and `.asciidoc` files are plain text.
+
+**Extract:**
+
+- `=` headings map to `#` markdown — use as atom SOURCE section names
+- Admonition blocks (`NOTE:`, `TIP:`, `WARNING:`, `IMPORTANT:`, `CAUTION:`) as `TYPE: constraint` atoms — prefix atom text with the admonition type
+- `[source,lang]` blocks as `TYPE: example` atoms — copy content verbatim
+- Definition lists (`term:: definition`) as `TYPE: parameter` atoms
+
+**Skip:**
+
+- AsciiDoc attribute definitions (`:toc:`, `:author:`, etc.)
+- Cross-reference anchors (`[[anchor-id]]`) — use heading text in SOURCE instead
+- Include directives — follow them and extract from the included file separately
+
+**Example — source AsciiDoc:**
+
+```text
+== Installation
+
+[source,bash]
+----
+pip install mypackage==2.1.0
+----
+
+WARNING: Installing without a version pin may break existing integrations.
+
+NOTE: Python 3.9 or later is required.
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: `pip install mypackage==2.1.0` installs the package at a pinned version
+TYPE: example
+SOURCE: install-guide.adoc:Installation
+
+ATOM: WARNING — installing without a version pin may break existing integrations
+TYPE: constraint
+SOURCE: install-guide.adoc:Installation
+
+ATOM: NOTE — Python 3.9 or later is required
+TYPE: constraint
+SOURCE: install-guide.adoc:Installation
+```
+
+---
+
+### reStructuredText
+
+**Tool:** Read directly with the Read tool. `.rst` files are plain text.
+
+**Extract:**
+
+- Underline-style headings (lines followed by `===`, `---`, `~~~`, `^^^`) map to `#`/`##`/`###` — use heading text in SOURCE fields
+- `.. code-block:: lang` directives — copy enclosed content as `TYPE: example` atoms
+- `.. warning::`, `.. note::`, `.. important::` directives as `TYPE: constraint` atoms
+- Field lists (`:param name:`, `:type name:`, `:returns:`) as `TYPE: parameter` atoms
+- Cross-references (`:ref:\`label\``) resolve to the referenced section name
+
+**Skip:**
+
+- RST substitution definitions (`.. |name| replace::`)
+- Directive options not affecting content (`:class:`, `:align:`)
+- `.. toctree::` directives — follow linked files and extract from each separately
+
+**Example — source RST:**
+
+```text
+connect
+-------
+
+.. code-block:: python
+
+    client.connect(host="localhost", port=5432)
+
+.. warning::
+
+    Calling connect() twice raises ConnectionError.
+
+:param host: Database hostname. Default: localhost.
+:param port: Database port. Default: 5432.
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: `client.connect(host="localhost", port=5432)` establishes a database connection
+TYPE: example
+SOURCE: api-reference.rst:connect
+
+ATOM: calling connect() twice raises ConnectionError
+TYPE: constraint
+SOURCE: api-reference.rst:connect
+
+ATOM: host parameter is type string, default localhost
+TYPE: parameter
+SOURCE: api-reference.rst:connect
+
+ATOM: port parameter is type integer, default 5432
+TYPE: parameter
+SOURCE: api-reference.rst:connect
+```
+
+---
+
+### Jupyter Notebooks
+
+**Tool:** Read directly with the Read tool. Claude supports `.ipynb` natively — cell types, outputs, and metadata are accessible.
+
+**Extract:**
+
+- Code cells as `TYPE: example` atoms — copy cell source verbatim
+- Markdown cells — apply standard markdown extraction patterns from other sections
+- Output cells containing error tracebacks as `TYPE: error` atoms — copy the exception type and message verbatim; skip the full traceback stack
+- Cell-level headings (markdown cells with `#`) as section context for SOURCE fields
+
+**Skip:**
+
+- Raw cell content (format-specific display directives not relevant to extraction)
+- Output cells containing rendered plots or images — note their presence in the atom description if the code cell references them
+- Kernel metadata and cell execution counts
+
+**Example — source notebook cells:**
+
+```text
+[markdown cell]
+## Loading Data
+
+[code cell]
+df = pd.read_csv("data/input.csv", parse_dates=["timestamp"])
+
+[output cell — error]
+FileNotFoundError: [Errno 2] No such file or directory: 'data/input.csv'
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: `df = pd.read_csv("data/input.csv", parse_dates=["timestamp"])` loads CSV with timestamp parsing
+TYPE: example
+SOURCE: analysis.ipynb:Loading Data
+
+ATOM: pd.read_csv raises FileNotFoundError when the target file does not exist
+TYPE: error
+SOURCE: analysis.ipynb:Loading Data
+```
+
+---
+
+### HTML Documentation
+
+**Tool:** Use the Read tool for local `.html` and `.htm` files. Use `WebFetch` for URLs. Both return text content with HTML stripped.
+
+**Extract:**
+
+- `<h1>`–`<h6>` headings as section structure for SOURCE fields
+- `<code>` and `<pre>` blocks as `TYPE: example` or `TYPE: command` atoms — copy content verbatim
+- `<table>` elements — apply the same extraction as spreadsheet rows: column headers as field names, each row as a `TYPE: parameter` atom
+- `<blockquote>` and `<aside>` elements labeled as notes or warnings as `TYPE: constraint` atoms
+
+**Skip:**
+
+- Navigation menus, sidebars, breadcrumbs, and footers — these are site chrome, not content
+- Cookie consent banners and analytics scripts
+- Social sharing buttons and feedback widgets
+- Repeated boilerplate present on every page (site header, global nav)
+
+**Example — source HTML:**
+
+```text
+<h2>Configuration</h2>
+<table>
+  <tr><th>Key</th><th>Type</th><th>Default</th></tr>
+  <tr><td>debug</td><td>boolean</td><td>false</td></tr>
+  <tr><td>port</td><td>integer</td><td>8080</td></tr>
+</table>
+<pre><code>export DEBUG=true PORT=9000 ./server</code></pre>
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: debug configuration key is type boolean, default false
+TYPE: parameter
+SOURCE: config.html:Configuration
+
+ATOM: port configuration key is type integer, default 8080
+TYPE: parameter
+SOURCE: config.html:Configuration
+
+ATOM: `export DEBUG=true PORT=9000 ./server` starts the server with debug and custom port
+TYPE: example
+SOURCE: config.html:Configuration
+```
+
+---
+
+### Man Pages
+
+**Tool:** Run `man -l <file> | col -b` via Bash to convert to plain text, then apply standard text extraction. The `col -b` flag strips backspace-encoded bold and underline formatting.
+
+**Extract:**
+
+- `SYNOPSIS` section — each usage line as a `TYPE: command` atom
+- `OPTIONS` section — each flag and its description as a `TYPE: parameter` atom
+- `DESCRIPTION` section — each behavioral statement as a `TYPE: pattern` or `TYPE: constraint` atom
+- `ERRORS` or `EXIT STATUS` sections — each code and meaning as a `TYPE: error` atom
+- `ENVIRONMENT` section — each variable as a `TYPE: parameter` atom
+
+**Skip:**
+
+- `SEE ALSO` references
+- `AUTHORS` and `BUGS` sections unless they document behavioral constraints
+- Repeated header/footer lines injected by `man` rendering
+
+**Example — source man page (after `col -b`):**
+
+```text
+SYNOPSIS
+    grep [OPTIONS] PATTERN [FILE...]
+
+OPTIONS
+    -i       Ignore case distinctions
+    -n       Prefix each match with line number
+    -r       Read files recursively under each directory
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: grep command syntax is `grep [OPTIONS] PATTERN [FILE...]`
+TYPE: command
+SOURCE: grep.1:SYNOPSIS
+
+ATOM: -i flag makes grep ignore case distinctions
+TYPE: parameter
+SOURCE: grep.1:OPTIONS
+
+ATOM: -n flag prefixes each match line with its line number
+TYPE: parameter
+SOURCE: grep.1:OPTIONS
+
+ATOM: -r flag reads files recursively under each directory
+TYPE: parameter
+SOURCE: grep.1:OPTIONS
+```
+
+---
+
+### TOML, YAML, and JSON Config Files
+
+**Tool:** Read directly with the Read tool. All three formats are plain text.
+
+**Extract:**
+
+- Each key that has an inline comment (`#` for TOML/YAML, not available in JSON) as a `TYPE: parameter` atom — include key name, value type inferred from the example value, and comment text as the description
+- Nested keys — use dot notation in the atom (e.g., `database.host`)
+- Each key's default value as part of the atom fact
+- Enum-constrained values (where comments list valid options) as `TYPE: constraint` atoms
+
+**Skip:**
+
+- Keys with no comment and no obvious semantic meaning (e.g., generated UUIDs, timestamps)
+- Structural nesting markers that carry no semantic meaning on their own
+- Commented-out keys — extract only active configuration
+
+**Example — source TOML:**
+
+```toml
+[server]
+host = "0.0.0.0"       # Bind address; use 127.0.0.1 for localhost-only
+port = 8080             # Listening port; must be > 1024 for non-root
+workers = 4             # Number of worker processes
+
+[logging]
+level = "INFO"          # Verbosity: DEBUG | INFO | WARN | ERROR
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: server.host sets the bind address; use 127.0.0.1 to restrict to localhost
+TYPE: parameter
+SOURCE: config.toml:server
+
+ATOM: server.port sets the listening port; must be greater than 1024 for non-root users
+TYPE: parameter
+SOURCE: config.toml:server
+
+ATOM: server.workers sets the number of worker processes; default 4
+TYPE: parameter
+SOURCE: config.toml:server
+
+ATOM: logging.level sets verbosity; accepts DEBUG | INFO | WARN | ERROR; default INFO
+TYPE: parameter
+SOURCE: config.toml:logging
+```
+
+---
+
+### Plain Text
+
+**Tool:** Read directly with the Read tool.
+
+**Extract:**
+
+- Lines in ALL CAPS that act as section headings — use as SOURCE section names
+- Lines followed by `===` or `---` that act as underline-style headings — use as SOURCE section names
+- Each paragraph as a candidate atom — evaluate whether it states a fact, constraint, or pattern
+- Lines matching command syntax patterns (starting with `$`, indented uniformly, containing flags) as `TYPE: command` atoms
+
+**Skip:**
+
+- Blank separator lines
+- Lines consisting only of punctuation used as visual dividers (`---`, `===`, `***`)
+- Repeated boilerplate lines (e.g., license notices copied verbatim into every section)
+
+**Note:** Plain text has no structural markup. Apply heuristic heading detection first to establish section context before extracting atoms. When no heading structure is detectable, use the filename as the SOURCE section.
+
+**Example — source plain text:**
+
+```text
+INSTALLATION
+============
+
+Run the installer script as root:
+
+    sudo ./install.sh --prefix /usr/local
+
+The installer writes files to /usr/local/bin and /usr/local/share.
+Do not interrupt the installer — partial installs require manual cleanup.
+```
+
+**Extracted atoms:**
+
+```text
+ATOM: `sudo ./install.sh --prefix /usr/local` installs the package as root
+TYPE: command
+SOURCE: README.txt:INSTALLATION
+
+ATOM: installer writes files to /usr/local/bin and /usr/local/share
+TYPE: pattern
+SOURCE: README.txt:INSTALLATION
+
+ATOM: interrupting the installer leaves a partial install requiring manual cleanup
+TYPE: constraint
+SOURCE: README.txt:INSTALLATION
+```
 
 ---
 

--- a/plugins/the-rewrite-room/skills/user-docs-to-ai-skill/references/input-resolution.md
+++ b/plugins/the-rewrite-room/skills/user-docs-to-ai-skill/references/input-resolution.md
@@ -8,7 +8,8 @@ Covers Phase 0 of `user-docs-to-ai-skill` — resolving the `source` input to a 
 2. [Project Name Derivation](#project-name-derivation)
 3. [output_skill Derivation](#output_skill-derivation)
 4. [Docs Discovery](#docs-discovery)
-5. [Anti-Patterns](#anti-patterns)
+5. [File Format Categories](#file-format-categories)
+6. [Anti-Patterns](#anti-patterns)
 
 ---
 
@@ -90,17 +91,13 @@ flowchart TD
     Q1 -->|Yes| UseDocs[docs_path = docs_root/docs/\nProceed to inventory]
     Q1 -->|No| Q2{docs_root/doc/ exists?}
     Q2 -->|Yes| UseDoc[docs_path = docs_root/doc/\nProceed to inventory]
-    Q2 -->|No| Scan["Delegate to Explore subagent:\nGlob all *.md files under docs_root\nReturn list of file paths"]
-    Scan --> Q3{Any .md files found?}
-    Q3 -->|Yes — include README.md| UseList[docs_path = list of discovered .md files\nProceed to inventory treating each as a source file]
-    Q3 -->|No markdown found| CheckRST["Glob *.rst files under docs_root"]
-    CheckRST --> Q4{Any .rst files found?}
-    Q4 -->|Yes| UseRST[docs_path = list of .rst files]
-    Q4 -->|No| Block([BLOCKED — no documentation found in docs_root\nReport what was searched])
+    Q2 -->|No| Scan["Delegate to general-purpose subagent:\nGlob all supported file types under docs_root\nExtensions: *.md *.rst *.adoc *.asciidoc\n*.html *.htm *.pdf *.docx *.doc *.ipynb\n*.txt *.pptx *.ppt *.xlsx *.xls *.csv\n*.toml *.yaml *.yml *.json\nReturn grouped list of file paths by format category"]
+    Scan --> Q3{Any supported files found?}
+    Q3 -->|Yes| UseList["docs_path = grouped list of discovered files\nGroup by format category (see File Format Categories)\nProceed to inventory treating each as a source file"]
+    Q3 -->|No| Block([BLOCKED — no documentation found in docs_root\nReport what was searched and extensions tried])
     UseDocs --> Inventory([Phase 0d — Inventory])
     UseDoc --> Inventory
     UseList --> Inventory
-    UseRST --> Inventory
 ```
 
 ### Explore Subagent Delegation
@@ -109,14 +106,43 @@ When no `docs/` or `doc/` directory exists, delegate discovery:
 
 ```text
 Task: subagent_type="general-purpose"
-Prompt: Glob all *.md and *.rst files under <docs_root>.
+Prompt: Glob all supported documentation file types under <docs_root>.
+        Extensions to search: *.md *.rst *.adoc *.asciidoc *.html *.htm
+        *.pdf *.docx *.doc *.ipynb *.txt *.pptx *.ppt *.xlsx *.xls *.csv
+        *.toml *.yaml *.yml *.json
         Also check for a README.md at docs_root root level.
-        Return the full list of file paths found.
+        Return file paths grouped by format category (Markdown, reStructuredText,
+        AsciiDoc, HTML, PDF, Word, Jupyter Notebook, Plain Text, PowerPoint,
+        Excel, CSV, Config).
         Do not read file contents — paths only.
-Output: flat list of file paths
+Output: grouped list of file paths by format category
 ```
 
 Use `general-purpose` (not `Explore`) because the Explore agent has a ~50% hallucination rate on pattern-matching tasks.
+
+---
+
+## File Format Categories
+
+Maps each supported file extension to a format category and the extraction method to use when reading content during Phase 0d inventory and later phases.
+
+| Extension | Category | Extraction Method |
+|-----------|----------|-------------------|
+| `.md` | Markdown | Read tool (direct) |
+| `.rst` | reStructuredText | Read tool (direct) |
+| `.adoc`, `.asciidoc` | AsciiDoc | Read tool (direct) |
+| `.html`, `.htm` | HTML | Read tool or WebFetch |
+| `.pdf` | PDF | Read tool (pages param) or MCP file-reader |
+| `.docx`, `.doc` | Word | MCP file-reader server |
+| `.ipynb` | Jupyter Notebook | Read tool (native support) |
+| `.txt` | Plain Text | Read tool (direct) |
+| `.pptx`, `.ppt` | PowerPoint | MCP file-reader server |
+| `.xlsx`, `.xls` | Excel | MCP file-reader server |
+| `.csv` | CSV/Data | Read tool (direct) |
+| `.toml`, `.yaml`, `.yml`, `.json` | Config | Read tool (direct) |
+| `.1`, `.3`, `.5`, `.7`, `.8` | Man Page | Bash: `man -l <file> \| col -b` |
+
+**Inventory grouping:** Phase 0d groups discovered files by the category column above. Report counts per category and flag any files requiring MCP file-reader server so the caller knows which tools must be available before extraction proceeds.
 
 ---
 

--- a/plugins/the-rewrite-room/skills/user-docs-to-ai-skill/references/quality-criteria.md
+++ b/plugins/the-rewrite-room/skills/user-docs-to-ai-skill/references/quality-criteria.md
@@ -9,7 +9,7 @@ Measurable criteria for evaluating the AI-facing skill output produced by `user-
 3. [Common Failure Modes](#common-failure-modes)
 4. [Distinguishing Good from Mediocre](#distinguishing-good-from-mediocre)
 
-Checklist categories: Frontmatter — SKILL.md Structure — Reference Files — Links — Coverage — Workflow Identification
+Checklist categories: Frontmatter — SKILL.md Structure — Reference Files — Links — Coverage — Format Handling — Workflow Identification
 
 ---
 
@@ -56,6 +56,17 @@ Run all items. Mark each PASS or FAIL. Fix all FAILs before proceeding.
 - [ ] CV-2: CLI commands or API methods from source docs are in the output — none silently dropped
 - [ ] CV-3: Error conditions documented in source docs are captured in a reference file
 - [ ] CV-4: Configuration parameters from source docs appear with their types and defaults
+
+### Format Handling
+
+- [ ] FH-1: Non-markdown files (PDF, DOCX, PPTX, XLSX) are extracted using the MCP `file-reader` server or appropriate tool — not skipped
+- [ ] FH-2: AsciiDoc admonition blocks (NOTE, TIP, WARNING, IMPORTANT, CAUTION) are converted to `TYPE: constraint` atoms
+- [ ] FH-3: Jupyter notebook code cells are preserved verbatim as `TYPE: example` atoms
+- [ ] FH-4: reStructuredText directives are mapped to corresponding atom types (code-block → example, warning → constraint)
+- [ ] FH-5: HTML content is stripped of navigation, sidebars, and footers before extraction
+- [ ] FH-6: Man page SYNOPSIS and OPTIONS sections produce `TYPE: command` and `TYPE: parameter` atoms respectively
+- [ ] FH-7: Config file keys (TOML/YAML/JSON) with comments produce `TYPE: parameter` atoms with dot-notation paths
+- [ ] FH-8: Scanned-image PDFs are flagged with a warning when text extraction yields empty results
 
 ### Workflow Identification (Phase 1.5)
 
@@ -184,6 +195,18 @@ description: Use when working with ty — running type checks, configuring ty.to
 ```
 
 **Fix:** Rewrite description using the template in skill-structure-guide.md. Include explicit trigger scenarios.
+
+---
+
+### Failure Mode 8 — Skipped Non-Markdown Formats
+
+**Symptom:** Reference files only contain content from `.md` sources; PDF, DOCX, or other format files in the docs directory are ignored.
+
+**Detection:** Compare the list of source files in the inventory (Phase 0d) against the SOURCE fields in all extracted atoms. Any source file with zero atoms is suspicious.
+
+**Root cause:** Extraction Phase did not use the MCP `file-reader` server for binary formats or did not apply format-specific extraction patterns.
+
+**Fix:** Re-run Phase 1 for the skipped files using the appropriate extraction method from [extraction-patterns.md](./extraction-patterns.md) Format-Specific Extraction section.
 
 ---
 


### PR DESCRIPTION
## Summary

Extended `user-docs-to-ai-skill` to support extraction from documentation in multiple formats beyond Markdown, including PDF, Word, Excel, PowerPoint, AsciiDoc, reStructuredText, Jupyter notebooks, HTML, man pages, and configuration files (TOML/YAML/JSON). Added comprehensive extraction patterns for each format and integrated MCP `file-reader` server for binary file handling.

## Key Changes

- **New extraction patterns section** (`extraction-patterns.md`): Added 11 format-specific subsections with detailed extraction rules, tools, examples, and anti-patterns for:
  - PDF documents (with fallback to MCP file-reader for scanned PDFs)
  - Word documents (.docx/.doc via MCP file-reader)
  - Excel/CSV spreadsheets
  - PowerPoint presentations
  - AsciiDoc (admonition blocks → constraint atoms)
  - reStructuredText (directives → typed atoms)
  - Jupyter notebooks (code cells → examples, errors → error atoms)
  - HTML documentation (with navigation/footer stripping)
  - Man pages (SYNOPSIS → commands, OPTIONS → parameters)
  - TOML/YAML/JSON config files (with dot-notation paths)
  - Plain text (heuristic heading detection)

- **Updated docs discovery** (`input-resolution.md`): Modified Phase 0c discovery flow to glob all supported file types (15+ extensions) and group results by format category instead of stopping at Markdown/RST

- **Added File Format Categories table** (`input-resolution.md`): Maps extensions to categories and extraction methods for consistent handling across phases

- **New quality criteria** (`quality-criteria.md`): Added "Format Handling" checklist section (FH-1 through FH-8) covering non-Markdown extraction, admonition conversion, notebook preservation, directive mapping, HTML cleanup, man page parsing, config key extraction, and scanned PDF warnings

- **Updated skill description** (`SKILL.md`): Clarified that the skill now handles "any format" documentation and uses MCP file-reader for binary formats

- **MCP server integration** (`plugin.json`): Added `mcp-file-contents-reader` as a configured MCP server for binary file access

- **Version bump** (`plugin.json`): Incremented from 2.5.6 to 2.5.7

## Implementation Details

- Each format section includes: recommended read tool, extraction targets, items to skip, and a worked example showing source → extracted atoms
- Extraction maintains consistency with existing atom types (pattern, constraint, example, parameter, error, command)
- SOURCE field format adapted per format (e.g., `file.pdf:Section Name`, `file.rst:heading`, `file.ipynb:Cell Heading`)
- Fallback strategies documented (e.g., PDF Read tool → MCP file-reader for scanned images)
- Plain text extraction uses heuristic heading detection (ALL CAPS, underline-style) to establish section context

https://claude.ai/code/session_01Fv6jWq4r6W624h4EusbD1s