### PR TITLE
feat(plugins): add spawn-tasks — parallel Claude Code session launcher

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.0.43"
+    "version": "6.1.0"
   },
   "plugins": [
     {
@@ -115,6 +115,10 @@
     {
       "name": "scientific-method",
       "source": "./plugins/scientific-method"
+    },
+    {
+      "name": "spawn-tasks",
+      "source": "./plugins/spawn-tasks"
     }
   ]
 }

--- a/plugins/spawn-tasks/.claude-plugin/plugin.json
+++ b/plugins/spawn-tasks/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "spawn-tasks",
+  "description": "Spawn parallel Claude Code sessions from confirmed subtasks. Each session gets its own isolated git worktree and tmux pane with full task context. Use after breaking down a project into independent subtasks.",
+  "version": "1.0.0",
+  "author": {
+    "name": "theradengai",
+    "url": "https://github.com/theradengai/spawn-tasks"
+  }
+}

--- a/plugins/spawn-tasks/README.md
+++ b/plugins/spawn-tasks/README.md
@@ -1,0 +1,24 @@
+# spawn-tasks
+
+Spawn parallel Claude Code sessions from confirmed subtasks. Each session gets its own isolated git worktree and tmux pane with full task context.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/spawn-tasks` | Write task files and spawn one Claude Code session per subtask |
+
+## Usage
+
+1. In a Claude Code session, plan and confirm your subtasks
+2. Run `/spawn-tasks`
+3. Claude shows the task list and asks for confirmation
+4. Sessions open as new tmux panes (falls back to Terminal.app on macOS)
+
+## Smart Spawning
+
+If tasks have sequential dependencies, Claude recommends running them in order instead of parallelizing blindly.
+
+## Source
+
+[github.com/theradengai/spawn-tasks](https://github.com/theradengai/spawn-tasks)

--- a/plugins/spawn-tasks/skills/spawn-tasks/SKILL.md
+++ b/plugins/spawn-tasks/skills/spawn-tasks/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: spawn-tasks
+description: Spawn parallel Claude Code sessions from planned subtasks. Each session gets its own worktree and tmux pane with full task context.
+user_invocable: true
+---
+
+# Spawn Tasks — Parallel Session Launcher
+
+## When to Use
+
+User triggers this skill after breaking down a project into subtasks in the current conversation. This skill writes task files and spawns independent Claude Code sessions for each subtask.
+
+## Workflow
+
+1. **Collect tasks from conversation context**: Gather all subtasks that were discussed and confirmed with the user. Each task needs: name, goal, context, relevant files, constraints, and acceptance criteria.
+
+2. **Write task files**: For each subtask, create a markdown file at `.tasks/spawn/{task-name}.md` in the current project directory. Create the directory if it doesn't exist.
+
+Task file template:
+
+```markdown
+# Task: {task name}
+
+## Goal
+{what this subtask should accomplish}
+
+## Context
+{architectural background, dependencies, related modules}
+
+## Relevant Files
+{list of key file paths}
+
+## Constraints
+{consensus docs to follow, technical limitations, things to avoid}
+
+## Acceptance Criteria
+{how to verify the task is complete}
+```
+
+3. **Spawn sessions**: For each task file, run the following Bash command:
+
+```bash
+claude -w "{task-name}" --tmux "$(cat .tasks/spawn/{task-name}.md)"
+```
+
+This command:
+- `-w "{task-name}"`: Creates an isolated git worktree named after the task
+- `--tmux`: Opens in a new tmux pane (uses iTerm2 native panes when available)
+- The task file content is passed as the initial prompt
+
+4. **Report**: After all sessions are spawned, tell the user:
+   - How many sessions were created
+   - The tmux session name so they can attach (`tmux attach` or check iTerm2 panes)
+   - How to switch between panes (Ctrl+B then number, or iTerm2 Cmd+[ ])
+   - Remind them that each session has its own worktree, so changes don't conflict
+
+## Important Notes
+
+- **Always confirm with the user** before spawning. Show the task list and ask for approval.
+- If tmux is not installed, fall back to opening Terminal.app windows via osascript:
+  ```bash
+  osascript -e "tell application \"Terminal\" to do script \"cd '$(pwd)' && claude -w '{task-name}' \\\"$(cat .tasks/spawn/{task-name}.md)\\\"\""
+  ```
+- Task files are kept in `.tasks/spawn/` for reference. They are NOT deleted after spawning.
+- The task file content should be self-contained — the spawned session has NO access to the main conversation's context.
+- Include references to project docs (like `docs/final-consensus/`) in the task context so the spawned session knows to check them.


### PR DESCRIPTION
## What this plugin does

\`/spawn-tasks\` spawns independent Claude Code sessions from subtasks confirmed in the current conversation. Each session gets its own isolated git worktree and tmux pane with full task context — no merge conflicts between parallel sessions.

**Smart spawning:** If tasks have sequential dependencies, Claude says so and recommends running them in order instead of parallelizing blindly.

## Changes

- Added \`plugins/spawn-tasks/\` with full plugin structure
- Added \`.claude-plugin/plugin.json\`
- Added \`skills/spawn-tasks/SKILL.md\`
- Updated \`.claude-plugin/marketplace.json\` (version bump 6.0.43 → 6.1.0)

## Source

https://github.com/theradengai/spawn-tasks