### PR TITLE
Standardize skills field format to YAML list syntax

### DIFF
--- a/.claude/agents/backlog-item-groomer.md
+++ b/.claude/agents/backlog-item-groomer.md
@@ -3,7 +3,8 @@ name: backlog-item-groomer
 description: Produce groomed content for a backlog item — discovers related skills, agents, prior work, and dependency graph; performs RT-ICA assessment; outputs groomed item template for writing into .claude/backlog/{priority}-{slug}.md. Activate when preparing to work on a backlog item, grooming the backlog, or needing a resource and dependency map before task delegation.
 tools: Glob, Grep, Read, mcp__plugin_dh_backlog__backlog_list, mcp__plugin_dh_backlog__backlog_view, mcp__plugin_dh_backlog__backlog_add, mcp__plugin_dh_backlog__backlog_update, mcp__plugin_dh_backlog__backlog_groom, mcp__plugin_dh_backlog__backlog_close, mcp__plugin_dh_backlog__backlog_resolve, mcp__plugin_dh_backlog__backlog_sync, mcp__plugin_dh_backlog__backlog_normalize, mcp__plugin_dh_backlog__backlog_pull
 model: sonnet
-skills: dh:rt-ica
+skills:
+  - dh:rt-ica
 mcpServers:
   backlog:
     command: uv

--- a/.claude/agents/fact-checker.md
+++ b/.claude/agents/fact-checker.md
@@ -1,7 +1,8 @@
 ---
 name: fact-checker
 description: Verify a single factual claim against primary sources using web lookups. MUST use WebFetch/WebSearch/gh — training data recall is rejected as evidence. Returns structured VERIFIED/REFUTED/INCONCLUSIVE verdict with citations.
-skills: gh
+skills:
+  - gh
 model: haiku
 ---
 

--- a/.claude/agents/plugin-docs-writer.md
+++ b/.claude/agents/plugin-docs-writer.md
@@ -3,7 +3,10 @@ name: plugin-docs-writer
 description: Generates user-facing README.md documentation for Claude Code plugins. Deeply researches plugin capabilities and writes compelling documentation that helps humans understand what the plugin does and why they should install it.
 model: sonnet
 permissionMode: acceptEdits
-skills: claude-skills-overview-2026, claude-plugins-reference-2026, hooks-guide
+skills:
+  - plugin-creator:claude-skills-overview-2026
+  - plugin-creator:claude-plugins-reference-2026
+  - plugin-creator:hooks-guide
 ---
 
 # Plugin Documentation Writer

--- a/.claude/agents/research-curator.md
+++ b/.claude/agents/research-curator.md
@@ -1,7 +1,8 @@
 ---
 name: research-curator
 description: Research and document a single tool, library, or resource into a structured research entry with quote-grounded claims and explicit confidence levels. Gathers information from primary sources using MCP tools and gh CLI. Applies extractive methodology — exact passages are pulled before any abstraction is written. Works standalone or orchestrated by the /research-curator skill.
-skills: gh
+skills:
+  - gh
 model: haiku
 ---
 

--- a/.claude/agents/topic-specialist.md
+++ b/.claude/agents/topic-specialist.md
@@ -3,7 +3,10 @@ name: topic-specialist
 description: Embodies a domain specialist by loading specified skills, then researches how something works using verified primary sources. Use when you need authoritative, fact-checked answers about a specific technology, library, or system. Invoke with a topic and optionally a list of skills to load as domain context. Can update or create skills with newly verified knowledge. DO NOT invoke without specifying the topic and question.
 tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bash, mcp__Ref__ref_read_url, mcp__Ref__ref_search_documentation, mcp__claude_ai_Ref__ref_read_url, mcp__claude_ai_Ref__ref_search_documentation
 model: haiku
-skills: fact-check, find-cause, research-curator
+skills:
+  - fact-check
+  - find-cause
+  - research-curator
 ---
 
 # Topic Specialist Agent


### PR DESCRIPTION
## Summary
Converted the `skills` field in agent configuration files from comma-separated string format to YAML list syntax for improved readability and consistency.

## Changes
- **plugin-docs-writer.md**: Converted `skills: claude-skills-overview-2026, claude-plugins-reference-2026, hooks-guide` to a 3-item YAML list with `plugin-creator:` namespace prefixes
- **topic-specialist.md**: Converted `skills: fact-check, find-cause, research-curator` to a 3-item YAML list
- **backlog-item-groomer.md**: Converted `skills: dh:rt-ica` to a single-item YAML list
- **fact-checker.md**: Converted `skills: gh` to a single-item YAML list
- **research-curator.md**: Converted `skills: gh` to a single-item YAML list

## Implementation Details
This change standardizes the YAML structure across all agent configuration files, making the format more maintainable and consistent with YAML best practices. The list syntax is more explicit and easier to parse programmatically compared to comma-separated strings.

https://claude.ai/code/session_01DmJQx572YnFNkjHrnUubjD