### PR TITLE
refactor(docs): remove hardcoded counts — reference finalize.md as source of truth (#1673)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.221"
+    "version": "6.3.222"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.8.6",
+  "version": "7.8.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -221,20 +221,20 @@ When adding a new dispatch step to any dh skill, reference file, or workflow doc
 
 ---
 
-## Skills Overview (30)
+## Skills Overview
 
 **Main orchestration:**
 
 - `/dh:development-harness` - Entry point. Detects language, resolves roles, orchestrates S1-S7.
 
-**SAM workflow (4):**
+**SAM workflow:**
 
 - `/dh:add-new-feature` - Plan a feature: discovery, analysis, architecture, task decomposition
 - `/dh:implement-feature` - Execute tasks from a SAM task file via agent delegation loop
 - `/dh:start-task` - Start or complete a specific task inside a SAM task file
 - `/dh:complete-implementation` - Quality gates after all tasks are COMPLETE
 
-**Workflow stages (7):**
+**Workflow stages:**
 
 - `/dh:discovery` - S1 feature and codebase understanding
 - `/dh:planning` - S2 plan generation with RT-ICA
@@ -244,7 +244,7 @@ When adding a new dispatch step to any dh skill, reference file, or workflow doc
 - `/dh:forensic-review` - S6 verify task completion
 - `/dh:final-verification` - S7 certify feature completion
 
-**Planning tools (4):**
+**Planning tools:**
 
 - `/dh:clear-cove-task-design` - Task design methodology
 - `/dh:generate-task` - Generate individual task files
@@ -255,7 +255,7 @@ When adding a new dispatch step to any dh skill, reference file, or workflow doc
 
 - `/dh:implementation-manager` - Coordinate implementation across tasks
 
-**Backlog management (4):**
+**Backlog management:**
 
 - `/dh:backlog` - Backlog overview and operations reference
 - `/dh:create-backlog-item` - Create new backlog items
@@ -273,7 +273,7 @@ When adding a new dispatch step to any dh skill, reference file, or workflow doc
 - `/dh:analyze-test-failures` - Diagnose and categorize test failures
 - `/dh:test-failure-mindset` - Systematic approach to understanding test failures
 
-**Other (4):**
+**Other:**
 
 - `/dh:dispatch` - Dispatch tasks to agents using teams-first parallel execution; prefer over implement-feature when milestone-scoped work needs concurrent agent dispatch
 - `/dh:dh-meta-docs` - Plugin meta-documentation
@@ -282,7 +282,7 @@ When adding a new dispatch step to any dh skill, reference file, or workflow doc
 
 ---
 
-## Agents Overview (21)
+## Agents Overview
 
 **Planning and decomposition:**
 

--- a/plugins/development-harness/docs/backlog-lifecycle.md
+++ b/plugins/development-harness/docs/backlog-lifecycle.md
@@ -61,7 +61,7 @@ stateDiagram-v2
 | State | Status value | Description |
 |---|---|---|
 | `needs-grooming` | `needs-grooming` | Item created, not yet fact-checked or groomed |
-| `groomed` | `groomed` | All 8 canonical sections present, RT-ICA APPROVED |
+| `groomed` | `groomed` | All required sections present (defined in finalize.md), RT-ICA APPROVED |
 | `blocked-grooming` | `blocked` | RT-ICA BLOCKED during grooming — missing information prevents grooming |
 | `blocked-work` | `blocked` | AC verification FAIL during work — implementation issue prevents completion |
 | `in-milestone` | `in-milestone` | Assigned to a milestone, awaiting work |
@@ -81,7 +81,7 @@ status determines which resolution path applies:
 
 - **`in-progress` timing**: Set only after the RT-ICA gate returns APPROVED and the SAM plan
   file is created. Not during grooming or RT-ICA checking.
-- **`groomed` timing**: Set only when ALL 8 canonical sections are present with minimum content.
+- **`groomed` timing**: Set only when ALL required sections are present with minimum content (defined in finalize.md).
   Partial grooming is not groomed.
 - **`blocked` and `in-progress` are exclusive**: If AC verification fails during close, set
   `blocked` — do not close.
@@ -111,7 +111,7 @@ The backend creates an issue at that point via `backlog_sync`.
 ```text
 Trigger:    work-backlog-item discovers during planning that a required groomed section
             is missing or the RT-ICA result is stale and cannot be re-run
-Precondition: grooming incomplete — at least one of the 8 required sections absent
+Precondition: grooming incomplete — at least one of the required sections absent (defined in finalize.md)
 Action:     backlog_update(selector='{item_ref}', status='needs-grooming')
             Report reason to user — which sections are missing
             User re-runs /dh:work-backlog-item groom {item_ref} before item can
@@ -141,7 +141,7 @@ NEXT-token handoff model where separate skills passed control to each other.
 | Stage | Route | Workflow file | Produces | Status on completion |
 |---|---|---|---|---|
 | Create | `create` | `workflows/create/scope.md` + `start.md` | `item_ref` (`#N`), backend issue | `needs-grooming` |
-| Groom | `groom` | `workflows/groom/scope.md` + `start.md` | DEEP item with 8 required sections | `groomed` |
+| Groom | `groom` | `workflows/groom/scope.md` + `start.md` | DEEP item with all required sections (defined in finalize.md) | `groomed` |
 | Work | `work` | `workflows/work/scope.md` + `start.md` | SAM plan | `open/groomed` → `in-progress` |
 
 ### Stage Transitions
@@ -250,7 +250,7 @@ and configuration.
 |---|---|---|
 | `status` | MCP tools | Current lifecycle state (`needs-grooming`, `groomed`, `blocked`, etc.) |
 | `priority` | `backlog_add` | P0, P1, P2, or Ideas |
-| `groomed` | `backlog_groom` | Date when grooming completed (set after all 7 sections present) |
+| `groomed` | `backlog_groom` | Date when grooming completed (set after all required sections present — defined in finalize.md) |
 | `plan` | `backlog_update(plan=...)` | SAM plan address (`P{NNN}`) — a backend reference, not a file path |
 | `issue` | `backlog_add` | Backend issue identifier (`#N` format) |
 | `milestone` | `group-items-to-milestone` | Milestone identifier |
@@ -283,7 +283,7 @@ may modify lifecycle state without being added to this table.
 | From State | To State | Initiating Route | Observable Trigger Condition |
 |---|---|---|---|
 | `[*]` | `needs-grooming` | `work-backlog-item create` | `backlog_add` returns success with `item_ref` |
-| `needs-grooming` | `groomed` | `work-backlog-item groom` | RT-ICA APPROVED AND all 8 canonical sections present |
+| `needs-grooming` | `groomed` | `work-backlog-item groom` | RT-ICA APPROVED AND all required sections present (defined in finalize.md) |
 | `needs-grooming` | `blocked` | `work-backlog-item groom` | RT-ICA BLOCKED — one or more MISSING conditions |
 | `blocked` | `needs-grooming` | (user re-queues) | User provides missing info; operator runs `groom` again |
 | `blocked` | `resolved` | any route | User cancels item; explicit reason provided |
@@ -380,10 +380,10 @@ metadata:
   updated_at: {ISO timestamp}
 ```
 
-### 8 Required Groomed Sections
+### Required Groomed Sections
 
-An item is considered fully groomed only when ALL 8 sections are present with minimum content.
-`metadata.groomed` MUST NOT be set until all 8 sections pass the presence check.
+An item is considered fully groomed only when ALL required sections are present with minimum content (defined in finalize.md validation table).
+`metadata.groomed` MUST NOT be set until all required sections pass the presence check.
 
 | Section | Required | Minimum Content |
 |---|---|---|

--- a/plugins/development-harness/skills/backlog/references/item-schema.md
+++ b/plugins/development-harness/skills/backlog/references/item-schema.md
@@ -20,7 +20,7 @@ metadata:
   priority: P0|P1|P2|Ideas   # REQUIRED — priority tier
   type: Feature|Bug|Refactor|Docs|Chore   # REQUIRED
   status: needs-grooming|groomed|blocked|in-milestone|in-progress|done|resolved|closed   # REQUIRED
-  groomed: YYYY-MM-DD     # optional — set by groom-backlog-item when all 8 sections present
+  groomed: YYYY-MM-DD     # optional — set by groom-backlog-item when all required sections present (defined in finalize.md)
   issue: '#N'             # optional — GitHub issue number (string with # prefix)
   milestone: integer      # optional — GitHub milestone number
   plan: string            # optional — relative path to SAM task file
@@ -39,7 +39,7 @@ metadata:
 | `metadata.priority` | create-backlog-item | Set at creation |
 | `metadata.type` | create-backlog-item | Set at creation |
 | `metadata.status` | all skills | Updated on state transitions (see state-machine.md) |
-| `metadata.groomed` | groom-backlog-item | Set when all 8 required sections present |
+| `metadata.groomed` | groom-backlog-item | Set when all required sections present (defined in finalize.md) |
 | `metadata.issue` | backlog script | Set on GitHub issue creation |
 | `metadata.milestone` | group-items-to-milestone | Set on milestone assignment |
 | `metadata.plan` | work-backlog-item | Set when SAM task file created |
@@ -154,7 +154,7 @@ Overall: FAIL (2/3 criteria met)
 | Newly created | All frontmatter fields | Description, optionally AC + Research First + Suggested Location |
 | Fact-checked | + | + Fact-Check section |
 | RT-ICA assessed | + | + RT-ICA section |
-| Fully groomed | `metadata.groomed` set | All 8 canonical sections: Fact-Check, RT-ICA, Reproducibility, Dependencies, Skills, Agents, Prior Work |
+| Fully groomed | `metadata.groomed` set | All required sections present (defined in finalize.md validation table) |
 | In-milestone | `metadata.milestone` set, `metadata.status: in-milestone` | (same as fully groomed) |
 | In-progress | `metadata.plan` set, `metadata.status: in-progress` | + plan file exists at path |
 | Done | `metadata.status: done` | + Acceptance Criteria Verification section (all criteria PASS) |

--- a/plugins/development-harness/skills/backlog/references/state-machine.md
+++ b/plugins/development-harness/skills/backlog/references/state-machine.md
@@ -45,7 +45,7 @@ stateDiagram-v2
 | State | Description | GitHub label |
 |---|---|---|
 | `needs-grooming` | Item created, not yet fact-checked or groomed | `status:needs-grooming` |
-| `groomed` | All 7 canonical sections present, RT-ICA APPROVED | `status:groomed` |
+| `groomed` | All required sections present (defined in finalize.md), RT-ICA APPROVED | `status:groomed` |
 | `blocked` | RT-ICA BLOCKED — missing information prevents grooming or work | `status:blocked` |
 | `in-milestone` | Assigned to a GitHub milestone, awaiting work | `status:in-milestone` |
 | `in-progress` | Work started, plan file created, implementation underway | `status:in-progress` |
@@ -60,8 +60,8 @@ stateDiagram-v2
 ### `needs-grooming` → `groomed`
 
 ```
-Trigger:    /groom-backlog-item completes Step 9 with all 7 sections present
-Precondition: RT-ICA Decision is APPROVED; all 7 canonical sections written
+Trigger:    /groom-backlog-item completes Step 9 with all required sections present (defined in finalize.md)
+Precondition: RT-ICA Decision is APPROVED; all required canonical sections written (defined in finalize.md)
 Action:     backlog script sets metadata.groomed = today's date
              GitHub label: remove status:needs-grooming, add status:groomed
 ```
@@ -193,7 +193,7 @@ priority:Ideas
 
 **`status:in-progress` timing**: The in-progress label MUST be set only after the RT-ICA gate returns APPROVED and the SAM plan file is created. Setting it during "checking RT-ICA" or "starting grooming" is incorrect and produces misleading state.
 
-**`metadata.groomed` timing**: Only set when ALL 7 canonical sections are present in the item file (see [./item-schema.md](./item-schema.md)). Partial grooming is not groomed.
+**`metadata.groomed` timing**: Only set when ALL required sections are present in the item file (defined in finalize.md; see [./item-schema.md](./item-schema.md)). Partial grooming is not groomed.
 
 **`blocked` and `in-progress` are exclusive**: An item cannot be both blocked and in-progress. If AC verification fails during close, revert to `blocked`, do not close.
 

--- a/plugins/development-harness/skills/backlog/templates/item.md
+++ b/plugins/development-harness/skills/backlog/templates/item.md
@@ -8,7 +8,7 @@ metadata:
   priority: P1
   type: Feature
   status: needs-grooming
-  # groomed: YYYY-MM-DD       # set by groom-backlog-item when all 7 sections present
+  # groomed: YYYY-MM-DD       # set by groom-backlog-item when all required sections present (see finalize.md)
   # issue: '#N'               # set by backlog script on GitHub issue creation
   # milestone: N              # set by group-items-to-milestone
   # plan: plan/slug.md        # set by work-backlog-item when SAM plan created

--- a/plugins/development-harness/skills/groom-backlog-item/references/groomer-output-validation.md
+++ b/plugins/development-harness/skills/groom-backlog-item/references/groomer-output-validation.md
@@ -9,7 +9,7 @@ SOURCE: Architect spec Issue #398, Section 7 (Groomer Output Validation AC3)
 
 ## Required Section Schema
 
-All 8 sections must be present in the groomer output with minimum content. Section
+All required sections must be present in the groomer output with minimum content (defined in finalize.md validation table). Section
 names are exact string matches against `backlog_view(selector=title, summary=false).sections`.
 
 | Section | Required | Minimum content |
@@ -21,6 +21,7 @@ names are exact string matches against `backlog_view(selector=title, summary=fal
 | `Reproducibility` | Required | Non-empty — may be "N/A for feature items" but must be present |
 | `Issue Classification` | Required | Contains `Type:` field with valid type value |
 | `Priority` | Required | Contains `Effort:` field |
+| `Design Intent Alignment` | Required | Contains `Alignment assessment:` field with ALIGNED/DIVERGENT/NOT_APPLICABLE |
 
 ## Optional Sections (Not Validated for Presence)
 
@@ -62,8 +63,8 @@ Located between end of Steps 4–8 swarm and the `backlog_groom(mark_groomed=Tru
 flowchart TD
     SwarmComplete(["Steps 4-8 swarm complete"]) --> GatherSections["Read backlog_view(selector=title, summary=false).sections"]
 
-    GatherSections --> PresenceCheck["Check all 8 required sections present<br>Apply minimum content checks per schema"]
-    PresenceCheck --> PresenceResult{"All 8 sections present<br>with minimum content?"}
+    GatherSections --> PresenceCheck["Check all required sections present (see finalize.md)<br>Apply minimum content checks per schema"]
+    PresenceCheck --> PresenceResult{"All required sections present<br>with minimum content?"}
 
     PresenceResult -->|"Yes"| ScopeCheck["Scan groomer sections for prohibited patterns"]
     PresenceResult -->|"No — sections missing"| MissingList["Build list of missing section names"]

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/groom/finalize.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/groom/finalize.md
@@ -93,7 +93,7 @@ Runs when RT-ICA Final Decision is APPROVED, before the final write with `mark_g
 mcp__plugin_dh_backlog__backlog_view(selector='{item_ref}', summary=false)
 ```
 
-2. Check all 8 required sections are present with minimum content:
+2. Check all required sections are present with minimum content (defined in the table below):
 
 | Section | Minimum content |
 |---|---|
@@ -117,7 +117,7 @@ Escalating to a more capable model does not address interrupted writes.
 
 ```mermaid
 flowchart TD
-    Check{"All 8 required sections<br>present with minimum content?"}
+    Check{"All required sections (see table)<br>present with minimum content?"}
     Check -->|Yes| ScopeCheck["Scan for prohibited patterns"]
     Check -->|No| Missing["Build list of missing section names"]
     Missing --> Verify["Verify: re-read item via backlog_view<br>Confirm sections are absent in backend,<br>not just missed in local read"]
@@ -145,7 +145,7 @@ mcp__plugin_dh_backlog__backlog_groom(selector='{item_ref}', section='Grooming N
   content='Scope violation: {pattern} in {section}')
 ```
 
-5. When validation passes (all 8 sections present, scope check logged) → proceed to write.
+5. When validation passes (all required sections present, scope check logged) → proceed to write.
 
 ## Write Groomed Content
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/groom/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/groom/start.md
@@ -61,7 +61,7 @@ Track progress using your task list. Check off each step as it completes.
    - RT-ICA final pass: re-assess conditions, self-resolve DERIVABLE/MISSING, write final report
      - If BLOCKED: present MISSING conditions to user, wait for answers, re-check
      - If APPROVED: continue
-   - Output validation gate: verify 8 required sections present with minimum content
+   - Output validation gate: verify all required sections present with minimum content (defined in finalize.md)
      - If missing: retry same model with targeted prompt (up to 3 attempts, then blocked)
      - If pass: continue
    - Write groomed content via `backlog_groom(selector='{item_ref}', sections={...}, mark_groomed=True)`


### PR DESCRIPTION
Replace 31 inline derived counts across 8 operational files with prose
references to finalize.md validation table. Fixes CLAUDE.md Skills/Agents
Overview headings (30→removed, 21→removed) and resolves 7-vs-8 section
count split in state-machine.md, item.md, item-schema.md, and
backlog-lifecycle.md.

Side fix: groomer-output-validation.md was missing the 'Design Intent
Alignment' row — table now matches finalize.md's 8-entry definition.

Excludes *.draft.md files per acceptance criteria.

https://claude.ai/code/session_01LLosXwdjDmXAxNpTRSuTSX