### PR TITLE
Mark async conversion tasks as complete in backlog

### DIFF
--- a/.claude/backlog/p2-convert-backlogcore-tools-to-async-def-for-non-blocking-gith.md
+++ b/.claude/backlog/p2-convert-backlogcore-tools-to-async-def-for-non-blocking-gith.md
@@ -5,9 +5,9 @@ metadata:
   topic: convert-backlogcore-tools-to-async-def-for-non-blocking-gith
   source: 'GitHub Issue #472'
   added: '2026-03-06'
-  priority: P2
+  priority: completed
   type: Refactor
-  status: needs-grooming
+  status: done
   issue: '#472'
   last_synced: '2026-03-06T17:48:59Z'
   groomed: '2026-03-06'

--- a/plan/tasks-1-convert-backlog-core-async.md
+++ b/plan/tasks-1-convert-backlog-core-async.md
@@ -239,7 +239,7 @@ Key asyncio behaviors to verify CoVe checks:
 ---
 task: T1
 title: "Convert all 10 server.py tools to async def with asyncio.to_thread()"
-status: not-started
+status: complete
 agent: python3-development:python-cli-architect
 dependencies: []
 priority: 1
@@ -334,7 +334,7 @@ Return: diff summary (count of `async def` conversions, count of `to_thread` wra
 ---
 task: T2
 title: "Verify all existing tests pass after async conversion"
-status: not-started
+status: complete
 agent: python3-development:python-pytest-architect
 dependencies: ["T1"]
 priority: 2
@@ -420,7 +420,7 @@ Return: pytest exit code, pass/fail/skip counts, list of any modified test files
 ---
 task: T3
 title: "Validate conversion completeness via shell acceptance criteria"
-status: not-started
+status: complete
 agent: python3-development:python-pytest-architect
 dependencies: ["T1"]
 priority: 2


### PR DESCRIPTION
## Summary
Update task status tracking to reflect completion of the asyncio conversion initiative for server.py tools.

## Changes
- **Task T1**: Mark "Convert all 10 server.py tools to async def with asyncio.to_thread()" as complete
- **Task T2**: Mark "Verify all existing tests pass after async conversion" as complete
- **Task T3**: Mark "Validate conversion completeness via shell acceptance criteria" as complete
- **Backlog metadata**: Update priority from P2 to "completed" and status from "needs-grooming" to "done"

## Details
All three tasks in the async conversion initiative have been successfully completed:
- Server tools have been converted to async/await patterns with proper thread handling
- Test suite validation has passed
- Acceptance criteria have been verified

The backlog entry metadata has been updated to reflect the completed status of this refactoring effort.

https://claude.ai/code/session_01J4iEY95FUWd9Z6LtndBnj5