### PR TITLE
feat(development-harness): add SessionStart hook to capture CLAUDE_CODE_SESSION_ID

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.182"
+    "version": "6.3.183"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.7.3",
+  "version": "6.7.4",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/hooks/hooks.json
+++ b/plugins/development-harness/hooks/hooks.json
@@ -1,6 +1,17 @@
 {
   "description": "Development-harness plugin hooks — task completion reminders and session hygiene",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-session-id.cjs\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
     "TaskCompleted": [
       {
         "hooks": [

--- a/plugins/development-harness/hooks/session-start-session-id.cjs
+++ b/plugins/development-harness/hooks/session-start-session-id.cjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * SessionStart hook — captures session_id from stdin JSON and injects it as
+ * CLAUDE_CODE_SESSION_ID into both conversation context and shell environment.
+ *
+ * Guards:
+ *   - Skips if CLAUDE_CODE_SESSION_ID is already set (user-level hook or resume)
+ *   - Skips env file write if CLAUDE_ENV_FILE is absent or already contains the var
+ *
+ * Scope: plugin (development-harness)
+ * Fires on: SessionStart (no matcher)
+ * Action: non-blocking — injects session ID into context and environment
+ *
+ * Test:
+ *   echo '{"hook_event_name":"SessionStart","session_id":"a4b692e2-9095-43e4-849d-385e9e454782"}' | node ./hooks/session-start-session-id.cjs
+ *
+ * SOURCE: https://github.com/anthropics/claude-code/issues/20132#issuecomment-3902811178
+ */
+
+const fs = require('node:fs');
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  // If already set in environment, do nothing — user-level hook or resumed session
+  if (process.env.CLAUDE_CODE_SESSION_ID) {
+    process.stdout.write(JSON.stringify({}));
+    process.exit(0);
+  }
+
+  // Parse stdin — exit cleanly on failure
+  let data = {};
+  try {
+    data = JSON.parse(input || '{}');
+  } catch {
+    process.stdout.write(JSON.stringify({}));
+    process.exit(0);
+  }
+
+  const sessionId = data.session_id;
+  if (!sessionId || typeof sessionId !== 'string') {
+    process.stdout.write(JSON.stringify({}));
+    process.exit(0);
+  }
+
+  // Inject into shell environment via CLAUDE_ENV_FILE so Bash tool calls can use it.
+  // Guard: each session gets its own env file — skip if already written (resume/continue)
+  const envFile = process.env.CLAUDE_ENV_FILE;
+  if (envFile) {
+    try {
+      const existing = fs.existsSync(envFile) ? fs.readFileSync(envFile, 'utf8') : '';
+      if (!existing.includes('CLAUDE_CODE_SESSION_ID')) {
+        fs.appendFileSync(envFile, `export CLAUDE_CODE_SESSION_ID="${sessionId}"\n`);
+      }
+    } catch {
+      // Non-fatal — env injection is best-effort
+    }
+  }
+
+  // Inject into conversation context so the model can reference it
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: `CLAUDE_CODE_SESSION_ID=${sessionId}`,
+    },
+  };
+
+  process.stdout.write(JSON.stringify(output));
+  process.exit(0);
+});


### PR DESCRIPTION
Injects session_id from hook stdin into both conversation context
(additionalContext) and shell environment (CLAUDE_ENV_FILE) so the
harness can reference its own session. Guards against overwriting
when the env var is already set by a user-level hook.

SOURCE: anthropics/claude-code#20132 (comment 3902811178)

https://claude.ai/code/session_01HSoayijoVXnCxDYWU5ckmr