### PR TITLE
fix(mcp): remove broken octocode MCP server from project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -16,10 +16,6 @@
         "--api-key",
         "$CONTEXT7_API_KEY"
       ]
-    },
-    "octocode": {
-      "command": "npx",
-      "args": ["-y", "octocode-mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
octocode-mcp closes the connection before completing the MCP initialize
handshake (confirmed via fastmcp list --command and raw JSON-RPC testing).
Its presence contributes to OOM kills during session startup when all MCP
servers are health-checked simultaneously.

https://claude.ai/code/session_01WazXbaVTS69DHAJLfPJ2wu