### PR TITLE
Add effort level support to kage-bunshin spawning and workflow docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.246"
+    "version": "6.3.247"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.251"
+    "version": "6.3.252"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.249"
+    "version": "6.3.250"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.247"
+    "version": "6.3.248"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.248"
+    "version": "6.3.249"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.250"
+    "version": "6.3.251"
   },
   "plugins": [
     {

--- a/.claude/rules/model-selection.md
+++ b/.claude/rules/model-selection.md
@@ -30,3 +30,22 @@ flowchart TD
 | feature-researcher | opus | Analyzes problem space |
 
 **If an agent does both checking AND analysis**: split it into two agents — a haiku checker and an opus analyzer. Do not run opus on work that haiku can handle.
+
+---
+
+## Effort Tier Guidance
+
+Assign `--effort` based on the cognitive requirement of the task, not the agent name. Use alongside `--model` selection — the two are orthogonal. A haiku agent doing a boilerplate task should use `low`; a sonnet agent designing a subsystem should use `high`.
+
+| Effort | Task type |
+|---|---|
+| `low` | Coordination, status checks, boilerplate generation, deterministic transforms |
+| `medium` | Standard implementation, file editing, test writing, documentation updates |
+| `high` | Architecture decisions, root-cause analysis, complex debugging, cross-file refactors |
+| `max` | Deep reasoning, planning under uncertainty, novel design problems |
+
+**Default (omit `--effort`)**: inherits model default.
+
+**Selection principle**: Match effort to the reasoning depth required, not the agent tier.
+
+**How to pass**: `kage-bunshin spawn --effort {level}` or `dispatch_spawn(effort="{level}")`. The spawned `claude` process receives `CLAUDE_CODE_EFFORT_LEVEL={level}` in its environment.

--- a/.claude/rules/model-selection.md
+++ b/.claude/rules/model-selection.md
@@ -48,4 +48,4 @@ Assign `--effort` based on the cognitive requirement of the task, not the agent 
 
 **Selection principle**: Match effort to the reasoning depth required, not the agent tier.
 
-**How to pass**: `kage-bunshin spawn --effort {level}` or `dispatch_spawn(effort="{level}")`. The spawned `claude` process receives `CLAUDE_CODE_EFFORT_LEVEL={level}` in its environment.
+**How to pass**: `spawn.py ... spawn --effort {level}` or `dispatch_spawn(effort="{level}")`. The spawned `claude` process receives `CLAUDE_CODE_EFFORT_LEVEL={level}` in its environment.

--- a/.claude/rules/model-selection.md
+++ b/.claude/rules/model-selection.md
@@ -46,6 +46,4 @@ Assign `--effort` based on the cognitive requirement of the task, not the agent 
 
 **Default (omit `--effort`)**: inherits model default.
 
-**Selection principle**: Match effort to the reasoning depth required, not the agent tier.
-
 **How to pass**: `spawn.py ... spawn --effort {level}` or `dispatch_spawn(effort="{level}")`. The spawned `claude` process receives `CLAUDE_CODE_EFFORT_LEVEL={level}` in its environment.

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.18",
+  "version": "7.10.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.19",
+  "version": "7.10.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.17",
+  "version": "7.10.18",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.15",
+  "version": "7.10.16",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.16",
+  "version": "7.10.17",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.14",
+  "version": "7.10.15",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -4160,7 +4160,13 @@ class _WaveCounters:
 
 
 def _build_spawn_cmd(
-    milestone: int, issue_num: int, item_title: str, model: str, phase: str, integration_branch: str
+    milestone: int,
+    issue_num: int,
+    item_title: str,
+    model: str,
+    phase: str,
+    integration_branch: str,
+    effort: str | None = None,
 ) -> list[str]:
     """Construct the spawn.py subprocess command for one dispatch item.
 
@@ -4171,11 +4177,15 @@ def _build_spawn_cmd(
         model: Model identifier string passed to spawn.py.
         phase: ``'work'`` adds ``--worktree``; any other value omits it.
         integration_branch: If non-empty, appended as ``--branch <value>``.
+        effort: Effort level passed to spawn.py as ``--effort``; ``None``
+            omits the flag and lets the model default apply.
 
     Returns:
         List of strings suitable for ``asyncio.create_subprocess_exec``.
     """
     cmd: list[str] = ["uv", "run", str(_SPAWN_SCRIPT), "--model", model, "--name", f"dispatch-{milestone}-{issue_num}"]
+    if effort is not None:
+        cmd += ["--effort", effort]
     if phase == "work":
         cmd.append("--worktree")
     if integration_branch:
@@ -4254,6 +4264,7 @@ async def _run_spawn_item(
     model: str,
     phase: str,
     integration_branch: str,
+    effort: str | None = None,
 ) -> None:
     """Spawn one dispatch item, monitor it, and update shared counters.
 
@@ -4271,9 +4282,11 @@ async def _run_spawn_item(
         model: Model identifier string.
         phase: ``'work'`` or ``'groom'``.
         integration_branch: Branch name for ``--branch`` flag; empty to omit.
+        effort: Effort level forwarded to spawn.py as ``--effort``; ``None``
+            uses the model default.
     """
     async with semaphore:
-        cmd = _build_spawn_cmd(milestone, issue_num, item_title, model, phase, integration_branch)
+        cmd = _build_spawn_cmd(milestone, issue_num, item_title, model, phase, integration_branch, effort=effort)
         pid = -1
         result_file = ""
         try:
@@ -4341,6 +4354,15 @@ async def dispatch_spawn(
     phase: Annotated[
         str, Field(description="Dispatch phase: 'groom' (no worktree) or 'work' (with worktree)")
     ] = "work",
+    effort: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Effort level for spawned sessions (sets CLAUDE_CODE_EFFORT_LEVEL). "
+                "Choices: low, medium, high, max. None (default) uses model default."
+            )
+        ),
+    ] = None,
 ) -> dict:
     """Spawn and monitor kage-bunshin sessions for a dispatch wave.
 
@@ -4356,6 +4378,17 @@ async def dispatch_spawn(
     5. On item failure: marks failed, continues with remaining items.
     6. Returns a :class:`~backlog_core.models.DispatchSpawnSummary` when all
        waves complete.
+
+    Args:
+        milestone: GitHub milestone number.
+        wave_num: Starting wave number (1-based); all subsequent waves run too.
+        ctx: FastMCP context (injected automatically).
+        max_concurrent: Maximum number of sessions running in parallel.
+        model: Model identifier forwarded to each spawned session.
+        phase: ``'work'`` adds ``--worktree``; ``'groom'`` omits it.
+        effort: Effort level forwarded to spawn.py as ``--effort``. Accepts
+            ``low``, ``medium``, ``high``, or ``max``. ``None`` (default)
+            omits the flag and lets the model default apply.
 
     Returns:
         Dict with :class:`~backlog_core.models.DispatchSpawnSummary` fields
@@ -4408,6 +4441,7 @@ async def dispatch_spawn(
                 model=model,
                 phase=phase,
                 integration_branch=integration_branch,
+                effort=effort,
             )
             for item in wave.items
         ])

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -15,7 +15,7 @@ import sys
 import time as _time
 from datetime import UTC, datetime as _datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Literal
 
 import dh_paths as _dh_paths
 import dispatch_schema as _ds
@@ -4166,7 +4166,7 @@ def _build_spawn_cmd(
     model: str,
     phase: str,
     integration_branch: str,
-    effort: str | None = None,
+    effort: Literal["low", "medium", "high", "max"] | None = None,
 ) -> list[str]:
     """Construct the spawn.py subprocess command for one dispatch item.
 
@@ -4264,7 +4264,7 @@ async def _run_spawn_item(
     model: str,
     phase: str,
     integration_branch: str,
-    effort: str | None = None,
+    effort: Literal["low", "medium", "high", "max"] | None = None,
 ) -> None:
     """Spawn one dispatch item, monitor it, and update shared counters.
 
@@ -4355,7 +4355,7 @@ async def dispatch_spawn(
         str, Field(description="Dispatch phase: 'groom' (no worktree) or 'work' (with worktree)")
     ] = "work",
     effort: Annotated[
-        str | None,
+        Literal["low", "medium", "high", "max"] | None,
         Field(
             description=(
                 "Effort level for spawned sessions (sets CLAUDE_CODE_EFFORT_LEVEL). "

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -15,7 +15,7 @@ import sys
 import time as _time
 from datetime import UTC, datetime as _datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias
 
 import dh_paths as _dh_paths
 import dispatch_schema as _ds
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from .operations import ImpactRadiusItem as _ImpactRadiusItem
+
+EffortLevel: TypeAlias = Literal["low", "medium", "high", "max"]
 
 # Token budget for auto-pagination in backlog_list: 4400 tokens (cl100k_base encoding).
 _LIST_TOKEN_BUDGET = 4_400
@@ -4166,7 +4168,7 @@ def _build_spawn_cmd(
     model: str,
     phase: str,
     integration_branch: str,
-    effort: Literal["low", "medium", "high", "max"] | None = None,
+    effort: EffortLevel | None = None,
 ) -> list[str]:
     """Construct the spawn.py subprocess command for one dispatch item.
 
@@ -4264,7 +4266,7 @@ async def _run_spawn_item(
     model: str,
     phase: str,
     integration_branch: str,
-    effort: Literal["low", "medium", "high", "max"] | None = None,
+    effort: EffortLevel | None = None,
 ) -> None:
     """Spawn one dispatch item, monitor it, and update shared counters.
 
@@ -4355,7 +4357,7 @@ async def dispatch_spawn(
         str, Field(description="Dispatch phase: 'groom' (no worktree) or 'work' (with worktree)")
     ] = "work",
     effort: Annotated[
-        Literal["low", "medium", "high", "max"] | None,
+        EffortLevel | None,
         Field(
             description=(
                 "Effort level for spawned sessions (sets CLAUDE_CODE_EFFORT_LEVEL). "

--- a/plugins/development-harness/skills/kage-bunshin/SKILL.md
+++ b/plugins/development-harness/skills/kage-bunshin/SKILL.md
@@ -14,7 +14,7 @@ This is NOT a subagent or teammate — it is an independent CLI process with its
 All operations go through `${CLAUDE_SKILL_DIR}/scripts/spawn.py`:
 
 ```text
-spawn.py --session-id ID spawn  --name X [--model MODEL] [--max-budget N] "prompt"
+spawn.py --session-id ID spawn  --name X [--model MODEL] [--max-budget N] [--effort LEVEL] "prompt"
 spawn.py --session-id ID send   --name X "message"
 spawn.py --session-id ID read   --name X
 spawn.py --session-id ID status --name X
@@ -120,6 +120,7 @@ $SPAWN spawn --name my-session --max-budget 5.00 "Your prompt"
 - `--name` — Session name (auto-derived from first 30 chars of prompt if omitted)
 - `--model` — Model for the spawned session (default: sonnet)
 - `--max-budget` — Maximum USD spend cap
+- `--effort` — Effort level (low, medium, high, max) for reasoning depth. Injects CLAUDE_CODE_EFFORT_LEVEL into the child env.
 
 **Output** (JSON to stdout):
 

--- a/plugins/development-harness/skills/kage-bunshin/scripts/spawn.py
+++ b/plugins/development-harness/skills/kage-bunshin/scripts/spawn.py
@@ -86,6 +86,7 @@ from typing import Any, NoReturn
 _DEFAULT_MODEL = "sonnet"
 _NAME_MAX_CHARS = 30
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
+EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "max")
 # Timeout waiting for the claude tmux session to appear after spawn.
 _SPAWN_WAIT_SECONDS = 30
 # Timeout waiting for a session to exit gracefully after Ctrl-C.
@@ -572,7 +573,6 @@ def _build_spawn_shell_cmd(
     #   KAGE_BUNSHIN_CHILD=1                  — skip sibling alerts, block recursive spawns
     #   KAGE_BUNSHIN_PARENT_SESSION_ID=<id>   — write notifications to the correct file
     #   KAGE_BUNSHIN_TMUX_SESSION=<name>      — identify this session in notifications
-    #   CLAUDE_CODE_EFFORT_LEVEL=<level>      — set compute effort tier (optional)
     parts: list[str] = [
         "env",
         "KAGE_BUNSHIN_CHILD=1",
@@ -1089,7 +1089,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_spawn.add_argument(
         "--effort",
         default=None,
-        choices=["low", "medium", "high", "max"],
+        choices=list(EFFORT_LEVELS),
         metavar="LEVEL",
         help="Effort level for the spawned session: low, medium, high, or max (default: inherit from model).",
     )

--- a/plugins/development-harness/skills/kage-bunshin/scripts/spawn.py
+++ b/plugins/development-harness/skills/kage-bunshin/scripts/spawn.py
@@ -544,7 +544,7 @@ def check_session_limit(session_id: str, state_dir: Path) -> tuple[bool, str]:
 
 
 def _build_spawn_shell_cmd(
-    name: str, model: str, max_budget: float | None, session_id: str, tmux_session_name: str
+    name: str, model: str, max_budget: float | None, session_id: str, tmux_session_name: str, effort: str | None = None
 ) -> list[str]:
     """Build the command argv list for launching claude in interactive tmux mode.
 
@@ -560,6 +560,10 @@ def _build_spawn_shell_cmd(
             so child hooks can write to the correct notifications file.
         tmux_session_name: The tmux session name being created — injected as
             KAGE_BUNSHIN_TMUX_SESSION so child hooks can identify themselves.
+        effort: Optional effort level (low, medium, high, max) injected as
+            CLAUDE_CODE_EFFORT_LEVEL env var so the child session uses the
+            correct compute budget. When None, no env var is injected and
+            claude uses its default effort for the selected model.
 
     Returns:
         Argv list suitable for passing directly to subprocess or tmux new-session.
@@ -568,19 +572,16 @@ def _build_spawn_shell_cmd(
     #   KAGE_BUNSHIN_CHILD=1                  — skip sibling alerts, block recursive spawns
     #   KAGE_BUNSHIN_PARENT_SESSION_ID=<id>   — write notifications to the correct file
     #   KAGE_BUNSHIN_TMUX_SESSION=<name>      — identify this session in notifications
+    #   CLAUDE_CODE_EFFORT_LEVEL=<level>      — set compute effort tier (optional)
     parts: list[str] = [
         "env",
         "KAGE_BUNSHIN_CHILD=1",
         f"KAGE_BUNSHIN_PARENT_SESSION_ID={session_id}",
         f"KAGE_BUNSHIN_TMUX_SESSION={tmux_session_name}",
-        "claude",
-        "--dangerously-skip-permissions",
-        "--worktree",
-        name,
-        "--tmux",
-        "--model",
-        model,
     ]
+    if effort is not None:
+        parts.append(f"CLAUDE_CODE_EFFORT_LEVEL={effort}")
+    parts += ["claude", "--dangerously-skip-permissions", "--worktree", name, "--tmux", "--model", model]
     if max_budget is not None:
         parts += ["--max-budget-usd", str(max_budget)]
     return parts
@@ -637,7 +638,12 @@ def cmd_spawn(args: argparse.Namespace) -> None:
     # --worktree creates an isolated git worktree for the session.
     # --tmux keeps claude alive in its own named tmux session.
     claude_argv = _build_spawn_shell_cmd(
-        name, args.model, args.max_budget, session_id=args.session_id, tmux_session_name=claude_tmux_session
+        name,
+        args.model,
+        args.max_budget,
+        session_id=args.session_id,
+        tmux_session_name=claude_tmux_session,
+        effort=args.effort,
     )
 
     # tmux new-session -d provides the TTY that --tmux requires.
@@ -1080,6 +1086,13 @@ def _build_parser() -> argparse.ArgumentParser:
     p_spawn.add_argument("--name", default=None, help="Session name (auto-derived from prompt if omitted).")
     p_spawn.add_argument("--model", default=_DEFAULT_MODEL, help=f"Model to use (default: {_DEFAULT_MODEL}).")
     p_spawn.add_argument("--max-budget", type=float, default=None, metavar="USD", help="Maximum USD spend.")
+    p_spawn.add_argument(
+        "--effort",
+        default=None,
+        choices=["low", "medium", "high", "max"],
+        metavar="LEVEL",
+        help="Effort level for the spawned session: low, medium, high, or max (default: inherit from model).",
+    )
     p_spawn.set_defaults(func=cmd_spawn)
 
     # send

--- a/plugins/development-harness/skills/kage-bunshin/tests/test_spawn.py
+++ b/plugins/development-harness/skills/kage-bunshin/tests/test_spawn.py
@@ -389,6 +389,7 @@ def _make_spawn_args(
     ns.model = model
     ns.max_budget = max_budget
     ns.session_id = session_id
+    ns.effort = None
     return ns
 
 

--- a/plugins/development-harness/skills/kage-bunshin/tests/test_spawn.py
+++ b/plugins/development-harness/skills/kage-bunshin/tests/test_spawn.py
@@ -370,6 +370,31 @@ def test_build_spawn_shell_cmd_omits_max_budget_when_none():
     assert "--max-budget-usd" not in argv
 
 
+def test_build_parser_spawn_effort_flag_listed_in_help(capsys: pytest.CaptureFixture[str]) -> None:
+    parser = _spawn._build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["spawn", "--help"])
+    help_text = capsys.readouterr().out
+    assert "--effort" in help_text
+    assert "low" in help_text
+    assert "medium" in help_text
+    assert "high" in help_text
+    assert "max" in help_text
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high", "max"])
+def test_build_spawn_shell_cmd_injects_effort_level_when_set(level: str):
+    argv = _spawn._build_spawn_shell_cmd("sess", "sonnet", None, "sess-id", "tmux-sess", effort=level)
+    effort_arg = f"CLAUDE_CODE_EFFORT_LEVEL={level}"
+    assert effort_arg in argv
+    assert argv.index(effort_arg) < argv.index("claude")
+
+
+def test_build_spawn_shell_cmd_omits_effort_level_when_none():
+    argv = _spawn._build_spawn_shell_cmd("sess", "sonnet", None, "sess-id", "tmux-sess", effort=None)
+    assert not any("CLAUDE_CODE_EFFORT_LEVEL" in arg for arg in argv)
+
+
 # ---------------------------------------------------------------------------
 # cmd_spawn — integration with subprocess mocked
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/skills/kage-bunshin/tests/test_spawn.py
+++ b/plugins/development-harness/skills/kage-bunshin/tests/test_spawn.py
@@ -376,13 +376,11 @@ def test_build_parser_spawn_effort_flag_listed_in_help(capsys: pytest.CaptureFix
         parser.parse_args(["spawn", "--help"])
     help_text = capsys.readouterr().out
     assert "--effort" in help_text
-    assert "low" in help_text
-    assert "medium" in help_text
-    assert "high" in help_text
-    assert "max" in help_text
+    for level in _spawn.EFFORT_LEVELS:
+        assert level in help_text
 
 
-@pytest.mark.parametrize("level", ["low", "medium", "high", "max"])
+@pytest.mark.parametrize("level", _spawn.EFFORT_LEVELS)
 def test_build_spawn_shell_cmd_injects_effort_level_when_set(level: str):
     argv = _spawn._build_spawn_shell_cmd("sess", "sonnet", None, "sess-id", "tmux-sess", effort=level)
     effort_arg = f"CLAUDE_CODE_EFFORT_LEVEL={level}"

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/plan.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/plan.md
@@ -46,5 +46,9 @@ flowchart TD
 
 ## Step 4.5: Post-Planning Output
 
-- **Interactive mode**: Load [post-planning.md](./post-planning.md) for the report template.
-- **When <mode/> is `auto`**: Load [post-planning.md](./post-planning.md) for the continuation procedure.
+```mermaid
+flowchart TD
+    Q{What is mode?}
+    Q -->|"interactive (default)"| Report["Load [post-planning.md](./post-planning.md)<br>Output the interactive summary template<br>Present to user — stop here"]
+    Q -->|"auto"| Continue["Do NOT stop for user input<br>Return to start.md and execute step 6<br>(Invoke implement-feature), then step 7<br>(Invoke complete-implementation), then step 8<br>(Close or resolve item) in order"]
+```

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/start.md
@@ -26,7 +26,7 @@ flowchart TD
    - Step 2.2: Issue-first path (`#N`, bare number, or URL)
    - Step 2.3: Find by title substring
    - Step 2.4: Extract item fields
-   - If item already has a Plan field: invoke `Skill(skill="dh:implement-feature", args="{plan_address}")` and stop
+   - If item already has a Plan field: invoke `Skill(skill: "dh:implement-feature", args: "{plan_address}")` and stop
 3. [ ] **Validate** ([validate.md](./validate.md)) — verify item state and sync with GitHub
    - Step 3.1: Already-implemented check
    - Step 3.2–3.4: GitHub issue sync, creation, in-progress label
@@ -39,12 +39,12 @@ flowchart TD
    - Step 4.4: Feasibility gate — if BLOCKED, stop
 5. [ ] **Plan** ([plan.md](./plan.md)) — compose feature request and invoke SAM planning
    - Step 5.1: Compose feature request
-   - Step 5.2: Invoke SAM planning via `Skill(skill="dh:add-new-feature", args="{feature_request}")`
+   - Step 5.2: Invoke SAM planning via `Skill(skill: "dh:add-new-feature", args: "{feature_request}")`
    - Step 5.3: Update backlog with plan reference
    - Step 5.4: Simplify (code changes only)
    - Step 5.5: Load [post-planning.md](./post-planning.md) for the interactive summary template
 6. [ ] **Present summary to user** — output the planning summary report from post-planning.md
-7. [ ] **Commit** — if running in a worktree, commit all changes before closing (`git add -A && git commit -m "<summary of changes>"`)
+7. [ ] **Commit** — if running in a worktree, commit all changes before closing (`git add -A && git commit -m "<type>(<scope>): <description>"`)
 
 **Auto mode checklist** — steps to add to TodoWrite when `<mode/>` is `auto`:
 
@@ -53,10 +53,10 @@ flowchart TD
 3. [ ] **Validate** ([validate.md](./validate.md)) — verify item state and sync with GitHub (same sub-steps as interactive)
 4. [ ] **Prepare** ([prepare.md](./prepare.md)) — groom if needed, RT-ICA gate, feasibility gate (same sub-steps as interactive)
 5. [ ] **Plan** ([plan.md](./plan.md)) — compose feature request and invoke SAM planning (Steps 5.1–5.4; Step 5.5 runs the auto-mode branch: continue to step 6 without stopping)
-6. [ ] **Invoke implement-feature** — `Skill(skill="dh:implement-feature", args="{plan_address}")` — do not stop for user input
-7. [ ] **Invoke complete-implementation** — `Skill(skill="dh:complete-implementation", args="{plan_address}")` — do not stop for user input
+6. [ ] **Invoke implement-feature** — `Skill(skill: "dh:implement-feature", args: "{plan_address}")` — do not stop for user input
+7. [ ] **Invoke complete-implementation** — `Skill(skill: "dh:complete-implementation", args: "{plan_address}")` — do not stop for user input
 8. [ ] **Close or resolve item** — follow the close/resolve path to mark the item done (see [post-planning.md](./post-planning.md))
-9. [ ] **Commit** — if running in a worktree, commit all changes before closing (`git add -A && git commit -m "<summary of changes>"`)
+9. [ ] **Commit** — if running in a worktree, commit all changes before closing (`git add -A && git commit -m "docs(workflow): update work backlog item instructions"`)
 
 ## Error Routing
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/start.md
@@ -4,33 +4,59 @@ Read [scope.md](./scope.md) before proceeding. All work actions operate within t
 
 ## Checklist
 
-Track progress using your task list. Check off each step as it completes.
+**At workflow start, create a TodoWrite checklist using the NUMBERED CHECKLIST for your mode (below the routing diagram) before executing any step. Use the numbered checklist items as the TodoWrite entries — not the Mermaid step names, which are summaries only.**
 
-1. [ ] Read `scope.md` — align all actions with the work scope boundary
-2. [ ] **Locate** (`locate.md`) — find and extract the backlog item's fields
+The numbered checklist to use depends on `<mode/>`:
+
+```mermaid
+flowchart TD
+    Start([Workflow begins]) --> ReadScope["Create TodoWrite entry: Read scope.md"]
+    ReadScope --> CreateList{What is mode?}
+    CreateList -->|"interactive (default)"| IList["Use INTERACTIVE MODE CHECKLIST below<br>as TodoWrite entries — ends at Present summary to user"]
+    CreateList -->|"auto"| AList["Use AUTO MODE CHECKLIST below<br>as TodoWrite entries — ends at Commit<br>MUST include Invoke implement-feature,<br>Invoke complete-implementation, Close or resolve item"]
+    IList --> Execute([Execute steps in order — do not skip])
+    AList --> Execute
+```
+
+**Interactive mode checklist** — steps to add to TodoWrite when `<mode/>` is `interactive`:
+
+1. [ ] Read [scope.md](./scope.md) — align all actions with the work scope boundary
+2. [ ] **Locate** ([locate.md](./locate.md)) — find and extract the backlog item's fields
    - Step 2.1: Interactive browser (no arguments only)
    - Step 2.2: Issue-first path (`#N`, bare number, or URL)
    - Step 2.3: Find by title substring
    - Step 2.4: Extract item fields
-   - If item already has a Plan field: invoke `/dh:implement-feature` and stop
-3. [ ] **Validate** (`validate.md`) — verify item state and sync with GitHub
+   - If item already has a Plan field: invoke `Skill(skill="dh:implement-feature", args="{plan_address}")` and stop
+3. [ ] **Validate** ([validate.md](./validate.md)) — verify item state and sync with GitHub
    - Step 3.1: Already-implemented check
    - Step 3.2–3.4: GitHub issue sync, creation, in-progress label
    - Step 3.5: Discovery gate (feature/refactor items only)
    - If discovery gate STOP: report and stop
-4. [ ] **Prepare** (`prepare.md`) — groom if needed, RT-ICA gate, feasibility gate
+4. [ ] **Prepare** ([prepare.md](./prepare.md)) — groom if needed, RT-ICA gate, feasibility gate
    - Step 4.1: Auto-groom (if needed)
    - Step 4.2: RT-ICA gate — if BLOCKED, stop and present MISSING conditions
    - Step 4.3: RT-ICA date stamp
    - Step 4.4: Feasibility gate — if BLOCKED, stop
-5. [ ] **Plan** (`plan.md`) — compose feature request and invoke SAM planning
+5. [ ] **Plan** ([plan.md](./plan.md)) — compose feature request and invoke SAM planning
    - Step 5.1: Compose feature request
-   - Step 5.2: Invoke SAM planning via `/dh:add-new-feature`
+   - Step 5.2: Invoke SAM planning via `Skill(skill="dh:add-new-feature", args="{feature_request}")`
    - Step 5.3: Update backlog with plan reference
    - Step 5.4: Simplify (code changes only)
-   - Step 5.5: Post-planning output
-6. [ ] **Report** — present planning summary to user
+   - Step 5.5: Load [post-planning.md](./post-planning.md) for the interactive summary template
+6. [ ] **Present summary to user** — output the planning summary report from post-planning.md
 7. [ ] **Commit** — if running in a worktree, commit all changes before closing (`git add -A && git commit -m "<summary of changes>"`)
+
+**Auto mode checklist** — steps to add to TodoWrite when `<mode/>` is `auto`:
+
+1. [ ] Read [scope.md](./scope.md) — align all actions with the work scope boundary
+2. [ ] **Locate** ([locate.md](./locate.md)) — find and extract the backlog item's fields (same sub-steps as interactive)
+3. [ ] **Validate** ([validate.md](./validate.md)) — verify item state and sync with GitHub (same sub-steps as interactive)
+4. [ ] **Prepare** ([prepare.md](./prepare.md)) — groom if needed, RT-ICA gate, feasibility gate (same sub-steps as interactive)
+5. [ ] **Plan** ([plan.md](./plan.md)) — compose feature request and invoke SAM planning (Steps 5.1–5.4; Step 5.5 runs the auto-mode branch: continue to step 6 without stopping)
+6. [ ] **Invoke implement-feature** — `Skill(skill="dh:implement-feature", args="{plan_address}")` — do not stop for user input
+7. [ ] **Invoke complete-implementation** — `Skill(skill="dh:complete-implementation", args="{plan_address}")` — do not stop for user input
+8. [ ] **Close or resolve item** — follow the close/resolve path to mark the item done (see [post-planning.md](./post-planning.md))
+9. [ ] **Commit** — if running in a worktree, commit all changes before closing (`git add -A && git commit -m "<summary of changes>"`)
 
 ## Error Routing
 

--- a/plugins/development-harness/skills/work-milestone/SKILL.md
+++ b/plugins/development-harness/skills/work-milestone/SKILL.md
@@ -45,7 +45,7 @@ flowchart TD
 
     CreateWorktrees --> WriteLocks["Step 5b: Write Lock Files<br>For each worktree:<br>Write .claude/kage-bunshin.lock<br>(prevents recursive spawning)"]
 
-    WriteLocks --> SpawnSessions["Step 5c: Spawn Kage-Bunshin Sessions<br>For each worktree: cd into it, then:<br>claude -p --model sonnet<br>--permission-mode auto --output-format json<br>'Load /dh:work-backlog-item #{issue}'<br>Each session is a FULL orchestrator —<br>has Agent tool, TeamCreate, all MCP.<br>All sessions launch as background processes."]
+    WriteLocks --> SpawnSessions["Step 5c: Spawn Kage-Bunshin Sessions<br>For each worktree: cd into it, then:<br>claude -p --model {model} [--effort {level}]<br>--permission-mode auto --output-format json<br>'Load /dh:work-backlog-item #{issue}'<br>Each session is a FULL orchestrator —<br>has Agent tool, TeamCreate, all MCP.<br>All sessions launch as background processes."]
 
     SpawnSessions --> WaitReturn["Step 6: Wait for All Sessions<br>Poll PIDs for exit.<br>Read result JSON from each<br>/tmp/kb-work-{issue}.json"]
 
@@ -126,7 +126,7 @@ for ISSUE in "${WAVE_ISSUES[@]}"; do
   OUTPUT=$($SPAWN --worktree \
     --branch "${INTEGRATION_BRANCH}" \
     --name "work-item-${ISSUE}" \
-    --model sonnet \
+    --model "${MODEL}" \
     "Load /dh:work-backlog-item #${ISSUE}. Execute the full work flow. \
      You are in a worktree on integration branch ${INTEGRATION_BRANCH}. \
      Use MCP tools for plan artifact discovery — plan/ files are in the root worktree. \
@@ -182,7 +182,7 @@ done
 
 The `--model` flag on the kage-bunshin controls the spawned session's orchestrator model only. Sub-agents spawned inside that session use their own model per their agent frontmatter definition.
 
-Recommended: `--model sonnet` for spawned sessions. Haiku viability as orchestrator is an open experiment.
+Recommended: `--model sonnet` for spawned sessions (configurable via `dispatch_spawn` `model` parameter). Haiku viability as orchestrator is an open experiment. Use `--effort` to tune reasoning depth independently of model selection.
 
 ## Agent Result Handling
 

--- a/plugins/development-harness/skills/work-milestone/SKILL.md
+++ b/plugins/development-harness/skills/work-milestone/SKILL.md
@@ -119,6 +119,7 @@ Use the kage-bunshin spawn script — it handles worktree creation, `.venv`/`nod
 
 ```bash
 SPAWN="plugins/development-harness/skills/kage-bunshin/scripts/spawn.py"
+MODEL="${MODEL:-sonnet}"
 PIDS=()
 SPAWN_INFO=()
 


### PR DESCRIPTION
## Summary
This PR adds support for the `--effort` flag to control compute budget allocation in spawned kage-bunshin sessions, along with comprehensive documentation updates for the work-backlog-item workflow and effort tier guidance.

## Key Changes

### Effort Level Support
- **spawn.py**: Added `--effort` argument (choices: low, medium, high, max) that injects `CLAUDE_CODE_EFFORT_LEVEL` environment variable into spawned claude processes
- **server.py**: Extended `_build_spawn_cmd()` and `_run_spawn_item()` to accept and forward optional `effort` parameter; added `dispatch_spawn()` API parameter with full documentation
- **test_spawn.py**: Added comprehensive test coverage for effort level injection, including parametrized tests for all effort levels and verification that the env var is omitted when not specified

### Workflow Documentation
- **start.md**: Completely restructured checklist guidance with:
  - Mermaid routing diagram showing mode-based branching (interactive vs auto)
  - Separate numbered checklists for interactive and auto modes
  - Clarified TodoWrite entry creation at workflow start
  - Updated skill invocation syntax to use `Skill()` function notation
  - Added explicit step numbering for auto mode (steps 6-9)
  
- **plan.md**: Added Mermaid flowchart for Step 4.5 (Post-Planning Output) showing mode-dependent branching between interactive report output and auto mode continuation

- **model-selection.md**: Added new "Effort Tier Guidance" section with:
  - Effort level selection matrix (low/medium/high/max mapped to task types)
  - Principle that effort is orthogonal to model selection
  - Instructions for passing effort via CLI and API

- **work-milestone/SKILL.md**: Updated spawn command examples to use parameterized `{model}` and `[--effort {level}]` placeholders instead of hardcoded values

### Version Bumps
- Plugin version: 7.10.14 → 7.10.18
- Marketplace version: 6.3.246 → 6.3.250

## Implementation Details
- Effort level is optional (defaults to None), allowing backward compatibility with existing code that doesn't specify it
- When effort is None, the flag is omitted entirely, letting the model use its default behavior
- Environment variable injection happens before the `claude` command in the shell argv list, ensuring proper precedence
- All effort-related parameters are properly documented in docstrings and API annotations

https://claude.ai/code/session_01BQtsEon6qkVmuiLgx2QYrZ