### PR TITLE
refactor(docs): remove hardcoded counts from dh documentation, add MCP connection-check reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.223"
+    "version": "6.3.224"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.222"
+    "version": "6.3.223"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.8.7",
+  "version": "7.8.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.8.8",
+  "version": "7.9.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -262,12 +262,12 @@ When adding a new dispatch step to any dh skill, reference file, or workflow doc
 - `/dh:work-backlog-item` - Work on a backlog item through its lifecycle
 - `/dh:groom-backlog-item` - Groom and prioritize backlog items
 
-**Milestone management (2):**
+**Milestone management:**
 
 - `/dh:groom-milestone` - Groom milestone issues into dispatch plans
 - `/dh:work-milestone` - Execute milestone tasks in isolated worktrees
 
-**Testing (3):**
+**Testing:**
 
 - `/dh:comprehensive-test-review` - Review test coverage and quality
 - `/dh:analyze-test-failures` - Diagnose and categorize test failures

--- a/plugins/development-harness/skills/backlog/SKILL.md
+++ b/plugins/development-harness/skills/backlog/SKILL.md
@@ -11,6 +11,8 @@ Skills and agents invoke MCP tools or the CLI — no direct `Write`/`Edit` on pe
 
 ## Primary Interface (MCP)
 
+**Server availability**: If any `mcp__plugin_dh_backlog__*` tool is unavailable or `ToolSearch` returns "still connecting", apply the retry procedure in [mcp-connection-check.md](./references/mcp-connection-check.md) before proceeding (up to 5 × 30-second retries).
+
 All 12 tools return a `dict`. On error the dict contains an `"error"` key. On success it
 contains result data keys plus `messages: list[str]` and `warnings: list[str]` (always present,
 may be empty). Always check for `"error"` before consuming result fields.

--- a/plugins/development-harness/skills/backlog/references/item-schema.md
+++ b/plugins/development-harness/skills/backlog/references/item-schema.md
@@ -160,17 +160,9 @@ Overall: FAIL (2/3 criteria met)
 | Done | `metadata.status: done` | + Acceptance Criteria Verification section (all criteria PASS) |
 | Closed | `metadata.status: closed` | Terminal — set by complete-milestone only |
 
-An item is **fully groomed** only when ALL 8 of these sections are present in the item file (in this order):
+An item is **fully groomed** only when all required sections are present in the item file. The authoritative list of required sections and minimum content requirements is defined in the [finalize.md validation table](../../work-backlog-item/references/workflows/groom/finalize.md) (lines 99–107).
 
-1. `Fact-Check` — must contain V/R/I counts
-2. `RT-ICA` — must contain `Decision: APPROVED` or `Decision: BLOCKED`
-3. `Reproducibility`
-4. `Dependencies`
-5. `Skills` — content or explicit "None"
-6. `Agents` — content or explicit "None"
-7. `Prior Work`
-
-`metadata.groomed` MUST NOT be set until all 8 are present. Partial grooming (e.g., only Fact-Check and RT-ICA written) is NOT considered groomed — groom-backlog-item resumes from the first missing section rather than restarting.
+`metadata.groomed` MUST NOT be set until all required sections pass the presence check (defined in finalize.md validation table). Partial grooming (e.g., only Fact-Check and RT-ICA written) is NOT considered groomed — groom-backlog-item resumes from the first missing section rather than restarting.
 
 ---
 

--- a/plugins/development-harness/skills/backlog/references/mcp-connection-check.md
+++ b/plugins/development-harness/skills/backlog/references/mcp-connection-check.md
@@ -1,0 +1,80 @@
+# MCP Server Connection Check
+
+Both `mcp__plugin_dh_backlog__*` and `mcp__plugin_dh_sam__*` tools require their servers
+to be connected before use. After a session disconnect and reconnect, these servers take
+10–30 seconds to initialize due to stacked module-level costs at startup:
+
+- `tiktoken.get_encoding("cl100k_base")` loaded at import time in both servers (~3–8 s cold)
+- PyGithub and gitpython transitive imports (~2–5 s)
+- Task/context backend initialization in the SAM server (~1–3 s)
+- Two servers starting sequentially, not in parallel
+
+Source: `backlog_core/server.py` line 65, `sam_schema/server.py` lines 68–78, 109.
+
+## When to Apply This Procedure
+
+Apply this procedure before any `mcp__plugin_dh_backlog__*` or `mcp__plugin_dh_sam__*`
+tool call when any of the following is true:
+
+- A tool call returns no result or a connection error
+- `ToolSearch` response contains `"Some MCP servers are still connecting: plugin:dh:backlog"`
+  or `"plugin:dh:sam"`
+- Beginning a workflow immediately after a session restart or reconnect event
+
+## Retry Procedure (up to 5 attempts)
+
+```mermaid
+flowchart TD
+    Start(["MCP tool unavailable or ToolSearch shows 'still connecting'"]) --> Attempt["attempt = 1"]
+    Attempt --> Check1["ToolSearch(query='backlog_list')<br>Check for mcp__plugin_dh_backlog__backlog_list in response"]
+    Check1 --> B1{"Available?"}
+    B1 -->|Yes| Check2["ToolSearch(query='sam_plan')<br>Check for mcp__plugin_dh_sam__sam_plan in response"]
+    B1 -->|"No — still connecting"| Count1{"attempt >= 5?"}
+    Count1 -->|Yes| Blocked(["BLOCKED — report and stop"])
+    Count1 -->|No| Wait1["Wait 30 seconds<br>attempt += 1"]
+    Wait1 --> Check1
+    Check2 --> B2{"Available?"}
+    B2 -->|Yes| Proceed(["Both servers ready — proceed with original tool call"])
+    B2 -->|"No — still connecting"| Count2{"attempt >= 5?"}
+    Count2 -->|Yes| Blocked
+    Count2 -->|No| Wait2["Wait 30 seconds<br>attempt += 1"]
+    Wait2 --> Check2
+```
+
+**Step-by-step:**
+
+1. Call `ToolSearch(query="backlog_list")` to check backlog server status.
+   - Response lists `mcp__plugin_dh_backlog__backlog_list` → proceed to step 2.
+   - Response says `"still connecting: plugin:dh:backlog"` → wait 30 s, increment attempt, repeat step 1.
+   - After 5 attempts still connecting → report BLOCKED (see below).
+
+2. Call `ToolSearch(query="sam_plan")` to check SAM server status.
+   - Response lists `mcp__plugin_dh_sam__sam_plan` → both servers ready, proceed.
+   - Response says `"still connecting: plugin:dh:sam"` → wait 30 s, increment attempt, repeat step 2.
+   - After 5 attempts still connecting → report BLOCKED (see below).
+
+3. Once both servers show as available, proceed with the original MCP tool call.
+
+## BLOCKED Report Format
+
+After 5 failed attempts (~2.5 minutes), output:
+
+```text
+BLOCKED — MCP server {plugin:dh:backlog | plugin:dh:sam} did not connect after 5 attempts
+(~2.5 minutes). Cannot proceed with {skill name or tool name}.
+
+To resolve: restart your Claude Code session. If the problem persists, check that uv is
+installed and the plugin cache is current (see CLAUDE.md — Testing MCP Servers).
+```
+
+## SAM CLI Fallback
+
+If the SAM server is unavailable and the task cannot wait, use the `uv run sam` CLI for
+SAM-only operations. For backlog operations there is no CLI equivalent — the MCP server
+must be available.
+
+```bash
+uv run sam list
+uv run sam status P{N}
+uv run sam ready P{N}
+```

--- a/plugins/development-harness/skills/complete-implementation/SKILL.md
+++ b/plugins/development-harness/skills/complete-implementation/SKILL.md
@@ -18,6 +18,7 @@ hooks:
 
 You MUST validate that the implemented feature meets its goals and quality gates. If follow-up task files are created, route them to backlog items first, then recurse only when the follow-up matches the current scope and priority (see Recursive Follow-up Handling section).
 
+
 <task_file>
 $ARGUMENTS
 </task_file>

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -15,6 +15,8 @@ This workflow continues from `add-new-feature`. It executes tasks from a SAM tas
 
 ---
 
+**MCP server availability**: This skill uses both `mcp__plugin_dh_backlog__*` and `mcp__plugin_dh_sam__*` tools. Both servers take 10–30 seconds to initialize after a session restart. If either is unavailable or `ToolSearch` reports "still connecting", follow [mcp-connection-check.md](../backlog/references/mcp-connection-check.md) before proceeding.
+
 ## Resolve Task File
 
 Rules:

--- a/plugins/development-harness/skills/start-task/SKILL.md
+++ b/plugins/development-harness/skills/start-task/SKILL.md
@@ -21,6 +21,8 @@ $ARGUMENTS
 
 ---
 
+**MCP server availability**: This skill uses `mcp__plugin_dh_sam__*` tools. The SAM server takes 10–30 seconds to initialize after a session restart. If unavailable or `ToolSearch` reports "still connecting", follow [mcp-connection-check.md](../backlog/references/mcp-connection-check.md) before proceeding.
+
 ## Parse Arguments
 
 - `task_file_path` (required): path to a `plan/tasks-*.md` file

--- a/plugins/development-harness/skills/work-backlog-item/SKILL.md
+++ b/plugins/development-harness/skills/work-backlog-item/SKILL.md
@@ -96,6 +96,8 @@ See the [Backlog Lifecycle reference](../../docs/backlog-lifecycle.md) for the c
 **SAM** — Stateless Agent Methodology. See [sam-definition.md](./references/workflows/work/sam-definition.md) for what SAM is and how to embody it. SAM lives in `../stateless-agent-methodology/` (or `bitflight-devops/stateless-agent-methodology` on GitHub).
 Primary source of truth is **GitHub Issues** (labels + milestone = canonical status). Agents interact with backlog items exclusively through MCP tools (`backlog_view`, `backlog_update`, `backlog_list`, etc.).
 
+**MCP server availability**: Both `plugin:dh:backlog` and `plugin:dh:sam` take 10–30 seconds to initialize after a session restart. If a tool is unavailable or `ToolSearch` reports "still connecting", follow [mcp-connection-check.md](../backlog/references/mcp-connection-check.md) before making any MCP call.
+
 When invoked with no arguments, shows an interactive browser. When invoked with `#N` or a title substring, proceeds directly to the planning workflow.
 
 ## Arguments


### PR DESCRIPTION
## Summary

Closes #1673

- Removed 35 hardcoded section/count values from 8 operational files in `plugins/development-harness/` — replaced with references to `finalize.md` as the single source of truth
- Added `mcp-connection-check.md` — a shared reference with a 5-retry / 30-second backoff procedure for when `plugin:dh:backlog` or `plugin:dh:sam` report "still connecting" after a session restart
- Linked the connection-check reference from `backlog`, `work-backlog-item`, `implement-feature`, and `start-task` SKILL.md files

### Files changed (issue #1673 work)

| File | Change |
|------|--------|
| `CLAUDE.md` | Removed sub-group counts from Skills/Agents Overview headings |
| `docs/backlog-lifecycle.md` | Replaced "8 required sections" with finalize.md references |
| `skills/backlog/references/item-schema.md` | Replaced stale 7-section list and hardcoded counts |
| `skills/backlog/references/state-machine.md` | Replaced "7 canonical sections" (4 instances) |
| `skills/backlog/templates/item.md` | Replaced 1 instance |
| `skills/groom-backlog-item/references/groomer-output-validation.md` | Replaced 3 instances; added missing Design Intent Alignment row |
| `skills/work-backlog-item/references/workflows/groom/finalize.md` | Replaced 3 self-referential count instances |
| `skills/work-backlog-item/references/workflows/groom/start.md` | Replaced 1 instance |
| `skills/backlog/references/mcp-connection-check.md` | New file — retry procedure for MCP startup delay |
| `skills/backlog/SKILL.md` + 3 other SKILL.md files | Added MCP availability link |

## Test plan

- [ ] Run `uv run prek run --files plugins/development-harness/` — all hooks pass (markdownlint, skilllint)
- [ ] Verify no remaining hardcoded section counts: `grep -r "8 required sections\|7 required sections\|ALL 8\|all 8 are present" plugins/development-harness/`
- [ ] Verify `mcp-connection-check.md` is reachable via relative links from each linking SKILL.md

https://claude.ai/code/session_01LLosXwdjDmXAxNpTRSuTSX