### PR TITLE
Fix development-harness plugin: typed dispatch input, UUID plan IDs, and path leak removal

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.240"
+    "version": "6.3.241"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.239"
+    "version": "6.3.240"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.243"
+    "version": "6.3.244"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.241"
+    "version": "6.3.242"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.242"
+    "version": "6.3.243"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.237"
+    "version": "6.3.238"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.238"
+    "version": "6.3.239"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.244"
+    "version": "6.3.245"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.245"
+    "version": "6.3.246"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.12",
+  "version": "7.10.13",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.6",
+  "version": "7.10.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.11",
+  "version": "7.10.12",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.7",
+  "version": "7.10.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.8",
+  "version": "7.10.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.9",
+  "version": "7.10.10",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.10",
+  "version": "7.10.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.5",
+  "version": "7.10.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.13",
+  "version": "7.10.14",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -86,7 +86,7 @@ Skills and agents access plan artifacts via MCP tools — not via `dh_paths` dir
 
 - `plan/feature-context-{slug}.md` - S1 output
 - `plan/architect-{slug}.md` - architecture output
-- `plan/P{NNN}-{slug}.yaml` - task plan
+- `plan/P{id}-{slug}.yaml` - task plan
 - `plan/T0-baseline-{slug}.yaml` - pre-implementation baseline
 - `plan/TN-verification-{slug}.yaml` - post-implementation verification
 - `backlog/*.md` - backlog item cache (synced from GitHub Issues)
@@ -102,7 +102,7 @@ The `plan_dir` parameter in `sam_read`, `sam_update`, `sam_create`, and related 
 
 Two distinct types of plan data exist:
 
-- **SAM task plan YAML files** (`P{NNN}-{slug}.yaml`, `T0-baseline-*.yaml`, etc.) — stored in `~/.dh/projects/{slug}/plan/` by the SAM MCP. Access via `sam_read`, `sam_list`, `sam_update` — never via direct filesystem path.
+- **SAM task plan YAML files** (`P{id}-{slug}.yaml`, `T0-baseline-*.yaml`, etc.) — stored in `~/.dh/projects/{slug}/plan/` by the SAM MCP. Access via `sam_read`, `sam_list`, `sam_update` — never via direct filesystem path.
 - **Plan artifact markdown files** (`plan/feature-context-{slug}.md`, `plan/architect-{slug}.md`, etc.) — written to the repo root worktree's `plan/` directory. Not visible from isolated worktrees. Access via `artifact_read(issue_number, artifact_type)` — not filesystem path.
 
 ---

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -141,7 +141,7 @@ Wave-based parallel execution state for `/work-milestone`. State is persisted to
 - `dispatch_read(milestone_number)` — Read an existing dispatch plan from `plan/milestone-{N}-dispatch.yaml`. Returns parsed plan structure or error.
 - `dispatch_validate(milestone_number)` — Validate structural integrity of an existing dispatch plan. Returns is_valid, errors, warnings.
 - `dispatch_stale_check(milestone_number)` — Check whether any wave items have stale or dead PIDs and return staleness summary.
-- `dispatch_create_plan(milestone_number, plan_yaml, overwrite, validate, issue)` — Validate and persist a dispatch plan YAML atomically. Returns plan_path, wave_count, item_count, and validation results. Set overwrite=True when re-grooming. Pass issue to auto-register as a `dispatch-plan` artifact.
+- `dispatch_create_plan(milestone_number, plan, overwrite, validate, issue)` — Validate and persist a dispatch plan atomically. `plan` is a typed DispatchPlan object. Returns `milestone_number`, `wave_count`, `item_count`, `is_valid`, `errors`, `warnings`, and `messages`. Set overwrite=True when re-grooming. Pass issue to auto-register as a `dispatch-plan` artifact.
 - `dispatch_wave_start(milestone, wave_num, items)` — Create a wave entry; initialise all items with `status=pending`. Call before spawning processes. Returns error if wave already exists.
 - `dispatch_item_status(milestone, issue, status, result, error, cost)` — Record completion or failure of one item. Looks up item by milestone+issue across all waves. Valid status: `complete`, `failed`, `skipped`.
 - `dispatch_wave_status(milestone, wave_num)` — Query wave progress with per-item detail and elapsed time. Checks stale PIDs (marks dead processes failed) before returning.

--- a/plugins/development-harness/README.md
+++ b/plugins/development-harness/README.md
@@ -50,7 +50,7 @@ All outputs land in `~/.dh/projects/{your-project}/plan/` as named files. The Gi
 Executes a SAM task plan produced by `/dh:add-new-feature`.
 
 ```text
-/dh:implement-feature plan/P001-jwt-authentication.yaml
+/dh:implement-feature plan/Pa1b2c3d4-jwt-authentication.yaml
 ```
 
 What happens:
@@ -66,7 +66,7 @@ What happens:
 Claims and executes a single task from a SAM plan. Used directly when you want to run one task at a time rather than the full loop.
 
 ```text
-/dh:start-task plan/P001-jwt-authentication.yaml T3
+/dh:start-task plan/Pa1b2c3d4-jwt-authentication.yaml T3
 ```
 
 Writes an active-task context file for hook tracking. Records divergence classification (`design-refinement` vs `intent-divergence`) when what gets built differs from what was planned.
@@ -76,7 +76,7 @@ Writes an active-task context file for hook tracking. Records divergence classif
 Runs quality gates after all tasks are complete. Takes either a plan file path or a GitHub issue number.
 
 ```text
-/dh:complete-implementation plan/P001-jwt-authentication.yaml
+/dh:complete-implementation plan/Pa1b2c3d4-jwt-authentication.yaml
 /dh:complete-implementation #42
 ```
 
@@ -259,7 +259,7 @@ flowchart TD
     Human2 --> S3
     ARL1 -->|No| S3[S3 Context Integration<br>context-gathering]
     S3 -->|contextualized plan| S4[S4 Task Decomposition<br>swarm-task-planner]
-    S4 -->|P001-slug.yaml| ARL2{ARL Check<br>High complexity?}
+    S4 -->|Pa1b2c3d4-slug.yaml| ARL2{ARL Check<br>High complexity?}
     ARL2 -->|Yes| Human3([Escalate to human])
     Human3 --> S5
     ARL2 -->|No| S5[S5 Execution<br>parallel task agents]
@@ -347,7 +347,7 @@ All state lives outside the repository at `~/.dh/projects/{project-slug}/`:
 plan/
   feature-context-{slug}.md       Discovery output (S1)
   architect-{slug}.md             Architecture specification (S2)
-  P{NNN}-{slug}.yaml              Task plan (S4)
+  P{id}-{slug}.yaml               Task plan (S4)
   T0-baseline-{slug}.yaml         Pre-implementation baseline
   TN-verification-{slug}.yaml     Post-implementation verification
   QG{NNN}-qg-{slug}.yaml          Quality gate plan
@@ -396,7 +396,7 @@ Claude runs 6 research phases. You're consulted if any required information is g
 **Step 2: Execute the plan**
 
 ```text
-/dh:implement-feature plan/P001-rate-limiting.yaml
+/dh:implement-feature plan/Pa1b2c3d4-rate-limiting.yaml
 ```
 
 Claude queries ready tasks. If tasks T1 (implement middleware) and T2 (write tests) are both ready and independent, it spawns parallel agents. Each agent claims its task, implements it, and the hook marks it complete. T0 captures your test suite state before any code changes. TN verifies all acceptance criteria after implementation.
@@ -404,7 +404,7 @@ Claude queries ready tasks. If tasks T1 (implement middleware) and T2 (write tes
 **Step 3: Run quality gates**
 
 ```text
-/dh:complete-implementation plan/P001-rate-limiting.yaml
+/dh:complete-implementation plan/Pa1b2c3d4-rate-limiting.yaml
 ```
 
 Code review, feature verification, integration check, documentation drift audit, documentation update, context refinement — all run in sequence. The GitHub issue receives `status:verified` when all gates pass.

--- a/plugins/development-harness/agents/dh-context-gathering.md
+++ b/plugins/development-harness/agents/dh-context-gathering.md
@@ -27,7 +27,7 @@ You are part of the feature development workflow for Python projects. A task fil
    mcp__plugin_dh_sam__sam_plan(config={"action": "read"}, plan="P{N}")
    ```
 
-   Replace `P{N}` with the plan address (e.g., `P1`, `P719`, or slug `integrate-sam-schema`). This returns a JSON object containing the plan goal, context, and all task fields.
+   Replace `P{N}` with the plan address (e.g., `P1`, `Pc7d8e9f0`, or slug `integrate-sam-schema`). This returns a JSON object containing the plan goal, context, and all task fields.
 
 2. LOCATE and READ the linked architecture spec (found in `architecture` field of the JSON response)
 3. Understand what needs to be built/fixed/refactored

--- a/plugins/development-harness/agents/plan-validator.md
+++ b/plugins/development-harness/agents/plan-validator.md
@@ -378,7 +378,7 @@ sam_task(plan="{plan_id}", task="T1", config={"action": "read"})
 sam_plan(config={"action": "list", "search": "{feature_slug}"})
 ```
 
-When delegated with a plan path like `plan/P1129-some-slug.yaml`, extract the plan ID (`P1129`) and use `sam_plan(config={"action": "read"}, plan="P1129")`. Do NOT attempt to read the file at the literal path — it is not repo-relative.
+When delegated with a plan path like `plan/Pa5b6c7d8-some-slug.yaml`, extract the plan ID (`Pa5b6c7d8`) and use `sam_plan(config={"action": "read"}, plan="Pa5b6c7d8")`. Do NOT attempt to read the file at the literal path — it is not repo-relative.
 
 Read the architect spec and feature context via artifact MCP tools:
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -270,7 +270,7 @@ stale or absent SAM state instead of the actual plan.
 mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks_yaml": "{YAML_CONTENT}"})
 ```
 
-After `sam_plan` succeeds, the plan ID returned (e.g., `P037`) is the canonical reference for
+After `sam_plan` succeeds, the plan ID returned (e.g., `Pd7e8f9a0`) is the canonical reference for
 all downstream tools. Record it and pass it to the plan-validator and any other consumers.
 PLAN.md / PLAN/ disk files are optional human-readable summaries — they do not replace SAM
 registration and must never be written as the only plan artifact.

--- a/plugins/development-harness/agents/t0-baseline-capture.md
+++ b/plugins/development-harness/agents/t0-baseline-capture.md
@@ -31,7 +31,6 @@ Read the plan file passed to you (the task file for this feature). Extract:
 
 - `feature` field (the slug — used to construct the output path)
 - `acceptance_criteria_structured` list (or `acceptance-criteria-structured` in YAML)
-- `plan_path` (the path to the plan file itself, for inclusion in output)
 
 ```bash
 # The plan file path is provided in your task delegation prompt.
@@ -70,7 +69,6 @@ Build the T0 baseline YAML string in memory — do not write it to disk. The sch
 ```yaml
 feature: "{slug}"
 captured_at: "2026-03-15T10:00:00Z"
-plan_path: "~/.dh/projects/{project-slug}/plan/tasks-5-{slug}.md"
 criteria_count: 2
 results:
   - criterion-id: AC-1
@@ -97,7 +95,6 @@ results:
 |-------|------|-------------|
 | `feature` | str | The plan's `feature` field (the slug) |
 | `captured_at` | str (ISO 8601 UTC) | Timestamp when T0 agent ran |
-| `plan_path` | str | Relative path to the plan file |
 | `criteria_count` | int | Number of criteria executed |
 | `results` | list | One entry per AcceptanceCriterion |
 | `results[].criterion-id` | str | The `criterion-id` from the plan |

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -87,7 +87,6 @@ Assemble the TN verification result as a YAML string in memory (do not write to 
 ```yaml
 feature: "{slug}"
 verified_at: "2026-03-15T14:00:00Z"
-plan_path: "~/.dh/projects/{project-slug}/plan/tasks-5-{slug}.md"
 t0_baseline_source: "artifact:T0-baseline:issue={issue_number}"
 verdict: "PASS"  # or "FAIL"
 criteria_count: 2
@@ -114,7 +113,6 @@ results:
 |-------|------|-------------|
 | `feature` | str | Feature slug |
 | `verified_at` | str (ISO 8601 UTC) | When TN agent ran |
-| `plan_path` | str | State-relative path to the plan file (under `dh_paths.plan_dir()`) |
 | `t0_baseline_source` | str | MCP artifact reference for the T0 baseline — `artifact:T0-baseline:issue={issue_number}` |
 | `verdict` | str | `"PASS"` or `"FAIL"` |
 | `criteria_count` | int | Total criteria evaluated |

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -14,7 +14,6 @@ import sqlite3
 import sys
 import time as _time
 from datetime import UTC, datetime as _datetime
-from io import StringIO as _StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -24,7 +23,7 @@ import tiktoken
 from fastmcp import Context, FastMCP
 from github import GithubException as _GithubException
 from mcp.types import ToolAnnotations
-from pydantic import Field, ValidationError as _ValidationError
+from pydantic import Field
 from ruamel.yaml import YAML as _YAML, YAMLError as _YAMLError
 
 from . import models as _models, operations
@@ -3166,19 +3165,9 @@ async def dispatch_stale_check(
         title="Create Dispatch Plan", readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True
     )
 )
-async def dispatch_create_plan(  # noqa: PLR0911
+async def dispatch_create_plan(
     milestone_number: Annotated[int, Field(description="GitHub milestone number")],
-    plan_yaml: Annotated[
-        str,
-        Field(
-            description=(
-                "YAML string containing the full dispatch plan. Must include top-level keys: "
-                "'milestone' (with number, title, integration-branch), 'waves' (list of wave dicts "
-                "with items), and optionally 'conflict-groups' and 'quality-gates'. "
-                "Both kebab-case and snake_case keys are accepted."
-            )
-        ),
-    ],
+    plan: Annotated[_ds.DispatchPlan, Field(description="The dispatch plan for this milestone.")],
     overwrite: Annotated[
         bool,
         Field(
@@ -3209,13 +3198,14 @@ async def dispatch_create_plan(  # noqa: PLR0911
 ) -> dict:
     """Create or overwrite a dispatch plan YAML file for a milestone.
 
-    Accepts a YAML string, validates it against the ``DispatchPlan`` Pydantic
-    model, writes it atomically to ``plan/milestone-{N}-dispatch.yaml``, and
-    optionally validates structural integrity after writing.
+    Accepts a typed ``DispatchPlan`` model, writes it atomically to
+    ``plan/milestone-{N}-dispatch.yaml``, and optionally validates structural
+    integrity after writing.
 
     Args:
         milestone_number: GitHub milestone number.
-        plan_yaml: Full dispatch plan as a YAML string.
+        plan: The dispatch plan for this milestone. ``plan.milestone.number``
+            must match ``milestone_number``.
         overwrite: When ``False`` (default) returns an error if the plan file
             already exists.
         validate: When ``True`` (default) runs ``validate_plan_integrity`` after
@@ -3231,60 +3221,19 @@ async def dispatch_create_plan(  # noqa: PLR0911
     out = Output()
     plan_path = _dispatch_plan_path(milestone_number)
 
-    # 1. Parse YAML
-    try:
-        yaml_parser = _YAML()
-        parsed = yaml_parser.load(_StringIO(plan_yaml))
-    except _YAMLError as exc:
+    # Verify plan.milestone.number matches the milestone_number parameter
+    if plan.milestone.number != milestone_number:
         return {
-            "error": f"Invalid YAML: {exc}",
+            "error": (
+                f"Milestone number mismatch: parameter is {milestone_number} "
+                f"but plan.milestone.number is {plan.milestone.number}"
+            ),
             "milestone_number": milestone_number,
             "plan_path": str(plan_path),
             **out.to_dict(),
         }
 
-    # 2. Verify parsed result is a mapping
-    if not isinstance(parsed, dict):
-        return {
-            "error": "plan_yaml must be a YAML mapping (dict), not a list or scalar",
-            "milestone_number": milestone_number,
-            "plan_path": str(plan_path),
-            **out.to_dict(),
-        }
-
-    # 3. Check milestone.number consistency; inject if absent
-    milestone_section = parsed.get("milestone")
-    if isinstance(milestone_section, dict):
-        yaml_number = milestone_section.get("number")
-        if yaml_number is not None and int(yaml_number) != milestone_number:
-            return {
-                "error": (
-                    f"Milestone number mismatch: parameter is {milestone_number} "
-                    f"but YAML milestone.number is {yaml_number}"
-                ),
-                "milestone_number": milestone_number,
-                "plan_path": str(plan_path),
-                **out.to_dict(),
-            }
-        if yaml_number is None:
-            milestone_section["number"] = milestone_number
-    else:
-        # No milestone key — inject a minimal one so model_validate can proceed
-        parsed["milestone"] = {"number": milestone_number}
-
-    # 4. Validate against DispatchPlan
-    try:
-        plan = _ds.DispatchPlan.model_validate(parsed)
-    except _ValidationError as exc:
-        violations = "; ".join(f"{e['loc']}: {e['msg']}" for e in exc.errors())
-        return {
-            "error": f"Plan validation failed: {violations}",
-            "milestone_number": milestone_number,
-            "plan_path": str(plan_path),
-            **out.to_dict(),
-        }
-
-    # 5. Check for existing file when overwrite is False
+    # Check for existing file when overwrite is False
     if not overwrite and plan_path.exists():
         return {
             "error": (f"Plan file already exists: {plan_path}. Pass overwrite=True to replace it."),

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -3062,21 +3062,17 @@ async def dispatch_read(milestone_number: Annotated[int, Field(description="GitH
     the plan file does not exist or fails YAML/schema validation.
 
     Returns:
-        Dict with ``milestone_number``, ``plan_path``, and ``plan`` (full plan
+        Dict with ``milestone_number`` and ``plan`` (full plan
         as a nested dict), or ``error`` on failure.
     """
     plan_path = _dispatch_plan_path(milestone_number)
     try:
         plan = await asyncio.to_thread(_ds.read_dispatch_plan, plan_path)
     except FileNotFoundError:
-        return {
-            "error": f"Dispatch plan not found: {plan_path}",
-            "milestone_number": milestone_number,
-            "plan_path": str(plan_path),
-        }
+        return {"error": f"Dispatch plan not found: {plan_path}", "milestone_number": milestone_number}
     except ValueError as exc:
-        return {"error": str(exc), "milestone_number": milestone_number, "plan_path": str(plan_path)}
-    return {"milestone_number": milestone_number, "plan_path": str(plan_path), "plan": plan.model_dump()}
+        return {"error": str(exc), "milestone_number": milestone_number}
+    return {"milestone_number": milestone_number, "plan": plan.model_dump()}
 
 
 @mcp.tool(
@@ -3103,9 +3099,9 @@ async def dispatch_validate(milestone_number: Annotated[int, Field(description="
     try:
         plan = await asyncio.to_thread(_ds.read_dispatch_plan, plan_path)
     except (FileNotFoundError, ValueError) as exc:
-        return {"error": str(exc), "milestone_number": milestone_number, "plan_path": str(plan_path)}
+        return {"error": str(exc), "milestone_number": milestone_number}
     result = await asyncio.to_thread(_ds.validate_plan_integrity, plan)
-    return {"milestone_number": milestone_number, "plan_path": str(plan_path), **dataclasses.asdict(result)}
+    return {"milestone_number": milestone_number, **dataclasses.asdict(result)}
 
 
 @mcp.tool(
@@ -3136,7 +3132,7 @@ async def dispatch_stale_check(
     try:
         plan = await asyncio.to_thread(_ds.read_dispatch_plan, plan_path)
     except (FileNotFoundError, ValueError) as exc:
-        return {"error": str(exc), "milestone_number": milestone_number, "plan_path": str(plan_path)}
+        return {"error": str(exc), "milestone_number": milestone_number}
 
     def _fetch_milestone_issue_numbers() -> list[int]:
         gh_repo = _get_config().backend.get_github(repo)
@@ -3157,7 +3153,7 @@ async def dispatch_stale_check(
         return {"error": f"GitHub API error: {exc}", "milestone_number": milestone_number}
 
     result = await asyncio.to_thread(_ds.detect_stale_plan, plan, current_numbers)
-    return {"milestone_number": milestone_number, "plan_path": str(plan_path), **dataclasses.asdict(result)}
+    return {"milestone_number": milestone_number, **dataclasses.asdict(result)}
 
 
 @mcp.tool(
@@ -3214,7 +3210,7 @@ async def dispatch_create_plan(
             plan file as a ``dispatch-plan`` artifact (best-effort).
 
     Returns:
-        Success dict with ``milestone_number``, ``plan_path``, ``wave_count``,
+        Success dict with ``milestone_number``, ``wave_count``,
         ``item_count``, ``is_valid``, ``errors``, ``warnings``, and ``messages``.
         Error dict contains an ``error`` key.
     """
@@ -3229,7 +3225,6 @@ async def dispatch_create_plan(
                 f"but plan.milestone.number is {plan.milestone.number}"
             ),
             "milestone_number": milestone_number,
-            "plan_path": str(plan_path),
             **out.to_dict(),
         }
 
@@ -3238,7 +3233,6 @@ async def dispatch_create_plan(
         return {
             "error": (f"Plan file already exists: {plan_path}. Pass overwrite=True to replace it."),
             "milestone_number": milestone_number,
-            "plan_path": str(plan_path),
             **out.to_dict(),
         }
 
@@ -3249,16 +3243,10 @@ async def dispatch_create_plan(
         return {
             "error": f"Cannot write plan (symlink target rejected): {exc}",
             "milestone_number": milestone_number,
-            "plan_path": str(plan_path),
             **out.to_dict(),
         }
     except OSError as exc:
-        return {
-            "error": f"Failed to write plan file: {exc}",
-            "milestone_number": milestone_number,
-            "plan_path": str(plan_path),
-            **out.to_dict(),
-        }
+        return {"error": f"Failed to write plan file: {exc}", "milestone_number": milestone_number, **out.to_dict()}
 
     out.info(f"Wrote dispatch plan to {plan_path}")
 
@@ -3281,7 +3269,6 @@ async def dispatch_create_plan(
 
     return {
         "milestone_number": milestone_number,
-        "plan_path": str(plan_path),
         "wave_count": wave_count,
         "item_count": item_count,
         "is_valid": is_valid,

--- a/plugins/development-harness/docs/TASK_FILE_FORMAT.md
+++ b/plugins/development-harness/docs/TASK_FILE_FORMAT.md
@@ -119,27 +119,27 @@ uv run sam migrate tasks-{N}-{slug}.md             # Migrate legacy format (CLI 
 Plan files are stored under the per-project state directory (`~/.dh/projects/{project-slug}/plan/`), resolved via `dh_paths.plan_dir()`. The `{project-slug}` is computed from the absolute project root path by replacing `/` with `-`.
 
 ```text
-~/.dh/projects/{project-slug}/plan/P{NNN}-{slug}.yaml            # single-file plan (under 500 lines)
-~/.dh/projects/{project-slug}/plan/P{NNN}-{slug}/                # directory plan (500+ lines)
-    P{NNN}-PLAN.yaml               # plan-level metadata, goal, context, task list
-    P{NNN}-ARCHITECT.md            # architecture spec
-    P{NNN}-CONTEXT.md              # feature context
+~/.dh/projects/{project-slug}/plan/P{id}-{slug}.yaml            # single-file plan (under 500 lines)
+~/.dh/projects/{project-slug}/plan/P{id}-{slug}/                # directory plan (500+ lines)
+    P{id}-PLAN.yaml               # plan-level metadata, goal, context, task list
+    P{id}-ARCHITECT.md            # architecture spec
+    P{id}-CONTEXT.md              # feature context
     tasks/
         T01.yaml
         T02.yaml
 ```
 
-`{NNN}` is a zero-padded sequential number assigned by `sam create`. `{slug}` is lowercase-hyphenated from the feature name.
+`{id}` is a hex string assigned by `sam create`. `{slug}` is lowercase-hyphenated from the feature name.
 
 ### Addressing
 
 ```text
-P{N}/T{M}     -- task M in plan N (numeric match, leading zeros ignored)
-P719/T04      -- task T04 in plan P719
-my-slug/T1    -- task T1 in plan matching slug "my-slug"
+P{id}/T{M}        -- task M in plan with id (hex match)
+Pc7d8e9f0/T04     -- task T04 in plan Pc7d8e9f0
+my-slug/T1        -- task T1 in plan matching slug "my-slug"
 ```
 
-`sam read P1/T3` globs the plan directory under `dh_paths.plan_dir()` for `P001-*/` and finds `T03.yaml` (or the T03 section in a single-file plan).
+`sam read P1/T3` globs the plan directory under `dh_paths.plan_dir()` for `P{id}-*/` and finds `T03.yaml` (or the T03 section in a single-file plan).
 
 ### Legacy Names
 
@@ -411,7 +411,7 @@ echo "$YAML_CONTENT" | uv run sam create my-feature \
   --stdin \
   --format json
 
-# Output: { "path": "~/.dh/projects/{project-slug}/plan/P719-my-feature.yaml", "plan_number": 719, "task_count": 14 }
+# Output: { "path": "~/.dh/projects/{project-slug}/plan/Pc7d8e9f0-my-feature.yaml", "plan_id": "Pc7d8e9f0", "task_count": 14 }
 ```
 
 Stdin YAML structure:
@@ -438,17 +438,17 @@ context: "Shared context"
 
 ```bash
 # Read a task — returns TaskAssignment (plan context + task details)
-uv run sam read P719/T04 --format json
+uv run sam read Pc7d8e9f0/T04 --format json
 
 # Read a plan — returns Plan JSON
-uv run sam read P719 --format json
+uv run sam read Pc7d8e9f0 --format json
 ```
 
 TaskAssignment response shape (see [TaskAssignment Schema](./assignment-schema.json)):
 
 ```json
 {
-  "plan_number": 719,
+  "plan_id": "Pc7d8e9f0",
   "plan_slug": "my-feature",
   "plan_goal": "Route all SAM workflow I/O through sam CLI",
   "plan_context": "Background context shared across all tasks",
@@ -470,13 +470,13 @@ TaskAssignment response shape (see [TaskAssignment Schema](./assignment-schema.j
 
 ```bash
 # Set plan context
-uv run sam update P719 --context "Background context for all tasks"
+uv run sam update Pc7d8e9f0 --context "Background context for all tasks"
 
 # Set a specific field
-uv run sam update P719 --set acceptance-criteria-structured=true
+uv run sam update Pc7d8e9f0 --set acceptance-criteria-structured=true
 
 # Append a section to a task body
-uv run sam update P719/T04 \
+uv run sam update Pc7d8e9f0/T04 \
   --append-section "Divergence Notes" \
   --section-content "### DN-1: Brief title\n..."
 ```
@@ -484,15 +484,15 @@ uv run sam update P719/T04 \
 ### sam state — Transition task status
 
 ```bash
-uv run sam state P719/T04 complete
-uv run sam state P719/T04 blocked
+uv run sam state Pc7d8e9f0/T04 complete
+uv run sam state Pc7d8e9f0/T04 blocked
 # Valid values: not-started | in-progress | complete | blocked | deferred | skipped
 ```
 
 ### sam claim — Claim a task (mark in-progress)
 
 ```bash
-uv run sam claim P719/T04 --format json
+uv run sam claim Pc7d8e9f0/T04 --format json
 # Output: { "claimed": true, "task_id": "T04", "started": "2026-03-15T13:00:00Z" }
 # Exit code 1: already claimed, not found, or status != not-started
 ```
@@ -500,7 +500,7 @@ uv run sam claim P719/T04 --format json
 ### sam ready — List ready tasks
 
 ```bash
-uv run sam ready P719 --format json
+uv run sam ready Pc7d8e9f0 --format json
 # Output: { "feature": "my-feature", "ready_tasks": [...], "count": 3 }
 # A task is ready when status=not-started and all dependencies are complete.
 ```
@@ -508,14 +508,14 @@ uv run sam ready P719 --format json
 ### sam status — Plan progress summary
 
 ```bash
-uv run sam status P719
+uv run sam status Pc7d8e9f0
 # Output: plan progress with task counts by status, blocked tasks, next ready tasks
 ```
 
 ### sam validate — Validate plan against schema
 
 ```bash
-uv run sam validate P719 --format json
+uv run sam validate Pc7d8e9f0 --format json
 # Output: { "valid": true/false, "errors": [...], "warnings": [...] }
 ```
 
@@ -524,7 +524,7 @@ uv run sam validate P719 --format json
 ```bash
 uv run sam migrate tasks-3-integrate-sam-schema.md
 # Converts YAML frontmatter .md file to pure YAML .yaml file
-# Output: ~/.dh/projects/{project-slug}/plan/P719-integrate-sam-schema.yaml
+# Output: ~/.dh/projects/{project-slug}/plan/Pc7d8e9f0-integrate-sam-schema.yaml
 ```
 
 ---
@@ -543,19 +543,19 @@ The `sam` CLI reads but does not write these legacy formats:
 
 ### Number Collision Warning
 
-When a canonical `P{NNN}-{slug}.yaml` file and a legacy `tasks-{NNN}-{slug}.md` file share the same number (both under `plan_dir()`), the canonical file takes precedence. The `sam` CLI emits a warning to stderr:
+When a canonical `P{id}-{slug}.yaml` file and a legacy `tasks-{NNN}-{slug}.md` file share the same identifier (both under `plan_dir()`), the canonical file takes precedence. The `sam` CLI emits a warning to stderr:
 
 ```text
-WARNING: P698 resolved to 'P698-research-curator-code-analysis.yaml' but a legacy file
-also exists with the same number: tasks-698-gates-subprocess-timeout.md.
-Run 'sam migrate P698' to remove the legacy file.
+WARNING: Pb5c6d7e8 resolved to 'Pb5c6d7e8-research-curator-code-analysis.yaml' but a legacy file
+also exists with the same slug: tasks-698-gates-subprocess-timeout.md.
+Run 'sam migrate Pb5c6d7e8' to remove the legacy file.
 ```
 
-To resolve: migrate or rename the legacy file so numbers are unique.
+To resolve: migrate or rename the legacy file so identifiers are unique.
 
 ### File Path Rejection
 
-Passing a raw file path (e.g., `tasks-698-foo.md`) as an address is rejected with a clear error. Use plan addresses (`P698`, `gates-subprocess-timeout`) instead.
+Passing a raw file path (e.g., `tasks-698-foo.md`) as an address is rejected with a clear error. Use plan addresses (`Pb5c6d7e8`, `gates-subprocess-timeout`) instead.
 
 ### Migration Path
 
@@ -566,7 +566,7 @@ Migrate a legacy plan to the canonical format:
 #    Legacy files are resolved from dh_paths.plan_dir() automatically
 uv run sam migrate tasks-3-my-feature.md
 
-# 2. Rename to P{NNN} convention (dry run first)
+# 2. Rename to P{id} convention (dry run first)
 uv run python scripts/rename_plan_files.py --dry-run
 uv run python scripts/rename_plan_files.py
 
@@ -598,7 +598,7 @@ Disabled hooks take precedence over profile and exit 0 after consuming stdin (Cl
 
 ### Deprecation Timeline
 
-- **2026-Q1**: `tasks-{N}-{slug}` naming deprecated. New plans use `P{NNN}-{slug}.yaml`.
+- **2026-Q1**: `tasks-{N}-{slug}` naming deprecated. New plans use `P{id}-{slug}.yaml`.
 - **2026-Q2**: Legacy markdown bold-field format (`**Status**: ...`) removed from read path after all plans migrated.
 - **Future**: `task_format.py` and `implementation_manager.py` fallback parsers removed once all consumers use `sam` CLI.
 

--- a/plugins/development-harness/docs/backend-providers.md
+++ b/plugins/development-harness/docs/backend-providers.md
@@ -565,7 +565,7 @@ class TaskBackend(Protocol):
         ...
 
     def read_plan(self, plan_id: str) -> PlanData:
-        """Read a plan by backend-assigned identifier (e.g. 'P912')."""
+        """Read a plan by backend-assigned identifier (e.g. 'Pd9e0f1a2')."""
         ...
 
     def list_plans(

--- a/plugins/development-harness/docs/backlog-item-lifecycle.md
+++ b/plugins/development-harness/docs/backlog-item-lifecycle.md
@@ -369,7 +369,7 @@ The following diagram is the authoritative procedure for Phase 4 — Planning (/
 
 ```mermaid
 flowchart TD
-    P4_DECOMPOSE["Phase 4: Task Decomposition<br>Agent: @dh:swarm-task-planner<br>Input: architect-{slug}.md + feature-context<br>Output: plan/P{NNN}-{slug}.yaml via sam_create<br>Every task has: status, dependencies,<br>priority, complexity, agent, AC (3+),<br>verification steps (3+)"]
+    P4_DECOMPOSE["Phase 4: Task Decomposition<br>Agent: @dh:swarm-task-planner<br>Input: architect-{slug}.md + feature-context<br>Output: plan/P{id}-{slug}.yaml via sam_create<br>Every task has: status, dependencies,<br>priority, complexity, agent, AC (3+),<br>verification steps (3+)"]
 
     P4_DECOMPOSE --> P4_BOOKEND{"acceptance-criteria-structured<br>non-empty?"}
     P4_BOOKEND -->|"Non-empty — generate bookends"| P4_BOOKEND_GEN["swarm-task-planner generates<br>T0 (baseline) + TN (verification)<br>bookend tasks inside the plan<br>T0: priority 1, deps []<br>TN: deps = all non-bookend task IDs"]
@@ -388,7 +388,7 @@ flowchart TD
 
     P4_CONTEXT["Phase 6: Context Manifest<br>Agent: @dh:dh-context-gathering<br>Writes context manifest INTO the plan<br>via sam_update (not a separate file)<br>Maps each task to files, artifacts,<br>external context it needs"]
 
-    P4_CONTEXT --> P4_LINK["work-backlog-item Step 7:<br>backlog_update(selector='{title}',<br>plan='plan/P{NNN}-{slug}.yaml')<br>Links plan to backlog item"]
+    P4_CONTEXT --> P4_LINK["work-backlog-item Step 7:<br>backlog_update(selector='{title}',<br>plan='plan/P{id}-{slug}.yaml')<br>Links plan to backlog item"]
     P4_LINK --> P4_DONE(["add-new-feature complete<br>Report slug + task file path<br>Next: /dh:implement-feature"])
 ```
 
@@ -396,7 +396,7 @@ flowchart TD
 
 | Node | Actor | Inputs | Outputs | Edge Conditions |
 |------|-------|--------|---------|-----------------|
-| P4_DECOMPOSE | `@dh:swarm-task-planner` | `plan/architect-{slug}.md`, `plan/feature-context-{slug}.md` | `plan/P{NNN}-{slug}.yaml` via `sam_create`, tasks with status/deps/priority/complexity/agent/AC/verification | always → P4_BOOKEND |
+| P4_DECOMPOSE | `@dh:swarm-task-planner` | `plan/architect-{slug}.md`, `plan/feature-context-{slug}.md` | `plan/P{id}-{slug}.yaml` via `sam_create`, tasks with status/deps/priority/complexity/agent/AC/verification | always → P4_BOOKEND |
 | P4_BOOKEND | orchestrator | `acceptance-criteria-structured` field | bookend decision | non-empty → P4_BOOKEND_GEN, empty → P4_NO_BOOKEND |
 | P4_BOOKEND_GEN | `@dh:swarm-task-planner` | structured acceptance criteria | T0 task (priority 1, deps=[]) + TN task (deps=all non-bookend IDs) inside plan | always → P4_REGISTER |
 | P4_NO_BOOKEND | orchestrator | — | no bookend tasks | always → P4_REGISTER |
@@ -412,11 +412,11 @@ flowchart TD
 
 **plan-validator returns READY or BLOCKED** (not PASS/BLOCKED as previously documented). BLOCKED includes specific gaps that must be fixed before retrying.
 
-**T0 baseline is a bookend task during EXECUTION, not during planning**. The `swarm-task-planner` generates T0 and TN as tasks inside `P{NNN}-{slug}.yaml` with appropriate priority and dependency settings. They dispatch automatically during execution via normal SAM readiness ordering — T0 fires first (priority 1, no deps), TN fires last (depends on all implementation tasks). No special handling is needed in the dispatch loop.
+**T0 baseline is a bookend task during EXECUTION, not during planning**. The `swarm-task-planner` generates T0 and TN as tasks inside `P{id}-{slug}.yaml` with appropriate priority and dependency settings. They dispatch automatically during execution via normal SAM readiness ordering — T0 fires first (priority 1, no deps), TN fires last (depends on all implementation tasks). No special handling is needed in the dispatch loop.
 
-**context-gathering writes into the plan YAML** via `sam_update`, not to a separate file. The plan file path remains `~/.dh/projects/{project-slug}/plan/P{NNN}-{slug}.yaml`.
+**context-gathering writes into the plan YAML** via `sam_update`, not to a separate file. The plan file path remains `~/.dh/projects/{project-slug}/plan/P{id}-{slug}.yaml`.
 
-**Status advance**: `backlog_update(selector="{title}", plan="plan/P{NNN}-{slug}.yaml")` links the SAM plan file to the GitHub issue. The `status` field transition to `in-progress` happens via `work-backlog-item` Step 7.
+**Status advance**: `backlog_update(selector="{title}", plan="plan/P{id}-{slug}.yaml")` links the SAM plan file to the GitHub issue. The `status` field transition to `in-progress` happens via `work-backlog-item` Step 7.
 
 **Failure paths**:
 

--- a/plugins/development-harness/docs/backlog-lifecycle.draft.md
+++ b/plugins/development-harness/docs/backlog-lifecycle.draft.md
@@ -199,21 +199,21 @@ file is created.
 
 ```bash
 uv run .claude/skills/backlog/scripts/backlog.py update "{title}" \
-  --plan "~/.dh/projects/{slug}/plan/P{NNN}-{slug}.yaml" \
+  --plan "~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml" \
   --status in-progress \
   -R Jamie-BitFlight/claude_skills
 ```
 
 **What gets written**:
 
-- `metadata.plan: ~/.dh/projects/{slug}/plan/P{NNN}-{slug}.yaml` in per-item file frontmatter
+- `metadata.plan: ~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml` in per-item file frontmatter
 - `metadata.status: in-progress` in frontmatter
 - GitHub label: current status label removed, `status:in-progress` added
 
 **Critical constraint**: `status:in-progress` MUST NOT be set before RT-ICA returns APPROVED
 and the plan file exists. Setting it during grooming or RT-ICA checking is incorrect.
 
-**Where data lives**: Both local and GitHub. Plan file exists at `~/.dh/projects/{slug}/plan/P{NNN}-{slug}.yaml`.
+**Where data lives**: Both local and GitHub. Plan file exists at `~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml`.
 
 ---
 
@@ -226,7 +226,7 @@ acceptance criteria verification passes.
 
 ```bash
 uv run .claude/skills/backlog/scripts/backlog.py close "{title}" \
-  --plan "~/.dh/projects/{slug}/plan/P{NNN}-{slug}.yaml" \
+  --plan "~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml" \
   --checklist-pass \
   [-R Jamie-BitFlight/claude_skills]
 ```
@@ -502,7 +502,7 @@ GitHub Issue #42:
 ```text
 ~/.dh/projects/{slug}/backlog/p1-{slug}.md  — MODIFIED
   frontmatter:
-    metadata.plan: "~/.dh/projects/{slug}/plan/P{NNN}-{slug}.yaml"
+    metadata.plan: "~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml"
     metadata.status: in-progress
 
 GitHub Issue #42:

--- a/plugins/development-harness/docs/backlog-lifecycle.md
+++ b/plugins/development-harness/docs/backlog-lifecycle.md
@@ -251,7 +251,7 @@ and configuration.
 | `status` | MCP tools | Current lifecycle state (`needs-grooming`, `groomed`, `blocked`, etc.) |
 | `priority` | `backlog_add` | P0, P1, P2, or Ideas |
 | `groomed` | `backlog_groom` | Date when grooming completed (set after all required sections present — defined in finalize.md) |
-| `plan` | `backlog_update(plan=...)` | SAM plan address (`P{NNN}`) — a backend reference, not a file path |
+| `plan` | `backlog_update(plan=...)` | SAM plan address (`P{id}`) — a backend reference, not a file path |
 | `issue` | `backlog_add` | Backend issue identifier (`#N` format) |
 | `milestone` | `group-items-to-milestone` | Milestone identifier |
 | Groomed sections | `backlog_groom` | RT-ICA, Impact Radius, Fact-Check, and other groomed subsections |
@@ -259,10 +259,10 @@ and configuration.
 ### SAM Plan Files
 
 Created by `add-new-feature` Phase 4 via `sam_create`. Managed by the SAM MCP server.
-Access via `sam_read(plan="P{NNN}")` and `sam_list(search="{slug}")` — not via filesystem path.
+Access via `sam_read(plan="P{id}")` and `sam_list(search="{slug}")` — not via filesystem path.
 
 The plan address is written to the backlog item via
-`backlog_update(selector='{item_ref}', plan='P{NNN}')`. The `plan` field is a backend
+`backlog_update(selector='{item_ref}', plan='P{id}')`. The `plan` field is a backend
 reference, not a filesystem path.
 
 SOURCE: Codebase architecture analysis Issue #398 (accessed 2026-03-30), Section 2.
@@ -376,7 +376,7 @@ metadata:
   groomed: {YYYY-MM-DD} | null
   issue: {item_ref #N} | null
   milestone: {milestone identifier} | null
-  plan: {plan address P{NNN}} | null
+  plan: {plan address P{id}} | null
   updated_at: {ISO timestamp}
 ```
 

--- a/plugins/development-harness/docs/plan-artifact-lifecycle.md
+++ b/plugins/development-harness/docs/plan-artifact-lifecycle.md
@@ -53,7 +53,7 @@ These artifacts are produced by agents during planning phases. They may be updat
 | Feature context | `artifact_read(issue_number, 'feature-context')` | `feature-researcher` agent | `context-refinement` agent |
 | Codebase analysis | `artifact_read(issue_number, 'codebase-analysis')` | `codebase-analyzer` agent | Not updated (informational snapshot) |
 | Architecture spec | `artifact_read(issue_number, 'architect')` | `python-cli-design-spec` agent | `context-refinement` agent |
-| Task plan | `sam_read(plan="P{NNN}")` | `swarm-task-planner` agent | Status fields by hooks; Context Manifest by `context-refinement` |
+| Task plan | `sam_read(plan="P{id}")` | `swarm-task-planner` agent | Status fields by hooks; Context Manifest by `context-refinement` |
 | Context Manifest | Embedded in task file (via `sam_read`) | `context-gathering` agent | `context-refinement` agent (existing behavior) |
 
 ---
@@ -225,7 +225,7 @@ artifacts:
     created_at: "2026-03-15T01:00:00Z"
     agent: python-cli-design-spec
   - type: task-plan
-    path: plan/P719-my-feature.yaml
+    path: plan/Pc7d8e9f0-my-feature.yaml
     status: current
     created_at: "2026-03-15T02:00:00Z"
     agent: swarm-task-planner

--- a/plugins/development-harness/docs/workflow-architecture-diagram.md
+++ b/plugins/development-harness/docs/workflow-architecture-diagram.md
@@ -227,7 +227,7 @@ Read by `task_status_hook.py` PostToolUse handler.
 
 ```json
 {
-  "task_file_path": "~/.dh/projects/{slug}/plan/P719-my-feature.yaml",
+  "task_file_path": "~/.dh/projects/{slug}/plan/Pc7d8e9f0-my-feature.yaml",
   "task_id": "T04",
   "parent_issue_number": 719
 }
@@ -263,7 +263,7 @@ Exit code 1 when: already claimed, task not found, or `status != not-started`.
 | `~/.dh/projects/{slug}/plan/feature-context-{slug}.md` | `feature-researcher` | `python-cli-design-spec`, `swarm-task-planner` |
 | `~/.dh/projects/{slug}/plan/codebase/{FOCUS}.md` | `codebase-analyzer` | `swarm-task-planner` |
 | `~/.dh/projects/{slug}/plan/architect-{slug}.md` | `python-cli-design-spec` | `swarm-task-planner`, executing agents via `/start-task` |
-| `~/.dh/projects/{slug}/plan/P{NNN}-{slug}.yaml` | `swarm-task-planner` via `sam_plan create` | `/implement-feature`, `sam_plan ready`, `sam_plan status`, all execution agents |
+| `~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml` | `swarm-task-planner` via `sam_plan create` | `/implement-feature`, `sam_plan ready`, `sam_plan status`, all execution agents |
 | `~/.dh/projects/{slug}/plan/T0-baseline-{slug}.yaml` | `t0-baseline-capture` | `tn-verification-gate` |
 | `~/.dh/projects/{slug}/plan/TN-verification-{slug}.yaml` | `tn-verification-gate` | `/complete-implementation` Pre-Phase 1 check |
 | `~/.dh/projects/{slug}/plan/QG{NNN}-qg-{slug}.yaml` | `/complete-implementation` via `build_quality_gate_plan` + `sam_create` | SAM dispatch loop (T1–T6 quality gate tasks) |
@@ -303,7 +303,7 @@ The `parent_issue_number` (GitHub issue) propagates through these fields:
 flowchart TD
     GH["GitHub Issue #N<br>created by backlog_add"]
     BI["BacklogItem.issue field<br>(string, e.g. '719')"]
-    PF["plan file name<br>~/.dh/projects/{slug}/plan/P{NNN}-{slug}.yaml<br>issue: N in plan YAML"]
+    PF["plan file name<br>~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml<br>issue: N in plan YAML"]
     CTX["~/.dh/projects/{slug}/context/active-task-{sid}.json<br>parent_issue_number: N<br>written by /start-task"]
     HOOK["task_status_hook.py<br>reads parent_issue_number<br>syncs completion to GitHub sub-issue"]
     TF["Task field: github_issue<br>linked sub-issue number"]
@@ -415,7 +415,7 @@ Only T5 (Documentation Update) may have `status: skipped`. Skipping is triggered
 
 ### QG Plan File Location
 
-The QG plan file is written by `sam_plan(action="create")` to `plan/QG{NNN}-qg-{slug}.yaml` (in the project plan directory). The `QG{N}` address is used in all subsequent `sam_plan(action="ready")`, `sam_task(action="claim")`, `sam_task(action="state")`, and `sam_plan(action="status")` calls for this quality gate run. The `QG{NNN}` number is auto-assigned by SAM (sequential, separate from implementation plan numbering `P{NNN}`).
+The QG plan file is written by `sam_plan(action="create")` to `plan/QG{NNN}-qg-{slug}.yaml` (in the project plan directory). The `QG{N}` address is used in all subsequent `sam_plan(action="ready")`, `sam_task(action="claim")`, `sam_task(action="state")`, and `sam_plan(action="status")` calls for this quality gate run. The `QG{NNN}` number is auto-assigned by SAM (sequential, separate from implementation plan numbering `P{id}`).
 
 ---
 

--- a/plugins/development-harness/sam_schema/cli.py
+++ b/plugins/development-harness/sam_schema/cli.py
@@ -609,7 +609,7 @@ def create(
 
     Output (JSON)::
 
-        {"path": "plan/P001-auth-system.yaml", "plan_number": 1, "task_count": 3}
+        {"path": "plan/Pa1b2c3d4-auth-system.yaml", "plan_id": "Pa1b2c3d4", "task_count": 3}
 
     Args:
         slug: Short slug identifier for the plan.
@@ -644,14 +644,14 @@ def create(
 
     source_path = plan.source_path
     path_str = str(source_path) if source_path is not None else str(plan_dir)
-    # Extract numeric plan number from written path stem
-    plan_number: int | None = None
+    # Extract UUID-based plan_id from written path stem (e.g. Pa1b2c3d4-slug.yaml -> Pa1b2c3d4)
+    plan_id: str | None = None
     if source_path is not None:
-        m = re.match(r"^P(\d+)-", source_path.name)
+        m = re.match(r"^(P[0-9a-f]+)-", source_path.name, re.IGNORECASE)
         if m:
-            plan_number = int(m.group(1))
+            plan_id = m.group(1)
 
-    result: dict[str, object] = {"path": path_str, "plan_number": plan_number, "task_count": len(plan.tasks)}
+    result: dict[str, object] = {"path": path_str, "plan_id": plan_id, "task_count": len(plan.tasks)}
     _output_json(result)
 
 

--- a/plugins/development-harness/sam_schema/core/addressing.py
+++ b/plugins/development-harness/sam_schema/core/addressing.py
@@ -27,8 +27,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
-# Pattern: P{NNN}-{slug}.yaml / P{NNN}-{slug}.md / P{NNN}-{slug}/
-_P_NUMERIC_RE = re.compile(r"^P(\d+)-")
+# Pattern: P{NNN}-{slug}.yaml or P{hex8}-{slug}.yaml (UUID-derived IDs).
+# Matches both legacy zero-padded numeric IDs (P001, P042) and the new
+# UUID-derived hex IDs (Pa1b2c3d4). Captured group is the ID suffix (digits or hex).
+_P_NUMERIC_RE = re.compile(r"^P([0-9a-f]+)-", re.IGNORECASE)
 
 # Pattern: QG{NNN}-{slug}.yaml / QG{NNN}-{slug}.md / QG{NNN}-{slug}/
 _QG_NUMERIC_RE = re.compile(r"^QG(\d+)-", re.IGNORECASE)

--- a/plugins/development-harness/sam_schema/core/backends/_utils.py
+++ b/plugins/development-harness/sam_schema/core/backends/_utils.py
@@ -1,0 +1,10 @@
+"""Shared utilities for SAM backend implementations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def _now_iso() -> str:
+    """Return current UTC time as an ISO 8601 string."""
+    return datetime.now(tz=UTC).isoformat()

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -14,9 +14,9 @@ or GraphQL calls are made from this module.
 from __future__ import annotations
 
 import re
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from sam_schema.core.backends._utils import _now_iso
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
 from sam_schema.core.exceptions import PlanNotFoundError, TaskNotFoundError, TaskValidationError
 from sam_schema.core.task_backend_types import (
@@ -70,11 +70,6 @@ _META_ROW_RE = re.compile(r"^\|\s*(?P<key>[^|]+?)\s*\|\s*(?P<value>[^|]*?)\s*\|$
 _TASK_TITLE_RE = re.compile(r"^\[(?P<tid>T\d+)\] (?P<title>.+)$")
 _PLAN_SLUG_RE = re.compile(r"<!-- sam-plan-slug: (?P<slug>[^>]+?) -->")
 _GOAL_RE = re.compile(r"## Goal\n\n(?P<goal>.+?)(?=\n\n##|\Z)", re.DOTALL)
-
-
-def _now_iso() -> str:
-    """Return current UTC timestamp as ISO 8601 string."""
-    return datetime.now(tz=UTC).isoformat()
 
 
 def _status_from_labels(labels: list[LabelNode]) -> str:

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -38,8 +38,10 @@ if TYPE_CHECKING:
 
 __all__ = ["LocalYamlTaskProvider"]
 
-# Extract plan_id from a plan file stem, e.g. "P912" from "P912-migrate-...".
-_P_STEM_RE = re.compile(r"^(P\d+)-")
+# Extract plan_id from a plan file stem.
+# Matches both legacy numeric IDs (e.g. "P912" from "P912-migrate-...")
+# and UUID-derived hex IDs (e.g. "Pa1b2c3d4" from "Pa1b2c3d4-migrate-...").
+_P_STEM_RE = re.compile(r"^(P[0-9a-f]+)-", re.IGNORECASE)
 _TASKS_STEM_RE = re.compile(r"^tasks-(\d+)-")
 _TASK_VALIDATION_RE = re.compile(r"Task at index (\d+) failed validation: (.+)", re.DOTALL)
 

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -286,7 +286,10 @@ class LocalYamlTaskProvider:
             result = query.load_plan(path)
         except FileNotFoundError as exc:
             raise PlanNotFoundError(plan_id) from exc
-        return _plan_to_plan_data(result.plan, plan_id)
+        # Prefer the plan_id stored in the record; fall back to filename-derived
+        # value for backwards compatibility with pre-existing files.
+        effective_plan_id = result.plan.plan_id or _plan_id_from_path(path)
+        return _plan_to_plan_data(result.plan, effective_plan_id)
 
     def list_plans(self, *, search: str | None = None, offset: int = 0, limit: int | None = None) -> list[PlanSummary]:
         """Return lightweight summaries for all plans, optionally filtered.
@@ -312,7 +315,9 @@ class LocalYamlTaskProvider:
                     text = f"{plan.feature} {plan.goal or ''} {plan.description}"
                     if search.lower() not in text.lower():
                         continue
-                plan_id = _plan_id_from_path(candidate)
+                # Prefer the plan_id stored in the record; fall back to filename-derived
+                # value for backwards compatibility with pre-existing files.
+                plan_id = plan.plan_id or _plan_id_from_path(candidate)
                 summary: PlanSummary = {
                     "plan_id": plan_id,
                     "feature": plan.feature,

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -180,9 +180,10 @@ class InMemoryTaskProvider:
     has no side effects outside this instance. No filesystem access and no
     external dependencies.
 
-    Plan IDs are auto-assigned as ``P1``, ``P2``, etc. in insertion order
-    when no ``issue`` is provided. When ``issue`` is provided, the plan ID
-    is ``P{issue}``.
+    Plan IDs are auto-assigned as ``P`` + first 8 hex chars of a UUID4
+    (e.g. ``Pa1b2c3d4``) for every new plan, regardless of whether an
+    ``issue`` is provided. The ``issue`` value is stored in plan metadata
+    but does not influence the plan ID.
     """
 
     def __init__(self) -> None:
@@ -191,8 +192,6 @@ class InMemoryTaskProvider:
         self._plans: dict[str, PlanData] = {}
         # content_ref -> DocumentData
         self._documents: dict[str, DocumentData] = {}
-        # Monotonically increasing counter for auto-assigned plan IDs.
-        self._next_plan_num: int = 1
 
     # ------------------------------------------------------------------
     # Plan lifecycle
@@ -226,11 +225,7 @@ class InMemoryTaskProvider:
             PlanExistsError: When the resolved plan_id already exists.
             TaskValidationError: When any task definition is missing required fields.
         """
-        if issue is not None:
-            plan_id = f"P{issue}"
-        else:
-            plan_id = f"P{self._next_plan_num}"
-            self._next_plan_num += 1
+        plan_id = "P" + uuid.uuid4().hex[:8]
 
         if plan_id in self._plans:
             raise PlanExistsError(plan_id)

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import copy
 import uuid
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, cast
 
+from sam_schema.core.backends._utils import _now_iso
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
 from sam_schema.core.exceptions import (
     DocumentNotFoundError,
@@ -30,6 +30,7 @@ from sam_schema.core.exceptions import (
     TaskNotFoundError,
     TaskValidationError,
 )
+from sam_schema.core.query import _new_plan_id
 
 if TYPE_CHECKING:
     from sam_schema.core.models import Task
@@ -53,11 +54,6 @@ _VALID_STATUSES: frozenset[str] = frozenset({
     "deferred",
     "skipped",
 })
-
-
-def _now_iso() -> str:
-    """Return current UTC time as an ISO 8601 string."""
-    return datetime.now(UTC).isoformat()
 
 
 def _task_def_to_task_data(task_def: TaskDefinition) -> TaskData:
@@ -225,7 +221,7 @@ class InMemoryTaskProvider:
             PlanExistsError: When the resolved plan_id already exists.
             TaskValidationError: When any task definition is missing required fields.
         """
-        plan_id = "P" + uuid.uuid4().hex[:8]
+        plan_id = _new_plan_id()
 
         if plan_id in self._plans:
             raise PlanExistsError(plan_id)

--- a/plugins/development-harness/sam_schema/core/models.py
+++ b/plugins/development-harness/sam_schema/core/models.py
@@ -260,6 +260,14 @@ class Plan(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+    # Backend-assigned plan identifier (e.g. "P912").  Persisted in the YAML
+    # body so that the ID survives state-directory wipes or backend migrations.
+    # None on Plan instances created before this field was introduced; in that
+    # case the local backend falls back to deriving the ID from the filename.
+    plan_id: str | None = Field(
+        default=None, validation_alias=AliasChoices("plan-id", "plan_id"), serialization_alias="plan-id"
+    )
+
     feature: str
     version: str = "1.0"
     description: str = ""

--- a/plugins/development-harness/sam_schema/core/query.py
+++ b/plugins/development-harness/sam_schema/core/query.py
@@ -154,7 +154,9 @@ def create_plan(
             msg = f"Task at index {i} failed validation: {exc}"
             raise ValueError(msg) from exc
 
+    plan_id_str = f"P{plan_number:03d}"
     plan = Plan(
+        plan_id=plan_id_str,
         feature=slug,
         goal=goal,
         context=context,

--- a/plugins/development-harness/sam_schema/core/query.py
+++ b/plugins/development-harness/sam_schema/core/query.py
@@ -55,7 +55,8 @@ def create_plan(
 
     The output file is named ``{plan_dir}/{plan_id}-{slug}.yaml`` where
     ``plan_id`` is ``P`` + first 8 hex characters of a UUID4 (e.g. ``Pa1b2c3d4``).
-    When ``issue`` is provided, it is stored in the ``plan_ref`` field only;
+    When ``issue`` is provided, it is stored in the ``issue`` field of the Plan model.
+    ``plan_ref`` is computed in server responses only and is not a Plan model field;
     it does not influence the plan's own ID.
 
     Each dict in ``tasks`` is validated against the ``Task`` Pydantic model
@@ -78,11 +79,19 @@ def create_plan(
 
     Raises:
         ValueError: If any task dict is invalid per the ``Task`` model.
-        OSError: If the plan file cannot be written.
+        OSError: If the plan file cannot be written, or if a UUID collision
+            occurs after 3 attempts (negligible in practice).
     """
-    plan_id_str = _new_plan_id()
-    file_name = f"{plan_id_str}-{slug}.yaml"
-    output_path = plan_dir / file_name
+    MAX_ID_ATTEMPTS = 3
+    for _attempt in range(MAX_ID_ATTEMPTS):
+        plan_id_str = _new_plan_id()
+        file_name = f"{plan_id_str}-{slug}.yaml"
+        output_path = plan_dir / file_name
+        if not output_path.exists():
+            break
+    else:
+        msg = f"UUID collision: failed to generate a unique plan ID after {MAX_ID_ATTEMPTS} attempts"
+        raise OSError(msg)
 
     validated_tasks: list[Task] = []
     for i, raw_task in enumerate(tasks):

--- a/plugins/development-harness/sam_schema/core/query.py
+++ b/plugins/development-harness/sam_schema/core/query.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import io
 import re
+import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -28,66 +29,18 @@ from sam_schema.writers.yaml_writer import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-# Matches the new P{NNN}-{slug}.yaml naming scheme to extract the numeric plan number.
-_P_NUMERIC_RE = re.compile(r"^P(\d+)-")
 _LEGACY_TASKS_RE = re.compile(r"^tasks-(\d+)-")
 
 
-def _next_plan_number(plan_dir: Path) -> int:
-    """Scan ``plan_dir`` for the highest existing plan number and return the next one.
-
-    Recognises both the new ``P{NNN}-{slug}`` naming scheme and the legacy
-    ``tasks-{N}-{slug}`` pattern so that numbering is monotonically increasing
-    across mixed directories.
-
-    Args:
-        plan_dir: Directory to search. Need not exist; returns 1 if absent.
+def _new_plan_id() -> str:
+    """Generate a collision-resistant plan ID using UUID4.
 
     Returns:
-        The next available plan number (highest found + 1, minimum 1).
+        A plan ID string of the form ``P`` + first 8 hex characters of a UUID4,
+        e.g. ``"Pa1b2c3d4"``. Collision probability is negligible for any
+        realistic number of plans per directory.
     """
-    if not plan_dir.exists():
-        return 1
-
-    highest = 0
-    for entry in plan_dir.iterdir():
-        name = entry.name
-        m = _P_NUMERIC_RE.match(name)
-        if m:
-            highest = max(highest, int(m.group(1)))
-            continue
-        m2 = _LEGACY_TASKS_RE.match(name)
-        if m2:
-            highest = max(highest, int(m2.group(1)))
-    return highest + 1
-
-
-def _find_collision(plan_dir: Path, plan_number: int) -> Path | None:
-    """Return the path of an existing plan file with ``plan_number``, or ``None``.
-
-    Checks both the canonical ``P{N}-*.yaml`` naming scheme and the legacy
-    ``tasks-{N}-*.md`` pattern so that issue-number collisions are caught
-    regardless of which format a plan was created with.
-
-    Args:
-        plan_dir: Directory to search. Returns ``None`` if the directory is absent.
-        plan_number: Plan number to check for collisions.
-
-    Returns:
-        Path of the first colliding file found, or ``None`` if none exists.
-    """
-    if not plan_dir.exists():
-        return None
-
-    for entry in plan_dir.iterdir():
-        name = entry.name
-        m = _P_NUMERIC_RE.match(name)
-        if m and int(m.group(1)) == plan_number:
-            return entry
-        m2 = _LEGACY_TASKS_RE.match(name)
-        if m2 and int(m2.group(1)) == plan_number:
-            return entry
-    return None
+    return "P" + uuid.uuid4().hex[:8]
 
 
 def create_plan(
@@ -98,13 +51,12 @@ def create_plan(
     context: str | None = None,
     issue: int | None = None,
 ) -> Plan:
-    """Create a new plan, assign a plan number, validate tasks, and write to disk.
+    """Create a new plan, assign a UUID-derived plan ID, validate tasks, and write to disk.
 
-    The output file is named ``{plan_dir}/P{NNN}-{slug}.yaml``.  When
-    ``issue`` is provided, ``NNN`` is the issue number itself so that the
-    plan file and the GitHub issue share an unambiguous identifier.  When
-    ``issue`` is omitted, ``NNN`` is the next sequential number derived by
-    scanning ``plan_dir``.
+    The output file is named ``{plan_dir}/{plan_id}-{slug}.yaml`` where
+    ``plan_id`` is ``P`` + first 8 hex characters of a UUID4 (e.g. ``Pa1b2c3d4``).
+    When ``issue`` is provided, it is stored in the ``plan_ref`` field only;
+    it does not influence the plan's own ID.
 
     Each dict in ``tasks`` is validated against the ``Task`` Pydantic model
     before the plan is written; invalid task dicts raise ``ValueError`` with the
@@ -118,30 +70,18 @@ def create_plan(
                ``dependencies``, ``priority``, ``complexity``).
         plan_dir: Directory in which to create the plan file.
         context: Optional plan-level context string (markdown prose).
-        issue: Optional GitHub issue number.  When provided, the issue number
-               is used directly as the plan number.  Raises ``ValueError`` if a
-               plan with that number already exists.
+        issue: Optional GitHub issue number stored in the plan metadata.
+               Does not affect the plan ID.
 
     Returns:
         The created ``Plan`` model (with ``source_path`` set to the written path).
 
     Raises:
-        ValueError: If any task dict is invalid per the ``Task`` model, or if
-                    a plan with the given issue number already exists.
+        ValueError: If any task dict is invalid per the ``Task`` model.
         OSError: If the plan file cannot be written.
     """
-    if issue is not None:
-        plan_number = issue
-        existing = _find_collision(plan_dir, plan_number)
-        if existing is not None:
-            msg = (
-                f"Plan P{plan_number} already exists: {existing}. "
-                f"Use a different issue number or rename the existing plan."
-            )
-            raise ValueError(msg)
-    else:
-        plan_number = _next_plan_number(plan_dir)
-    file_name = f"P{plan_number:03d}-{slug}.yaml"
+    plan_id_str = _new_plan_id()
+    file_name = f"{plan_id_str}-{slug}.yaml"
     output_path = plan_dir / file_name
 
     validated_tasks: list[Task] = []
@@ -154,7 +94,6 @@ def create_plan(
             msg = f"Task at index {i} failed validation: {exc}"
             raise ValueError(msg) from exc
 
-    plan_id_str = f"P{plan_number:03d}"
     plan = Plan(
         plan_id=plan_id_str,
         feature=slug,

--- a/plugins/development-harness/sam_schema/readers/normalize.py
+++ b/plugins/development-harness/sam_schema/readers/normalize.py
@@ -392,6 +392,7 @@ def normalize_plan(plan_meta: dict, task_dicts: list[dict], source_format: Forma
     ac = plan_meta.get("acceptance-criteria") or plan_meta.get("acceptance_criteria")
 
     plan = Plan(
+        plan_id=_coerce_str(plan_meta.get("plan-id") or plan_meta.get("plan_id")),
         feature=str(feature),
         version=str(plan_meta.get("version", "1.0")),
         description=str(plan_meta.get("description", "")),

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -289,7 +289,12 @@ def _sam_plan_create(config: CreatePlanConfig, plan_dir: str) -> dict:
     if plan_id_str.startswith("P"):
         with contextlib.suppress(ValueError):
             plan_number = int(plan_id_str[1:])
-    result: dict[str, Any] = {"plan_number": plan_number, "task_count": len(plan_data["tasks"])}
+    plan_ref: str | None
+    if plan_number is not None:
+        plan_ref = f"#{config.issue},P{plan_number:03d}" if config.issue is not None else f"P{plan_number:03d}"
+    else:
+        plan_ref = None
+    result: dict[str, Any] = {"plan_number": plan_number, "task_count": len(plan_data["tasks"]), "plan_ref": plan_ref}
     if config.issue is not None and plan_data["source_path"]:
         _try_register_task_plan_artifact(config.issue, Path(plan_data["source_path"]))
     return result
@@ -304,7 +309,14 @@ def _sam_plan_list(config: ListPlansConfig, plan_dir: str) -> dict:
     backend = _get_backend(plan_dir)
     summaries = backend.list_plans(search=config.search)
     all_items: list[dict[str, Any]] = [
-        {"feature": s["feature"], "goal": s["goal"], "description": s["description"], "task_count": s["task_count"]}
+        {
+            "feature": s["feature"],
+            "goal": s["goal"],
+            "description": s["description"],
+            "task_count": s["task_count"],
+            "issue": s.get("issue"),
+            "plan_ref": (f"#{s['issue']},P{s['plan_id'][1:]}" if s.get("issue") else s.get("plan_id")),
+        }
         for s in summaries
     ]
     return _paginate_results(

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -273,7 +273,7 @@ def _sam_plan_create(config: CreatePlanConfig, plan_dir: str) -> dict:
     """Create a new plan from YAML task definitions.
 
     Returns:
-        Dict with ``path``, ``plan_number``, and ``task_count`` keys.
+        Dict with ``plan_number`` and ``task_count`` keys.
     """
     yaml_parser: Any = YAML()
     parsed: dict[str, Any] = yaml_parser.load(config.tasks_yaml)
@@ -289,11 +289,7 @@ def _sam_plan_create(config: CreatePlanConfig, plan_dir: str) -> dict:
     if plan_id_str.startswith("P"):
         with contextlib.suppress(ValueError):
             plan_number = int(plan_id_str[1:])
-    result: dict[str, Any] = {
-        "path": str(plan_data["source_path"] or ""),
-        "plan_number": plan_number,
-        "task_count": len(plan_data["tasks"]),
-    }
+    result: dict[str, Any] = {"plan_number": plan_number, "task_count": len(plan_data["tasks"])}
     if config.issue is not None and plan_data["source_path"]:
         _try_register_task_plan_artifact(config.issue, Path(plan_data["source_path"]))
     return result
@@ -308,13 +304,7 @@ def _sam_plan_list(config: ListPlansConfig, plan_dir: str) -> dict:
     backend = _get_backend(plan_dir)
     summaries = backend.list_plans(search=config.search)
     all_items: list[dict[str, Any]] = [
-        {
-            "feature": s["feature"],
-            "goal": s["goal"],
-            "description": s["description"],
-            "task_count": s["task_count"],
-            "path": str(s["source_path"] or s["plan_id"]),
-        }
+        {"feature": s["feature"], "goal": s["goal"], "description": s["description"], "task_count": s["task_count"]}
         for s in summaries
     ]
     return _paginate_results(
@@ -332,7 +322,7 @@ def _sam_plan_ready(plan: str, config: ReadyPlanConfig, plan_dir: str) -> dict:
     """List tasks ready for dispatch.
 
     Returns:
-        Dict with ``ready_tasks``, ``count``, ``feature``, ``source_path``, and ``issue`` keys.
+        Dict with ``ready_tasks``, ``count``, ``feature``, and ``issue`` keys.
     """
     backend = _get_backend(plan_dir)
     plan_data = backend.read_plan(plan)
@@ -356,7 +346,6 @@ def _sam_plan_ready(plan: str, config: ReadyPlanConfig, plan_dir: str) -> dict:
         "ready_tasks": ready_tasks,
         "count": len(tasks_data),
         "feature": plan_data["feature"],
-        "source_path": str(plan_data["source_path"] or plan),
         "issue": plan_data["issue"],
     }
 

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -11,7 +11,6 @@ Tools:
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 from datetime import UTC, datetime
@@ -284,17 +283,11 @@ def _sam_plan_create(config: CreatePlanConfig, plan_dir: str) -> dict:
     plan_data = backend.create_plan(
         slug=config.slug, goal=config.goal, tasks=task_defs, context=config.context, issue=config.issue
     )
-    plan_number: int | None = None
     plan_id_str = plan_data["plan_id"]
-    if plan_id_str.startswith("P"):
-        with contextlib.suppress(ValueError):
-            plan_number = int(plan_id_str[1:])
-    plan_ref: str | None
-    if plan_number is not None:
-        plan_ref = f"#{config.issue},P{plan_number:03d}" if config.issue is not None else f"P{plan_number:03d}"
-    else:
-        plan_ref = None
-    result: dict[str, Any] = {"plan_number": plan_number, "task_count": len(plan_data["tasks"]), "plan_ref": plan_ref}
+    plan_ref: str | None = (
+        (f"#{config.issue},{plan_id_str}" if config.issue is not None else plan_id_str) if plan_id_str else None
+    )
+    result: dict[str, Any] = {"plan_id": plan_id_str, "task_count": len(plan_data["tasks"]), "plan_ref": plan_ref}
     if config.issue is not None and plan_data["source_path"]:
         _try_register_task_plan_artifact(config.issue, Path(plan_data["source_path"]))
     return result
@@ -315,7 +308,7 @@ def _sam_plan_list(config: ListPlansConfig, plan_dir: str) -> dict:
             "description": s["description"],
             "task_count": s["task_count"],
             "issue": s.get("issue"),
-            "plan_ref": (f"#{s['issue']},P{s['plan_id'][1:]}" if s.get("issue") else s.get("plan_id")),
+            "plan_ref": (f"#{s['issue']},{s['plan_id']}" if s.get("issue") else s.get("plan_id")),
         }
         for s in summaries
     ]

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -272,7 +272,10 @@ def _sam_plan_create(config: CreatePlanConfig, plan_dir: str) -> dict:
     """Create a new plan from YAML task definitions.
 
     Returns:
-        Dict with ``plan_number`` and ``task_count`` keys.
+        Dict with ``plan_id``, ``plan_ref``, and ``task_count`` keys.
+        ``plan_ref`` is computed in the server response as ``#{issue},{plan_id}``
+        when an issue number is present, or just ``plan_id`` otherwise.
+        It is not stored in the Plan model.
     """
     yaml_parser: Any = YAML()
     parsed: dict[str, Any] = yaml_parser.load(config.tasks_yaml)
@@ -297,7 +300,9 @@ def _sam_plan_list(config: ListPlansConfig, plan_dir: str) -> dict:
     """List all plans with optional search and auto-pagination.
 
     Returns:
-        Paginated dict with ``items``, ``total``, ``offset``, and ``limit`` keys.
+        Paginated dict with ``items``, ``count``, ``pagination``, ``messages``,
+        ``warnings``, and ``errors`` keys. Each item contains ``feature``,
+        ``goal``, ``description``, ``task_count``, ``issue``, and ``plan_ref``.
     """
     backend = _get_backend(plan_dir)
     summaries = backend.list_plans(search=config.search)

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -16,7 +16,7 @@ You MUST convert the user's request into **durable SAM artifacts** registered vi
 - `feature-context-{slug}.md` (discovery)
 - `codebase/{FOCUS}.md` (optional, analysis)
 - `architect-{slug}.md` (architecture/design spec)
-- `P{NNN}-{slug}.yaml` (executable task plan with Agents, deps, and verification)
+- `P{id}-{slug}.yaml` (executable task plan with Agents, deps, and verification)
 
 <feature_request>
 $ARGUMENTS
@@ -345,7 +345,7 @@ mcp__plugin_dh_backlog__artifact_register(
 
 Delegate to `@dh:swarm-task-planner` to:
 
-- create `plan/P{NNN}-{slug}.yaml` (via `sam create`)
+- create `plan/P{id}-{slug}.yaml` (via `sam create`)
 - ensure every task has:
   - **Status**, **Dependencies**, **Priority**, **Complexity**, **Agent**
   - Acceptance Criteria (3+)
@@ -397,20 +397,20 @@ back to the backlog item:
 mcp__plugin_dh_backlog__artifact_register(
     issue_number={issue},
     artifact_type="task-plan",
-    path="plan/P{NNN}-{slug}.yaml",  # state-relative path; auto-registered by sam_plan when issue is set
+    path="plan/P{id}-{slug}.yaml",  # state-relative path; auto-registered by sam_plan when issue is set
     agent="swarm-task-planner"
 )
 
 mcp__plugin_dh_backlog__backlog_update(
     selector="{title}",
-    plan="P{NNN}"
+    plan="P{id}"
 )
 ```
 
 The `backlog_update(plan=...)` call writes the plan address into the backlog item's `metadata.plan`
 field. This is a backend signal — it records that a plan exists and its address, not a filesystem
 path. `work-backlog-item` uses this to route directly to `implement-feature` on subsequent
-invocations. The SAM MCP resolves `P{NNN}` to the full plan without filesystem access.
+invocations. The SAM MCP resolves `P{id}` to the full plan without filesystem access.
 
 ---
 

--- a/plugins/development-harness/skills/backlog/references/known-patterns.md
+++ b/plugins/development-harness/skills/backlog/references/known-patterns.md
@@ -1,6 +1,6 @@
 # Known Patterns — backlog_core Section Replacement
 
-## YAML Format (Current — Post P964 Migration)
+## YAML Format (Current — Post Pe1f2a3b4 Migration)
 
 Backlog items are stored as `.yaml` files. Groomed fields (priority, effort, decision, fact-check,
 rt-ica) are top-level YAML keys on the `BacklogItem` model. Updates go through
@@ -9,13 +9,13 @@ rt-ica) are top-level YAML keys on the `BacklogItem` model. Updates go through
 To update a single field on a `BacklogItem`, mutate the field and call `save_item(item, path)`.
 There are no section-level helpers for the YAML format — the model is the single source of truth.
 
-SOURCE: P964 YAML migration — `_md_append_or_replace_section`, `_md_replace_groomed_subsection`,
+SOURCE: Pe1f2a3b4 YAML migration — `_md_append_or_replace_section`, `_md_replace_groomed_subsection`,
 and `_md_build_section_block` were removed from `operations.py` after zero callers remained
 (confirmed by grep, 2026-03-31).
 
 ## Legacy `.md` Format (Historical Reference Only)
 
-The following patterns applied to `.md` backlog files before the P964 YAML migration. They are
+The following patterns applied to `.md` backlog files before the Pe1f2a3b4 YAML migration. They are
 preserved here for archaeological reference — the implementation no longer exists.
 
 ### Markdown Heading Regex Must Use `[^\n]*`

--- a/plugins/development-harness/skills/complete-implementation/SKILL.md
+++ b/plugins/development-harness/skills/complete-implementation/SKILL.md
@@ -247,8 +247,8 @@ The issue-only path does not produce follow-up task files. Skip directly to "Fin
 
 Extract the plan address `P{N}` from the task file path:
 
-- `plan/P003-integrate-sam-schema.yaml` → plan number `003` → address `P003`
-- Strip `plan/P` prefix, take the leading integer NNN, format as `P{NNN}`
+- `plan/Pb3c4d5e6-integrate-sam-schema.yaml` → plan id `b3c4d5e6` → address `Pb3c4d5e6`
+- Strip `plan/P` prefix, take the hex id, format as `P{id}`
 
 Use `P{N}` in all `sam` CLI calls below.
 
@@ -258,7 +258,7 @@ Use `P{N}` in all `sam` CLI calls below.
 
 Before invoking Phase 1, check for a TN verification report produced by `tn-verification-gate` (which reads the T0 baseline written by `t0-baseline-capture`).
 
-Extract `{slug}` from the task file path (`plan/P{NNN}-{slug}.yaml` — strip the `P{NNN}-` prefix and `.yaml` suffix).
+Extract `{slug}` from the task file path (`plan/P{id}-{slug}.yaml` — strip the `P{id}-` prefix and `.yaml` suffix).
 
 Read the TN-verification artifact via `artifact_read(issue_number={N}, artifact_type="TN-verification")`. Fallback: if no artifact is registered, read `dh_paths.plan_dir() / "TN-verification-{slug}.yaml"`.
 
@@ -305,7 +305,7 @@ Before proceeding to Artifact Discovery, check for migration signals.
 Check:
 1. Issue title — contains: "migrat", "convert format", "replace .md", "format conversion", "move from", "transition from"
 2. Issue body / description section — same keywords
-3. P{NNN}.yaml tasks — read each task's `acceptance_criteria` field for: "delete", "remove source", "after migration complete", "drop the source"
+3. P{id}.yaml tasks — read each task's `acceptance_criteria` field for: "delete", "remove source", "after migration complete", "drop the source"
 
 Note: `acceptance_criteria` is a dedicated `str` field on the Task model (`sam_schema/core/models.py`) — it can be read directly, not parsed out of a body blob.
 
@@ -381,7 +381,7 @@ If no concerns section exists, proceed to Phase 1.
 
 After the pre-phases complete, set up the SAM-enforced quality gate plan for the 6 phases.
 
-Extract `{slug}` from the task file path (`plan/P{NNN}-{slug}.yaml` — strip the `P{NNN}-` prefix and `.yaml` suffix).
+Extract `{slug}` from the task file path (`plan/P{id}-{slug}.yaml` — strip the `P{id}-` prefix and `.yaml` suffix).
 
 ### Step 1: Check for existing QG plan
 
@@ -623,7 +623,7 @@ If `artifact_read` returns an error or the artifact is absent, fall back to the 
 mcp__plugin_dh_sam__sam_plan(config={"action": "list", "search": "{slug}-followup"})
 ```
 
-Where `{slug}` is extracted from the parent task file path (`plan/P{NNN}-{slug}.yaml` — strip `P{NNN}-` prefix and `.yaml` suffix).
+Where `{slug}` is extracted from the parent task file path (`plan/P{id}-{slug}.yaml` — strip `P{id}-` prefix and `.yaml` suffix).
 
 If both `artifact_read` and the SAM search return empty: skip the entire routing section (no follow-ups to route).
 
@@ -634,10 +634,10 @@ If both `artifact_read` and the SAM search return empty: skip the entire routing
 For each follow-up file, derive a search slug from the filename using this algorithm:
 
 ```text
-Input:  plan/P008-data-validation-followup-1.yaml
-Step 1: Strip directory prefix      --> P008-data-validation-followup-1.yaml
-Step 2: Strip .yaml extension       --> P008-data-validation-followup-1
-Step 3: Strip P{NNN}- prefix        --> data-validation-followup-1
+Input:  plan/Pc5d6e7f8-data-validation-followup-1.yaml
+Step 1: Strip directory prefix      --> Pc5d6e7f8-data-validation-followup-1.yaml
+Step 2: Strip .yaml extension       --> Pc5d6e7f8-data-validation-followup-1
+Step 3: Strip P{id}- prefix         --> data-validation-followup-1
 Step 4: Strip -followup-{k} suffix  --> data-validation
 Step 5: Replace hyphens with spaces --> data validation
 Output: "data validation"
@@ -691,7 +691,7 @@ If both strategies return zero results, treat as "no match found" and proceed to
 **Error handling**: If either `mcp__plugin_dh_backlog__backlog_list` call fails, log the error, skip
 that strategy, and continue to the next strategy (or to Step 4 as "no match found" if all
 strategies fail). If the follow-up filename does not match the expected
-`P{NNN}-{slug}-followup-{k}.yaml` pattern, log a warning and use the full filename (without
+`P{id}-{slug}-followup-{k}.yaml` pattern, log a warning and use the full filename (without
 directory prefix and `.yaml` extension) as the derived slug.
 
 ### Step 3: Classify Follow-up Findings
@@ -729,10 +729,10 @@ Based on Step 2 result, for each follow-up file:
 
 **Match found** -- attach follow-up as plan to the existing backlog item:
 
-Extract the plan address from the follow-up file path: `plan/P{NNN}-{slug}-followup-{k}.yaml` → `P{NNN}`.
+Extract the plan address from the follow-up file path: `plan/P{id}-{slug}-followup-{k}.yaml` → `P{id}`.
 
 ```text
-mcp__plugin_dh_backlog__backlog_update(selector="{matched_item_title}", plan="P{NNN}")
+mcp__plugin_dh_backlog__backlog_update(selector="{matched_item_title}", plan="P{id}")
 ```
 
 **No match found** -- create a new backlog item, then attach the follow-up as plan:
@@ -744,7 +744,7 @@ Skill(skill: "dh:create-backlog-item", args: "--auto {derived_title}")
 Then attach the follow-up as the plan (extract plan address first — see above):
 
 ```text
-mcp__plugin_dh_backlog__backlog_update(selector="{derived_title}", plan="P{NNN}")
+mcp__plugin_dh_backlog__backlog_update(selector="{derived_title}", plan="P{id}")
 ```
 
 **Error handling**:
@@ -809,7 +809,7 @@ If no BLOCKED-FOR-PLANNING signal: continue to Condition 1 (ADR-3).
 
 For each follow-up file, evaluate two conditions. BOTH must be true for recursion.
 
-**Condition 1 -- Same session scope (ADR-3)**: The follow-up file's slug matches the parent task file's slug. Extract the slug from each filename: strip the `P{NNN}-` prefix, then strip `-followup-{k}.yaml` for the follow-up or `.yaml` for the parent. Compare the two slugs.
+**Condition 1 -- Same session scope (ADR-3)**: The follow-up file's slug matches the parent task file's slug. Extract the slug from each filename: strip the `P{id}-` prefix, then strip `-followup-{k}.yaml` for the follow-up or `.yaml` for the parent. Compare the two slugs.
 
 **Condition 2 -- High priority (ADR-2)**: Read the follow-up file content and extract the `## Priority` section. Only `High` qualifies for immediate recursion.
 
@@ -848,7 +848,7 @@ After all six phases and follow-up routing complete, apply the `status:verified`
 Derive the search slug from the task file path (same algorithm as Recursive Follow-up Handling):
 
 ```text
-plan/P003-integrate-sam-schema.yaml → slug: integrate-sam-schema
+plan/Pb3c4d5e6-integrate-sam-schema.yaml → slug: integrate-sam-schema
 ```
 
 Search the backlog:
@@ -934,9 +934,9 @@ Store the first result. Check `item.plan` as a boolean only (is it set and non-e
 If item found AND item.plan is set (non-empty):
   Resolve the plan address via SAM — do NOT pass item.plan directly:
     mcp__plugin_dh_sam__sam_list(search="{slug}")
-  Use the plan address P{NNN} from the result.
+  Use the plan address P{id} from the result.
   Clear context and run:
-    /dh:implement-feature P{NNN}
+    /dh:implement-feature P{id}
 
 If item found AND item.plan is NOT set:
   Clear context and run:

--- a/plugins/development-harness/skills/development-harness/SKILL.md
+++ b/plugins/development-harness/skills/development-harness/SKILL.md
@@ -41,7 +41,7 @@ flowchart TD
 
     Q1 -->|Plan AND execute a backlog item<br>end-to-end through closure| Work["/dh:work-backlog-item {title|#N|--auto}<br>Handles: auto-groom, RT-ICA gate, SAM planning,<br>GitHub sync, close, resolve<br>STOPS if item already has a Plan field"]
 
-    Q1 -->|Plan a feature — produce SAM artifacts<br>without executing| Plan["/dh:add-new-feature {feature description}<br>Phases: discovery → codebase analysis →<br>architecture spec → task decomposition →<br>validation → context manifest<br>Output: feature slug + P{NNN} task plan"]
+    Q1 -->|Plan a feature — produce SAM artifacts<br>without executing| Plan["/dh:add-new-feature {feature description}<br>Phases: discovery → codebase analysis →<br>architecture spec → task decomposition →<br>validation → context manifest<br>Output: feature slug + P{id} task plan"]
 
     Q1 -->|Execute an existing plan —<br>task plan already produced| Execute["/dh:implement-feature {plan path or slug}<br>Loops ready tasks, dispatches agents,<br>calls complete-implementation when all tasks COMPLETE"]
 

--- a/plugins/development-harness/skills/dispatch/SKILL.md
+++ b/plugins/development-harness/skills/dispatch/SKILL.md
@@ -46,7 +46,7 @@ Each worker gets exactly the context needed — no more.
 Agent(
   team_name="feature-slug-wave-1",
   name="T42-worker",
-  prompt="Your ROLE_TYPE is sub-agent. You are working on P500/T42."
+  prompt="Your ROLE_TYPE is sub-agent. You are working on Pf1a2b3c4/T42."
 )
 ```
 

--- a/plugins/development-harness/skills/forensic-review/SKILL.md
+++ b/plugins/development-harness/skills/forensic-review/SKILL.md
@@ -53,7 +53,7 @@ sam_task(plan="{plan_id}", task="{task_id}", config={"action": "read"})
 
 Extract:
 
-- `task_file_path` — the path to the task YAML file (e.g., `plan/P{NNN}-{slug}.yaml`)
+- `task_file_path` — the path to the task YAML file (e.g., `plan/P{id}-{slug}.yaml`)
 - `issue_number` — required for artifact registration; if absent, BLOCK immediately
 - `expected_outputs` — the implementation files produced by Stage 5 (listed in the task's
   "Files Changed" or "Expected Outputs" section)

--- a/plugins/development-harness/skills/groom-milestone/SKILL.md
+++ b/plugins/development-harness/skills/groom-milestone/SKILL.md
@@ -74,7 +74,7 @@ flowchart TD
 
     Prioritize["Step 8: Priority Ordering<br>Action: Order items by:<br>1. Dependency constraints (blocked-by first)<br>2. Priority label (P0 > P1 > P2)<br>3. Conflict group (parallel-safe first)<br>Output: ordered list with wave assignments"]
 
-    Prioritize --> WavePlan["Step 9: Build Dispatch Plan<br>Action: Assign items to waves.<br>Wave 1: all items with no dependencies and no conflict group overlap.<br>Wave 2: items unblocked after Wave 1. Continue until all items assigned.<br>Verify wave ordering and dependency references.<br>Construct YAML string from wave assignments.<br>Call dispatch_create_plan(milestone_number=N, plan_yaml=yaml_str) to persist plan atomically.<br>For re-grooming a stale plan, pass overwrite=True.<br>Call dispatch_wave_start per wave to register state.<br>Output: plan/milestone-{N}-dispatch.yaml"]
+    Prioritize --> WavePlan["Step 9: Build Dispatch Plan<br>Action: Assign items to waves.<br>Wave 1: all items with no dependencies and no conflict group overlap.<br>Wave 2: items unblocked after Wave 1. Continue until all items assigned.<br>Verify wave ordering and dependency references.<br>Construct DispatchPlan object from wave assignments.<br>Call dispatch_create_plan(milestone_number=N, plan=dispatch_plan) to persist plan atomically.<br>For re-grooming a stale plan, pass overwrite=True.<br>Call dispatch_wave_start per wave to register state.<br>Output: plan/milestone-{N}-dispatch.yaml"]
 
     WavePlan --> Report["Step 10: Report<br>Output: milestone summary with wave assignments,<br>conflict groups, estimated parallelism per wave,<br>and next command: /work-milestone {N}"]
 
@@ -92,11 +92,11 @@ flowchart TD
 
 The backlog MCP server exposes these dispatch tools used at plan-write time:
 
-- `dispatch_create_plan(milestone_number, plan_yaml, overwrite, validate, issue)` — Step 9: validates and persists the dispatch plan YAML atomically; use overwrite=True when re-grooming a stale plan
+- `dispatch_create_plan(milestone_number, plan, overwrite, validate, issue)` — Step 9: validates and persists the dispatch plan atomically; `plan` is a typed DispatchPlan object; use overwrite=True when re-grooming a stale plan
 - `dispatch_wave_start(milestone, wave_num, items)` — Step 9: registers each wave in the dispatch state database; call after dispatch_create_plan to initialise wave state
 - `dispatch_wave_status(milestone, wave_num)` — available after `/work-milestone` launches; returns item-level progress with stale PID detection
 
-The dispatch plan is persisted via the `dispatch_create_plan` MCP tool, which validates the YAML against the DispatchPlan schema and writes atomically. The schema for `plan_yaml` is defined in [./references/dispatch-plan-schema.md](./references/dispatch-plan-schema.md). The conflict analysis and wave assignment logic (Steps 5–9) runs in-session — it does not call external module functions.
+The dispatch plan is persisted via the `dispatch_create_plan` MCP tool, which validates the DispatchPlan object against the schema and writes atomically. The DispatchPlan schema is defined in [./references/dispatch-plan-schema.md](./references/dispatch-plan-schema.md). The conflict analysis and wave assignment logic (Steps 5–9) runs in-session — it does not call external module functions.
 
 ## Error Handling
 

--- a/plugins/development-harness/skills/groom-milestone/references/dispatch-plan-schema.md
+++ b/plugins/development-harness/skills/groom-milestone/references/dispatch-plan-schema.md
@@ -155,14 +155,14 @@ This section clarifies how `/work-milestone` uses the dispatch plan when spawnin
 
 ## Creating Plans via MCP
 
-Use the `dispatch_create_plan` MCP tool (on the backlog server) to create or update dispatch plans. The YAML content shown in the schema example above is exactly what the `plan_yaml` parameter accepts.
+Use the `dispatch_create_plan` MCP tool (on the backlog server) to create or update dispatch plans. The `plan` parameter accepts a typed DispatchPlan object matching the schema above.
 
 **Parameters:**
 
 - `milestone_number` — GitHub milestone number; the tool writes to `plan/milestone-{N}-dispatch.yaml`
-- `plan_yaml` — YAML string containing the full dispatch plan (accepts both kebab-case and snake_case keys)
+- `plan` — typed DispatchPlan object containing the full dispatch plan (accepts both kebab-case and snake_case keys)
 - `overwrite` — Allow replacing an existing plan file; set to `True` when re-grooming (default: `False`)
 - `validate` — Run `validate_plan_integrity()` after writing and include results in response (default: `True`)
 - `issue` — Optional GitHub issue number; when provided, auto-registers the plan file as a `dispatch-plan` artifact
 
-**Response:** Returns `plan_path`, `wave_count`, `item_count`, `is_valid`, `errors`, and `warnings`. On error, the response contains an `error` key with a description.
+**Response:** Returns `milestone_number`, `wave_count`, `item_count`, `is_valid`, `errors`, `warnings`, and `messages`. On error, the response contains an `error` key with a description.

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement-feature
-description: Use when a SAM task plan exists and you need to execute the implementation loop — picks up ready tasks, delegates each to its specified agent, and relies on hooks to update task timestamps and status. Activates when a plan address (P{NNN}) or feature slug is provided after planning is complete. Task plans are managed by the SAM MCP server (sam_plan, sam_task).
+description: Use when a SAM task plan exists and you need to execute the implementation loop — picks up ready tasks, delegates each to its specified agent, and relies on hooks to update task timestamps and status. Activates when a plan address (P{id}) or feature slug is provided after planning is complete. Task plans are managed by the SAM MCP server (sam_plan, sam_task).
 argument-hint: <task-file-path or feature-slug>
 user-invocable: true
 ---

--- a/plugins/development-harness/skills/implementation-manager/SKILL.md
+++ b/plugins/development-harness/skills/implementation-manager/SKILL.md
@@ -38,8 +38,7 @@ mcp__plugin_dh_sam__sam_plan(config={"action": "list"})
   "features": [
     {
       "slug": "prepare-host",
-      "task_file": "tasks-1-prepare-host.md",
-      "path": "~/.dh/projects/{project-slug}/plan/tasks-1-prepare-host.md"
+      "task_file": "tasks-1-prepare-host.md"
     }
   ],
   "count": 1

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/close/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/close/start.md
@@ -83,7 +83,7 @@ If operation is `resolve`:
 
 1. Extract `**Plan**:` field from the matched item. If absent, skip to Step 5.7 (no plan = simple resolve with summary only).
 
-2. Extract the plan address from the plan path (e.g., `plan/P398-backlog-lifecycle-process-gaps.yaml` → `P398`). Call:
+2. Extract the plan address from the plan path (e.g., `plan/Pe9f0a1b2-backlog-lifecycle-process-gaps.yaml` → `Pe9f0a1b2`). Call:
 
    ```text
    mcp__plugin_dh_sam__sam_plan(config={"action": "status"}, plan="{address}")
@@ -115,7 +115,7 @@ If operation is `resolve`:
 
    Parse each `-` line as a separate criterion.
 
-5. Spawn a verification agent with subagent_type="dh:task-worker". Prompt must include: item title, plan address (e.g., `P{NNN}`), checklist status (100%), and each criterion listed individually as "Criterion N: {text}". Instruct the agent to: read the plan via `sam_plan(action='read')`, search `git log --oneline -20`, check relevant files for each criterion, and return per-criterion PASS/FAIL with file:line evidence. Required return format:
+5. Spawn a verification agent with subagent_type="dh:task-worker". Prompt must include: item title, plan address (e.g., `P{id}`), checklist status (100%), and each criterion listed individually as "Criterion N: {text}". Instruct the agent to: read the plan via `sam_plan(action='read')`, search `git log --oneline -20`, check relevant files for each criterion, and return per-criterion PASS/FAIL with file:line evidence. Required return format:
 
    ```text
    [PASS] {criterion} — verified at {file}:{line} (or commit {sha})
@@ -186,7 +186,7 @@ If operation is `resolve`:
 
     - `selector`: `"{title}"` or `"#{N}"`
     - `summary`: `"{summary}"`
-    - `plan`: `"{plan_address}"` (if present — e.g., `"P{NNN}"`)
+    - `plan`: `"{plan_address}"` (if present — e.g., `"P{id}"`)
     - `method`: `"{method}"` (if provided)
     - `notes`: `"{notes}"` (if provided)
     - `follow_ups`: `"{follow_ups}"` (if provided)

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/locate.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/locate.md
@@ -38,10 +38,10 @@ From the matched item's entry in the `mcp__plugin_dh_backlog__backlog_list` retu
 - `research_first` — from `backlog_view` response body, `**Research first**:` line (optional)
 - `suggested_location` — from `backlog_view` response body, `**Suggested location**:` line (optional)
 
-If the item already has a `**Plan**:` field, extract the plan address from the YAML filename (e.g., `plan/P1079-machine-readable-inter-item-dependencies.yaml` → `P1079`). Invoke immediately:
+If the item already has a `**Plan**:` field, extract the plan address from the YAML filename (e.g., `plan/Pf3a4b5c6-machine-readable-inter-item-dependencies.yaml` → `Pf3a4b5c6`). Invoke immediately:
 
 ```text
-Skill(skill: "dh:implement-feature", args: "P{NNN}")
+Skill(skill: "dh:implement-feature", args: "P{id}")
 ```
 
 After extracting fields, proceed to `validate.md` (Step 2.1) before continuing.

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/plan.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/plan.md
@@ -29,7 +29,7 @@ Call the `mcp__plugin_dh_backlog__backlog_update` tool to add the Plan:
 | Parameter | Value |
 |-----------|-------|
 | `selector` | `"{title}"` |
-| `plan` | `"P{NNN}"` (plan address — backend signal, not a file path) |
+| `plan` | `"P{id}"` (plan address — backend signal, not a file path) |
 
 If the item has `**Issue**: #N`, record it in the plan file header comment. Do NOT include `Fixes #N`, `Closes #N`, or `Resolves #N` in task-level commit messages — issue closure is handled exclusively by `/complete-implementation` in its final commit step.
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/scope.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/scope.md
@@ -22,5 +22,5 @@ Work does NOT produce:
 A completed work result must produce:
 
 - a SAM plan file created by `dh:add-new-feature` and retrievable via `sam_plan(action='list')`
-- a `plan` field on the backlog item set to the plan address `P{NNN}` via `backlog_update`
+- a `plan` field on the backlog item set to the plan address `P{id}` via `backlog_update`
 - item status transitioned to `in-progress` via `backlog_update(status="in-progress")`

--- a/plugins/development-harness/tests/test_dispatch_tools.py
+++ b/plugins/development-harness/tests/test_dispatch_tools.py
@@ -23,6 +23,7 @@ from backlog_core.dispatch_state import DispatchStateManager
 from backlog_core.models import DispatchItemRecord
 from backlog_core.server import mcp
 from fastmcp.client import Client
+from fastmcp.exceptions import ToolError
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -665,38 +666,30 @@ class TestDispatchSpawn:
 # ---------------------------------------------------------------------------
 
 
-def _make_valid_plan_yaml(milestone: int = 10, issue: int = 101) -> str:
-    """Return a minimal valid dispatch plan YAML string for TestDispatchCreatePlan.
+def _make_valid_plan_dict(milestone: int = 10, issue: int = 101) -> dict:
+    """Return a minimal valid dispatch plan dict for TestDispatchCreatePlan.
 
     Args:
         milestone: Milestone number to embed in the plan.
         issue: Issue number for the single wave item.
 
     Returns:
-        YAML string conforming to the DispatchPlan schema with one wave and one item.
+        Dict conforming to the DispatchPlan JSON schema with one wave and one item.
     """
-    return f"""\
-milestone:
-  number: {milestone}
-  title: Test Milestone {milestone}
-  integration-branch: main
-waves:
-  - wave: 1
-    items:
-      - title: Issue {issue}
-        issue: {issue}
-        priority: P2
-"""
+    return {
+        "milestone": {"number": milestone, "title": f"Test Milestone {milestone}", "integration_branch": "main"},
+        "waves": [{"wave": 1, "items": [{"title": f"Issue {issue}", "issue": issue, "priority": "P2"}]}],
+    }
 
 
 @pytest.fixture
-def valid_plan_yaml() -> str:
-    """Provide a minimal valid dispatch plan YAML string for milestone 10.
+def valid_plan_dict() -> dict:
+    """Provide a minimal valid dispatch plan dict for milestone 10.
 
     Returns:
-        YAML string with milestone number 10, one wave, one item (issue 101).
+        Dict with milestone number 10, one wave, one item (issue 101).
     """
-    return _make_valid_plan_yaml(milestone=10, issue=101)
+    return _make_valid_plan_dict(milestone=10, issue=101)
 
 
 @pytest.fixture
@@ -728,7 +721,7 @@ def existing_plan_file(tmp_path: Path, mocker: MockerFixture) -> Path:
         Path to the pre-written dispatch plan file.
     """
     plan_path = tmp_path / "milestone-10-dispatch.yaml"
-    plan_path.write_text(_make_valid_plan_yaml())
+    plan_path.write_text(_make_dispatch_plan_yaml())
     mocker.patch("backlog_core.server._dispatch_plan_path", return_value=plan_path)
     return plan_path
 
@@ -736,14 +729,14 @@ def existing_plan_file(tmp_path: Path, mocker: MockerFixture) -> Path:
 class TestDispatchCreatePlan:
     """Integration tests for the dispatch_create_plan MCP tool.
 
-    Tests the full creation lifecycle: valid YAML acceptance (kebab-case and
-    snake_case keys), overwrite protection, milestone number consistency,
+    Tests the full creation lifecycle: typed plan dict acceptance (kebab-case and
+    snake_case alias keys), overwrite protection, milestone number consistency,
     post-write integrity validation, and best-effort artifact registration.
     All calls use the FastMCP in-memory Client against the real ``mcp``
     application instance; no HTTP transport is used.
 
     Fixtures:
-        valid_plan_yaml: Minimal valid YAML for milestone 10 with one wave/item.
+        valid_plan_dict: Minimal valid plan dict for milestone 10 with one wave/item.
         plan_target_path: Non-existent path in tmp_path for creation tests.
         patch_create_plan_path: Patches _dispatch_plan_path to non-existent tmp path.
         existing_plan_file: Pre-written plan file for overwrite/exists tests.
@@ -753,62 +746,51 @@ class TestDispatchCreatePlan:
     # Happy-path tests
     # ------------------------------------------------------------------
 
-    async def test_create_plan_valid_yaml(self, valid_plan_yaml: str, patch_create_plan_path: Path) -> None:
-        """dispatch_create_plan writes a file and returns success metadata for valid YAML.
+    async def test_create_plan_valid_yaml(self, valid_plan_dict: dict, patch_create_plan_path: Path) -> None:
+        """dispatch_create_plan writes a file and returns success metadata for a valid plan dict.
 
         Tests: dispatch_create_plan — happy path
-        How: Call the tool with a minimal valid YAML for milestone 10. Verify the
-             response has no error key, plan_path matches the patched path, wave_count
-             and item_count are correct, and is_valid is True (default validate=True).
-        Why: Callers depend on plan_path, wave_count, and item_count to confirm the
-             plan was accepted and written before invoking dispatch_wave_start.
+        How: Call the tool with a minimal valid plan dict for milestone 10. Verify the
+             response has no error key, wave_count and item_count are correct, and
+             is_valid is True (default validate=True).
+        Why: Callers depend on wave_count and item_count to confirm the plan was accepted
+             and written before invoking dispatch_wave_start.
         """
         # Arrange
         target = patch_create_plan_path
 
         # Act
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": valid_plan_yaml}
-            )
+            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": valid_plan_dict})
 
         # Assert
         data: dict[str, Any] = result.data
         assert "error" not in data, f"Unexpected error: {data.get('error')}"
         assert data["milestone_number"] == 10
-        assert data["plan_path"] == str(target)
         assert data["wave_count"] == 1
         assert data["item_count"] == 1
         assert data["is_valid"] is True
         assert target.exists()
 
     async def test_create_plan_kebab_case_keys(self, patch_create_plan_path: Path) -> None:
-        """dispatch_create_plan accepts kebab-case YAML keys.
+        """dispatch_create_plan accepts kebab-case alias keys in the plan dict.
 
         Tests: dispatch_create_plan — kebab-case key acceptance
-        How: Provide YAML with 'integration-branch' and 'conflict-groups' in kebab-case.
+        How: Provide a dict with 'integration-branch' and 'conflict-groups' in kebab-case.
              Verify the tool accepts and writes without error.
         Why: The DispatchPlan schema uses AliasChoices for both forms; callers
-             from groom-milestone produce kebab-case YAML by convention.
+             from groom-milestone produce kebab-case dicts by convention.
         """
-        # Arrange
-        plan_yaml = """\
-milestone:
-  number: 10
-  title: Test Milestone
-  integration-branch: feature/test
-conflict-groups: []
-waves:
-  - wave: 1
-    items:
-      - title: Issue 101
-        issue: 101
-        priority: P1
-"""
+        # Arrange — use kebab-case alias keys that Pydantic resolves via AliasChoices
+        plan_dict = {
+            "milestone": {"number": 10, "title": "Test Milestone", "integration-branch": "feature/test"},
+            "conflict-groups": [],
+            "waves": [{"wave": 1, "items": [{"title": "Issue 101", "issue": 101, "priority": "P1"}]}],
+        }
 
         # Act
         async with Client(mcp) as client:
-            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan_yaml": plan_yaml})
+            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": plan_dict})
 
         # Assert
         data: dict[str, Any] = result.data
@@ -817,32 +799,24 @@ waves:
         assert patch_create_plan_path.exists()
 
     async def test_create_plan_snake_case_keys(self, patch_create_plan_path: Path) -> None:
-        """dispatch_create_plan accepts snake_case YAML keys.
+        """dispatch_create_plan accepts snake_case alias keys in the plan dict.
 
         Tests: dispatch_create_plan — snake_case key acceptance
-        How: Provide YAML with 'integration_branch' and 'conflict_groups' in snake_case.
+        How: Provide a dict with 'integration_branch' and 'conflict_groups' in snake_case.
              Verify the tool accepts and writes without error.
         Why: The AliasChoices on DispatchPlan fields accept both forms; both must work
              so callers are not forced to canonicalise keys before calling.
         """
-        # Arrange
-        plan_yaml = """\
-milestone:
-  number: 10
-  title: Test Milestone
-  integration_branch: main
-conflict_groups: []
-waves:
-  - wave: 1
-    items:
-      - title: Issue 202
-        issue: 202
-        priority: P0
-"""
+        # Arrange — use snake_case keys (the other alias form)
+        plan_dict = {
+            "milestone": {"number": 10, "title": "Test Milestone", "integration_branch": "main"},
+            "conflict_groups": [],
+            "waves": [{"wave": 1, "items": [{"title": "Issue 202", "issue": 202, "priority": "P0"}]}],
+        }
 
         # Act
         async with Client(mcp) as client:
-            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan_yaml": plan_yaml})
+            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": plan_dict})
 
         # Assert
         data: dict[str, Any] = result.data
@@ -850,11 +824,11 @@ waves:
         assert data["item_count"] == 1
         assert patch_create_plan_path.exists()
 
-    async def test_create_plan_validate_false(self, valid_plan_yaml: str, patch_create_plan_path: Path) -> None:
+    async def test_create_plan_validate_false(self, valid_plan_dict: dict, patch_create_plan_path: Path) -> None:
         """dispatch_create_plan skips integrity validation when validate=False.
 
         Tests: dispatch_create_plan — validate=False path
-        How: Call with validate=False and a valid YAML. Verify is_valid is None in
+        How: Call with validate=False and a valid plan dict. Verify is_valid is None in
              the response and the file is still written.
         Why: Callers that have already validated externally can skip the post-write
              check for performance; is_valid=None signals validation was not run.
@@ -865,7 +839,7 @@ waves:
         # Act
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": valid_plan_yaml, "validate": False}
+                "dispatch_create_plan", {"milestone_number": 10, "plan": valid_plan_dict, "validate": False}
             )
 
         # Assert
@@ -885,26 +859,23 @@ waves:
              prior one atomically; overwrite=True is the groom-milestone use case.
         """
         # Arrange — existing_plan_file fixture has already written one item
-        new_yaml = """\
-milestone:
-  number: 10
-  title: Updated Milestone
-  integration-branch: main
-waves:
-  - wave: 1
-    items:
-      - title: Issue 101
-        issue: 101
-        priority: P2
-      - title: Issue 102
-        issue: 102
-        priority: P3
-"""
+        new_plan = {
+            "milestone": {"number": 10, "title": "Updated Milestone", "integration_branch": "main"},
+            "waves": [
+                {
+                    "wave": 1,
+                    "items": [
+                        {"title": "Issue 101", "issue": 101, "priority": "P2"},
+                        {"title": "Issue 102", "issue": 102, "priority": "P3"},
+                    ],
+                }
+            ],
+        }
 
         # Act
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": new_yaml, "overwrite": True}
+                "dispatch_create_plan", {"milestone_number": 10, "plan": new_plan, "overwrite": True}
             )
 
         # Assert
@@ -914,7 +885,7 @@ waves:
         assert existing_plan_file.exists()
 
     async def test_create_plan_with_issue(
-        self, valid_plan_yaml: str, patch_create_plan_path: Path, mocker: MockerFixture
+        self, valid_plan_dict: dict, patch_create_plan_path: Path, mocker: MockerFixture
     ) -> None:
         """dispatch_create_plan attempts artifact registration when issue is provided.
 
@@ -930,7 +901,7 @@ waves:
         # Act
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": valid_plan_yaml, "issue": 42}
+                "dispatch_create_plan", {"milestone_number": 10, "plan": valid_plan_dict, "issue": 42}
             )
 
         # Assert
@@ -942,105 +913,85 @@ waves:
     # Error-case tests
     # ------------------------------------------------------------------
 
-    async def test_create_plan_invalid_yaml(self, patch_create_plan_path: Path) -> None:
-        """dispatch_create_plan returns an error dict for malformed YAML input.
+    async def test_create_plan_invalid_plan_structure(self, patch_create_plan_path: Path) -> None:
+        """dispatch_create_plan raises ToolError when the plan dict fails Pydantic validation.
 
-        Tests: dispatch_create_plan — YAML parse failure
-        How: Pass a string that is not valid YAML (unbalanced braces). Verify
-             the response contains an 'error' key and no file is written.
-        Why: Callers must receive a structured error, not an unhandled exception,
-             when YAML is malformed so they can surface it to the operator.
+        Tests: dispatch_create_plan — Pydantic validation failure for structurally invalid input
+        How: Pass a dict where milestone.number is a string instead of an int. Verify
+             the call raises ToolError (FastMCP rejects at the MCP layer before the
+             tool function runs) and no file is written.
+        Why: With the typed plan parameter, Pydantic validates the input before the
+             function is called; invalid types raise ToolError rather than returning
+             an error dict.
         """
-        # Arrange
-        bad_yaml = "{{invalid: yaml: string"
+        # Arrange — milestone.number must be int >= 1; pass a string to trigger validation error
+        bad_plan = {
+            "milestone": {"number": "not-a-number", "title": "Bad Plan", "integration_branch": "main"},
+            "waves": [{"wave": 1, "items": [{"title": "Issue 101", "issue": 101, "priority": "P2"}]}],
+        }
 
-        # Act
+        # Act + Assert — FastMCP raises ToolError for Pydantic validation failures
         async with Client(mcp) as client:
-            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan_yaml": bad_yaml})
+            with pytest.raises(ToolError, match=r"int_parsing|not-a-number|integer"):
+                await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": bad_plan})
 
-        # Assert
-        data: dict[str, Any] = result.data
-        assert "error" in data
-        assert "Invalid YAML" in data["error"] or "YAML" in data["error"]
         assert not patch_create_plan_path.exists()
 
-    async def test_create_plan_yaml_not_mapping(self, patch_create_plan_path: Path) -> None:
-        """dispatch_create_plan returns an error when YAML parses to a list, not a dict.
+    async def test_create_plan_missing_milestone_field(self, patch_create_plan_path: Path) -> None:
+        """dispatch_create_plan raises ToolError when the plan dict is missing the milestone block.
 
-        Tests: dispatch_create_plan — non-mapping YAML rejection
-        How: Pass a YAML list string. Verify the response has an error key describing
-             that a mapping is required.
-        Why: The DispatchPlan schema requires a mapping at the root; a list or scalar
-             cannot be fed to model_validate() and must be rejected early.
+        Tests: dispatch_create_plan — missing required top-level field
+        How: Pass a dict with only waves and no milestone key. Verify the call raises
+             ToolError (FastMCP rejects at the MCP layer) and no file is written.
+        Why: The DispatchPlan schema requires milestone; Pydantic raises before the
+             function runs, so callers receive a ToolError for missing required fields.
         """
-        # Arrange
-        list_yaml = "- item1\n- item2\n"
+        # Arrange — no milestone key at all
+        no_milestone_plan = {"waves": [{"wave": 1, "items": [{"title": "Issue 101", "issue": 101, "priority": "P2"}]}]}
 
-        # Act
+        # Act + Assert — FastMCP raises ToolError for missing required field
         async with Client(mcp) as client:
-            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan_yaml": list_yaml})
+            with pytest.raises(ToolError, match=r"milestone|missing|required"):
+                await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": no_milestone_plan})
 
-        # Assert
-        data: dict[str, Any] = result.data
-        assert "error" in data
-        assert "mapping" in data["error"].lower() or "dict" in data["error"].lower()
+        assert not patch_create_plan_path.exists()
 
     async def test_create_plan_missing_required_field(self, patch_create_plan_path: Path) -> None:
-        """dispatch_create_plan returns a validation error when 'waves' is absent.
+        """dispatch_create_plan raises ToolError when 'waves' is absent from the plan dict.
 
-        Tests: dispatch_create_plan — Pydantic validation failure for missing field
-        How: Provide YAML with a valid milestone block but no 'waves' key. Verify the
-             response contains an error key mentioning validation failure.
-        Why: waves is required (min_length=1); callers must receive a descriptive error
-             rather than a generic crash when they omit required fields.
+        Tests: dispatch_create_plan — Pydantic validation failure for missing required field
+        How: Provide a dict with a valid milestone block but no 'waves' key. Verify the
+             call raises ToolError (FastMCP rejects before the function runs).
+        Why: waves is required (min_length=1); Pydantic rejects at the MCP layer so
+             callers receive a ToolError with a descriptive message.
         """
-        # Arrange
-        no_waves_yaml = """\
-milestone:
-  number: 10
-  title: Missing waves
-  integration-branch: main
-"""
+        # Arrange — valid milestone but no waves key
+        no_waves_plan = {"milestone": {"number": 10, "title": "Missing waves", "integration_branch": "main"}}
 
-        # Act
+        # Act + Assert — FastMCP raises ToolError for missing required field
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": no_waves_yaml}
-            )
-
-        # Assert
-        data: dict[str, Any] = result.data
-        assert "error" in data
-        assert "validation" in data["error"].lower() or "waves" in data["error"].lower()
+            with pytest.raises(ToolError, match=r"waves|missing|required"):
+                await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": no_waves_plan})
 
     async def test_create_plan_empty_waves(self, patch_create_plan_path: Path) -> None:
-        """dispatch_create_plan returns an error when waves is an empty list.
+        """dispatch_create_plan raises ToolError when waves is an empty list.
 
         Tests: dispatch_create_plan — min_length=1 enforcement on waves
-        How: Provide YAML with waves: [] (empty list). Verify the error response
-             mentions the validation constraint on waves.
-        Why: DispatchPlan.waves has min_length=1; an empty list would produce a plan
-             that cannot be dispatched and must be rejected at creation time.
+        How: Provide a dict with waves: [] (empty list). Verify the call raises
+             ToolError (FastMCP rejects the min_length constraint before the function runs).
+        Why: DispatchPlan.waves has min_length=1; Pydantic enforces this at the MCP
+             layer so an empty list is rejected before reaching the tool function.
         """
-        # Arrange
-        empty_waves_yaml = """\
-milestone:
-  number: 10
-  title: Empty waves
-  integration-branch: main
-waves: []
-"""
+        # Arrange — empty waves list violates min_length=1
+        empty_waves_plan = {
+            "milestone": {"number": 10, "title": "Empty waves", "integration_branch": "main"},
+            "waves": [],
+        }
 
-        # Act
+        # Act + Assert — FastMCP raises ToolError for min_length violation
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": empty_waves_yaml}
-            )
-
-        # Assert
-        data: dict[str, Any] = result.data
-        assert "error" in data
-        assert "validation" in data["error"].lower() or "waves" in data["error"].lower()
+            with pytest.raises(ToolError, match=r"waves|too_short|min"):
+                await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": empty_waves_plan})
 
     async def test_create_plan_file_exists_no_overwrite(self, existing_plan_file: Path) -> None:
         """dispatch_create_plan returns an error when the file exists and overwrite=False.
@@ -1056,7 +1007,7 @@ waves: []
         # Act
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": _make_valid_plan_yaml()}
+                "dispatch_create_plan", {"milestone_number": 10, "plan": _make_valid_plan_dict()}
             )
 
         # Assert
@@ -1073,25 +1024,15 @@ waves: []
         Why: A mismatch means the caller is writing a plan for a different milestone
              than the YAML describes; this would corrupt the plan directory naming.
         """
-        # Arrange
-        mismatched_yaml = """\
-milestone:
-  number: 20
-  title: Wrong milestone
-  integration-branch: main
-waves:
-  - wave: 1
-    items:
-      - title: Issue 101
-        issue: 101
-        priority: P2
-"""
+        # Arrange — milestone_number=10 but plan embeds number=20
+        mismatched_plan = {
+            "milestone": {"number": 20, "title": "Wrong milestone", "integration_branch": "main"},
+            "waves": [{"wave": 1, "items": [{"title": "Issue 101", "issue": 101, "priority": "P2"}]}],
+        }
 
         # Act
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": mismatched_yaml}
-            )
+            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": mismatched_plan})
 
         # Assert
         data: dict[str, Any] = result.data
@@ -1099,7 +1040,7 @@ waves:
         assert "mismatch" in data["error"].lower() or "10" in data["error"]
 
     async def test_create_plan_symlink_target(
-        self, valid_plan_yaml: str, patch_create_plan_path: Path, mocker: MockerFixture
+        self, valid_plan_dict: dict, patch_create_plan_path: Path, mocker: MockerFixture
     ) -> None:
         """dispatch_create_plan returns an error when write_dispatch_plan raises ValueError.
 
@@ -1121,9 +1062,7 @@ waves:
 
         # Act
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": valid_plan_yaml}
-            )
+            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": valid_plan_dict})
 
         # Assert
         data: dict[str, Any] = result.data
@@ -1149,29 +1088,17 @@ waves:
         of this known key-collision in the success return dict (divergence DN-1 in T02).
         """
         # Arrange — issue 101 appears in both waves
-        duplicate_yaml = """\
-milestone:
-  number: 10
-  title: Duplicate issue test
-  integration-branch: main
-waves:
-  - wave: 1
-    items:
-      - title: Issue 101
-        issue: 101
-        priority: P2
-  - wave: 2
-    items:
-      - title: Issue 101 again
-        issue: 101
-        priority: P3
-"""
+        duplicate_plan = {
+            "milestone": {"number": 10, "title": "Duplicate issue test", "integration_branch": "main"},
+            "waves": [
+                {"wave": 1, "items": [{"title": "Issue 101", "issue": 101, "priority": "P2"}]},
+                {"wave": 2, "items": [{"title": "Issue 101 again", "issue": 101, "priority": "P3"}]},
+            ],
+        }
 
         # Act
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": duplicate_yaml}
-            )
+            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": duplicate_plan})
 
         # Assert — file is written and integrity check reports failure
         data: dict[str, Any] = result.data
@@ -1194,31 +1121,17 @@ waves:
         of this known key-collision in the success return dict (divergence DN-1 in T02).
         """
         # Arrange — issue 102 depends on 999 which is not in the plan
-        broken_deps_yaml = """\
-milestone:
-  number: 10
-  title: Broken depends_on test
-  integration-branch: main
-waves:
-  - wave: 1
-    items:
-      - title: Issue 101
-        issue: 101
-        priority: P2
-  - wave: 2
-    items:
-      - title: Issue 102
-        issue: 102
-        priority: P3
-        depends-on:
-          - 999
-"""
+        broken_deps_plan = {
+            "milestone": {"number": 10, "title": "Broken depends_on test", "integration_branch": "main"},
+            "waves": [
+                {"wave": 1, "items": [{"title": "Issue 101", "issue": 101, "priority": "P2"}]},
+                {"wave": 2, "items": [{"title": "Issue 102", "issue": 102, "priority": "P3", "depends_on": [999]}]},
+            ],
+        }
 
         # Act
         async with Client(mcp) as client:
-            result = await client.call_tool(
-                "dispatch_create_plan", {"milestone_number": 10, "plan_yaml": broken_deps_yaml}
-            )
+            result = await client.call_tool("dispatch_create_plan", {"milestone_number": 10, "plan": broken_deps_plan})
 
         # Assert — file is written and integrity check reports failure
         data: dict[str, Any] = result.data

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -640,7 +640,7 @@ def test_update_task_round_trips_list_fields_without_coercion(tmp_path: Path) ->
         )
         assert "error" not in result, f"sam_create failed: {result}"
         plan_number = result["plan_number"]
-        plan_path = _Path(result["path"])
+        plan_path = _Path(p_dir) / f"P{plan_number:03d}-roundtrip.yaml"
 
         # Act: update task with a Task model that has non-empty dependencies
         task_data = backend.read_task(f"P{plan_number}", "T01")

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -639,13 +639,13 @@ def test_update_task_round_trips_list_fields_without_coercion(tmp_path: Path) ->
             config=CreatePlanConfig(slug="roundtrip", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
         )
         assert "error" not in result, f"sam_create failed: {result}"
-        plan_number = result["plan_number"]
-        plan_path = _Path(p_dir) / f"P{plan_number:03d}-roundtrip.yaml"
+        plan_id = result["plan_id"]
+        plan_path = _Path(p_dir) / f"{plan_id}-roundtrip.yaml"
 
         # Act: update task with a Task model that has non-empty dependencies
-        task_data = backend.read_task(f"P{plan_number}", "T01")
+        task_data = backend.read_task(plan_id, "T01")
         updated_task = _Task.model_validate({**task_data, "dependencies": ["T01", "T02"]})
-        backend.update_task(f"P{plan_number}", updated_task)
+        backend.update_task(plan_id, updated_task)
 
         # Assert: read the raw YAML file — dependencies must be a sequence, not a string
         yaml = YAML()

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -19,13 +19,7 @@ from typing import TYPE_CHECKING
 import pytest
 from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
 from sam_schema.core.backends.memory import InMemoryTaskProvider
-from sam_schema.core.exceptions import (
-    DocumentNotFoundError,
-    PlanExistsError,
-    PlanNotFoundError,
-    TaskNotFoundError,
-    TaskValidationError,
-)
+from sam_schema.core.exceptions import DocumentNotFoundError, PlanNotFoundError, TaskNotFoundError, TaskValidationError
 from sam_schema.core.task_backend import TaskBackend
 
 if TYPE_CHECKING:
@@ -127,14 +121,24 @@ class TestTaskBackendConformance:
         assert read_back["tasks"][0]["title"] == "First task"
 
     def test_create_plan_duplicate_raises(self, backend: TaskBackend) -> None:
-        """Creating two plans with the same issue number should raise PlanExistsError."""
+        """Creating two plans with the same issue number assigns distinct UUID plan IDs.
+
+        With UUID-derived IDs, the issue number is stored in metadata only and does not
+        constrain plan_id uniqueness. Each create call generates a new UUID plan_id.
+        """
+        import re
+
         # Arrange
         tasks = [_make_task_def("T01", "Task")]
 
-        # Act / Assert
-        backend.create_plan("slug-a", "Goal A", tasks, issue=9001)
-        with pytest.raises(PlanExistsError):
-            backend.create_plan("slug-b", "Goal B", tasks, issue=9001)
+        # Act — two plans for the same issue succeed (UUID IDs are collision-resistant)
+        plan_a = backend.create_plan("slug-a", "Goal A", tasks, issue=9001)
+        plan_b = backend.create_plan("slug-b", "Goal B", tasks, issue=9001)
+
+        # Assert — each plan gets a unique UUID plan_id
+        assert re.match(r"^P[0-9a-f]{8}$", plan_a["plan_id"]), f"Expected UUID plan_id, got: {plan_a['plan_id']!r}"
+        assert re.match(r"^P[0-9a-f]{8}$", plan_b["plan_id"]), f"Expected UUID plan_id, got: {plan_b['plan_id']!r}"
+        assert plan_a["plan_id"] != plan_b["plan_id"], "Two create calls must produce distinct plan IDs"
 
     def test_read_nonexistent_plan_raises(self, backend: TaskBackend) -> None:
         """Reading a plan that does not exist should raise PlanNotFoundError."""

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -428,6 +428,42 @@ class TestTaskBackendConformance:
             backend.read_document(bad_handle)  # type: ignore[arg-type]
 
     # ------------------------------------------------------------------
+    # plan_id durability
+    # ------------------------------------------------------------------
+
+    def test_plan_id_stored_in_record(self, backend: TaskBackend) -> None:
+        """plan_id must be stored in the plan record itself, not only in the filename.
+
+        Reading a plan back must return the same plan_id regardless of how the
+        backend resolves the record — the ID must survive round-trips without
+        depending on the filename or path.
+        """
+        # Arrange
+        tasks = [_make_task_def("T01", "Task")]
+
+        # Act
+        created = backend.create_plan("my-slug", "Do the thing", tasks)
+        plan_id = created["plan_id"]
+        read_back = backend.read_plan(plan_id)
+
+        # Assert — plan_id is present in the stored record, not derived at read time
+        assert read_back["plan_id"] == plan_id
+
+    def test_plan_id_preserved_in_list(self, backend: TaskBackend) -> None:
+        """list_plans must return the stored plan_id for each plan."""
+        # Arrange
+        tasks = [_make_task_def("T01", "Task")]
+        created = backend.create_plan("my-slug", "Do the thing", tasks)
+        plan_id = created["plan_id"]
+
+        # Act
+        summaries = backend.list_plans()
+
+        # Assert — the summary contains the same plan_id that was assigned at create time
+        assert len(summaries) == 1
+        assert summaries[0]["plan_id"] == plan_id
+
+    # ------------------------------------------------------------------
     # Protocol structural check
     # ------------------------------------------------------------------
 

--- a/plugins/development-harness/tests_sam/test_cli_create.py
+++ b/plugins/development-harness/tests_sam/test_cli_create.py
@@ -9,6 +9,7 @@ plan creation across the entire SAM pipeline.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,8 @@ from sam_schema.cli import app
 from typer.testing import CliRunner
 
 runner = CliRunner()
+
+_UUID_PLAN_ID_RE = re.compile(r"^P[0-9a-f]{8}$", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -96,16 +99,16 @@ class TestSamCreateBasic:
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         assert "path" in data
-        assert "plan_number" in data
+        assert "plan_id" in data
         assert "task_count" in data
         assert data["task_count"] == 0
 
-    def test_create_assigns_plan_number_starting_at_1(self, plan_dir: Path) -> None:
-        """First plan in empty directory gets plan number 1.
+    def test_create_assigns_uuid_plan_id(self, plan_dir: Path) -> None:
+        """First plan in empty directory gets a UUID-based plan_id.
 
-        Tests: Plan number assignment.
-        How: Create in empty dir, check plan_number == 1.
-        Why: Sequential numbering is the addressing foundation.
+        Tests: UUID plan_id assignment.
+        How: Create in empty dir, check plan_id matches UUID format.
+        Why: plan_id is the addressing foundation.
         """
         # Arrange -- empty plan_dir
         # Act
@@ -115,7 +118,7 @@ class TestSamCreateBasic:
         # Assert
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["plan_number"] == 1
+        assert _UUID_PLAN_ID_RE.match(data["plan_id"]), f"Expected UUID plan_id, got: {data['plan_id']!r}"
 
     def test_create_writes_file_to_disk(self, plan_dir: Path) -> None:
         """Created plan file exists on disk at the reported path.
@@ -150,23 +153,29 @@ class TestSamCreateBasic:
         data = json.loads(result.output)
         assert data["path"].endswith(".yaml")
 
-    def test_create_sequential_numbering(self, plan_dir: Path) -> None:
-        """Second plan gets plan_number 2 when plan_number 1 already exists.
+    def test_create_assigns_unique_plan_ids(self, plan_dir: Path) -> None:
+        """Two consecutive creates produce distinct UUID plan_ids.
 
-        Tests: Sequential numbering across multiple creates.
-        How: Create two plans, verify plan_numbers are 1 and 2.
-        Why: Collisions in plan numbers break addressing.
+        Tests: UUID uniqueness across multiple creates.
+        How: Create two plans, verify both plan_ids are UUID format and distinct.
+        Why: Collisions in plan IDs break addressing.
         """
-        # Arrange -- create first plan
-        runner.invoke(app, ["create", "first", "--goal", "First", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
+        # Arrange / Act -- create first plan
+        r1 = runner.invoke(
+            app, ["create", "first", "--goal", "First", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"}
+        )
         # Act -- create second plan
-        result = runner.invoke(
+        r2 = runner.invoke(
             app, ["create", "second", "--goal", "Second", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"}
         )
         # Assert
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["plan_number"] == 2
+        assert r1.exit_code == 0
+        assert r2.exit_code == 0
+        id1 = json.loads(r1.output)["plan_id"]
+        id2 = json.loads(r2.output)["plan_id"]
+        assert _UUID_PLAN_ID_RE.match(id1), f"Expected UUID plan_id, got: {id1!r}"
+        assert _UUID_PLAN_ID_RE.match(id2), f"Expected UUID plan_id, got: {id2!r}"
+        assert id1 != id2, "Two consecutive creates should produce distinct plan_ids"
 
 
 # ---------------------------------------------------------------------------
@@ -294,7 +303,7 @@ class TestSamCreateOptionalFields:
         """Create with --context persists the context field.
 
         Tests: Context field persistence.
-        How: Create with --context, load plan, check context value.
+        How: Create with --context, load plan via plan_id, check context value.
         Why: Plan context drives agent behavior during task execution.
         """
         # Arrange / Act
@@ -305,10 +314,10 @@ class TestSamCreateOptionalFields:
         )
         # Assert
         assert result.exit_code == 0
-        # Verify by reading back
-        json.loads(result.output)
-        read_result = runner.invoke(app, ["read", "P1", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
-        assert read_result.exit_code == 0
+        plan_id = json.loads(result.output)["plan_id"]
+        # Verify by reading back using the UUID plan_id
+        read_result = runner.invoke(app, ["read", plan_id, "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
+        assert read_result.exit_code == 0, read_result.output
         plan_data = json.loads(read_result.output)
         assert plan_data.get("context") == "Some shared context"
 
@@ -316,7 +325,7 @@ class TestSamCreateOptionalFields:
         """Create with --issue persists the issue number.
 
         Tests: Issue field persistence.
-        How: Create with --issue 42, load plan, check issue value.
+        How: Create with --issue 42, load plan via plan_id, check issue value.
         Why: Issue links plans to GitHub issues for traceability.
         """
         # Arrange / Act
@@ -327,9 +336,10 @@ class TestSamCreateOptionalFields:
         )
         # Assert
         assert result.exit_code == 0
-        # --issue 42 produces P42, not P1
-        read_result = runner.invoke(app, ["read", "P42", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
-        assert read_result.exit_code == 0
+        plan_id = json.loads(result.output)["plan_id"]
+        # Read back using the UUID plan_id
+        read_result = runner.invoke(app, ["read", plan_id, "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
+        assert read_result.exit_code == 0, read_result.output
         plan_data = json.loads(read_result.output)
         assert plan_data.get("issue") == "42"
 
@@ -351,7 +361,7 @@ class TestSamCreateRoundTrip:
         """Tasks created via stdin can be read back with identical fields.
 
         Tests: Task data round-trip fidelity.
-        How: Create with tasks, read P1/T1, verify fields match.
+        How: Create with tasks, read {plan_id}/T1, verify fields match.
         Why: Data loss during create->read breaks the entire workflow.
         """
         # Arrange / Act -- create
@@ -361,12 +371,13 @@ class TestSamCreateRoundTrip:
             input=MINIMAL_TASKS_YAML,
             env={"NO_COLOR": "1"},
         )
-        assert create_result.exit_code == 0
+        assert create_result.exit_code == 0, create_result.output
+        plan_id = json.loads(create_result.output)["plan_id"]
 
         # Act -- read back
-        read_result = runner.invoke(app, ["read", "P1/T1", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
+        read_result = runner.invoke(app, ["read", f"{plan_id}/T1", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
         # Assert
-        assert read_result.exit_code == 0
+        assert read_result.exit_code == 0, read_result.output
         data = json.loads(read_result.output)
         task = data["task"]
         assert task["id"] == "T1"
@@ -387,12 +398,13 @@ class TestSamCreateRoundTrip:
             input=MINIMAL_TASKS_YAML,
             env={"NO_COLOR": "1"},
         )
-        assert create_result.exit_code == 0
+        assert create_result.exit_code == 0, create_result.output
+        plan_id = json.loads(create_result.output)["plan_id"]
 
         # Act -- read plan-level
-        read_result = runner.invoke(app, ["read", "P1", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
+        read_result = runner.invoke(app, ["read", plan_id, "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
         # Assert
-        assert read_result.exit_code == 0
+        assert read_result.exit_code == 0, read_result.output
         plan_data = json.loads(read_result.output)
         assert len(plan_data.get("tasks", [])) == 2
 
@@ -400,7 +412,7 @@ class TestSamCreateRoundTrip:
         """TaskAssignment from read includes the plan goal set during create.
 
         Tests: Plan-level field propagation in TaskAssignment.
-        How: Create with goal, read P1/T1, check plan-goal field.
+        How: Create with goal, read {plan_id}/T1, check plan-goal field.
         Why: AC5 -- sam read includes plan context in TaskAssignment response.
         """
         # Arrange / Act
@@ -410,11 +422,12 @@ class TestSamCreateRoundTrip:
             input=MINIMAL_TASKS_YAML,
             env={"NO_COLOR": "1"},
         )
-        assert create_result.exit_code == 0
+        assert create_result.exit_code == 0, create_result.output
+        plan_id = json.loads(create_result.output)["plan_id"]
 
-        read_result = runner.invoke(app, ["read", "P1/T1", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
+        read_result = runner.invoke(app, ["read", f"{plan_id}/T1", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
         # Assert
-        assert read_result.exit_code == 0
+        assert read_result.exit_code == 0, read_result.output
         data = json.loads(read_result.output)
         assert data.get("plan-goal") == "My specific goal"
 
@@ -422,7 +435,7 @@ class TestSamCreateRoundTrip:
         """Task ``body`` field round-trips through create -> read without data loss.
 
         Tests: body field preservation during stdin create.
-        How: Create with a task containing a multiline body, read back P1/T1, verify body.
+        How: Create with a task containing a multiline body, read back {plan_id}/T1, verify body.
         Why: Pydantic drops unknown fields silently -- body was missing from Task model,
              causing body content to be discarded at validation time (reproduced on P577, P964).
         """
@@ -451,9 +464,10 @@ tasks:
             env={"NO_COLOR": "1"},
         )
         assert create_result.exit_code == 0, create_result.output
+        plan_id = json.loads(create_result.output)["plan_id"]
 
         # Act -- read back
-        read_result = runner.invoke(app, ["read", "P1/T1", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
+        read_result = runner.invoke(app, ["read", f"{plan_id}/T1", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
         # Assert
         assert read_result.exit_code == 0, read_result.output
         data = json.loads(read_result.output)
@@ -482,27 +496,24 @@ tasks:
 
 
 # ---------------------------------------------------------------------------
-# sam create -- --issue as plan number
+# sam create -- --issue as metadata (UUID-based plan IDs)
 # ---------------------------------------------------------------------------
 
 
-class TestSamCreateIssueAsPlanNumber:
-    """Test that --issue N makes the plan number N, not the next sequential number.
+class TestSamCreateWithIssue:
+    """Test that --issue N stores issue metadata but plan_id is still UUID-based.
 
-    Tests: Issue-number-as-plan-number behaviour.
-    How: Invoke create with --issue, verify path, plan_number, and file on disk.
-    Why: GitHub issue number == plan number makes addressing unambiguous and
-         eliminates the collision class where sequential plan numbering and
-         sequential issue numbering independently produce the same integer.
+    Tests: Issue-as-metadata behaviour.
+    How: Invoke create with --issue, verify plan_id is UUID format and issue is stored.
+    Why: GitHub issue is metadata; plan addressing uses UUID to avoid collisions.
     """
 
-    def test_create_with_issue_uses_issue_as_plan_number(self, plan_dir: Path) -> None:
-        """--issue 951 produces a plan file named P951-{slug}.yaml.
+    def test_create_with_issue_produces_uuid_plan_id(self, plan_dir: Path) -> None:
+        """--issue 951 produces a UUID plan_id, not P951.
 
-        Tests: File naming when --issue is provided.
-        How: Create with --issue 951, check plan_number and path in JSON output.
-        Why: plan_number must equal the issue number so callers can rely on
-             the identity plan-file = P{issue}.
+        Tests: plan_id format when --issue is provided.
+        How: Create with --issue 951, check plan_id is UUID format.
+        Why: With UUID-based IDs, issue number no longer determines plan_id.
         """
         # Arrange -- empty plan_dir
         # Act
@@ -514,14 +525,13 @@ class TestSamCreateIssueAsPlanNumber:
         # Assert
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
-        assert data["plan_number"] == 951
-        assert "P951-my-feature.yaml" in data["path"]
+        assert _UUID_PLAN_ID_RE.match(data["plan_id"]), f"Expected UUID plan_id, got: {data['plan_id']!r}"
         assert Path(data["path"]).exists()
 
     def test_create_with_issue_file_exists_at_reported_path(self, plan_dir: Path) -> None:
         """File created with --issue exists on disk at the path returned in JSON.
 
-        Tests: Disk write side effect for issue-numbered plans.
+        Tests: Disk write side effect for issue-annotated plans.
         How: Create with --issue, stat the reported path.
         Why: If the file is not written, all downstream read/claim operations fail.
         """
@@ -536,126 +546,50 @@ class TestSamCreateIssueAsPlanNumber:
         data = json.loads(result.output)
         assert Path(data["path"]).exists()
 
-    def test_create_with_issue_skips_sequential_numbering(self, plan_dir: Path) -> None:
-        """Sequential fallback is bypassed when --issue is provided.
+    def test_create_with_issue_stores_issue_in_plan(self, plan_dir: Path) -> None:
+        """--issue value is persisted inside the plan file.
 
-        Tests: --issue overrides sequential assignment.
-        How: Create P1 sequentially, then create with --issue 500; verify P500.
-        Why: Without this, --issue might still return plan_number 2 because
-             sequential scanning found P1 and returned 2.
+        Tests: issue field written to plan.
+        How: Create with --issue 951, read back, verify issue field.
+        Why: Issue metadata is needed for backlog integration.
         """
-        # Arrange -- create a sequential plan first (will be P1)
-        runner.invoke(app, ["create", "first", "--goal", "First", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
-        # Act -- create with explicit issue number
+        # Arrange
         result = runner.invoke(
             app,
-            ["create", "jumped", "--goal", "Jumped", "--issue", "500", "--plan-dir", str(plan_dir)],
+            ["create", "with-issue", "--goal", "Test", "--issue", "951", "--plan-dir", str(plan_dir)],
             env={"NO_COLOR": "1"},
         )
-        # Assert
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert data["plan_number"] == 500
+        plan_id = json.loads(result.output)["plan_id"]
 
-    def test_create_without_issue_still_sequential(self, plan_dir: Path) -> None:
-        """Sequential numbering is preserved when --issue is not given.
+        # Act -- read back
+        read_result = runner.invoke(app, ["read", plan_id, "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
+        assert read_result.exit_code == 0, read_result.output
+        plan_data = json.loads(read_result.output)
+        assert plan_data.get("issue") == "951"
 
-        Tests: Fallback to sequential numbering when --issue is absent.
-        How: Create two plans without --issue, verify numbers 1 and 2.
-        Why: The sequential path must continue to work after adding --issue support.
+    def test_two_creates_with_same_issue_produce_distinct_plan_ids(self, plan_dir: Path) -> None:
+        """Two creates with the same --issue number produce different UUID plan_ids.
+
+        Tests: No collision on duplicate issue number.
+        How: Create twice with --issue 500, verify distinct plan_ids.
+        Why: UUID generation ensures no collision regardless of issue number.
         """
         # Arrange / Act
-        r1 = runner.invoke(app, ["create", "seq-a", "--goal", "A", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
-        r2 = runner.invoke(app, ["create", "seq-b", "--goal", "B", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
-        # Assert
-        assert r1.exit_code == 0
-        assert r2.exit_code == 0
-        assert json.loads(r1.output)["plan_number"] == 1
-        assert json.loads(r2.output)["plan_number"] == 2
-
-
-# ---------------------------------------------------------------------------
-# sam create -- collision guard
-# ---------------------------------------------------------------------------
-
-
-class TestSamCreateCollisionGuard:
-    """Test that creating a plan with a duplicate issue number is rejected.
-
-    Tests: Collision guard behaviour.
-    How: Create a plan, then attempt to create another with the same --issue.
-    Why: Duplicate plan numbers break addressing -- two P951 files cannot coexist.
-    """
-
-    def test_create_collision_on_duplicate_issue_exits_1(self, plan_dir: Path) -> None:
-        """Second create with same --issue exits 1 with error message.
-
-        Tests: Collision detection on duplicate issue number.
-        How: Create P951, attempt to create P951 again, expect exit 1.
-        Why: Silent overwrite would destroy the existing plan file.
-        """
-        # Arrange -- create the first plan with issue 951
-        first = runner.invoke(
+        r1 = runner.invoke(
             app,
-            ["create", "original", "--goal", "Original", "--issue", "951", "--plan-dir", str(plan_dir)],
+            ["create", "first", "--goal", "First", "--issue", "500", "--plan-dir", str(plan_dir)],
             env={"NO_COLOR": "1"},
         )
-        assert first.exit_code == 0, first.output
-        # Act -- attempt duplicate
-        second = runner.invoke(
+        r2 = runner.invoke(
             app,
-            ["create", "duplicate", "--goal", "Duplicate", "--issue", "951", "--plan-dir", str(plan_dir)],
+            ["create", "second", "--goal", "Second", "--issue", "500", "--plan-dir", str(plan_dir)],
             env={"NO_COLOR": "1"},
         )
-        # Assert
-        assert second.exit_code == 1
-        assert "P951" in second.output
-
-    def test_create_collision_error_message_names_existing_file(self, plan_dir: Path) -> None:
-        """Collision error message includes the existing plan path.
-
-        Tests: Error message content for collision.
-        How: Create P10, attempt duplicate, check stderr/output mentions the file.
-        Why: Error must tell the caller what already exists so they can act.
-        """
-        # Arrange
-        runner.invoke(
-            app,
-            ["create", "existing", "--goal", "Existing", "--issue", "10", "--plan-dir", str(plan_dir)],
-            env={"NO_COLOR": "1"},
-        )
-        # Act
-        result = runner.invoke(
-            app,
-            ["create", "collision", "--goal", "Collision", "--issue", "10", "--plan-dir", str(plan_dir)],
-            env={"NO_COLOR": "1"},
-        )
-        # Assert -- error text should mention the existing plan path
-        assert result.exit_code == 1
-        combined = result.output + (result.stderr if hasattr(result, "stderr") and result.stderr else "")
-        assert "P10" in combined
-
-    def test_create_collision_does_not_overwrite_existing_file(self, plan_dir: Path) -> None:
-        """Rejected duplicate create leaves the original file intact.
-
-        Tests: File preservation on collision.
-        How: Create P7, attempt duplicate, read P7, verify original goal survives.
-        Why: Collision must be a hard stop -- no partial overwrites.
-        """
-        # Arrange
-        runner.invoke(
-            app,
-            ["create", "safe-original", "--goal", "Original goal", "--issue", "7", "--plan-dir", str(plan_dir)],
-            env={"NO_COLOR": "1"},
-        )
-        # Act -- collision attempt
-        runner.invoke(
-            app,
-            ["create", "intruder", "--goal", "Intruder goal", "--issue", "7", "--plan-dir", str(plan_dir)],
-            env={"NO_COLOR": "1"},
-        )
-        # Assert -- original plan still readable with original goal
-        read_result = runner.invoke(app, ["read", "P7", "--plan-dir", str(plan_dir)], env={"NO_COLOR": "1"})
-        assert read_result.exit_code == 0
-        plan_data = json.loads(read_result.output)
-        assert plan_data.get("goal") == "Original goal"
+        assert r1.exit_code == 0, r1.output
+        assert r2.exit_code == 0, r2.output
+        id1 = json.loads(r1.output)["plan_id"]
+        id2 = json.loads(r2.output)["plan_id"]
+        assert _UUID_PLAN_ID_RE.match(id1), f"Expected UUID plan_id, got: {id1!r}"
+        assert _UUID_PLAN_ID_RE.match(id2), f"Expected UUID plan_id, got: {id2!r}"
+        assert id1 != id2, "Same issue should produce distinct UUID plan_ids"

--- a/plugins/development-harness/tests_sam/test_consolidated_tools.py
+++ b/plugins/development-harness/tests_sam/test_consolidated_tools.py
@@ -138,10 +138,11 @@ async def test_sam_task_read_returns_task_assignment(client: Client, task_backen
     Why: Verifies MCP schema validation and JSON round-trip of a nested TaskAssignment.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act
-    result = await client.call_tool("sam_task", {"plan": "P1", "task": "T01", "config": {"action": "read"}})
+    result = await client.call_tool("sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "read"}})
 
     # Assert
     data = result.data
@@ -159,11 +160,12 @@ async def test_sam_task_read_missing_task_raises_tool_error(client: Client, task
     Why: FastMCP converts unhandled TaskNotFoundError to ToolError.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act / Assert
     with pytest.raises(ToolError, match="T99"):
-        await client.call_tool("sam_task", {"plan": "P1", "task": "T99", "config": {"action": "read"}})
+        await client.call_tool("sam_task", {"plan": plan_id, "task": "T99", "config": {"action": "read"}})
 
 
 async def test_sam_task_read_missing_plan_raises_tool_error(client: Client) -> None:
@@ -193,10 +195,11 @@ async def test_sam_task_claim_transitions_to_in_progress(client: Client, task_ba
     Why: Claim is the primary write operation that prevents duplicate dispatch.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act
-    result = await client.call_tool("sam_task", {"plan": "P1", "task": "T01", "config": {"action": "claim"}})
+    result = await client.call_tool("sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "claim"}})
 
     # Assert
     data = result.data
@@ -215,11 +218,12 @@ async def test_sam_task_claim_double_claim_returns_claimed_false(
     Why: Duplicate dispatch prevention must work through the MCP protocol.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
-    await client.call_tool("sam_task", {"plan": "P1", "task": "T01", "config": {"action": "claim"}})
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
+    await client.call_tool("sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "claim"}})
 
     # Act
-    result = await client.call_tool("sam_task", {"plan": "P1", "task": "T01", "config": {"action": "claim"}})
+    result = await client.call_tool("sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "claim"}})
 
     # Assert
     data = result.data
@@ -238,10 +242,11 @@ async def test_sam_task_claim_complete_task_returns_claimed_false(
     Why: Completed tasks must not be re-claimed — confirms guard fires for all non-not-started states.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def(status="complete")])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def(status="complete")])
+    plan_id = plan_data["plan_id"]
 
     # Act
-    result = await client.call_tool("sam_task", {"plan": "P1", "task": "T01", "config": {"action": "claim"}})
+    result = await client.call_tool("sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "claim"}})
 
     # Assert
     assert result.data["claimed"] is False
@@ -261,11 +266,12 @@ async def test_sam_task_state_updates_task_status(client: Client, task_backend: 
     Why: Status mutation is the primary write operation in the task workflow.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act
     result = await client.call_tool(
-        "sam_task", {"plan": "P1", "task": "T01", "config": {"action": "state", "status": "in-progress"}}
+        "sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "state", "status": "in-progress"}}
     )
 
     # Assert
@@ -282,11 +288,12 @@ async def test_sam_task_state_complete_sets_status(client: Client, task_backend:
     Why: Agents use state to mark tasks done after verification steps pass.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act
     result = await client.call_tool(
-        "sam_task", {"plan": "P1", "task": "T01", "config": {"action": "state", "status": "complete"}}
+        "sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "state", "status": "complete"}}
     )
 
     # Assert
@@ -303,12 +310,13 @@ async def test_sam_task_state_invalid_status_raises_tool_error(
     Why: FastMCP converts unhandled TaskValidationError to ToolError.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act / Assert
     with pytest.raises(ToolError):
         await client.call_tool(
-            "sam_task", {"plan": "P1", "task": "T01", "config": {"action": "state", "status": "not-a-valid-status"}}
+            "sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "state", "status": "not-a-valid-status"}}
         )
 
 
@@ -325,20 +333,25 @@ async def test_sam_task_update_set_fields_patches_task(client: Client, task_back
     Why: Agents patch task fields mid-execution to record divergence notes.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act
     result = await client.call_tool(
         "sam_task",
-        {"plan": "P1", "task": "T01", "config": {"action": "update", "set_fields_json": '{"title": "Updated title"}'}},
+        {
+            "plan": plan_id,
+            "task": "T01",
+            "config": {"action": "update", "set_fields_json": '{"title": "Updated title"}'},
+        },
     )
 
     # Assert
     assert result.data["updated"] is True
-    assert result.data["address"] == "P1/T01"
+    assert result.data["address"] == f"{plan_id}/T01"
 
     # Verify the change persisted (round-trip)
-    read_result = await client.call_tool("sam_task", {"plan": "P1", "task": "T01", "config": {"action": "read"}})
+    read_result = await client.call_tool("sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "read"}})
     assert read_result.data["task"]["title"] == "Updated title"
 
 
@@ -352,13 +365,14 @@ async def test_sam_task_update_append_section_stores_content(
     Why: start-task skill appends progress sections to task bodies during execution.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act
     result = await client.call_tool(
         "sam_task",
         {
-            "plan": "P1",
+            "plan": plan_id,
             "task": "T01",
             "config": {"action": "update", "append_section": "Progress Notes", "section_content": "Work in progress."},
         },
@@ -366,7 +380,7 @@ async def test_sam_task_update_append_section_stores_content(
 
     # Assert
     assert result.data["updated"] is True
-    assert result.data["address"] == "P1/T01"
+    assert result.data["address"] == f"{plan_id}/T01"
 
 
 async def test_sam_task_update_invalid_json_raises_tool_error(
@@ -379,12 +393,13 @@ async def test_sam_task_update_invalid_json_raises_tool_error(
     Why: json.loads raises ValueError which FastMCP wraps as ToolError.
     """
     # Arrange
-    task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act / Assert
     with pytest.raises(ToolError):
         await client.call_tool(
-            "sam_task", {"plan": "P1", "task": "T01", "config": {"action": "update", "set_fields_json": "not-json"}}
+            "sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "update", "set_fields_json": "not-json"}}
         )
 
 
@@ -394,12 +409,14 @@ async def test_sam_task_update_invalid_json_raises_tool_error(
 
 
 async def test_sam_plan_create_returns_plan_number_and_task_count(client: Client) -> None:
-    """sam_plan action=create returns plan_number and task_count on success.
+    """sam_plan action=create returns plan_id and task_count on success.
 
     Tests: sam_plan create happy path.
     How: Pass two-task YAML string; verify the return shape.
-    Why: plan_number is used by subsequent tool calls; task_count confirms parsing.
+    Why: plan_id is used by subsequent tool calls; task_count confirms parsing.
     """
+    import re
+
     # Act
     result = await client.call_tool(
         "sam_plan",
@@ -408,7 +425,7 @@ async def test_sam_plan_create_returns_plan_number_and_task_count(client: Client
 
     # Assert
     data = result.data
-    assert data["plan_number"] == 1
+    assert re.match(r"^P[0-9a-f]{8}$", data["plan_id"]), f"Expected UUID plan_id, got: {data['plan_id']!r}"
     assert data["task_count"] == 2
 
 
@@ -431,9 +448,9 @@ async def test_sam_plan_create_sets_plan_goal(client: Client) -> None:
             }
         },
     )
-    plan_number = create_result.data["plan_number"]
+    plan_id = create_result.data["plan_id"]
 
-    read_result = await client.call_tool("sam_plan", {"config": {"action": "read"}, "plan": f"P{plan_number}"})
+    read_result = await client.call_tool("sam_plan", {"config": {"action": "read"}, "plan": plan_id})
 
     # Assert
     assert read_result.data.get("goal") == "Specific goal string"
@@ -474,10 +491,11 @@ async def test_sam_plan_read_returns_plan_fields(client: Client, task_backend: I
     Why: Plan read is used by orchestrators to load goal/context before dispatch.
     """
     # Arrange
-    task_backend.create_plan("read-plan", "Read test goal", [_task_def()])
+    plan_data = task_backend.create_plan("read-plan", "Read test goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act
-    result = await client.call_tool("sam_plan", {"config": {"action": "read"}, "plan": "P1"})
+    result = await client.call_tool("sam_plan", {"config": {"action": "read"}, "plan": plan_id})
 
     # Assert
     data = result.data
@@ -624,10 +642,13 @@ async def test_sam_plan_status_returns_progress_summary(client: Client, task_bac
     Why: Orchestrators use status to decide when to close a plan.
     """
     # Arrange
-    task_backend.create_plan("progress-plan", "Progress goal", [_task_def("T01", status="complete"), _task_def("T02")])
+    plan_data = task_backend.create_plan(
+        "progress-plan", "Progress goal", [_task_def("T01", status="complete"), _task_def("T02")]
+    )
+    plan_id = plan_data["plan_id"]
 
     # Act
-    result = await client.call_tool("sam_plan", {"config": {"action": "status"}, "plan": "P1"})
+    result = await client.call_tool("sam_plan", {"config": {"action": "status"}, "plan": plan_id})
 
     # Assert
     data = result.data
@@ -665,12 +686,13 @@ async def test_sam_plan_ready_returns_tasks_with_satisfied_deps(
     Why: Orchestrators call ready to discover which tasks can be dispatched next.
     """
     # Arrange
-    task_backend.create_plan(
+    plan_data = task_backend.create_plan(
         "ready-plan", "Ready goal", [_task_def("T01", status="complete"), _task_def("T02", deps=["T01"])]
     )
+    plan_id = plan_data["plan_id"]
 
     # Act
-    result = await client.call_tool("sam_plan", {"config": {"action": "ready"}, "plan": "P1"})
+    result = await client.call_tool("sam_plan", {"config": {"action": "ready"}, "plan": plan_id})
 
     # Assert
     data = result.data
@@ -688,10 +710,11 @@ async def test_sam_plan_ready_full_returns_complete_task_fields(
     Why: full=True is needed when agents require all task fields, not just the 7-field manifest.
     """
     # Arrange
-    task_backend.create_plan("full-plan", "Full goal", [_task_def("T01")])
+    plan_data = task_backend.create_plan("full-plan", "Full goal", [_task_def("T01")])
+    plan_id = plan_data["plan_id"]
 
     # Act
-    result = await client.call_tool("sam_plan", {"config": {"action": "ready", "full": True}, "plan": "P1"})
+    result = await client.call_tool("sam_plan", {"config": {"action": "ready", "full": True}, "plan": plan_id})
 
     # Assert
     data = result.data
@@ -729,16 +752,17 @@ async def test_sam_plan_update_sets_context_field(client: Client, task_backend: 
     Why: Context is set by the context-gathering agent after discovery.
     """
     # Arrange
-    task_backend.create_plan("update-plan", "Update goal", [_task_def()])
+    plan_data = task_backend.create_plan("update-plan", "Update goal", [_task_def()])
+    plan_id = plan_data["plan_id"]
 
     # Act
     result = await client.call_tool(
-        "sam_plan", {"config": {"action": "update", "context": "New context text"}, "plan": "P1"}
+        "sam_plan", {"config": {"action": "update", "context": "New context text"}, "plan": plan_id}
     )
 
     # Assert
     assert result.data["updated"] is True
-    assert result.data["address"] == "P1"
+    assert result.data["address"] == plan_id
 
 
 async def test_sam_plan_update_missing_plan_raises_tool_error(client: Client) -> None:
@@ -901,8 +925,9 @@ async def test_sam_active_task_update_patches_task_via_active_context(
          re-specify plan/task on every call.
     """
     # Arrange
-    task_backend.create_plan("active-plan", "Active goal", [_task_def("T01")])
-    await client.call_tool("sam_active_task", {"config": {"action": "set", "plan": "P1", "task": "T01"}})
+    plan_data = task_backend.create_plan("active-plan", "Active goal", [_task_def("T01")])
+    plan_id = plan_data["plan_id"]
+    await client.call_tool("sam_active_task", {"config": {"action": "set", "plan": plan_id, "task": "T01"}})
 
     # Act
     result = await client.call_tool(
@@ -914,7 +939,7 @@ async def test_sam_active_task_update_patches_task_via_active_context(
     assert result.data["updated"] is True
 
     # Verify patch persisted through sam_task read
-    read_result = await client.call_tool("sam_task", {"plan": "P1", "task": "T01", "config": {"action": "read"}})
+    read_result = await client.call_tool("sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "read"}})
     assert read_result.data["task"]["title"] == "Updated via active context"
 
 

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -540,7 +540,6 @@ def test_sam_create_valid_tasks_yaml_returns_path_and_counts(tmp_path: Path) -> 
 
     # Assert
     assert "error" not in result
-    assert "path" in result
     assert result["task_count"] == 1
     assert result["plan_number"] == 1
 
@@ -702,7 +701,7 @@ def test_sam_update_append_section_adds_to_task_body(tmp_path: Path) -> None:
     )
     assert "error" not in create_result
     plan_number = create_result["plan_number"]
-    plan_path = create_result["path"]
+    plan_path = p_dir / f"P{plan_number:03d}-append-sec.yaml"
 
     # Act
     update_result = sam_task(
@@ -717,9 +716,7 @@ def test_sam_update_append_section_adds_to_task_body(tmp_path: Path) -> None:
     assert update_result.get("updated") is True
 
     # Verify by reading the raw file — the section should be appended to task body
-    from pathlib import Path as _Path
-
-    raw = _Path(plan_path).read_text(encoding="utf-8")
+    raw = plan_path.read_text(encoding="utf-8")
     assert "Divergence Notes" in raw
     assert "No divergence observed." in raw
 

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -538,10 +538,12 @@ def test_sam_create_valid_tasks_yaml_returns_path_and_counts(tmp_path: Path) -> 
         config=CreatePlanConfig(slug="test-create", goal="Test goal", tasks_yaml=tasks_yaml), plan_dir=str(p_dir)
     )
 
+    import re
+
     # Assert
     assert "error" not in result
     assert result["task_count"] == 1
-    assert result["plan_number"] == 1
+    assert re.match(r"^P[0-9a-f]{8}$", result["plan_id"]), f"Expected UUID plan_id, got: {result['plan_id']!r}"
 
 
 def test_sam_create_file_is_readable_by_sam_task(tmp_path: Path) -> None:
@@ -570,9 +572,9 @@ def test_sam_create_file_is_readable_by_sam_task(tmp_path: Path) -> None:
     )
     assert "error" not in create_result
 
-    # Act — read back the task through sam_task using plan_number from create result
-    plan_number = create_result["plan_number"]
-    read_result = sam_task(plan=f"P{plan_number}", task="T01", config=ReadTaskConfig(), plan_dir=str(p_dir))
+    # Act — read back the task through sam_task using plan_id from create result
+    plan_id = create_result["plan_id"]
+    read_result = sam_task(plan=plan_id, task="T01", config=ReadTaskConfig(), plan_dir=str(p_dir))
 
     # Assert
     assert "error" not in read_result
@@ -597,13 +599,15 @@ def test_sam_create_invalid_tasks_yaml_returns_error(tmp_path: Path) -> None:
         sam_plan(config=CreatePlanConfig(slug="bad", goal="Bad goal", tasks_yaml="not_tasks: []"), plan_dir=str(p_dir))
 
 
-def test_sam_create_assigns_incrementing_plan_numbers(tmp_path: Path) -> None:
-    """sam_plan(create) assigns monotonically increasing plan numbers.
+def test_sam_create_assigns_unique_plan_ids(tmp_path: Path) -> None:
+    """sam_plan(create) assigns unique UUID-derived plan IDs for each plan.
 
-    Tests: sam_plan create plan number assignment.
-    How: Create two plans; second should have plan_number = 2.
-    Why: Correct numbering is required for address resolution to work.
+    Tests: sam_plan create plan ID uniqueness.
+    How: Create two plans; each must have a distinct UUID-format plan_id.
+    Why: UUID IDs prevent collisions regardless of filesystem state.
     """
+    import re
+
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
@@ -625,7 +629,9 @@ def test_sam_create_assigns_incrementing_plan_numbers(tmp_path: Path) -> None:
     # Assert
     assert "error" not in r1
     assert "error" not in r2
-    assert r2["plan_number"] == r1["plan_number"] + 1
+    assert re.match(r"^P[0-9a-f]{8}$", r1["plan_id"]), f"Expected UUID plan_id, got: {r1['plan_id']!r}"
+    assert re.match(r"^P[0-9a-f]{8}$", r2["plan_id"]), f"Expected UUID plan_id, got: {r2['plan_id']!r}"
+    assert r1["plan_id"] != r2["plan_id"], "Each plan must get a unique plan_id"
 
 
 # ---------------------------------------------------------------------------
@@ -658,11 +664,11 @@ def test_sam_update_context_sets_plan_context(tmp_path: Path) -> None:
         config=CreatePlanConfig(slug="update-ctx", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
-    plan_number = create_result["plan_number"]
+    plan_id = create_result["plan_id"]
 
     # Act
     update_result = sam_plan(
-        config=UpdatePlanConfig(context="Shared context narrative."), plan=f"P{plan_number}", plan_dir=str(p_dir)
+        config=UpdatePlanConfig(context="Shared context narrative."), plan=plan_id, plan_dir=str(p_dir)
     )
 
     # Assert
@@ -670,7 +676,7 @@ def test_sam_update_context_sets_plan_context(tmp_path: Path) -> None:
     assert update_result.get("updated") is True
 
     # Verify via sam_task that context is persisted
-    read_result = sam_task(plan=f"P{plan_number}", task="T01", config=ReadTaskConfig(), plan_dir=str(p_dir))
+    read_result = sam_task(plan=plan_id, task="T01", config=ReadTaskConfig(), plan_dir=str(p_dir))
     assert "error" not in read_result
     assert read_result.get("plan-context") == "Shared context narrative."
 
@@ -700,12 +706,12 @@ def test_sam_update_append_section_adds_to_task_body(tmp_path: Path) -> None:
         config=CreatePlanConfig(slug="append-sec", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
-    plan_number = create_result["plan_number"]
-    plan_path = p_dir / f"P{plan_number:03d}-append-sec.yaml"
+    plan_id = create_result["plan_id"]
+    plan_path = p_dir / f"{plan_id}-append-sec.yaml"
 
     # Act
     update_result = sam_task(
-        plan=f"P{plan_number}",
+        plan=plan_id,
         task="T01",
         config=UpdateTaskConfig(append_section="Divergence Notes", section_content="No divergence observed."),
         plan_dir=str(p_dir),
@@ -768,10 +774,10 @@ def test_sam_claim_not_started_task_returns_claimed_true(tmp_path: Path) -> None
         config=CreatePlanConfig(slug="claim-test", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
-    plan_number = create_result["plan_number"]
+    plan_id = create_result["plan_id"]
 
     # Act
-    result = sam_task(plan=f"P{plan_number}", task="T01", config=ClaimTaskConfig(), plan_dir=str(p_dir))
+    result = sam_task(plan=plan_id, task="T01", config=ClaimTaskConfig(), plan_dir=str(p_dir))
 
     # Assert
     assert result.get("claimed") is True
@@ -804,13 +810,13 @@ def test_sam_claim_already_claimed_returns_claimed_false(tmp_path: Path) -> None
         config=CreatePlanConfig(slug="double-claim", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
-    plan_number = create_result["plan_number"]
+    plan_id = create_result["plan_id"]
 
-    first = sam_task(plan=f"P{plan_number}", task="T01", config=ClaimTaskConfig(), plan_dir=str(p_dir))
+    first = sam_task(plan=plan_id, task="T01", config=ClaimTaskConfig(), plan_dir=str(p_dir))
     assert first.get("claimed") is True
 
     # Act — second claim
-    second = sam_task(plan=f"P{plan_number}", task="T01", config=ClaimTaskConfig(), plan_dir=str(p_dir))
+    second = sam_task(plan=plan_id, task="T01", config=ClaimTaskConfig(), plan_dir=str(p_dir))
 
     # Assert
     assert second.get("claimed") is False
@@ -843,11 +849,11 @@ def test_sam_claim_missing_task_returns_claimed_false(tmp_path: Path) -> None:
         config=CreatePlanConfig(slug="missing-task", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
-    plan_number = create_result["plan_number"]
+    plan_id = create_result["plan_id"]
 
     # Act / Assert
     with pytest.raises(TaskNotFoundError, match="T99"):
-        sam_task(plan=f"P{plan_number}", task="T99", config=ClaimTaskConfig(), plan_dir=str(p_dir))
+        sam_task(plan=plan_id, task="T99", config=ClaimTaskConfig(), plan_dir=str(p_dir))
 
 
 def test_sam_claim_invalid_plan_returns_error(tmp_path: Path) -> None:
@@ -868,12 +874,14 @@ def test_sam_claim_invalid_plan_returns_error(tmp_path: Path) -> None:
 
 
 def test_sam_create_returns_plan_ref_without_issue(tmp_path: Path) -> None:
-    """sam_plan(create) without issue returns plan_ref as plain P-format identifier.
+    """sam_plan(create) without issue returns plan_ref as plain UUID-format identifier.
 
     Tests: plan_ref field in create response — no-issue path.
-    How: Create a plan with no issue; verify plan_ref is "P001".
-    Why: plan_ref must be globally addressable; without issue it falls back to P<NNN>.
+    How: Create a plan with no issue; verify plan_ref matches P[hex8] pattern.
+    Why: plan_ref must be globally addressable; without issue it is the plan_id itself.
     """
+    import re
+
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
@@ -895,17 +903,18 @@ def test_sam_create_returns_plan_ref_without_issue(tmp_path: Path) -> None:
 
     # Assert
     assert "error" not in result
-    assert result["plan_ref"] == "P001"
+    assert re.match(r"^P[0-9a-f]{8}$", result["plan_ref"]), f"Expected UUID plan_ref, got: {result['plan_ref']!r}"
 
 
 def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
-    """sam_plan(create) with issue returns plan_ref as '#<issue>,P<NNN>' composite identifier.
+    """sam_plan(create) with issue returns plan_ref as '#<issue>,P<hex8>' composite identifier.
 
     Tests: plan_ref field in create response — issue-scoped path.
-    How: Create a plan with issue=42; verify plan_ref is "#42,P042" (backend uses issue
-         number as plan number when issue is provided).
-    Why: plan_ref must be globally unique when an issue is associated (PR #1725 review comment).
+    How: Create a plan with issue=42; verify plan_ref is "#42,P<hex8>".
+    Why: plan_ref must be globally unique when an issue is associated; UUID IDs prevent collisions.
     """
+    import re
+
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
@@ -926,6 +935,6 @@ def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
         plan_dir=str(p_dir),
     )
 
-    # Assert — when issue=42, backend names the plan file P042, so plan_number=42
+    # Assert — plan_ref includes issue number and UUID plan_id
     assert "error" not in result
-    assert result["plan_ref"] == "#42,P042"
+    assert re.match(r"^#42,P[0-9a-f]{8}$", result["plan_ref"]), f"Expected '#42,P<hex8>', got: {result['plan_ref']!r}"

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -865,3 +865,67 @@ def test_sam_claim_invalid_plan_returns_error(tmp_path: Path) -> None:
     # Act / Assert
     with pytest.raises(PlanNotFoundError):
         sam_task(plan="P99", task="T01", config=ClaimTaskConfig(), plan_dir=str(p_dir))
+
+
+def test_sam_create_returns_plan_ref_without_issue(tmp_path: Path) -> None:
+    """sam_plan(create) without issue returns plan_ref as plain P-format identifier.
+
+    Tests: plan_ref field in create response — no-issue path.
+    How: Create a plan with no issue; verify plan_ref is "P001".
+    Why: plan_ref must be globally addressable; without issue it falls back to P<NNN>.
+    """
+    # Arrange
+    p_dir = tmp_path / "plan"
+    p_dir.mkdir()
+    tasks_yaml = (
+        "tasks:\n"
+        "  - task: T01\n"
+        "    title: First task\n"
+        "    status: not-started\n"
+        "    agent: test-agent\n"
+        "    dependencies: []\n"
+        "    priority: 1\n"
+        "    complexity: low\n"
+    )
+
+    # Act
+    result = sam_plan(
+        config=CreatePlanConfig(slug="ref-no-issue", goal="Test goal", tasks_yaml=tasks_yaml), plan_dir=str(p_dir)
+    )
+
+    # Assert
+    assert "error" not in result
+    assert result["plan_ref"] == "P001"
+
+
+def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
+    """sam_plan(create) with issue returns plan_ref as '#<issue>,P<NNN>' composite identifier.
+
+    Tests: plan_ref field in create response — issue-scoped path.
+    How: Create a plan with issue=42; verify plan_ref is "#42,P042" (backend uses issue
+         number as plan number when issue is provided).
+    Why: plan_ref must be globally unique when an issue is associated (PR #1725 review comment).
+    """
+    # Arrange
+    p_dir = tmp_path / "plan"
+    p_dir.mkdir()
+    tasks_yaml = (
+        "tasks:\n"
+        "  - task: T01\n"
+        "    title: First task\n"
+        "    status: not-started\n"
+        "    agent: test-agent\n"
+        "    dependencies: []\n"
+        "    priority: 1\n"
+        "    complexity: low\n"
+    )
+
+    # Act
+    result = sam_plan(
+        config=CreatePlanConfig(slug="ref-with-issue", goal="Test goal", tasks_yaml=tasks_yaml, issue=42),
+        plan_dir=str(p_dir),
+    )
+
+    # Assert — when issue=42, backend names the plan file P042, so plan_number=42
+    assert "error" not in result
+    assert result["plan_ref"] == "#42,P042"

--- a/plugins/development-harness/tests_sam/test_server_mcp.py
+++ b/plugins/development-harness/tests_sam/test_server_mcp.py
@@ -308,10 +308,12 @@ async def test_mcp_sam_create_creates_plan_file(tmp_path: Path) -> None:
 
     # Assert
     data = result.data
+    import re
+
     assert isinstance(data, dict)
     assert "error" not in data
     assert data["task_count"] == 1
-    assert data["plan_number"] == 1
+    assert re.match(r"^P[0-9a-f]{8}$", data["plan_id"]), f"Expected UUID plan_id, got: {data['plan_id']!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -348,12 +350,11 @@ async def test_mcp_sam_claim_returns_claimed_true(tmp_path: Path) -> None:
                 "plan_dir": str(p_dir),
             },
         )
-        plan_number = create_result.data["plan_number"]
+        plan_id = create_result.data["plan_id"]
 
         # Act
         result = await client.call_tool(
-            "sam_task",
-            {"plan": f"P{plan_number}", "task": "T01", "config": {"action": "claim"}, "plan_dir": str(p_dir)},
+            "sam_task", {"plan": plan_id, "task": "T01", "config": {"action": "claim"}, "plan_dir": str(p_dir)}
         )
 
     # Assert
@@ -393,8 +394,7 @@ async def test_mcp_sam_claim_double_claim_returns_claimed_false(tmp_path: Path) 
                 "plan_dir": str(p_dir),
             },
         )
-        plan_number = create_result.data["plan_number"]
-        plan_addr = f"P{plan_number}"
+        plan_addr = create_result.data["plan_id"]
 
         first = await client.call_tool(
             "sam_task", {"plan": plan_addr, "task": "T01", "config": {"action": "claim"}, "plan_dir": str(p_dir)}
@@ -445,8 +445,7 @@ async def test_mcp_sam_update_sets_context(tmp_path: Path) -> None:
                 "plan_dir": str(p_dir),
             },
         )
-        plan_number = create_result.data["plan_number"]
-        plan_addr = f"P{plan_number}"
+        plan_addr = create_result.data["plan_id"]
 
         # Act
         update_result = await client.call_tool(
@@ -711,10 +710,12 @@ async def test_sam_list_items_include_plan_ref(multi_plan_dir: Path) -> None:
         result = await client.call_tool("sam_plan", {"config": {"action": "list"}, "plan_dir": str(multi_plan_dir)})
 
     # Assert — all items have plan_ref present and matching P-format (no issue in fixture)
+    # Plans in this fixture used tasks-{N}-{slug} naming (legacy format), so plan_id is the
+    # filename stem's P-prefix portion. Legacy files expose their plan_id from the file stem.
     items = result.data["items"]
     assert len(items) > 0
     for item in items:
         assert "plan_ref" in item
         plan_ref = item["plan_ref"]
         assert plan_ref is not None
-        assert re.match(r"^P\d+$", plan_ref), f"Expected P<digits> format, got: {plan_ref!r}"
+        assert re.match(r"^P[0-9a-f\d]+", plan_ref), f"Expected P-format plan_ref, got: {plan_ref!r}"

--- a/plugins/development-harness/tests_sam/test_server_mcp.py
+++ b/plugins/development-harness/tests_sam/test_server_mcp.py
@@ -695,3 +695,26 @@ async def test_sam_list_items_include_required_summary_fields(multi_plan_dir: Pa
     assert "description" in item
     assert "task_count" in item
     assert item["task_count"] == 1
+
+
+async def test_sam_list_items_include_plan_ref(multi_plan_dir: Path) -> None:
+    """sam_plan list items include plan_ref with correct P-format when no issue is set.
+
+    Tests: plan_ref field in list response — global composite identifier (PR #1725).
+    How: Call sam_plan list; verify each item has plan_ref matching 'P<digits>' pattern.
+    Why: Callers need plan_ref to construct globally unique plan addresses without issue scope.
+    """
+    import re
+
+    # Act
+    async with Client(mcp) as client:
+        result = await client.call_tool("sam_plan", {"config": {"action": "list"}, "plan_dir": str(multi_plan_dir)})
+
+    # Assert — all items have plan_ref present and matching P-format (no issue in fixture)
+    items = result.data["items"]
+    assert len(items) > 0
+    for item in items:
+        assert "plan_ref" in item
+        plan_ref = item["plan_ref"]
+        assert plan_ref is not None
+        assert re.match(r"^P\d+$", plan_ref), f"Expected P<digits> format, got: {plan_ref!r}"

--- a/plugins/development-harness/tests_sam/test_server_mcp.py
+++ b/plugins/development-harness/tests_sam/test_server_mcp.py
@@ -694,5 +694,4 @@ async def test_sam_list_items_include_required_summary_fields(multi_plan_dir: Pa
     assert "goal" in item
     assert "description" in item
     assert "task_count" in item
-    assert "path" in item
     assert item["task_count"] == 1


### PR DESCRIPTION
## Summary

Three coordinated fixes to the development-harness plugin that clean up the MCP API surface:

1. **Typed `dispatch_create_plan` input** — Replaced the raw `plan_yaml: str` parameter with a typed `DispatchPlan` Pydantic model, shifting YAML parsing/validation to the client and simplifying server-side logic.

2. **UUID-derived SAM plan IDs** — Replaced sequential/filesystem-count-derived `plan_number` (e.g. `P001`) with collision-resistant UUID-derived `plan_id` (e.g. `Pa1b2c3d4`). Added `plan_ref` for issue-scoped references (`#42,Pa1b2c3d4`). This is a breaking API change — MCP consumers reading `plan_number` must migrate to `plan_id`/`plan_ref`.

3. **Internal path leak removal** — Removed `plan_path` and `source_path` fields from MCP tool responses. These were filesystem paths from the server's local state directory (`~/.dh/`), inaccessible to worktree-isolated agents and CI environments. Artifacts are now identified by `issue_number` + `artifact_type` via `artifact_read`.

## Key Changes

### dispatch_create_plan
- `plan_yaml: str` → `plan: Annotated[_ds.DispatchPlan, ...]`
- Removed YAML parsing, dict validation, and multi-step Pydantic error handling
- Single remaining validation: `plan.milestone.number` must match `milestone_number` parameter

### SAM plan addressing
- `_next_plan_number()` (counted files in directory — fragile, resets on empty dir) → `_new_plan_id()` (`"P" + uuid.uuid4().hex[:8]`)
- `Plan` model gains optional `plan_id` field (persisted in YAML frontmatter)
- MCP responses: `plan_number` / `path` removed; `plan_id` / `plan_ref` added
- Filename regex updated to match both legacy `P{NNN}` and new `P{hex8}` formats (backwards compatible reads)
- 23 documentation/skill files updated with `P{id}` examples

### Path leak removal
- `plan_path` removed from: `dispatch_read`, `dispatch_validate`, `dispatch_stale_check`, `dispatch_create_plan` responses
- `source_path` removed from `_sam_plan_ready` response
- T0/TN agent artifact schemas no longer include `plan_path`

## Breaking Changes

MCP consumers that read `plan_number` from `sam_plan` create/list responses must update to `plan_id`. The `plan_ref` field (`#<issue>,P<id>` or just `P<id>`) replaces the previous `path` field for cross-referencing plans.

https://claude.ai/code/session_01EEipMjtRWKUnFvxVAsGMWJ