### PR TITLE
Add seven-prompt-content-engine skill with 7-step workflow

### DIFF
--- a/.claude/skills/seven-prompt-content-engine/SKILL.md
+++ b/.claude/skills/seven-prompt-content-engine/SKILL.md
@@ -48,6 +48,7 @@ Collect or infer before starting:
 | Rough idea / frustration / client situation / lesson / observation | Required | Core material for Step 1 |
 | Target audience | Required | Shapes angle, voice, platform fit |
 | Desired platform or primary destination | Required | Drives Step 6 |
+| Offer / business context | Optional | Sharpens angle specificity in Step 1 |
 | Writing sample | Optional | Used in Step 4 for voice matching |
 | Banned phrases / tone constraints / formatting constraints | Optional | Applied in Steps 4 and 5 |
 

--- a/.claude/skills/seven-prompt-content-engine/references/prompt-templates.md
+++ b/.claude/skills/seven-prompt-content-engine/references/prompt-templates.md
@@ -148,7 +148,6 @@ Input:
 - Core asset: [FINAL_DRAFT]
 - Platform: [PLATFORM]
 - Audience/context: [AUDIENCE]
-- CTA preference: [CTA]
 
 Task: Rewrite the asset so it feels native to the platform rather than copied over.
 


### PR DESCRIPTION
## Summary

Introduces a new Claude skill that implements a structured 7-step sequential workflow for converting rough content ideas into finished, platform-adapted posts and repurposed assets. This skill provides a repeatable, linear process to reduce blank-page friction and ensure consistent content output.

## Changes

- **SKILL.md**: Comprehensive skill definition documenting:
  - Purpose and use cases for the content engine
  - Core operating rules enforcing linear step progression
  - Intake requirements (idea, audience, platform, optional writing sample)
  - Detailed specifications for all 7 steps:
    - Step 1: Idea Extractor — converts rough input to singular, specific angle
    - Step 2: Hook Generator — produces 5 opening lines using distinct psychological structures
    - Step 3: Structure Architect — builds tight outline with no filler sections
    - Step 4: Draft Engine — generates full draft approximating user's voice
    - Step 5: Humanizer — audits and removes AI-signaling patterns
    - Step 6: Platform Adapter — creates native variants for LinkedIn, Reddit, Telegram, newsletter, X/Twitter
    - Step 7: Repurpose Engine — extracts standalone hooks, one-liners, and summary bullets
  - Quality checklist for validating output before finalization

- **prompt-templates.md**: Reusable prompt templates for each of the 7 steps, including:
  - Role definitions for each step
  - Input/output specifications
  - Operational constraints and rules
  - Placeholder variables for customization

## Notable Details

- Skill enforces linear execution — each step's output feeds the next; steps cannot be skipped unless upstream material is provided
- Step 4 (Draft Engine) explicitly avoids voice fabrication; only matches tone from user-provided evidence
- Step 5 (Humanizer) includes detailed audit categories to detect and remove AI-writing fingerprints
- Step 6 (Platform Adapter) defines platform-specific constraints to ensure native adaptation rather than copy-paste
- Step 7 (Repurpose Engine) requires standalone assets that don't reference the original piece

https://claude.ai/code/session_01NecSCCGXMpFARkvqEQ1zqY