### PR TITLE
fix(ci): resolve Ruff lint and ty type-check failures

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.0.13"
+    "version": "6.0.14"
   },
   "plugins": [
     {

--- a/.claude/skills/backlog/scripts/state_handler.py
+++ b/.claude/skills/backlog/scripts/state_handler.py
@@ -31,7 +31,7 @@ from enum import StrEnum
 from typing import Any
 
 try:
-    from github import GithubException  # type: ignore[import-untyped]
+    from github import GithubException
 except ImportError:
     GithubException = Exception  # type: ignore[misc,assignment]
 

--- a/.claude/skills/backlog/tests/test_backlog_core_parsing.py
+++ b/.claude/skills/backlog/tests/test_backlog_core_parsing.py
@@ -739,7 +739,7 @@ class TestBuildIssueBodyFromFileDict:
         """
         # Arrange
         item = {"_raw_body": _UNGROOMED_RAW_BODY, "_title": "Test"}
-        build = build_fn  # type: ignore[operator]
+        build = build_fn
 
         # Act
         result = build(item)
@@ -756,7 +756,7 @@ class TestBuildIssueBodyFromFileDict:
         """
         # Arrange
         item = {"_raw_body": _GROOMED_RAW_BODY, "_title": "Test"}
-        build = build_fn  # type: ignore[operator]
+        build = build_fn
 
         # Act
         result = build(item)
@@ -774,7 +774,7 @@ class TestBuildIssueBodyFromFileDict:
         """
         # Arrange
         item = {"_raw_body": _GROOMED_RAW_BODY}
-        build = build_fn  # type: ignore[operator]
+        build = build_fn
 
         # Act
         result = build(item)
@@ -793,7 +793,7 @@ class TestBuildIssueBodyFromFileDict:
         """
         # Arrange
         item: dict[str, str] = {"_title": "No body"}
-        build = build_fn  # type: ignore[operator]
+        build = build_fn
 
         # Act
         result = build(item)
@@ -810,7 +810,7 @@ class TestBuildIssueBodyFromFileDict:
         """
         # Arrange
         item = {"_raw_body": _GROOMED_RAW_BODY, "_title": "Detect Duplicates"}
-        build = build_fn  # type: ignore[operator]
+        build = build_fn
 
         # Act
         result = build(item)

--- a/.claude/skills/session-historian/scripts/session_query.py
+++ b/.claude/skills/session-historian/scripts/session_query.py
@@ -26,8 +26,7 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from collections.abc import Iterator
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import duckdb
 import typer
@@ -36,6 +35,9 @@ from rich.console import Console
 from rich.measure import Measurement
 from rich.panel import Panel
 from rich.table import Table
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 app = typer.Typer(
     name="session-historian",
@@ -350,7 +352,7 @@ def _index_file(con: duckdb.DuckDBPyConnection, path: Path) -> tuple[int, int]:
     Returns:
         A tuple of ``(user_msgs_indexed, assistant_turns)`` for the file.
     """
-    stats = _scan_records(path, _iter_records(path))
+    stats = _scan_records(path, list(_iter_records(path)))
     sid = path.stem  # filename UUID — stable, never changes
     SUMMARIES_DIR.mkdir(parents=True, exist_ok=True)
     has_summary = (SUMMARIES_DIR / f"{sid}.md").exists()
@@ -857,7 +859,7 @@ def cmd_errors(
     """
     con = _open_db()
     session_id, path = _resolve_session(con, session_id)
-    records = _iter_records(path)
+    records = list(_iter_records(path))
 
     tool_name_map = _build_tool_name_map(records)
     errors = _collect_errors(records, tool_name_map)
@@ -994,7 +996,7 @@ def cmd_tools(
     """
     con = _open_db()
     session_id, path = _resolve_session(con, session_id)
-    records = _iter_records(path)
+    records = list(_iter_records(path))
 
     tool_uses = _collect_tool_uses(records)
     if not tool_uses:
@@ -1133,7 +1135,7 @@ def cmd_irritation(
     """
     con = _open_db()
     session_id, path = _resolve_session(con, session_id)
-    records = _iter_records(path)
+    records = list(_iter_records(path))
 
     phrases = _collect_correction_phrases(records)
     loops = _collect_stuck_loops(records)

--- a/plugins/frustration-analyzer/.claude-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs the triggering assistant output, and renders a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/tests/test_ecosystem_registry.py
+++ b/plugins/plugin-creator/tests/test_ecosystem_registry.py
@@ -67,7 +67,7 @@ class TestGetEcosystemOwnedKeys:
 
         # Act / Assert
         with pytest.raises(AttributeError):
-            owned.add("test")  # type: ignore[attr-defined]
+            owned.add("test")
 
     def test_description_not_in_owned_keys(self) -> None:
         """Claude Code's 'description' field is not in ecosystem-owned keys.

--- a/plugins/plugin-creator/tests/test_hook_script_discovery.py
+++ b/plugins/plugin-creator/tests/test_hook_script_discovery.py
@@ -20,7 +20,7 @@ from git import Repo
 # Add parent directory to path to import plugin_validator
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from plugin_validator import FrontmatterValidator, HookValidator
+from plugin_validator import FrontmatterValidator, HookValidator, YamlValue
 
 
 class TestIsFilePathReference:
@@ -108,7 +108,7 @@ class TestValidateCommandScriptReferences:
 
         validator = HookValidator()
         errors: list = []
-        entries = [{"type": "command", "command": "./hook.sh"}]
+        entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "./hook.sh"}]
         validator._validate_command_script_references(entries, tmp_path, errors)
 
         hk_codes = [e.code for e in errors]
@@ -124,7 +124,7 @@ class TestValidateCommandScriptReferences:
         """
         validator = HookValidator()
         errors: list = []
-        entries = [{"type": "command", "command": "./nonexistent.sh"}]
+        entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "./nonexistent.sh"}]
         validator._validate_command_script_references(entries, tmp_path, errors)
 
         hk_codes = [e.code for e in errors]
@@ -146,7 +146,7 @@ class TestValidateCommandScriptReferences:
 
         validator = HookValidator()
         errors: list = []
-        entries = [{"type": "command", "command": "./hook.sh"}]
+        entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "./hook.sh"}]
         validator._validate_command_script_references(entries, tmp_path, errors)
 
         hk_codes = [e.code for e in errors]
@@ -161,7 +161,7 @@ class TestValidateCommandScriptReferences:
         """
         validator = HookValidator()
         errors: list = []
-        entries = [{"type": "command", "command": "echo hello"}]
+        entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "echo hello"}]
         validator._validate_command_script_references(entries, tmp_path, errors)
 
         assert len(errors) == 0
@@ -189,7 +189,7 @@ class TestValidateCommandScriptReferences:
 
         validator = HookValidator()
         errors: list = []
-        entries = [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook.sh"}]
+        entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook.sh"}]
         validator._validate_command_script_references(entries, hooks_dir, errors)
 
         hk_codes = [e.code for e in errors]
@@ -211,7 +211,7 @@ class TestHookScriptReferencesInHooksDict:
         script.write_text("#!/bin/bash\necho ok\n")
         script.chmod(script.stat().st_mode | stat.S_IEXEC)
 
-        hooks_dict = {"PreToolUse": [{"hooks": [{"type": "command", "command": "./hook.sh"}]}]}
+        hooks_dict: dict[str, YamlValue] = {"PreToolUse": [{"hooks": [{"type": "command", "command": "./hook.sh"}]}]}
 
         validator = HookValidator()
         errors: list = []
@@ -228,7 +228,9 @@ class TestHookScriptReferencesInHooksDict:
         How: Build hooks dict referencing non-existent script, validate
         Why: Verify HK004 is reported for missing scripts in full dict structure
         """
-        hooks_dict = {"PostToolUse": [{"hooks": [{"type": "command", "command": "./missing-script.sh"}]}]}
+        hooks_dict: dict[str, YamlValue] = {
+            "PostToolUse": [{"hooks": [{"type": "command", "command": "./missing-script.sh"}]}]
+        }
 
         validator = HookValidator()
         errors: list = []
@@ -244,7 +246,9 @@ class TestHookScriptReferencesInHooksDict:
         How: Build hooks dict with prompt type entry, validate
         Why: Verify only command-type hooks are checked for file paths
         """
-        hooks_dict = {"PreToolUse": [{"hooks": [{"type": "prompt", "prompt": "Check tool usage"}]}]}
+        hooks_dict: dict[str, YamlValue] = {
+            "PreToolUse": [{"hooks": [{"type": "prompt", "prompt": "Check tool usage"}]}]
+        }
 
         validator = HookValidator()
         errors: list = []

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/scripts/migrate_tasks_to_github.py
+++ b/plugins/python3-development/scripts/migrate_tasks_to_github.py
@@ -77,8 +77,8 @@ SamTask = None
 
 if _BACKLOG_CORE.exists():
     try:
-        from backlog_core.github import create_task_issue, get_github  # type: ignore[import-not-found,assignment]
-        from backlog_core.models import SamTask  # type: ignore[import-not-found,assignment]
+        from backlog_core.github import create_task_issue, get_github
+        from backlog_core.models import SamTask
     except ImportError:
         pass
 

--- a/plugins/python3-development/skills/implementation-manager/tests/test_task_status_hook/test_github_sync.py
+++ b/plugins/python3-development/skills/implementation-manager/tests/test_task_status_hook/test_github_sync.py
@@ -239,8 +239,8 @@ class TestSyncCompletionToGithub:
         mock_bc = types.ModuleType("backlog_core")
         mock_bc_github = types.ModuleType("backlog_core.github")
         mock_update = MagicMock(return_value=True)
-        mock_bc_github.update_task_status = mock_update  # type: ignore[attr-defined]
-        mock_bc_github.get_github = MagicMock()  # type: ignore[attr-defined]
+        mock_bc_github.update_task_status = mock_update
+        mock_bc_github.get_github = MagicMock()
 
         with patch.dict(sys.modules, {"backlog_core": mock_bc, "backlog_core.github": mock_bc_github}):
             # Act
@@ -273,8 +273,8 @@ class TestSyncCompletionToGithub:
         mock_bc_github = types.ModuleType("backlog_core.github")
         mock_get_github = MagicMock(return_value=mock_repo)
         mock_update = MagicMock(return_value=True)
-        mock_bc_github.get_github = mock_get_github  # type: ignore[attr-defined]
-        mock_bc_github.update_task_status = mock_update  # type: ignore[attr-defined]
+        mock_bc_github.get_github = mock_get_github
+        mock_bc_github.update_task_status = mock_update
 
         with patch.dict(sys.modules, {"backlog_core": mock_bc, "backlog_core.github": mock_bc_github}):
             # Act
@@ -305,8 +305,8 @@ class TestSyncCompletionToGithub:
         mock_bc_github = types.ModuleType("backlog_core.github")
         mock_get_github = MagicMock(return_value=mock_repo)
         mock_update = MagicMock(side_effect=RuntimeError("GitHub API error"))
-        mock_bc_github.get_github = mock_get_github  # type: ignore[attr-defined]
-        mock_bc_github.update_task_status = mock_update  # type: ignore[attr-defined]
+        mock_bc_github.get_github = mock_get_github
+        mock_bc_github.update_task_status = mock_update
 
         with patch.dict(sys.modules, {"backlog_core": mock_bc, "backlog_core.github": mock_bc_github}):
             # Act
@@ -336,8 +336,8 @@ class TestSyncCompletionToGithub:
         mock_bc_github = types.ModuleType("backlog_core.github")
         mock_get_github = MagicMock(side_effect=RuntimeError("No token"))
         mock_update = MagicMock()
-        mock_bc_github.get_github = mock_get_github  # type: ignore[attr-defined]
-        mock_bc_github.update_task_status = mock_update  # type: ignore[attr-defined]
+        mock_bc_github.get_github = mock_get_github
+        mock_bc_github.update_task_status = mock_update
 
         with patch.dict(sys.modules, {"backlog_core": mock_bc, "backlog_core.github": mock_bc_github}):
             # Act

--- a/plugins/python3-development/skills/implementation-manager/tests/test_task_status_hook/test_subagent_stop_integration.py
+++ b/plugins/python3-development/skills/implementation-manager/tests/test_task_status_hook/test_subagent_stop_integration.py
@@ -126,8 +126,8 @@ def _make_mock_backlog_core_github(
     """
     mock_bc = types.ModuleType("backlog_core")
     mock_bc_github = types.ModuleType("backlog_core.github")
-    mock_bc_github.get_github = MagicMock(return_value=mock_repo)  # type: ignore[attr-defined]
-    mock_bc_github.update_task_status = update_task_status_mock  # type: ignore[attr-defined]
+    mock_bc_github.get_github = MagicMock(return_value=mock_repo)
+    mock_bc_github.update_task_status = update_task_status_mock
     return mock_bc, mock_bc_github
 
 

--- a/plugins/rtfp/.claude-plugin/plugin.json
+++ b/plugins/rtfp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rtfp",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Read The Fucking Prompt \u2014 mines Claude Code session transcripts to surface the strongest user reactions to assistant instruction-following failures and renders the exchange as a terminal-style PNG",
   "author": {
     "name": "Jamie-BitFlight",

--- a/plugins/rtfp/skills/rtfp/scripts/render_artifact.py
+++ b/plugins/rtfp/skills/rtfp/scripts/render_artifact.py
@@ -374,12 +374,7 @@ def render(
 
     # Create image with rounded-corner background
     img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
-    draw_rounded_rect(
-        img,
-        (0, 0, width, height),
-        CORNER_RADIUS,
-        BG,  # type: ignore[arg-type]
-    )
+    draw_rounded_rect(img, (0, 0, width, height), CORNER_RADIUS, BG)
     draw = ImageDraw.Draw(img)
 
     # Chrome

--- a/plugins/scientific-method/.claude-plugin/plugin.json
+++ b/plugins/scientific-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scientific-method",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/scientific-method/mcp/experiment-registry/tests/test_complete_step_integration.py
+++ b/plugins/scientific-method/mcp/experiment-registry/tests/test_complete_step_integration.py
@@ -48,7 +48,7 @@ def _error_codes(result: dict[str, object]) -> set[str]:
     codes: set[str] = set()
     for e in errors:
         assert isinstance(e, dict)
-        code = e["code"]
+        code = e["code"]  # type: ignore[index]
         assert isinstance(code, str)
         codes.add(code)
     return codes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -380,6 +380,8 @@ max-complexity = 12
 ]
 # Lazy import for optional duckdb dependency in _write_duckdb
 "plugins/agentskill-kaizen/scripts/sentiment-score.py" = ["PLC0415"]
+# Hyphenated package directory name is required by MCP convention
+"plugins/scientific-method/mcp/experiment-registry/__init__.py" = ["N999"]
 "research/knowledge-explorer.py" = [
     "ANN401", # Any required for YAMLHandler base class kwargs and JSON return types
     "S",      # Security checks relaxed for CLI scripts


### PR DESCRIPTION
## Summary

- Fix 4 Ruff auto-fixable lint errors (import reorganization, noqa restoration)
- Fix all 36 `ty` type-check diagnostics across 10 files (unused `type: ignore` comments, `Iterator`→`list[dict]` conversions, explicit type annotations for dict invariance)
- Add `per-file-ignores` for N999 on `experiment-registry` (hyphenated MCP package name)

## Test plan

- [x] `uv run ruff check` → "All checks passed!"
- [x] `uv run ty check` → "All checks passed!"
- [x] All pre-commit hooks pass
- [ ] CI Code quality workflow passes on this PR

https://claude.ai/code/session_015RM2yyKAKN7Zv1jayGd4Qa