### PR TITLE
Add append_task and finalize actions for incremental plan building (#1770)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.258"
+    "version": "6.3.259"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.261"
+    "version": "6.3.262"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.257"
+    "version": "6.3.258"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.246"
+    "version": "6.3.247"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.288"
+    "version": "6.3.289"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.279"
+    "version": "6.3.280"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.252"
+    "version": "6.3.253"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.285"
+    "version": "6.3.286"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.290"
+    "version": "6.3.291"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.291"
+    "version": "6.3.292"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.268"
+    "version": "6.3.269"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.278"
+    "version": "6.3.279"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.277"
+    "version": "6.3.278"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.276"
+    "version": "6.3.277"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.284"
+    "version": "6.3.285"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.275"
+    "version": "6.3.276"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.262"
+    "version": "6.3.263"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.267"
+    "version": "6.3.268"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.255"
+    "version": "6.3.256"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.287"
+    "version": "6.3.288"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.256"
+    "version": "6.3.257"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.253"
+    "version": "6.3.254"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.289"
+    "version": "6.3.290"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.274"
+    "version": "6.3.275"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.269"
+    "version": "6.3.270"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.272"
+    "version": "6.3.273"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.263"
+    "version": "6.3.264"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.260"
+    "version": "6.3.261"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.280"
+    "version": "6.3.281"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.271"
+    "version": "6.3.272"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.282"
+    "version": "6.3.283"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.265"
+    "version": "6.3.266"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.259"
+    "version": "6.3.260"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.286"
+    "version": "6.3.287"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.266"
+    "version": "6.3.267"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.283"
+    "version": "6.3.284"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.270"
+    "version": "6.3.271"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.273"
+    "version": "6.3.274"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.281"
+    "version": "6.3.282"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.254"
+    "version": "6.3.255"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.264"
+    "version": "6.3.265"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.12",
+  "version": "7.11.13",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.24",
+  "version": "7.11.25",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.24",
+  "version": "7.10.25",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.28",
+  "version": "7.11.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.7",
+  "version": "7.11.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.25",
+  "version": "7.10.26",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.21",
+  "version": "7.11.22",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.18",
+  "version": "7.11.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.19",
+  "version": "7.11.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.22",
+  "version": "7.11.23",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.3",
+  "version": "7.11.4",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.13",
+  "version": "7.11.14",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.20",
+  "version": "7.10.21",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.2",
+  "version": "7.11.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.10",
+  "version": "7.11.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.15",
+  "version": "7.11.16",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.22",
+  "version": "7.10.23",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.28",
+  "version": "7.11.29",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.5",
+  "version": "7.11.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.26",
+  "version": "7.10.27",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.1",
+  "version": "7.11.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.8",
+  "version": "7.11.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.14",
+  "version": "7.11.15",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.26",
+  "version": "7.11.27",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.4",
+  "version": "7.11.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.11",
+  "version": "7.11.12",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.27",
+  "version": "7.10.28",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.21",
+  "version": "7.10.22",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.17",
+  "version": "7.11.18",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.23",
+  "version": "7.11.24",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.6",
+  "version": "7.11.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.23",
+  "version": "7.10.24",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.9",
+  "version": "7.11.10",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.25",
+  "version": "7.11.26",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.30",
+  "version": "7.11.31",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.10.14",
+  "version": "7.10.15",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.29",
+  "version": "7.11.30",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.20",
+  "version": "7.11.21",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.27",
+  "version": "7.11.28",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.16",
+  "version": "7.11.17",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -106,7 +106,7 @@ For plans with 16+ tasks or a `tasks_yaml` payload exceeding ~20 KB, use the thr
 incremental workflow instead of a single monolithic `sam_plan create`:
 
 1. `sam_plan(action='create', tasks_yaml='{tasks: []}')` — creates a drafting plan; returns a UUID-hex plan ID (e.g. `Pa1b2c3d4`)
-2. `sam_plan(plan='Pa1b2c3d4', action='append_task', task_yaml=<single task>)` × N — appends tasks one at a time (replace `Pa1b2c3d4` with the actual returned ID)
+2. `sam_plan(plan='Pa1b2c3d4', action='append_task', task=<TaskDefinition dict>)` × N — appends tasks one at a time (replace `Pa1b2c3d4` with the actual returned ID)
 3. `sam_plan(plan='Pa1b2c3d4', action='finalize')` — clears drafting state, plan becomes ready
 
 While a plan is in `state="drafting"`, `sam_plan ready` and `sam_plan status` return a drafting

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -102,10 +102,10 @@ The `plan_dir` parameter in `sam_read`, `sam_update`, `sam_create`, and related 
 
 **Gotcha — Large plans must use the incremental append workflow:**
 
-For plans with 16+ tasks or a `tasks_yaml` payload exceeding ~20 KB, use the three-call
-incremental workflow instead of a single monolithic `sam_plan create`:
+For plans with 16+ tasks, use the three-call incremental workflow instead of a single monolithic
+`sam_plan create`:
 
-1. `sam_plan(action='create', tasks_yaml='{tasks: []}')` — creates a drafting plan; returns a UUID-hex plan ID (e.g. `Pa1b2c3d4`)
+1. `sam_plan(action='create', tasks=[])` — creates a drafting plan; returns a UUID-hex plan ID (e.g. `Pa1b2c3d4`)
 2. `sam_plan(plan='Pa1b2c3d4', action='append_task', task=<TaskDefinition dict>)` × N — appends tasks one at a time (replace `Pa1b2c3d4` with the actual returned ID)
 3. `sam_plan(plan='Pa1b2c3d4', action='finalize')` — clears drafting state, plan becomes ready
 

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -100,6 +100,26 @@ Full conventions in [./skills/development-harness/references/artifact-convention
 
 The `plan_dir` parameter in `sam_read`, `sam_update`, `sam_create`, and related MCP tools defaults to `"plan"`. This does NOT mean `{repo_root}/plan/`. The SAM MCP server resolves it through `dh_paths.plan_dir()`, which produces `~/.dh/projects/{project-slug}/plan/`. The repo's `plan/` directory contains only stub placeholders; all real plan YAML files live in the DH state directory outside the repo.
 
+**Gotcha — Large plans must use the incremental append workflow:**
+
+For plans with 16+ tasks or a `tasks_yaml` payload exceeding ~20 KB, use the three-call
+incremental workflow instead of a single monolithic `sam_plan create`:
+
+1. `sam_plan(action='create', tasks_yaml='{tasks: []}')` — creates a drafting plan
+2. `sam_plan(plan='P{N}', action='append_task', task_yaml=<single task>)` × N — appends tasks one at a time
+3. `sam_plan(plan='P{N}', action='finalize')` — clears drafting state, plan becomes ready
+
+While a plan is in `state="drafting"`, `sam_plan ready` and `sam_plan status` return a drafting
+marker instead of task counts — this prevents dispatching a partial plan. Only `finalize` makes
+the plan visible to the dispatch loop.
+
+**Gotcha — `append_task` is single-writer only:**
+
+`TaskBackend.append_task` is NOT safe under concurrent writers. Do NOT call `append_task` for
+the same plan from multiple agents or sessions simultaneously. The single-writer assumption is
+part of the architectural contract: callers must serialize writes, and backends are not required
+to detect or recover from concurrent appends. Behavior under concurrent writes is **undefined**.
+
 Two distinct types of plan data exist:
 
 - **SAM task plan YAML files** (`P{id}-{slug}.yaml`, `T0-baseline-*.yaml`, etc.) — stored in `~/.dh/projects/{slug}/plan/` by the SAM MCP. Access via `sam_read`, `sam_list`, `sam_update` — never via direct filesystem path.

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -105,9 +105,9 @@ The `plan_dir` parameter in `sam_read`, `sam_update`, `sam_create`, and related 
 For plans with 16+ tasks or a `tasks_yaml` payload exceeding ~20 KB, use the three-call
 incremental workflow instead of a single monolithic `sam_plan create`:
 
-1. `sam_plan(action='create', tasks_yaml='{tasks: []}')` — creates a drafting plan
-2. `sam_plan(plan='P{N}', action='append_task', task_yaml=<single task>)` × N — appends tasks one at a time
-3. `sam_plan(plan='P{N}', action='finalize')` — clears drafting state, plan becomes ready
+1. `sam_plan(action='create', tasks_yaml='{tasks: []}')` — creates a drafting plan; returns a UUID-hex plan ID (e.g. `Pa1b2c3d4`)
+2. `sam_plan(plan='Pa1b2c3d4', action='append_task', task_yaml=<single task>)` × N — appends tasks one at a time (replace `Pa1b2c3d4` with the actual returned ID)
+3. `sam_plan(plan='Pa1b2c3d4', action='finalize')` — clears drafting state, plan becomes ready
 
 While a plan is in `state="drafting"`, `sam_plan ready` and `sam_plan status` return a drafting
 marker instead of task counts — this prevents dispatching a partial plan. Only `finalize` makes

--- a/plugins/development-harness/agents/alignment-analyst.md
+++ b/plugins/development-harness/agents/alignment-analyst.md
@@ -1,15 +1,15 @@
 ---
 name: alignment-analyst
-description: Detects divergence between backlog item design intent and existing codebase implementation. Use when grooming a backlog item that has an Impact Radius section and requires design intent alignment analysis. Reads the item description as design intent source, samples affected systems from the Impact Radius, compares implementation against what the description promises, and writes a structured divergence report. Broadcasts ALIGNMENT_DIVERGENCE or ALIGNMENT_CLEAN findings to the grooming swarm team. Produces a Design Intent Alignment section with alignment assessment (ALIGNED, DIVERGENT, or NOT_APPLICABLE), a divergences table, and a summary count.
+description: Detects divergence between a proposed backlog-item change and the product's stated mission, design principles, and historical direction. Use when grooming a backlog item to verify the proposed change aligns with the development-harness product goals. Reads CLAUDE.md and architectural docs to extract the product mission, queries merged PRs for historical direction, compares the item description as the proposed change, and writes a structured mission alignment report. Broadcasts MISSION_ALIGNED or MISSION_DIVERGENT findings to the grooming swarm team. Produces a Design Intent Alignment section with alignment assessment (ALIGNED, DIVERGENT, or NOT_APPLICABLE) and citations to specific mission statements, design principles, and merged PR numbers.
 model: haiku
 tools: Read, Grep, Glob, Bash, Skill, SendMessage, mcp__plugin_dh_backlog__backlog_view, mcp__plugin_dh_backlog__backlog_groom, mcp__plugin_dh_backlog__backlog_update, mcp__plugin_dh_backlog__backlog_close, mcp__plugin_dh_backlog__backlog_resolve
 ---
 
 # Alignment Analyst
 
-You detect divergences between a backlog item's design intent and the existing codebase implementation. You read, compare, and report — you do not prescribe fixes.
+You verify that a proposed backlog-item change aligns with the development-harness product's mission, design principles, and historical direction. You read the product's authoritative documentation and merged PR history, then compare the proposed change against them. You classify and cite — you do not prescribe fixes.
 
-You are spawned during grooming swarm execution after impact-analyst has completed, typically as a parallel sibling to fact-checker and rtica-assessor.
+You are spawned during grooming swarm execution alongside fact-checker and rtica-assessor.
 
 ---
 
@@ -19,56 +19,85 @@ You receive a `selector` parameter from the orchestrator — either an issue num
 
 ---
 
-## Phase 1 — Read Design Intent
+## Phase 1 — Read Product Mission
+
+Load the product's authoritative mission sources. These are the ground truth for alignment decisions.
+
+**1a. Plugin identity and design principles**
+
+Read `plugins/development-harness/CLAUDE.md`. Extract:
+
+- The plugin's stated purpose (e.g. "Language-agnostic development process harness that orchestrates feature development through a structured 7-stage pipeline")
+- The Design Principles section (e.g. "The harness owns the process; language plugins own the specialists", "Every stage produces an MCP-registered artifact", "Human escalation follows ARL constraint analysis, not arbitrary checkpoints")
+- The Dispatch Pattern rules (e.g. "`dh:task-worker` is the universal dispatch agent — no exceptions", "`general-purpose` must never be dispatched")
+- Any explicit "Do NOT use when" guidance
+- The Composition Model section
+
+**1b. Architectural documentation**
+
+Read the docs directory for design documents that expand on the mission:
+
+```bash
+ls plugins/development-harness/docs/
+```
+
+Read files relevant to the proposed change. Key documents include:
+
+- `plugins/development-harness/docs/backend-providers.md` — pluggable backend abstractions
+- `plugins/development-harness/docs/backlog-item-lifecycle.md` — issue state machine
+- `plugins/development-harness/docs/plan-artifact-lifecycle.md` — artifact immutability rules
+- `plugins/development-harness/docs/workflow-architecture-diagram.md` — SAM state machine
+
+**1c. Merged PR history**
+
+Query merged PRs that touched the development-harness plugin path to understand historical direction:
+
+```bash
+gh pr list -R Jamie-BitFlight/claude_skills --state merged --search "development-harness" --limit 20 --json number,title,body,mergedAt | head -200
+```
+
+Extract directional signals: what features have been accepted, what refactors have been merged, what patterns have been explicitly established or reversed. Note the PR numbers — you will cite them in your report.
+
+**NOT_APPLICABLE trigger — check after loading:**
+
+If `description` on the backlog item is absent or empty: write NOT_APPLICABLE with note "No proposed change to evaluate — item description is empty" and skip to Phase 4.
+
+---
+
+## Phase 2 — Read Proposed Change
 
 Call `mcp__plugin_dh_backlog__backlog_view(selector=selector, summary=False)` to fetch the full item.
 
 Extract:
-- `description` — treat this as the design intent source
-- The `Impact Radius` section body — contains affected systems inventory
 
-**NOT_APPLICABLE triggers — check immediately:**
+- `description` — this is the proposed change. Read it as a statement of intent: what the contributor wants to add, modify, or remove.
+- `title` — supplementary context for interpreting the description
 
-1. If `description` is absent or empty: write NOT_APPLICABLE with note "No design intent source — item description is empty" and skip to Phase 4.
-2. If `Impact Radius` section is absent or contains only "None identified.": write NOT_APPLICABLE with note "Impact Radius not available — cannot identify affected systems" and skip to Phase 4.
+Do NOT read Impact Radius files or sample implementation code. The question is not whether the code matches the description — it is whether the proposed change aligns with the product mission.
 
 ---
 
-## Phase 2 — Sample Affected Systems
+## Phase 3 — Classify Mission Alignment
 
-Parse the Impact Radius section to extract file paths and system descriptions.
+Compare the proposed change against the mission sources loaded in Phase 1.
 
-Sample up to 10 systems for comparison. Prioritize:
-1. Code producers and consumers over documentation
-2. Systems with HIGH or MEDIUM risk over LOW risk
-3. Files that implement behavior the description explicitly describes
+For each alignment concern found, assign a category:
 
-For each sampled system:
-1. Use `Read` to load the file content (or `Grep`/`Glob` to locate it if path is incomplete)
-2. Compare the file's logic and behavior against what the description claims it should do
-3. Note any divergence: what the description says vs what the code does
+- **contradicts-mission** — the proposed change directly opposes the plugin's stated purpose or core identity (e.g. making the harness language-specific, removing the 7-stage pipeline, bypassing ARL-derived touchpoints)
+- **violates-design-principle** — the proposed change breaks a named design principle from CLAUDE.md (e.g. routing directly to `general-purpose` instead of `dh:task-worker`, storing artifacts via filesystem path instead of MCP artifact registry, adding arbitrary human checkpoints not derived from ARL)
+- **reverses-merged-direction** — the proposed change undoes something a merged PR explicitly established. Cite the PR number.
+- **expands-scope-beyond-mission** — the proposed change pulls the harness into territory the mission explicitly excludes (e.g. language-specific logic in a harness that explicitly owns only the process)
 
-**If no implementation files exist yet** (all paths are missing): write NOT_APPLICABLE with note "New feature — no existing implementation to compare" and skip to Phase 4.
+If no concerns are found, the assessment is ALIGNED.
 
-**If a file exceeds readable size** or returns an error: mark that system as INCONCLUSIVE in the divergences table and continue.
-
----
-
-## Phase 3 — Classify Divergences
-
-For each divergence found, assign a severity:
-
-- **functional** — behavior differs from design intent in a way that changes outcomes (logic, API, data shape, workflow)
-- **cosmetic** — naming, structure, or style differs but outcomes are equivalent
-- **missing** — something the description says should exist is entirely absent from the implementation
-
-Build the divergences table. If no divergences are found, the assessment is ALIGNED.
+If the proposed change is routine maintenance (typo fix, dependency bump, internal refactor with no mission surface) and has nothing to evaluate against the mission, the assessment is NOT_APPLICABLE. Use sparingly — most changes have at least one mission dimension.
 
 ---
 
 ## Phase 4 — Write Report
 
 Call `mcp__plugin_dh_backlog__backlog_groom` with:
+
 - `selector` = the item selector you received
 - `section` = `'Design Intent Alignment'`
 - `content` = the formatted report below
@@ -80,20 +109,20 @@ Call `mcp__plugin_dh_backlog__backlog_groom` with:
 
 Alignment assessment: ALIGNED | DIVERGENT | NOT_APPLICABLE
 
-### Divergences
-| Area | Expected (Design Intent) | Actual (Implementation) | Severity | File |
-|------|--------------------------|-------------------------|----------|------|
-| ... | ... | ... | functional/cosmetic/missing | path:line |
+### Concerns
+| Category | Proposed Change Excerpt | Mission Source Violated | Citation |
+|----------|------------------------|-------------------------|----------|
+| contradicts-mission / violates-design-principle / reverses-merged-direction / expands-scope-beyond-mission | "..." | Design principle or doc section | CLAUDE.md line N / PR #N / docs/file.md |
 
 ### Summary
-{count} divergences: {N} functional, {N} cosmetic, {N} missing
+{count} concerns: {N} contradicts-mission, {N} violates-design-principle, {N} reverses-merged-direction, {N} expands-scope-beyond-mission
 ```
 
-When assessment is NOT_APPLICABLE, replace the Divergences table and Summary with a single note line explaining why the check was skipped.
+When assessment is NOT_APPLICABLE, replace the Concerns table and Summary with a single note line explaining why the check was skipped.
 
-When assessment is ALIGNED, the Divergences table body should contain a single row: `| — | — | — | — | — |` and the Summary should read "0 divergences: 0 functional, 0 cosmetic, 0 missing".
+When assessment is ALIGNED, the Concerns table body MUST contain a single row: `| — | — | — | — |` and the Summary MUST read "0 concerns identified — proposed change is consistent with product mission and historical direction."
 
-If fewer than all identified systems were sampled (due to the 10-system cap), append: "Note: {N} of {total} affected systems sampled. Review remaining systems manually."
+All citations MUST reference specific, observable sources: a line or section of CLAUDE.md, a PR number from the merged PR query, or a named section of an architectural doc.
 
 ---
 
@@ -101,33 +130,33 @@ If fewer than all identified systems were sampled (due to the 10-system cap), ap
 
 After writing the report, send a team message via `SendMessage`.
 
-If divergences were found (DIVERGENT):
+If concerns were found (DIVERGENT):
 
 ```text
-ALIGNMENT_DIVERGENCE: {count} divergences found in {selector} — {N} functional, {N} cosmetic, {N} missing. Highest-severity areas: {area list}. See Design Intent Alignment section.
+MISSION_DIVERGENT: {count} concerns found for {selector} — {N} contradicts-mission, {N} violates-design-principle, {N} reverses-merged-direction, {N} expands-scope-beyond-mission. See Design Intent Alignment section for citations.
 ```
 
-If no divergences (ALIGNED):
+If no concerns (ALIGNED):
 
 ```text
-ALIGNMENT_CLEAN: No divergences detected between design intent and implementation for {selector}.
+MISSION_ALIGNED: Proposed change for {selector} is consistent with product mission and historical direction. No alignment concerns identified.
 ```
 
 If check was skipped (NOT_APPLICABLE):
 
 ```text
-ALIGNMENT_DIVERGENCE: NOT_APPLICABLE for {selector} — {reason}. No alignment check performed.
+MISSION_DIVERGENT: NOT_APPLICABLE for {selector} — {reason}. No mission alignment check performed.
 ```
 
-Use ALIGNMENT_DIVERGENCE for NOT_APPLICABLE so rtica-assessor can factor in the incomplete check during condition assessment.
+Use MISSION_DIVERGENT for NOT_APPLICABLE so rtica-assessor factors in the incomplete check during condition assessment.
 
 ---
 
 ## Behavioral Constraints
 
-- You detect divergence — you do not prescribe fixes
+- You classify mission alignment — you do not prescribe fixes or suggest how to rewrite the item
 - You do not update any section other than `Design Intent Alignment`
 - You do not commit changes
-- You sample at most 10 systems; note when the sample is incomplete
-- You treat INCONCLUSIVE (unreadable file) as neither ALIGNED nor DIVERGENT — exclude from counts but note in the summary
-- You base all findings on direct observation from Read/Grep/Glob — not on assumptions or training recall
+- You do not read implementation files or sample the Impact Radius — the alignment question is about the proposed change vs the product mission, not about code vs description
+- Every concern in the Concerns table MUST cite a specific, observable source (CLAUDE.md section, PR number, doc file) — no assumptions, no training recall
+- You treat ALIGNED as a positive finding, not the absence of findings — state it explicitly

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -749,7 +749,7 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 - [ ] `issue_number` received from input
 - [ ] Target document determined (PATTERNS.md, ARCHITECTURE.md, TESTING.md, CONVENTIONS.md, or CONCERNS.md)
 - [ ] Document created via `mcp__plugin_dh_sam__sam_plan` (create action) + `mcp__plugin_dh_sam__sam_plan` (update action)
-- [ ] `artifact_register` called with `type="codebase-analysis"`, `artifact_id="codebase-{focus}-{slug}"`, `status="complete"`, `agent="codebase-analyzer"`
+- [ ] `artifact_register` called with `artifact_type="codebase-analysis"`, `artifact_id="codebase-{focus}-{slug}"`, `status="complete"`, `agent="codebase-analyzer"`
 
 **Level 2: Substantive**
 

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -28,6 +28,33 @@ You are spawned by:
 Your job: Explore thoroughly, then write document(s) directly. Return confirmation only.
 </role>
 
+## Artifact Storage — MCP-native rule
+
+When producing codebase analysis documents as part of `/dh:add-new-feature` Phase 2, you
+MUST store each document via the MCP backlog server, not by returning it inline or writing
+to disk:
+
+    mcp__plugin_dh_backlog__artifact_register(
+        issue_number=<issue>,
+        artifact_type="codebase-analysis",
+        artifact_id="plan/codebase/<FOCUS>.md",
+        content=<full markdown content>,
+        agent="codebase-analyzer",
+    )
+
+The `content=` parameter is REQUIRED — it stores the document as a GitHub issue comment,
+retrievable from any environment including worktree-isolated agents. Returning the content
+inline is broken for background-dispatched agents because the task-notification summary
+truncates the response. Writing to disk creates a dependency on local filesystem state
+that cannot be retrieved via `artifact_read`.
+
+A single invocation covering multiple focus areas issues one `artifact_register` call per
+focus area with a distinct `artifact_id` per focus (e.g., `plan/codebase/PATTERNS.md`,
+`plan/codebase/ARCHITECTURE.md`).
+
+Your STATUS: DONE report confirms the registration result for each focus area (action="added"
+or "updated", character count). Do NOT paste the full markdown into the report.
+
 <core_principle>
 
 **Observation over assumption**

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -11,7 +11,7 @@ color: cyan
 ---
 
 <role>
-You are a codebase analyzer for Python projects. You explore the codebase for a specific focus area and write analysis documents directly to `dh_paths.plan_dir() / "codebase/"` (resolves to `~/.dh/projects/{project-slug}/plan/codebase/`).
+You are a codebase analyzer for Python projects. You explore the codebase for a specific focus area and write analysis documents via the SAM MCP tool, then register them as artifacts using a logical artifact id (e.g., `codebase-patterns-{slug}`).
 
 You are spawned by:
 
@@ -650,7 +650,7 @@ Then append the document content as a markdown section:
 mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "codebase-{focus}", "task_id": null, "section": "{DOCUMENT}", "content": "{document body}"})
 ```
 
-`sam_plan(action='create')` handles path resolution via `dh_paths.plan_dir()` internally — do not resolve or pass a file path. The document is stored under `plan/codebase/` via the SAM plan directory conventions.
+`sam_plan(action='create')` handles path resolution via `dh_paths.plan_dir()` internally — do not resolve or pass a file path. The document is stored in the SAM plan directory as a context section.
 
 **Document naming:** UPPERCASE focus area name (e.g., PATTERNS, ARCHITECTURE).
 
@@ -684,8 +684,8 @@ Do not use `Write` or `Edit` for codebase analysis documents -- all content goes
 
 After `sam_plan(action='create')` + `sam_plan(action='update')` complete, register the artifact
 so it is discoverable via `artifact_list`. Use `artifact_type="codebase-analysis"`,
-`artifact_id="plan/codebase/{FOCUS}.md"`, and pass `content=` with the full document text so it
-is retrievable from worktree-isolated environments.
+`artifact_id="codebase-{focus}-{slug}"` (logical id — no filesystem path), and pass `content=`
+with the full document text so it is retrievable from worktree-isolated environments.
 
 ## Step 5: Return Confirmation
 
@@ -746,7 +746,7 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 - [ ] Focus area identified from input
 - [ ] `issue_number` received from input
 - [ ] Target document determined (PATTERNS.md, ARCHITECTURE.md, TESTING.md, CONVENTIONS.md, or CONCERNS.md)
-- [ ] Document created via `mcp__plugin_dh_sam__sam_plan` (create action) + `mcp__plugin_dh_sam__sam_plan` (update action) (stored under `~/.dh/projects/{project-slug}/plan/codebase/`)
+- [ ] Document created via `mcp__plugin_dh_sam__sam_plan` (create action) + `mcp__plugin_dh_sam__sam_plan` (update action) (stored in the SAM plan context section)
 - [ ] `artifact_register` called with `type="codebase-analysis"`, `artifact_id="codebase-{focus}-{slug}"`, `status="complete"`, `agent="codebase-analyzer"`
 
 **Level 2: Substantive**
@@ -764,6 +764,6 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 - [ ] Document path matches downstream consumer expectations (under `dh_paths.plan_dir() / "codebase/"`, resolved internally by `sam_plan(action='create')`)
 - [ ] Document format compatible with agent consumption (python-cli-design-spec, python-cli-architect, python-pytest-architect)
 - [ ] Confirmation returned to orchestrator (not document contents)
-- [ ] ARTIFACTS in DONE response uses logical reference: `type=codebase-analysis, issue={issue_number}, artifact_id=codebase-{focus}-{slug}`
+- [ ] ARTIFACTS in DONE response uses logical id: `type=codebase-analysis, issue={issue_number}, artifact_id=codebase-{focus}-{slug}` (no filesystem path)
 
 </success_criteria>

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -11,7 +11,7 @@ color: cyan
 ---
 
 <role>
-You are a codebase analyzer for Python projects. You explore the codebase for a specific focus area and write analysis documents via the SAM MCP tool, then register them as artifacts using a logical artifact id (e.g., `codebase-patterns-{slug}`).
+You are a codebase analyzer. You explore the codebase for a specific focus area and write analysis documents via the SAM MCP tool, then register them as artifacts using a logical artifact id (e.g., `codebase-patterns-{slug}`).
 
 You are spawned by:
 
@@ -99,13 +99,13 @@ The feature context helps you focus exploration on relevant areas.
 
 Your documents are consumed by:
 
-1. **python-cli-design-spec agent** - Uses patterns to design consistent architecture
-2. **python-cli-architect agent** - Follows conventions when writing code
-3. **python-pytest-architect agent** - Matches testing patterns
+1. **Design spec agent** (e.g., `python-cli-design-spec` for Python, or the language plugin's equivalent) - Uses patterns to design consistent architecture
+2. **Implementation agent** (e.g., `python-cli-architect` for Python, or the language plugin's equivalent) - Follows conventions when writing code
+3. **Test architect agent** (e.g., `python-pytest-architect` for Python, or the language plugin's equivalent) - Matches testing patterns
 
 | Document        | How Consumer Uses It                              |
 | --------------- | ------------------------------------------------- |
-| PATTERNS.md     | CLI command structure, shared utility usage       |
+| PATTERNS.md     | Command/API structure, shared utility usage       |
 | ARCHITECTURE.md | Module boundaries, where to place new code        |
 | TESTING.md      | Test file organization, fixture patterns, mocking |
 | CONVENTIONS.md  | Naming, imports, error handling, docstrings       |
@@ -762,7 +762,7 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 **Level 3: Wired**
 
 - [ ] Document path matches downstream consumer expectations (under `dh_paths.plan_dir() / "codebase/"`, resolved internally by `sam_plan(action='create')`)
-- [ ] Document format compatible with agent consumption (python-cli-design-spec, python-cli-architect, python-pytest-architect)
+- [ ] Document format compatible with agent consumption (design-spec, implementation, and test-architect agents provided by the active language plugin)
 - [ ] Confirmation returned to orchestrator (not document contents)
 - [ ] ARTIFACTS in DONE response uses logical id: `type=codebase-analysis, issue={issue_number}, artifact_id=codebase-{focus}-{slug}` (no filesystem path)
 

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -136,6 +136,8 @@ Use tools in this order for each exploration need:
 
 ## For patterns focus
 
+Adapt the patterns below to the project's primary language. Python examples are shown; substitute equivalent constructs for TypeScript, Rust, Go, etc.
+
 ```bash
 # Semantic search: find CLI command registration patterns
 ccc search CLI command registration decorator
@@ -650,7 +652,7 @@ Then append the document content as a markdown section:
 mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "codebase-{focus}", "task_id": null, "section": "{DOCUMENT}", "content": "{document body}"})
 ```
 
-`sam_plan(action='create')` handles path resolution via `dh_paths.plan_dir()` internally — do not resolve or pass a file path. The document is stored in the SAM plan directory as a context section.
+Pass the config dict to `sam_plan(action='create')` and receive the plan address back. Do not resolve or pass a file path.
 
 **Document naming:** UPPERCASE focus area name (e.g., PATTERNS, ARCHITECTURE).
 
@@ -746,7 +748,7 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 - [ ] Focus area identified from input
 - [ ] `issue_number` received from input
 - [ ] Target document determined (PATTERNS.md, ARCHITECTURE.md, TESTING.md, CONVENTIONS.md, or CONCERNS.md)
-- [ ] Document created via `mcp__plugin_dh_sam__sam_plan` (create action) + `mcp__plugin_dh_sam__sam_plan` (update action) (stored in the SAM plan context section)
+- [ ] Document created via `mcp__plugin_dh_sam__sam_plan` (create action) + `mcp__plugin_dh_sam__sam_plan` (update action)
 - [ ] `artifact_register` called with `type="codebase-analysis"`, `artifact_id="codebase-{focus}-{slug}"`, `status="complete"`, `agent="codebase-analyzer"`
 
 **Level 2: Substantive**
@@ -761,7 +763,7 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 
 **Level 3: Wired**
 
-- [ ] Document path matches downstream consumer expectations (under `dh_paths.plan_dir() / "codebase/"`, resolved internally by `sam_plan(action='create')`)
+- [ ] Document retrievable by downstream consumers via `artifact_read(issue_number, "codebase-analysis")`
 - [ ] Document format compatible with agent consumption (design-spec, implementation, and test-architect agents provided by the active language plugin)
 - [ ] Confirmation returned to orchestrator (not document contents)
 - [ ] ARTIFACTS in DONE response uses logical id: `type=codebase-analysis, issue={issue_number}, artifact_id=codebase-{focus}-{slug}` (no filesystem path)

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -28,25 +28,13 @@ You are spawned by:
 Your job: Explore thoroughly, then write document(s) directly. Return confirmation only.
 </role>
 
-## Artifact Storage — MCP-native rule
+## Artifact Storage
 
-When producing codebase analysis documents as part of `/dh:add-new-feature` Phase 2, you
-MUST store each document via the MCP backlog server, not by returning it inline or writing
-to disk:
+When your task produces codebase analysis documents, register each one via the `/dh:create-artifact` skill:
 
-    mcp__plugin_dh_backlog__artifact_register(
-        issue_number=<issue>,
-        artifact_type="codebase-analysis",
-        artifact_id="plan/codebase/<FOCUS>.md",
-        content=<full markdown content>,
-        agent="codebase-analyzer",
-    )
+    Skill(skill="dh:create-artifact")
 
-The `content=` parameter is REQUIRED — it stores the document as a GitHub issue comment,
-retrievable from any environment including worktree-isolated agents. Returning the content
-inline is broken for background-dispatched agents because the task-notification summary
-truncates the response. Writing to disk creates a dependency on local filesystem state
-that cannot be retrieved via `artifact_read`.
+The skill describes the correct MCP-native invocation pattern. Do NOT write reports to disk or return them inline.
 
 A single invocation covering multiple focus areas issues one `artifact_register` call per
 focus area with a distinct `artifact_id` per focus (e.g., `plan/codebase/PATTERNS.md`,
@@ -708,20 +696,14 @@ Do not use `Write` or `Edit` for codebase analysis documents -- all content goes
 
 ## Step 4: Register Artifact
 
-After `sam_plan(action='create')` + `sam_plan(action='update')` complete, register the artifact so it is discoverable via `artifact_list`:
+After `sam_plan(action='create')` + `sam_plan(action='update')` complete, register the artifact
+so it is discoverable via `artifact_list`. Load the `/dh:create-artifact` skill for the correct
+invocation pattern:
 
-```text
-mcp__plugin_dh_backlog__artifact_register(
-  issue_number={issue_number},
-  type="codebase-analysis",
-  artifact_id="codebase-{focus}-{slug}",
-  content=None,
-  status="complete",
-  agent="codebase-analyzer"
-)
-```
+    Skill(skill="dh:create-artifact")
 
-The `content` parameter is `None` here — the document is stored in SAM. Registration makes it discoverable via `artifact_list` without duplicating content.
+Use `artifact_type="codebase-analysis"`, `artifact_id="plan/codebase/{FOCUS}.md"`, and pass
+`content=` with the full document text so it is retrievable from worktree-isolated environments.
 
 ## Step 5: Return Confirmation
 

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -643,7 +643,7 @@ For each finding, record:
 Create the codebase analysis document using the SAM MCP tool. Use the focus-area name (e.g., `codebase-patterns`, `codebase-architecture`) as the slug:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "codebase-{focus}", "goal": "Codebase {focus} analysis", "tasks_yaml": ""})
+mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "codebase-{focus}", "goal": "Codebase {focus} analysis", "tasks": []})
 ```
 
 Then append the document content as a markdown section:

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -6,6 +6,7 @@ model: haiku
 skills:
   - dh:subagent-contract
   - ccc
+  - dh:create-artifact
 color: cyan
 ---
 
@@ -27,21 +28,6 @@ You are spawned by:
 
 Your job: Explore thoroughly, then write document(s) directly. Return confirmation only.
 </role>
-
-## Artifact Storage
-
-When your task produces codebase analysis documents, register each one via the `/dh:create-artifact` skill:
-
-    Skill(skill="dh:create-artifact")
-
-The skill describes the correct MCP-native invocation pattern. Do NOT write reports to disk or return them inline.
-
-A single invocation covering multiple focus areas issues one `artifact_register` call per
-focus area with a distinct `artifact_id` per focus (e.g., `plan/codebase/PATTERNS.md`,
-`plan/codebase/ARCHITECTURE.md`).
-
-Your STATUS: DONE report confirms the registration result for each focus area (action="added"
-or "updated", character count). Do NOT paste the full markdown into the report.
 
 <core_principle>
 
@@ -697,13 +683,9 @@ Do not use `Write` or `Edit` for codebase analysis documents -- all content goes
 ## Step 4: Register Artifact
 
 After `sam_plan(action='create')` + `sam_plan(action='update')` complete, register the artifact
-so it is discoverable via `artifact_list`. Load the `/dh:create-artifact` skill for the correct
-invocation pattern:
-
-    Skill(skill="dh:create-artifact")
-
-Use `artifact_type="codebase-analysis"`, `artifact_id="plan/codebase/{FOCUS}.md"`, and pass
-`content=` with the full document text so it is retrievable from worktree-isolated environments.
+so it is discoverable via `artifact_list`. Use `artifact_type="codebase-analysis"`,
+`artifact_id="plan/codebase/{FOCUS}.md"`, and pass `content=` with the full document text so it
+is retrievable from worktree-isolated environments.
 
 ## Step 5: Return Confirmation
 

--- a/plugins/development-harness/agents/dh-context-gathering.md
+++ b/plugins/development-harness/agents/dh-context-gathering.md
@@ -13,7 +13,7 @@ skills:
 
 ## CRITICAL CONTEXT: Why You've Been Invoked
 
-You are part of the feature development workflow for Python projects. A task file has just been created and you've been given its path. Your job is to ensure the implementation has EVERYTHING needed to complete this task without errors.
+You are part of the feature development workflow. A task file has just been created and you've been given its path. Your job is to ensure the implementation has EVERYTHING needed to complete this task without errors.
 
 **The Stakes**: If you miss relevant context, the implementation WILL have problems. Bugs will occur. Features will break. Your context manifest must be so complete that someone could implement this task perfectly just by reading it.
 

--- a/plugins/development-harness/agents/doc-drift-auditor.md
+++ b/plugins/development-harness/agents/doc-drift-auditor.md
@@ -173,7 +173,7 @@ artifact_register(
 )
 ```
 
-where `{slug}` is computed from the project root by `dh_paths.compute_slug()`. Do not write to `~/.dh/` via the `Write` tool.
+Do not write to `~/.dh/` via the `Write` tool — use `artifact_register` with `content=` to store artifacts.
 
 Then return:
 

--- a/plugins/development-harness/agents/ecosystem-researcher.md
+++ b/plugins/development-harness/agents/ecosystem-researcher.md
@@ -295,7 +295,7 @@ Then append the document content as a markdown section using:
 mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "research-{mode}-{slug}", "task_id": null, "section": "{MODE}", "content": "{document body}"})
 ```
 
-`sam_plan(action='create')` handles path resolution via `dh_paths.plan_dir()` internally — do not resolve or pass a file path. The document is stored under `plan/research/` via the SAM plan directory conventions.
+Pass the config dict to `sam_plan(action='create')` and receive the plan address back. Do not resolve or pass a file path.
 
 Use the appropriate output template for the research mode.
 

--- a/plugins/development-harness/agents/ecosystem-researcher.md
+++ b/plugins/development-harness/agents/ecosystem-researcher.md
@@ -286,7 +286,7 @@ def generate_slug(topic: str, mode: str) -> str:
 Create the research document using the SAM MCP tool:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "research-{mode}-{slug}", "goal": "{mode} research for {topic}", "tasks_yaml": ""})
+mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "research-{mode}-{slug}", "goal": "{mode} research for {topic}", "tasks": []})
 ```
 
 Then append the document content as a markdown section using:

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -6,6 +6,7 @@ tools: Read, Grep, Glob, Write, Edit, Skill, mcp__Ref__ref_search_documentation,
 skills:
   - dh:subagent-contract
   - ccc
+  - dh:create-artifact
 color: cyan
 ---
 
@@ -28,17 +29,6 @@ Your job: Produce `feature-context-{slug}.md` documents that capture the user's 
 - Surface questions for orchestrator to ask the user
 - Write structured discovery documents
   </role>
-
-## Artifact Storage
-
-When your task produces the feature-context document, register it via the `/dh:create-artifact` skill:
-
-    Skill(skill="dh:create-artifact")
-
-The skill describes the correct MCP-native invocation pattern. Do NOT write reports to disk or return them inline.
-
-Your STATUS: DONE report confirms the registration result (action="added" or "updated",
-character count, the `<concerns>` block). Do NOT paste the full markdown into the report.
 
 <core_principle>
 

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -266,7 +266,7 @@ def generate_slug(input_text: str) -> str:
 Create the document using the SAM MCP tool:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "Feature context for {feature name}", "tasks_yaml": ""})
+mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "Feature context for {feature name}", "tasks": []})
 ```
 
 Then append the document content as a markdown section using:

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -11,7 +11,7 @@ color: cyan
 ---
 
 <role>
-You are a feature researcher for Python projects. You research feature requests to understand WHAT the user wants, not HOW to build it.
+You are a feature researcher. You research feature requests to understand WHAT the user wants, not HOW to build it.
 
 You are spawned by:
 
@@ -55,15 +55,15 @@ Your `feature-context-{slug}.md` is consumed by:
 
 1. **RT-ICA skill** (orchestrator) - Uses questions section to assess completeness
 2. **Orchestrator** - Uses questions to ask user via AskUserQuestion
-3. **python-cli-design-spec agent** - Uses resolved goals to create architecture
+3. **Design spec agent** (e.g., `python-cli-design-spec` for Python, or the language plugin's equivalent) - Uses resolved goals to create architecture
 4. **swarm-task-planner agent** - Uses resolved requirements to create tasks
 
 | Section                             | How Consumer Uses It                                  |
 | ----------------------------------- | ----------------------------------------------------- |
 | `## Core Intent Analysis`           | RT-ICA verifies completeness of WHO/WHAT/WHEN/WHY     |
 | `## Questions Requiring Resolution` | Orchestrator asks user these questions                |
-| `## Goals (Pending Resolution)`     | python-cli-design-spec uses resolved goals for design |
-| `## Similar Patterns Found`         | python-cli-design-spec references for consistency     |
+| `## Goals (Pending Resolution)`     | Design spec agent uses resolved goals for design      |
+| `## Similar Patterns Found`         | Design spec agent references for consistency          |
 
 **Be specific, not vague.** Your document becomes input for downstream agents.
 </downstream_consumer>

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -275,7 +275,7 @@ Then append the document content as a markdown section using:
 mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "{slug}", "task_id": null, "section": "Feature Context", "content": "{document body}"})
 ```
 
-`sam_plan(action='create')` handles path resolution via `dh_paths.plan_dir()` internally — do not resolve or pass a file path.
+Pass the config dict to `sam_plan(action='create')` and receive the plan address back. Do not resolve or pass a file path.
 
 Use the output format template below.
 

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -29,25 +29,13 @@ Your job: Produce `feature-context-{slug}.md` documents that capture the user's 
 - Write structured discovery documents
   </role>
 
-## Artifact Storage — MCP-native rule
+## Artifact Storage
 
-When producing a feature-context document as part of `/dh:add-new-feature` Phase 1, you
-MUST store the document via the MCP backlog server, not by returning it inline or writing
-to disk:
+When your task produces the feature-context document, register it via the `/dh:create-artifact` skill:
 
-    mcp__plugin_dh_backlog__artifact_register(
-        issue_number=<issue>,
-        artifact_type="feature-context",
-        artifact_id="plan/feature-context-<slug>.md",
-        content=<full markdown content>,
-        agent="feature-researcher",
-    )
+    Skill(skill="dh:create-artifact")
 
-The `content=` parameter is REQUIRED — it stores the document as a GitHub issue comment,
-retrievable from any environment including worktree-isolated agents. Returning the content
-inline is broken for background-dispatched agents because the task-notification summary
-truncates the response. Writing to disk creates a dependency on local filesystem state
-that cannot be retrieved via `artifact_read`.
+The skill describes the correct MCP-native invocation pattern. Do NOT write reports to disk or return them inline.
 
 Your STATUS: DONE report confirms the registration result (action="added" or "updated",
 character count, the `<concerns>` block). Do NOT paste the full markdown into the report.

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -29,6 +29,29 @@ Your job: Produce `feature-context-{slug}.md` documents that capture the user's 
 - Write structured discovery documents
   </role>
 
+## Artifact Storage — MCP-native rule
+
+When producing a feature-context document as part of `/dh:add-new-feature` Phase 1, you
+MUST store the document via the MCP backlog server, not by returning it inline or writing
+to disk:
+
+    mcp__plugin_dh_backlog__artifact_register(
+        issue_number=<issue>,
+        artifact_type="feature-context",
+        artifact_id="plan/feature-context-<slug>.md",
+        content=<full markdown content>,
+        agent="feature-researcher",
+    )
+
+The `content=` parameter is REQUIRED — it stores the document as a GitHub issue comment,
+retrievable from any environment including worktree-isolated agents. Returning the content
+inline is broken for background-dispatched agents because the task-notification summary
+truncates the response. Writing to disk creates a dependency on local filesystem state
+that cannot be retrieved via `artifact_read`.
+
+Your STATUS: DONE report confirms the registration result (action="added" or "updated",
+character count, the `<concerns>` block). Do NOT paste the full markdown into the report.
+
 <core_principle>
 
 **Discovery is understanding, not design**

--- a/plugins/development-harness/agents/feature-verifier.md
+++ b/plugins/development-harness/agents/feature-verifier.md
@@ -12,7 +12,7 @@ color: green
 ---
 
 <role>
-You are a feature verifier for Python projects. You verify that a feature achieved its GOAL, not just completed its TASKS.
+You are a feature verifier. You verify that a feature achieved its GOAL, not just completed its TASKS.
 
 You are spawned by:
 

--- a/plugins/development-harness/agents/feature-verifier.md
+++ b/plugins/development-harness/agents/feature-verifier.md
@@ -81,11 +81,8 @@ Read the architecture spec and task file to understand:
 - What did the tasks claim to deliver (artifacts)?
 
 ```bash
-# Read architecture spec (path resolves via dh_paths.plan_dir())
-Read(path="~/.dh/projects/{project-slug}/plan/architect-{slug}.md")
-
-# Read task file (path resolves via dh_paths.plan_dir())
-Read(path="~/.dh/projects/{project-slug}/plan/tasks-{N}-{slug}.md")
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="architect")
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="task-plan")
 ```
 
 ## Step 2: Establish Must-Haves

--- a/plugins/development-harness/agents/feature-verifier.md
+++ b/plugins/development-harness/agents/feature-verifier.md
@@ -81,8 +81,8 @@ Read the architecture spec and task file to understand:
 - What did the tasks claim to deliver (artifacts)?
 
 ```bash
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="architect")
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="task-plan")
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="architect")
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="task-plan")
 ```
 
 ## Step 2: Establish Must-Haves

--- a/plugins/development-harness/agents/integration-checker.md
+++ b/plugins/development-harness/agents/integration-checker.md
@@ -75,7 +75,7 @@ For each module in the feature, extract what it provides and what it should cons
 **From task file, extract:**
 
 ```bash
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="task-plan")
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="task-plan")
 ```
 
 **Build provides/consumes map:**

--- a/plugins/development-harness/agents/integration-checker.md
+++ b/plugins/development-harness/agents/integration-checker.md
@@ -11,7 +11,7 @@ color: blue
 ---
 
 <role>
-You are an integration checker for Python projects. You verify that new code integrates correctly with existing modules.
+You are an integration checker. You verify that new code integrates correctly with existing modules.
 
 You are spawned by:
 

--- a/plugins/development-harness/agents/integration-checker.md
+++ b/plugins/development-harness/agents/integration-checker.md
@@ -75,8 +75,7 @@ For each module in the feature, extract what it provides and what it should cons
 **From task file, extract:**
 
 ```bash
-# Read task file to get expected outputs (path resolves via dh_paths.plan_dir())
-Read(path="~/.dh/projects/{project-slug}/plan/tasks-{N}-{slug}.md")
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="task-plan")
 ```
 
 **Build provides/consumes map:**

--- a/plugins/development-harness/agents/plan-validator.md
+++ b/plugins/development-harness/agents/plan-validator.md
@@ -10,7 +10,7 @@ color: green
 ---
 
 <role>
-You are a plan validator for Python projects. You verify plans WILL achieve the goal BEFORE execution begins.
+You are a plan validator. You verify plans WILL achieve the goal BEFORE execution begins.
 
 You are spawned by:
 

--- a/plugins/development-harness/agents/plan-validator.md
+++ b/plugins/development-harness/agents/plan-validator.md
@@ -413,7 +413,7 @@ SOURCE: Adapted from gsd-plan-checker.md (Scope Sanity dimension)
 1. Locate the backlog item file:
    - Check the task plan's `issue` frontmatter field for a backlog item path or GitHub issue number
    - If a path is present, read it directly
-   - If a GitHub issue number is present, search `~/.dh/projects/{slug}/backlog/` for a file containing that issue number
+   - If a GitHub issue number is present, retrieve the backlog item via `backlog_view(selector="{issue_number}")`
    - If neither is present, skip this dimension and record as `skipped — no backlog item reference`
 2. Extract the Impact Radius section from the backlog item:
    - Find the section headed `## Impact Radius` or `**Impact Radius**`

--- a/plugins/development-harness/agents/plan-validator.md
+++ b/plugins/development-harness/agents/plan-validator.md
@@ -67,6 +67,107 @@ Same methodology (goal-backward), different timing, different subject matter.
 
 </critical_rules>
 
+<drafting_state_handling>
+
+## Drafting State Handling
+
+Plans created with `tasks_yaml='{tasks: []}'` enter `state="drafting"`. This is an explicit
+intermediate state cleared only by `sam_plan(action='finalize')`. A drafting plan is a valid
+work-in-progress artifact — NOT a malformed or incomplete final plan.
+
+### Decision Table: Drafting vs Ready Validation Modes
+
+| Condition | Plan state | Drafting marker in response | Validation mode | Full dispatchability checks |
+|---|---|---|---|---|
+| Plan under construction | `drafting` | Present | Structural only | Deferred |
+| Plan ready for dispatch | `ready` (or absent) | Absent | Full | Applied |
+| Malformed: finalized but marker still present | `ready` (or absent) | Present | Flag as malformed | N/A — flag error |
+| Malformed: drafting but no marker | `drafting` | Absent | Structural only | Deferred |
+
+### Flowchart: Validation Mode Selection
+
+```text
+Read plan via sam_plan(action='read')
+        |
+        v
+Is state == "drafting"?
+  YES --> Apply Structural-Only checks (see below)
+          Return: STATUS=DRAFTING (not READY/BLOCKED)
+  NO  --> Is drafting marker present in response?
+            YES --> Flag: MALFORMED (non-drafting plan contains drafting marker)
+                    Return: STATUS=BLOCKED with STRUCTURE gap
+            NO  --> Apply Full Dispatchability checks (all dimensions)
+                    Return: STATUS=READY or STATUS=BLOCKED
+```
+
+### Structural-Only Checks (Drafting Plans)
+
+When `state="drafting"`, run ONLY these checks — defer the rest until `finalize` is called:
+
+**Apply:**
+
+- Dimension 3 (Dependency Correctness) on tasks present so far — partial DAG is valid; missing downstream deps are expected
+- Dimension 4 (Agent Capability Match) on tasks present so far
+- Dimension 9 (Architectural Boundary Compliance) on tasks present so far
+
+**Defer until finalized:**
+
+- Dimension 1 (Requirement Coverage) — plan may not yet have all tasks
+- Dimension 2 (Task Completeness) — tasks may still be incomplete stubs
+- Dimension 5 (Input/Output Validity) — downstream outputs may not exist yet
+- Dimension 6 (Artifact Wiring) — connections form as tasks are appended
+- Dimension 7 (Testability) — acceptance criteria may be placeholders
+- Dimension 8 (Scope Sanity) — phase structure incomplete
+- Dimension 10 (Impact Radius Coverage) — plan not yet fully built
+
+### Output: Drafting Status Signal
+
+When a drafting plan passes structural checks:
+
+```text
+STATUS: DRAFTING
+SUMMARY: Plan is in drafting state — structural checks passed on {N} tasks.
+         Full dispatchability checks deferred until sam_plan(action='finalize') is called.
+STRUCTURAL_CHECKS:
+  - Dependency correctness: pass (partial DAG valid)
+  - Agent capability match: pass
+  - Boundary compliance: pass
+DEFERRED_CHECKS:
+  - Requirement coverage, task completeness, input/output validity,
+    artifact wiring, testability, scope sanity, impact radius coverage
+NEXT_STEP: Continue appending tasks. Call finalize when plan construction is complete.
+```
+
+When a drafting plan has structural issues:
+
+```text
+STATUS: BLOCKED
+SUMMARY: Drafting plan has {N} structural issue(s) in current tasks.
+BLOCKERS:
+  1. [dependency] Task {ID}: circular dependency detected even in partial DAG
+     Fix: remove the cycle before appending more tasks
+```
+
+### Malformed Plan Detection
+
+A plan is malformed when `state` is `ready` (or absent) BUT the `sam_plan(action='read')` response
+contains a drafting marker (`{drafting: True}` or `{state: "drafting"}` embedded in the
+plan data).
+
+This indicates `finalize` was never called or the state field was corrupted. Report as:
+
+```text
+STATUS: BLOCKED
+SUMMARY: Plan state is inconsistent — non-drafting plan still contains drafting marker.
+BLOCKERS:
+  1. [STRUCTURE] Plan: state field is absent or 'ready' but drafting marker is present in data.
+     Fix: Call sam_plan(action='finalize') to clear the drafting marker, then re-validate.
+```
+
+SOURCE: Architectural Decision 2 — Drafting State (plan-context artifact #1770, 2026-04-13)
+
+</drafting_state_handling>
+
 <validation_dimensions>
 
 ## Dimension 1: Requirement Coverage

--- a/plugins/development-harness/agents/plan-validator.md
+++ b/plugins/development-harness/agents/plan-validator.md
@@ -71,7 +71,7 @@ Same methodology (goal-backward), different timing, different subject matter.
 
 ## Drafting State Handling
 
-Plans created with `tasks_yaml='{tasks: []}'` enter `state="drafting"`. This is an explicit
+Plans created with `tasks=[]` enter `state="drafting"`. This is an explicit
 intermediate state cleared only by `sam_plan(action='finalize')`. A drafting plan is a valid
 work-in-progress artifact — NOT a malformed or incomplete final plan.
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -7,6 +7,27 @@ skills:
   - dh:clear-cove-task-design
 ---
 
+## Artifact Storage — MCP-native rule
+
+For the task-plan artifact, the canonical registration path is `sam_plan(action='create', issue=<N>)`,
+which AUTO-REGISTERS the task-plan artifact. Do NOT manually call `artifact_register` for the
+`task-plan` artifact type — it is redundant with `sam_plan` auto-registration.
+
+Any secondary documents this agent produces (e.g., critique notes, decomposition rationale)
+SHOULD use `artifact_register(artifact_type="research", content=..., ...)` directly.
+
+    mcp__plugin_dh_backlog__artifact_register(
+        issue_number=<issue>,
+        artifact_type="research",
+        artifact_id="plan/swarm-rationale-<slug>.md",
+        content=<full markdown content>,
+        agent="swarm-task-planner",
+    )
+
+The `content=` parameter is REQUIRED for any artifact you register directly — it stores the
+document as a GitHub issue comment retrievable from any environment. Do NOT write secondary
+documents to disk and do NOT return them inline in your response.
+
 # AI Agent Swarm Coordination Planner
 
 You are an AI agent swarm coordinator specializing in creating execution roadmaps for massively parallel AI agent work. Your role is to transform architectural specifications into dependency-based task plans that enable concurrent agent execution with clear convergence points and quality gates.

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -268,27 +268,29 @@ stale or absent SAM state instead of the actual plan.
 
 Before calling `sam_plan`, estimate the total number of tasks the plan will contain (including bookend tasks T0 and TN when generated).
 
-| Estimated task count | `tasks_yaml` payload | Required path |
-|---|---|---|
-| < 16 tasks | < 20 KB | Monolithic `create` — single call |
-| >= 16 tasks OR payload >= 20 KB | any | Incremental append — three-step sequence |
+| Estimated task count | Required path |
+|---|---|
+| < 16 tasks | Monolithic `create` — single call |
+| >= 16 tasks | Incremental append — three-step sequence |
 
-**Note**: For 16+ task plans, use the incremental path. The monolithic `create` call sends the full `tasks_yaml` payload in a single MCP call; large payloads increase the risk of timeouts mid-call. The incremental path (create empty → append_task × N → finalize) sends one task per call and avoids this. See #1770 for the architectural decision record.
+**Note**: For 16+ task plans, use the incremental path. The monolithic `create` call sends all task objects in a single MCP call; large task lists increase the risk of timeouts mid-call. The incremental path (create empty → append_task × N → finalize) sends one task per call and avoids this. See #1770 for the architectural decision record.
 
-#### Path A — Monolithic create (< 16 tasks, payload < 20 KB)
+#### Path A — Monolithic create (< 16 tasks)
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks_yaml": "{YAML_CONTENT}"})
+mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks": [{task_dict}, ...]})
 ```
 
-#### Path B — Incremental append (>= 16 tasks OR payload >= 20 KB)
+`tasks` is a list of task definition objects. Required fields per object: `id` (str, e.g. `"T01"`), `title` (str). Optional fields: `status` (default `"not-started"`), `agent` (str), `dependencies` (list of task ID strings), `priority` (int 1–5), `complexity` (`"low"`, `"medium"`, or `"high"`).
+
+#### Path B — Incremental append (>= 16 tasks)
 
 Execute the three-step sequence in order:
 
 **Step 1** — Create a drafting plan with an empty task list:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks_yaml": "{tasks: []}"})
+mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks": []})
 ```
 
 Record the returned plan ID (e.g., `Pa1b2c3d4`). The plan enters `state="drafting"` — `sam_plan status` and `sam_plan ready` return a drafting marker instead of task counts until Step 3. This prevents the dispatch loop from seeing a partial plan.
@@ -299,7 +301,7 @@ Record the returned plan ID (e.g., `Pa1b2c3d4`). The plan enters `state="draftin
 mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "append_task", "task": {task_dict}})
 ```
 
-`task_dict` is a JSON object matching the `TaskDefinition` model shape. Required fields: `id` (str, e.g. `"T01"`), `title` (str). Optional fields: `status` (default `"not-started"`), `agent` (str), `dependencies` (list of task ID strings), `priority` (int 1–5), `complexity` (`"low"`, `"medium"`, or `"high"`). The MCP schema self-describes all available fields — pass a dict, not a YAML string. Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
+`task_dict` is a JSON object matching the `TaskDefinition` model shape. Required fields: `id` (str, e.g. `"T01"`), `title` (str). Optional fields: `status` (default `"not-started"`), `agent` (str), `dependencies` (list of task ID strings), `priority` (int 1–5), `complexity` (`"low"`, `"medium"`, or `"high"`). Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
 
 **Step 3** — Finalize the plan (clears drafting state, makes the plan visible to the dispatch loop):
 
@@ -309,7 +311,7 @@ mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "finalize"})
 
 After `finalize` succeeds, the plan transitions from `state="drafting"` to `state="ready"`.
 
-**Creating the plan file**: Generate task definitions as YAML, then call `sam_plan` using the appropriate path above.
+**Creating the plan file**: Build task definitions as typed objects, then call `sam_plan` using the appropriate path above.
 
 After `sam_plan` succeeds, the plan ID returned (e.g., `Pa1b2c3d4`) is the canonical reference for
 all downstream tools. Record it and pass it to the plan-validator and any other consumers.

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -375,7 +375,7 @@ Run all structured acceptance criteria commands and record baseline results via 
 ## Requirements
 1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
 2. Record exit code, stdout, stderr, and timestamp per criterion
-3. Register results via `artifact_register(issue_number, type="T0-baseline", content=..., status="complete", agent="t0-baseline-capture")`
+3. Register results via `artifact_register(issue_number, artifact_type="T0-baseline", content=..., status="complete", agent="t0-baseline-capture")`
 
 ## Expected Outputs
 - T0-baseline artifact registered and retrievable via `artifact_read(issue_number, "T0-baseline")`
@@ -417,7 +417,7 @@ Re-run acceptance criteria and compare against T0 baseline; register verdict via
 ## Requirements
 1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
 2. Compare exit code against T0 baseline using the 4-cell status matrix
-3. Assemble per-criterion verdict and overall verdict in memory; register via `artifact_register(issue_number, type="TN-verification", content=...)`
+3. Assemble per-criterion verdict and overall verdict in memory; register via `artifact_register(issue_number, artifact_type="TN-verification", content=...)`
 4. Overall verdict is PASS only when no criterion has status `regressed`
 
 ## Expected Outputs

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -5,20 +5,8 @@ tools: Read, Write, Edit, Glob, Grep, TodoWrite, Skill, mcp__Ref__ref_search_doc
 model: opus
 skills:
   - dh:clear-cove-task-design
+  - dh:create-artifact
 ---
-
-## Artifact Storage
-
-For the task-plan artifact, `sam_plan(action='create', issue=<N>)` AUTO-REGISTERS it.
-Do NOT manually call `artifact_register` for `task-plan` — it is redundant.
-
-When your task produces secondary documents (critique notes, decomposition rationale), register
-them via the `/dh:create-artifact` skill:
-
-    Skill(skill="dh:create-artifact")
-
-The skill describes the correct MCP-native invocation pattern. Do NOT write secondary documents
-to disk and do NOT return them inline in your response.
 
 # AI Agent Swarm Coordination Planner
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -6,13 +6,12 @@ model: opus
 skills:
   - dh:clear-cove-task-design
   - dh:create-artifact
+  - python-engineering:specialist-skill-routing
 ---
 
 # AI Agent Swarm Coordination Planner
 
 You are an AI agent swarm coordinator specializing in creating execution roadmaps for massively parallel AI agent work. Your role is to transform architectural specifications into dependency-based task plans that enable concurrent agent execution with clear convergence points and quality gates.
-
-Before starting your task, activate `Skill(skill="python-engineering:specialist-skill-routing")`.
 
 This agent writes plans for AI worker agents. Plans must contain task prompts that are unambiguous, verifiable, and resistant to hallucination. Use CLEAR (Concise, Logical, Explicit, Adaptive, Reflective) as the canonical task writing standard, and apply CoVe (Chain of Verification) selectively when accuracy risk is meaningful.
 
@@ -297,10 +296,10 @@ Record the returned plan ID (e.g., `Pa1b2c3d4`). The plan enters `state="draftin
 **Step 2** — Append each task individually (repeat N times, one call per task):
 
 ```text
-mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "append_task", "task_yaml": "{SINGLE_TASK_YAML}"})
+mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "append_task", "task_yaml": "{task_definition}"})
 ```
 
-`SINGLE_TASK_YAML` is the YAML block for one task only. Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
+`task_definition` is the YAML content for one task only — the value passed to `AppendTaskConfig.task_yaml` (the current API field; see backlog item #1775 for the planned typed `TaskDefinition` replacement). Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
 
 **Step 3** — Finalize the plan (clears drafting state, makes the plan visible to the dispatch loop):
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -367,7 +367,7 @@ skills: []
 T0 runs before any implementation work. It captures the current pass/fail state of every structured acceptance criterion so TN can detect regressions after implementation.
 
 ## Objective
-Run all structured acceptance criteria commands and record baseline results in `dh_paths.plan_dir() / "T0-baseline-{slug}.yaml"`.
+Run all structured acceptance criteria commands and record baseline results via `artifact_register`.
 
 ## Inputs
 - Plan file: the task file containing `acceptance-criteria-structured` entries
@@ -375,17 +375,17 @@ Run all structured acceptance criteria commands and record baseline results in `
 ## Requirements
 1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
 2. Record exit code, stdout, stderr, and timestamp per criterion
-3. Write results to `dh_paths.plan_dir() / "T0-baseline-{slug}.yaml"` (one entry per criterion)
+3. Register results via `artifact_register(issue_number, type="T0-baseline", content=..., status="complete", agent="t0-baseline-capture")`
 
 ## Expected Outputs
-- `~/.dh/projects/{project-slug}/plan/T0-baseline-{slug}.yaml`
+- T0-baseline artifact registered and retrievable via `artifact_read(issue_number, "T0-baseline")`
 
 ## Acceptance Criteria
-1. `~/.dh/projects/{project-slug}/plan/T0-baseline-{slug}.yaml` exists
-2. File contains one entry per structured criterion with exit code, stdout, stderr, timestamp
+1. `artifact_read(issue_number, "T0-baseline")` returns content
+2. Content contains one entry per structured criterion with exit code, stdout, stderr, timestamp
 
 ## Verification Steps
-1. Read `dh_paths.plan_dir() / "T0-baseline-{slug}.yaml"` and confirm `criteria_count` matches plan
+1. Call `artifact_read(issue_number, "T0-baseline")` and confirm `criteria_count` matches plan
 ```
 
 ### TN Task Template
@@ -408,27 +408,27 @@ skills: []
 TN runs after all implementation tasks complete. It re-runs every structured acceptance criterion and compares results against the T0 baseline to detect regressions.
 
 ## Objective
-Re-run acceptance criteria and compare against T0 baseline; write verdict to `dh_paths.plan_dir() / "TN-verification-{slug}.yaml"`.
+Re-run acceptance criteria and compare against T0 baseline; register verdict via `artifact_register`.
 
 ## Inputs
 - Plan file: the task file containing `acceptance-criteria-structured` entries
-- T0 baseline: `dh_paths.plan_dir() / "T0-baseline-{slug}.yaml"`
+- T0 baseline: retrieved via `artifact_read(issue_number, "T0-baseline")`
 
 ## Requirements
 1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
 2. Compare exit code against T0 baseline using the 4-cell status matrix
-3. Write per-criterion verdict and overall verdict to `dh_paths.plan_dir() / "TN-verification-{slug}.yaml"`
+3. Assemble per-criterion verdict and overall verdict in memory; register via `artifact_register(issue_number, type="TN-verification", content=...)`
 4. Overall verdict is PASS only when no criterion has status `regressed`
 
 ## Expected Outputs
-- `~/.dh/projects/{project-slug}/plan/TN-verification-{slug}.yaml`
+- TN-verification artifact registered on the issue via `artifact_register`
 
 ## Acceptance Criteria
-1. `~/.dh/projects/{project-slug}/plan/TN-verification-{slug}.yaml` exists with overall `verdict: PASS`
+1. TN-verification artifact registered with overall `verdict: PASS`
 2. No criterion has status `regressed`
 
 ## Verification Steps
-1. Read `dh_paths.plan_dir() / "TN-verification-{slug}.yaml"` and confirm `verdict` is `PASS`
+1. Read TN-verification artifact via `artifact_read(issue_number, "TN-verification")` and confirm `verdict` is `PASS`
 ```
 
 ### Dependency Rule

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -285,11 +285,52 @@ cannot locate — the plan-validator reads exclusively from SAM (`sam_plan(actio
 from the filesystem. Disk-only writes cause false BLOCKED results because the validator reads
 stale or absent SAM state instead of the actual plan.
 
-**Creating the plan file**: Generate task definitions as YAML, then call `sam_plan(action='create')`:
+### Plan Creation Path Selection
+
+Before calling `sam_plan`, estimate the total number of tasks the plan will contain (including bookend tasks T0 and TN when generated).
+
+| Estimated task count | `tasks_yaml` payload | Required path |
+|---|---|---|
+| < 16 tasks | < 20 KB | Monolithic `create` — single call |
+| >= 16 tasks OR payload >= 20 KB | any | Incremental append — three-step sequence |
+
+**Self-note**: `swarm-task-planner` itself produces large `tasks_yaml` payloads for complex feature plans. For 16+ task plans, the monolithic `create` call risks a streaming stall mid-emission — the exact failure mode documented in #1770. Use the incremental path for your own output to avoid this.
+
+#### Path A — Monolithic create (< 16 tasks, payload < 20 KB)
 
 ```text
 mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks_yaml": "{YAML_CONTENT}"})
 ```
+
+#### Path B — Incremental append (>= 16 tasks OR payload >= 20 KB)
+
+Execute the three-step sequence in order:
+
+**Step 1** — Create a drafting plan with an empty task list:
+
+```text
+mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks_yaml": "{tasks: []}"})
+```
+
+Record the returned plan ID (e.g., `P1770`). The plan enters `state="drafting"` — `sam_plan status` and `sam_plan ready` return a drafting marker instead of task counts until Step 3. This prevents the dispatch loop from seeing a partial plan.
+
+**Step 2** — Append each task individually (repeat N times, one call per task):
+
+```text
+mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "append_task", "task_yaml": "{SINGLE_TASK_YAML}"})
+```
+
+`SINGLE_TASK_YAML` is the YAML block for one task only. Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
+
+**Step 3** — Finalize the plan (clears drafting state, makes the plan visible to the dispatch loop):
+
+```text
+mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "finalize"})
+```
+
+After `finalize` succeeds, the plan transitions from `state="drafting"` to `state="ready"`.
+
+**Creating the plan file**: Generate task definitions as YAML, then call `sam_plan` using the appropriate path above.
 
 After `sam_plan` succeeds, the plan ID returned (e.g., `Pd7e8f9a0`) is the canonical reference for
 all downstream tools. Record it and pass it to the plan-validator and any other consumers.

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -7,26 +7,18 @@ skills:
   - dh:clear-cove-task-design
 ---
 
-## Artifact Storage — MCP-native rule
+## Artifact Storage
 
-For the task-plan artifact, the canonical registration path is `sam_plan(action='create', issue=<N>)`,
-which AUTO-REGISTERS the task-plan artifact. Do NOT manually call `artifact_register` for the
-`task-plan` artifact type — it is redundant with `sam_plan` auto-registration.
+For the task-plan artifact, `sam_plan(action='create', issue=<N>)` AUTO-REGISTERS it.
+Do NOT manually call `artifact_register` for `task-plan` — it is redundant.
 
-Any secondary documents this agent produces (e.g., critique notes, decomposition rationale)
-SHOULD use `artifact_register(artifact_type="research", content=..., ...)` directly.
+When your task produces secondary documents (critique notes, decomposition rationale), register
+them via the `/dh:create-artifact` skill:
 
-    mcp__plugin_dh_backlog__artifact_register(
-        issue_number=<issue>,
-        artifact_type="research",
-        artifact_id="plan/swarm-rationale-<slug>.md",
-        content=<full markdown content>,
-        agent="swarm-task-planner",
-    )
+    Skill(skill="dh:create-artifact")
 
-The `content=` parameter is REQUIRED for any artifact you register directly — it stores the
-document as a GitHub issue comment retrievable from any environment. Do NOT write secondary
-documents to disk and do NOT return them inline in your response.
+The skill describes the correct MCP-native invocation pattern. Do NOT write secondary documents
+to disk and do NOT return them inline in your response.
 
 # AI Agent Swarm Coordination Planner
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -274,7 +274,7 @@ Before calling `sam_plan`, estimate the total number of tasks the plan will cont
 | < 16 tasks | < 20 KB | Monolithic `create` — single call |
 | >= 16 tasks OR payload >= 20 KB | any | Incremental append — three-step sequence |
 
-**Self-note**: `swarm-task-planner` itself produces large `tasks_yaml` payloads for complex feature plans. For 16+ task plans, the monolithic `create` call risks a streaming stall mid-emission — the exact failure mode documented in #1770. Use the incremental path for your own output to avoid this.
+**Note**: For 16+ task plans, use the incremental path. The monolithic `create` call sends the full `tasks_yaml` payload in a single MCP call; large payloads increase the risk of timeouts mid-call. The incremental path (create empty → append_task × N → finalize) sends one task per call and avoids this. See #1770 for the architectural decision record.
 
 #### Path A — Monolithic create (< 16 tasks, payload < 20 KB)
 
@@ -292,7 +292,7 @@ Execute the three-step sequence in order:
 mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks_yaml": "{tasks: []}"})
 ```
 
-Record the returned plan ID (e.g., `P1770`). The plan enters `state="drafting"` — `sam_plan status` and `sam_plan ready` return a drafting marker instead of task counts until Step 3. This prevents the dispatch loop from seeing a partial plan.
+Record the returned plan ID (e.g., `Pa1b2c3d4`). The plan enters `state="drafting"` — `sam_plan status` and `sam_plan ready` return a drafting marker instead of task counts until Step 3. This prevents the dispatch loop from seeing a partial plan.
 
 **Step 2** — Append each task individually (repeat N times, one call per task):
 
@@ -312,7 +312,7 @@ After `finalize` succeeds, the plan transitions from `state="drafting"` to `stat
 
 **Creating the plan file**: Generate task definitions as YAML, then call `sam_plan` using the appropriate path above.
 
-After `sam_plan` succeeds, the plan ID returned (e.g., `Pd7e8f9a0`) is the canonical reference for
+After `sam_plan` succeeds, the plan ID returned (e.g., `Pa1b2c3d4`) is the canonical reference for
 all downstream tools. Record it and pass it to the plan-validator and any other consumers.
 PLAN.md / PLAN/ disk files are optional human-readable summaries — they do not replace SAM
 registration and must never be written as the only plan artifact.

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -296,10 +296,10 @@ Record the returned plan ID (e.g., `Pa1b2c3d4`). The plan enters `state="draftin
 **Step 2** — Append each task individually (repeat N times, one call per task):
 
 ```text
-mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "append_task", "task_yaml": "{task_definition}"})
+mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "append_task", "task": {task_dict}})
 ```
 
-`task_definition` is the YAML content for one task only — the value passed to `AppendTaskConfig.task_yaml` (the current API field; see backlog item #1775 for the planned typed `TaskDefinition` replacement). Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
+`task_dict` is a JSON object matching the `TaskDefinition` model shape. Required fields: `id` (str, e.g. `"T01"`), `title` (str). Optional fields: `status` (default `"not-started"`), `agent` (str), `dependencies` (list of task ID strings), `priority` (int 1–5), `complexity` (`"low"`, `"medium"`, or `"high"`). The MCP schema self-describes all available fields — pass a dict, not a YAML string. Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
 
 **Step 3** — Finalize the plan (clears drafting state, makes the plan visible to the dispatch loop):
 

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -39,13 +39,13 @@ The `issue_number` and plan path are provided in your task delegation prompt. Th
 Retrieve T0 baseline and read plan file:
 
 ```bash
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="T0-baseline")
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="task-plan")
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="T0-baseline")
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="task-plan")
 ```
 
 Parse the content returned by `artifact_read` as YAML to extract the T0 results.
 
-If `artifact_read` returns an error or empty result for type `T0-baseline`, return STATUS: BLOCKED with: "T0 baseline not found — `artifact_read(issue_number={issue_number}, type='T0-baseline')` returned no content. T0 agent must run first."
+If `artifact_read` returns an error or empty result for type `T0-baseline`, return STATUS: BLOCKED with: "T0 baseline not found — `artifact_read(issue_number={issue_number}, artifact_type='T0-baseline')` returned no content. T0 agent must run first."
 
 ## Step 2: Re-Run Each Check Command
 

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -32,7 +32,7 @@ You are the TN verification gate agent. You run after all implementation tasks a
 You need two inputs:
 
 1. **T0 baseline**: Retrieved via `artifact_read(issue_number, "T0-baseline")` — stored by the T0 agent as a GitHub issue comment artifact
-2. **Plan file**: `~/.dh/projects/{project-slug}/plan/tasks-{N}-{slug}.md` — to re-read `acceptance_criteria_structured`
+2. **Plan file**: retrieved via `artifact_read(issue_number, "task-plan")` — to re-read `acceptance_criteria_structured`
 
 The `issue_number` and plan path are provided in your task delegation prompt. The slug is inferred from the T0 baseline's `feature` field after retrieval.
 
@@ -40,7 +40,7 @@ Retrieve T0 baseline and read plan file:
 
 ```bash
 mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="T0-baseline")
-Read(file_path=str(dh_paths.plan_dir() / "tasks-{N}-{slug}.md"))
+mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, type="task-plan")
 ```
 
 Parse the content returned by `artifact_read` as YAML to extract the T0 results.

--- a/plugins/development-harness/docs/TASK_FILE_FORMAT.md
+++ b/plugins/development-harness/docs/TASK_FILE_FORMAT.md
@@ -19,15 +19,15 @@ discriminated union `config` parameter where `action` selects the operation.
 **sam_task** — task-scoped operations (requires `plan` and `task`):
 
 ```text
-mcp__plugin_dh_sam__sam_task(plan="P{N}", task="T{M}", config={"action":"read"})
+mcp__plugin_dh_sam__sam_task(plan="P{id}", task="T{M}", config={"action":"read"})
     -- Read task (returns TaskAssignment with plan context + task fields)
-mcp__plugin_dh_sam__sam_task(plan="P{N}", task="T{M}", config={"action":"claim"})
+mcp__plugin_dh_sam__sam_task(plan="P{id}", task="T{M}", config={"action":"claim"})
     -- Claim task (transition from not-started to in-progress)
-mcp__plugin_dh_sam__sam_task(plan="P{N}", task="T{M}", config={"action":"state","status":"complete"})
+mcp__plugin_dh_sam__sam_task(plan="P{id}", task="T{M}", config={"action":"state","status":"complete"})
     -- Transition task status (complete | blocked | deferred | skipped)
-mcp__plugin_dh_sam__sam_task(plan="P{N}", task="T{M}", config={"action":"update","set_fields_json":"{...}"})
+mcp__plugin_dh_sam__sam_task(plan="P{id}", task="T{M}", config={"action":"update","set_fields_json":"{...}"})
     -- Patch task fields (JSON object {"field": "value", ...})
-mcp__plugin_dh_sam__sam_task(plan="P{N}", task="T{M}", config={"action":"update","append_section":"Heading","section_content":"..."})
+mcp__plugin_dh_sam__sam_task(plan="P{id}", task="T{M}", config={"action":"update","append_section":"Heading","section_content":"..."})
     -- Append a markdown section to the task body
 ```
 
@@ -40,19 +40,19 @@ mcp__plugin_dh_sam__sam_plan(config={"action":"list","search":"text"})
     -- List plans with case-insensitive substring filter
 mcp__plugin_dh_sam__sam_plan(config={"action":"create","slug":"...","goal":"...","tasks_yaml":"..."})
     -- Create a new plan from YAML task definitions
-mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"read"})
+mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"read"})
     -- Read plan summary (Plan fields)
-mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"status"})
+mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"status"})
     -- Plan progress summary (task counts, completion %)
-mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"ready"})
+mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"ready"})
     -- List tasks ready for dispatch (not-started, all deps resolved)
-mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"update","context":"..."})
+mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"update","context":"..."})
     -- Update plan context field
-mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"update","set_fields_json":"{...}"})
+mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"update","set_fields_json":"{...}"})
     -- Patch plan-level fields
-mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"append_task","task_yaml":"<single-task YAML string>"})
+mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"append_task","task_yaml":"<single-task YAML string>"})
     -- Append a single task to a drafting plan (plan must be in state="drafting")
-mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"finalize"})
+mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"finalize"})
     -- Finalize a drafting plan: clear state="drafting" → state="ready", making tasks dispatchable
 ```
 
@@ -65,12 +65,12 @@ three-call incremental workflow instead of a single monolithic `create` call:
 1. sam_plan(action='create', tasks_yaml='{tasks: []}')
    -- Creates a plan in state="drafting". Returns plan_id (e.g. "Pd9e0f1a2").
 
-2. sam_plan(plan='P{N}', action='append_task', task_yaml=<single task YAML>) × N
+2. sam_plan(plan='P{id}', action='append_task', task_yaml=<single task YAML>) × N
    -- Appends one task at a time. Each call validates the task via Task.model_validate().
    -- state remains "drafting" throughout. Callers must serialize writes (single-writer
       assumption — concurrent append_task calls for the same plan are not safe).
 
-3. sam_plan(plan='P{N}', action='finalize')
+3. sam_plan(plan='P{id}', action='finalize')
    -- Clears state="drafting" → state="ready". Plan is now visible to sam_plan ready/status.
 ```
 
@@ -92,7 +92,7 @@ This prevents partial plans from being dispatched before all tasks have been app
 **sam_active_task** — session-scoped active task context:
 
 ```text
-mcp__plugin_dh_sam__sam_active_task(config={"action":"set","plan":"P{N}","task":"T{M}"})
+mcp__plugin_dh_sam__sam_active_task(config={"action":"set","plan":"P{id}","task":"T{M}"})
     -- Register active task for current session (replaces direct active-task-{sid}.json writes)
 mcp__plugin_dh_sam__sam_active_task(config={"action":"get"})
     -- Retrieve active task context for current session
@@ -133,18 +133,18 @@ The following 8 tools are replaced by the 3-tool interface above. They return a
 When MCP is unavailable, use the `uv run sam` CLI:
 
 ```bash
-uv run sam list                                    # List all plans
-uv run sam list --search "my-feature"              # List with search filter
+uv run sam list                                      # List all plans
+uv run sam list --search "my-feature"                # List with search filter
 echo "$YAML" | uv run sam create {slug} --goal "..." --stdin  # Create plan
-uv run sam read P{N} --format json                 # Read plan summary
-uv run sam read P{N}/T{M} --format json            # Read task (TaskAssignment)
-uv run sam update P{N} --context "..."             # Update plan context
-uv run sam state P{N}/T{M} {status}                # Transition task status
-uv run sam claim P{N}/T{M}                         # Claim a task
-uv run sam ready P{N} --format json                # List ready tasks
-uv run sam status P{N}                             # Plan progress summary
-uv run sam validate P{N} --format json             # Validate plan (CLI only)
-uv run sam migrate tasks-{N}-{slug}.md             # Migrate legacy format (CLI only)
+uv run sam read P{id} --format json                  # Read plan summary (e.g. Pc7d8e9f0)
+uv run sam read P{id}/T{M} --format json             # Read task (e.g. Pc7d8e9f0/T04)
+uv run sam update P{id} --context "..."              # Update plan context
+uv run sam state P{id}/T{M} {status}                 # Transition task status
+uv run sam claim P{id}/T{M}                          # Claim a task
+uv run sam ready P{id} --format json                 # List ready tasks
+uv run sam status P{id}                              # Plan progress summary
+uv run sam validate P{id} --format json              # Validate plan (CLI only)
+uv run sam migrate tasks-{N}-{slug}.md               # Migrate legacy format (CLI only)
 ```
 
 ---
@@ -401,13 +401,13 @@ Task metadata fields are owned by specific components. The SAM MCP server and `s
 | Field | Written By | Via |
 |-------|-----------|-----|
 | All task fields at creation | `swarm-task-planner` agent | `sam create {slug} --goal "..." --stdin` |
-| `status: in-progress`, `started` | `start-task` skill | `sam claim P{N}/T{M}` |
-| `status: complete`, `completed` | `task_status_hook.py` SubagentStop handler | `sam state P{N}/T{M} complete` |
-| `status: blocked` | Agent or human operator | `sam state P{N}/T{M} blocked` |
+| `status: in-progress`, `started` | `start-task` skill | `sam claim P{id}/T{M}` (e.g. `Pc7d8e9f0/T04`) |
+| `status: complete`, `completed` | `task_status_hook.py` SubagentStop handler | `sam state P{id}/T{M} complete` |
+| `status: blocked` | Agent or human operator | `sam state P{id}/T{M} blocked` |
 | `last-activity` | `task_status_hook.py` PostToolUse handler | `sam_schema` API — skipped if status is `complete` |
-| `context` | `context-gathering` agent | `sam update P{N} --context "..."` |
-| Plan metadata | orchestrator or `add-new-feature` skill | `sam update P{N} --set field=value` |
-| `divergence-notes`, body sections | executing agent via `start-task` skill | `sam update P{N}/T{M} --append-section "..."` |
+| `context` | `context-gathering` agent | `sam update P{id} --context "..."` |
+| Plan metadata | orchestrator or `add-new-feature` skill | `sam update P{id} --set field=value` |
+| `divergence-notes`, body sections | executing agent via `start-task` skill | `sam update P{id}/T{M} --append-section "..."` |
 
 ### Field Ownership Rules
 

--- a/plugins/development-harness/docs/TASK_FILE_FORMAT.md
+++ b/plugins/development-harness/docs/TASK_FILE_FORMAT.md
@@ -50,7 +50,44 @@ mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"update","context":".
     -- Update plan context field
 mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"update","set_fields_json":"{...}"})
     -- Patch plan-level fields
+mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"append_task","task_yaml":"<single-task YAML string>"})
+    -- Append a single task to a drafting plan (plan must be in state="drafting")
+mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"finalize"})
+    -- Finalize a drafting plan: clear state="drafting" → state="ready", making tasks dispatchable
 ```
+
+#### Incremental Append Workflow
+
+For large plans (rule of thumb: 16+ tasks or `tasks_yaml` payload exceeding ~20 KB), use the
+three-call incremental workflow instead of a single monolithic `create` call:
+
+```text
+1. sam_plan(action='create', tasks_yaml='{tasks: []}')
+   -- Creates a plan in state="drafting". Returns plan_id (e.g. "Pd9e0f1a2").
+
+2. sam_plan(plan='P{N}', action='append_task', task_yaml=<single task YAML>) × N
+   -- Appends one task at a time. Each call validates the task via Task.model_validate().
+   -- state remains "drafting" throughout. Callers must serialize writes (single-writer
+      assumption — concurrent append_task calls for the same plan are not safe).
+
+3. sam_plan(plan='P{N}', action='finalize')
+   -- Clears state="drafting" → state="ready". Plan is now visible to sam_plan ready/status.
+```
+
+**Drafting state semantics**: While a plan is in `state="drafting"`:
+
+- `sam_plan(action='read')` returns the plan with the drafting marker (`{state: "drafting"}` or `{drafting: True}`)
+- `sam_plan(action='status')` returns the drafting marker instead of task counts
+- `sam_plan(action='ready')` returns the drafting marker instead of a ready-tasks list
+
+This prevents partial plans from being dispatched before all tasks have been appended.
+
+**When to choose incremental vs monolithic**:
+
+| Condition | Recommendation |
+|-----------|---------------|
+| < 16 tasks and `tasks_yaml` < ~20 KB | Monolithic `create` (single call) |
+| 16+ tasks or `tasks_yaml` > ~20 KB | Incremental: `create` → `append_task` × N → `finalize` |
 
 **sam_active_task** — session-scoped active task context:
 

--- a/plugins/development-harness/docs/TASK_FILE_FORMAT.md
+++ b/plugins/development-harness/docs/TASK_FILE_FORMAT.md
@@ -176,7 +176,7 @@ Pc7d8e9f0/T04     -- task T04 in plan Pc7d8e9f0
 my-slug/T1        -- task T1 in plan matching slug "my-slug"
 ```
 
-`sam read P1/T3` globs the plan directory under `dh_paths.plan_dir()` for `P{id}-*/` and finds `T03.yaml` (or the T03 section in a single-file plan).
+`sam read Pc7d8e9f0/T3` globs the plan directory under `dh_paths.plan_dir()` for `P{id}-*/` and finds `T03.yaml` (or the T03 section in a single-file plan). Plans created by `sam_plan(action='create')` have UUID-hex IDs (8 hex chars, e.g. `Pc7d8e9f0`); legacy numeric IDs (`P1`, `P42`) exist only for unmigrated plans created before this naming scheme.
 
 ### Legacy Names
 

--- a/plugins/development-harness/docs/TASK_FILE_FORMAT.md
+++ b/plugins/development-harness/docs/TASK_FILE_FORMAT.md
@@ -38,8 +38,8 @@ mcp__plugin_dh_sam__sam_plan(config={"action":"list"})
     -- List all plans
 mcp__plugin_dh_sam__sam_plan(config={"action":"list","search":"text"})
     -- List plans with case-insensitive substring filter
-mcp__plugin_dh_sam__sam_plan(config={"action":"create","slug":"...","goal":"...","tasks_yaml":"..."})
-    -- Create a new plan from YAML task definitions
+mcp__plugin_dh_sam__sam_plan(config={"action":"create","slug":"...","goal":"...","tasks":[...]})
+    -- Create a new plan from a list of task definition objects
 mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"read"})
     -- Read plan summary (Plan fields)
 mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"status"})
@@ -58,14 +58,14 @@ mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"finalize"})
 
 #### Incremental Append Workflow
 
-For large plans (rule of thumb: 16+ tasks or `tasks_yaml` payload exceeding ~20 KB), use the
-three-call incremental workflow instead of a single monolithic `create` call:
+For large plans (rule of thumb: 16+ tasks), use the three-call incremental workflow instead of a
+single monolithic `create` call:
 
 ```text
-1. sam_plan(action='create', tasks_yaml='{tasks: []}')
+1. sam_plan(action='create', tasks=[])
    -- Creates a plan in state="drafting". Returns plan_id (e.g. "Pd9e0f1a2").
 
-2. sam_plan(plan='P{id}', action='append_task', task_yaml=<single task YAML>) × N
+2. sam_plan(plan='P{id}', action='append_task', task=<single task dict>) × N
    -- Appends one task at a time. Each call validates the task via Task.model_validate().
    -- state remains "drafting" throughout. Callers must serialize writes (single-writer
       assumption — concurrent append_task calls for the same plan are not safe).
@@ -86,8 +86,8 @@ This prevents partial plans from being dispatched before all tasks have been app
 
 | Condition | Recommendation |
 |-----------|---------------|
-| < 16 tasks and `tasks_yaml` < ~20 KB | Monolithic `create` (single call) |
-| 16+ tasks or `tasks_yaml` > ~20 KB | Incremental: `create` → `append_task` × N → `finalize` |
+| < 16 tasks | Monolithic `create` (single call with `tasks=[...]`) |
+| 16+ tasks | Incremental: `create(tasks=[])` → `append_task` × N → `finalize` |
 
 **sam_active_task** — session-scoped active task context:
 

--- a/plugins/development-harness/docs/TASK_FILE_FORMAT.md
+++ b/plugins/development-harness/docs/TASK_FILE_FORMAT.md
@@ -51,7 +51,7 @@ mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"update","context":"
 mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"update","set_fields_json":"{...}"})
     -- Patch plan-level fields
 mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"append_task","task_yaml":"<single-task YAML string>"})
-    -- Append a single task to a drafting plan (plan must be in state="drafting")
+    -- Append a single task to a plan in state="drafting"; backends do not enforce the drafting precondition
 mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action":"finalize"})
     -- Finalize a drafting plan: clear state="drafting" → state="ready", making tasks dispatchable
 ```

--- a/plugins/development-harness/docs/adrs/ADR-1770-1-single-writer-task-backend.md
+++ b/plugins/development-harness/docs/adrs/ADR-1770-1-single-writer-task-backend.md
@@ -1,0 +1,87 @@
+# ADR-1770-1: Single-Writer Contract for TaskBackend.append_task and finalize_plan
+
+**Status:** Accepted
+**Date:** 2026-04-13
+**Issue:** [#1770](https://github.com/Jamie-BitFlight/claude_skills/issues/1770)
+
+## Context
+
+The `TaskBackend` Protocol defines two mutating operations that involve a
+read-modify-write cycle on the same plan document:
+
+- `append_task(plan_id, task)` — loads the plan, checks for duplicate IDs,
+  appends the task, and writes back.
+- `finalize_plan(plan_id)` — loads the plan, sets `state = "ready"`, writes back.
+
+All three concrete backends (`InMemoryTaskProvider`, `LocalYamlTaskProvider`,
+`GitHubTaskProvider`) implement these as non-atomic read-modify-write sequences.
+Under concurrent writes from multiple callers, the last write wins and earlier
+writes are silently lost.
+
+## Decision
+
+`TaskBackend.append_task` and `TaskBackend.finalize_plan` operate under a
+**single-writer contract**: the caller is responsible for ensuring that at most
+one writer operates on a given plan at any point in time. Backends are NOT
+required to detect, reject, or recover from concurrent writes. Behavior under
+concurrent writes to the same plan is **undefined**.
+
+This is the correct trade-off for the current architecture because:
+
+1. **SAM plans are authored sequentially.** The incremental build flow
+   (`create → append_task × N → finalize`) is orchestrated by a single session.
+   The orchestrator controls sequencing.
+
+2. **The complexity cost of distributed locking is not justified.** Adding
+   file-locking (`fcntl.flock`), YAML-level version fields, or optimistic
+   concurrency control would triple the implementation complexity of
+   `local_yaml.py` and require GitHub Issue etags for `github_task.py`. The
+   defect this would prevent (two orchestrators appending to the same plan
+   simultaneously) is not a realistic scenario in the current deployment model.
+
+3. **Backends cannot reliably enumerate callers.** The memory backend has no
+   IPC; the YAML backend has no process-safe advisory lock API across platforms;
+   the GitHub backend relies on the GitHub API which has its own eventual
+   consistency guarantees.
+
+## Consequences
+
+- **Callers must serialize writes.** Any code that calls `append_task` or
+  `finalize_plan` on the same plan from multiple threads or processes must
+  provide external coordination (e.g., process-level scheduling, task queue).
+- **Docstrings must state the contract.** Every `append_task` and
+  `finalize_plan` implementation must include the single-writer warning and
+  reference this ADR.
+- **The contract is centralized.** The `validate_appended_task` helper in
+  `sam_schema.core.backends._utils` performs the duplicate-ID check that all
+  three backends share, providing a single place to update if the contract
+  changes.
+- **Future backends must honour the contract.** Any new `TaskBackend`
+  implementation must document whether it provides stronger guarantees. If it
+  does not, it must state the single-writer assumption in its docstring and
+  reference this ADR.
+
+## Alternatives Considered
+
+### File-level locking (fcntl.flock)
+
+Rejected. Platform-specific (not available on Windows); does not protect against
+concurrent writes from separate machines; requires cleanup on crash.
+
+### Optimistic concurrency control (YAML version fields)
+
+Rejected. Would require callers to catch `ConflictError` and retry, adding
+significant complexity to the server layer. No current caller has a retry loop.
+
+### GitHub API etags
+
+Rejected. The GitHub REST API does not expose etags on Issue update responses in
+a way that maps cleanly to our update flow. GraphQL mutations do not support
+conditional updates.
+
+## References
+
+- Issue #1770: Incremental plan build pattern (create → append_task × N → finalize)
+- `sam_schema.core.backends._utils.validate_appended_task` — shared duplicate-ID check
+- `sam_schema.core.task_backend.TaskBackend.append_task` — Protocol docstring
+- `sam_schema.core.task_backend.TaskBackend.finalize_plan` — Protocol docstring

--- a/plugins/development-harness/docs/backend-providers.md
+++ b/plugins/development-harness/docs/backend-providers.md
@@ -167,7 +167,17 @@ All protocol methods are synchronous. The MCP layer wraps calls in `asyncio.to_t
 
 - **Plan lifecycle**: `create_plan`, `read_plan`, `list_plans`, `update_plan_fields`
 - **Task access**: `read_task`, `claim_task`, `update_task_status`, `update_task_fields`, `append_task_section`, `get_ready_tasks`, `get_plan_status`
+- **Incremental append**: `append_task`, `finalize_plan`
 - **Documents**: `store_document`, `read_document`
+
+`append_task` adds a single validated task to a plan that is in `state="drafting"`. The method
+validates the task via `Task.model_validate()` before writing. **Single-writer assumption**:
+`append_task` is NOT required to be atomic under concurrent writers. Callers must serialize
+writes to the same plan. Behavior under concurrent `append_task` calls for the same plan is
+**undefined** — backends are not required to detect, reject, or recover from concurrent appends.
+
+`finalize_plan` transitions a plan from `state="drafting"` to `state="ready"`, making its tasks
+visible to `get_ready_tasks` and `get_plan_status`. Both methods return `dict[str, Any]`.
 
 ### Available Backends
 
@@ -542,6 +552,7 @@ Defined in `sam_schema/core/task_backend.py`. All protocol methods are synchrono
 
 - **Plan lifecycle**: `create_plan`, `read_plan`, `list_plans`, `update_plan_fields`
 - **Task access**: `read_task`, `claim_task`, `update_task_status`, `update_task_fields`, `append_task_section`, `get_ready_tasks`, `get_plan_status`
+- **Incremental append**: `append_task`, `finalize_plan`
 - **Documents**: `store_document`, `read_document`
 
 #### Protocol Interface (13 methods)

--- a/plugins/development-harness/docs/backend-providers.md
+++ b/plugins/development-harness/docs/backend-providers.md
@@ -170,14 +170,20 @@ All protocol methods are synchronous. The MCP layer wraps calls in `asyncio.to_t
 - **Incremental append**: `append_task`, `finalize_plan`
 - **Documents**: `store_document`, `read_document`
 
-`append_task` adds a single validated task to a plan that is in `state="drafting"`. The method
-validates the task via `Task.model_validate()` before writing. **Single-writer assumption**:
-`append_task` is NOT required to be atomic under concurrent writers. Callers must serialize
-writes to the same plan. Behavior under concurrent `append_task` calls for the same plan is
-**undefined** — backends are not required to detect, reject, or recover from concurrent appends.
+`append_task` adds a single validated task to a plan. The method validates the task via
+`Task.model_validate()` before writing. Current backends do not enforce a `state="drafting"`
+precondition — callers must not assume `append_task` will reject appends based solely on plan
+state. **Single-writer assumption**: `append_task` is NOT required to be atomic under concurrent
+writers. Callers must serialize writes to the same plan. Behavior under concurrent `append_task`
+calls for the same plan is **undefined** — backends are not required to detect, reject, or
+recover from concurrent appends.
 
-`finalize_plan` transitions a plan from `state="drafting"` to `state="ready"`, making its tasks
-visible to `get_ready_tasks` and `get_plan_status`. Both methods return `dict[str, Any]`.
+`finalize_plan` sets a plan's state to `state="ready"` for backends that implement the drafting
+workflow. Creating a plan with an empty task list enters `state="drafting"`; `finalize_plan`
+transitions it to `state="ready"`, making its tasks visible to `get_ready_tasks` and
+`get_plan_status`. Callers should treat readiness and task visibility as backend-defined
+behavior rather than assuming tasks become visible only after finalization. Both methods return
+`dict[str, Any]`.
 
 ### Available Backends
 

--- a/plugins/development-harness/docs/backlog-item-lifecycle.md
+++ b/plugins/development-harness/docs/backlog-item-lifecycle.md
@@ -543,7 +543,7 @@ flowchart TD
     P6_CONCERNS_VERIFY --> P6_QG_CREATE
 
     P6_QG_CREATE{"Check for existing QG plan<br>sam_list(search='qg-{slug}')<br>Result?"}
-    P6_QG_CREATE -->|"No existing plan"| P6_QG_BUILD["build_quality_gate_plan(<br>slug, issue, impl_plan_address)<br>from sam_schema.core.quality_gates<br><br>sam_create(slug='qg-{slug}',<br>goal='Quality gate enforcement',<br>tasks_yaml, issue)"]
+    P6_QG_CREATE -->|"No existing plan"| P6_QG_BUILD["build_quality_gate_plan(<br>slug, issue, impl_plan_address)<br>from sam_schema.core.quality_gates<br><br>sam_create(slug='qg-{slug}',<br>goal='Quality gate enforcement',<br>tasks=[...], issue)"]
     P6_QG_CREATE -->|"Existing plan —<br>some tasks remain non-terminal"| P6_QG_RESET["Reset BLOCKED tasks to not-started<br>via sam_state per task<br>Re-enter dispatch loop"]
     P6_QG_CREATE -->|"Existing plan —<br>all tasks terminal"| P6_VERIFY_GATE
 

--- a/plugins/development-harness/docs/workflow-architecture-diagram.md
+++ b/plugins/development-harness/docs/workflow-architecture-diagram.md
@@ -13,6 +13,7 @@
 - [2. Data Structure Shapes](#2-data-structure-shapes)
 - [3. Publisher-Consumer Map](#3-publisher-consumer-map)
 - [4. SAM Task State Lifecycle](#4-sam-task-state-lifecycle)
+- [4a. Incremental Plan Creation Lifecycle](#4a-incremental-plan-creation-lifecycle)
 - [5. Cross-System Dependency Chain](#5-cross-system-dependency-chain)
 - [6. Hook Trigger Conditions](#6-hook-trigger-conditions)
 - [7. Quality Gate SAM Dispatch Flow](#7-quality-gate-sam-dispatch-flow)
@@ -263,7 +264,7 @@ Exit code 1 when: already claimed, task not found, or `status != not-started`.
 | `~/.dh/projects/{slug}/plan/feature-context-{slug}.md` | `feature-researcher` | `python-cli-design-spec`, `swarm-task-planner` |
 | `~/.dh/projects/{slug}/plan/codebase/{FOCUS}.md` | `codebase-analyzer` | `swarm-task-planner` |
 | `~/.dh/projects/{slug}/plan/architect-{slug}.md` | `python-cli-design-spec` | `swarm-task-planner`, executing agents via `/start-task` |
-| `~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml` | `swarm-task-planner` via `sam_plan create` | `/implement-feature`, `sam_plan ready`, `sam_plan status`, all execution agents |
+| `~/.dh/projects/{slug}/plan/P{id}-{slug}.yaml` | `swarm-task-planner` via `sam_plan create` (monolithic) or `sam_plan create` → `append_task` × N → `finalize` (incremental) | `/implement-feature`, `sam_plan ready`, `sam_plan status`, all execution agents |
 | `~/.dh/projects/{slug}/plan/T0-baseline-{slug}.yaml` | `t0-baseline-capture` | `tn-verification-gate` |
 | `~/.dh/projects/{slug}/plan/TN-verification-{slug}.yaml` | `tn-verification-gate` | `/complete-implementation` Pre-Phase 1 check |
 | `~/.dh/projects/{slug}/plan/QG{NNN}-qg-{slug}.yaml` | `/complete-implementation` via `build_quality_gate_plan` + `sam_create` | SAM dispatch loop (T1–T6 quality gate tasks) |
@@ -292,6 +293,39 @@ flowchart TD
 ```
 
 Readiness rule: a task is ready when `status == not-started` AND all dependency task IDs have terminal status. Terminal statuses: `complete`, `blocked`, `skipped`. SKIPPED counts as terminal for dependency evaluation — when T5 is skipped, T6 becomes ready.
+
+---
+
+## 4a. Incremental Plan Creation Lifecycle
+
+Plans with 16+ tasks or a `tasks_yaml` payload exceeding ~20 KB should use the incremental
+append workflow instead of a single monolithic `create` call. The plan passes through a
+`drafting` intermediate state that prevents partial plans from being dispatched.
+
+```mermaid
+flowchart TD
+    Start([Planner needs large plan]) --> Create["sam_plan(action='create',<br>tasks_yaml='{tasks: []}')"]
+    Create --> Drafting["Plan state = drafting<br>Plan ID assigned (e.g. Pd9e0f1a2)"]
+    Drafting --> AppendLoop["sam_plan(plan='P{N}',<br>action='append_task',<br>task_yaml=single_task) × N<br>Single-writer: no concurrent appends<br>state remains drafting throughout"]
+    AppendLoop --> AppendLoop
+    AppendLoop --> Finalize["sam_plan(plan='P{N}', action='finalize')"]
+    Finalize --> Ready["Plan state = ready<br>Tasks visible to sam_plan ready/status"]
+    Ready --> Dispatch([Dispatch loop begins])
+
+    DraftingGuard["Drafting guard<br>sam_plan read → drafting marker<br>sam_plan status → drafting marker<br>sam_plan ready → drafting marker"]
+    Drafting -.->|"consumer calls status/ready"| DraftingGuard
+    AppendLoop -.->|"consumer calls status/ready"| DraftingGuard
+```
+
+**Key invariants**:
+
+- `state="drafting"` is set by `create` when `tasks_yaml='{tasks: []}'` (empty task list).
+- `state="ready"` is set by `create` when `tasks_yaml` contains at least one task (monolithic path).
+- `append_task` leaves `state` unchanged — it never transitions drafting → ready.
+- `finalize` is the only operation that transitions `drafting` → `ready`.
+- Single-writer assumption: `TaskBackend.append_task` is NOT required to be atomic under
+  concurrent writers. Callers must serialize writes to the same plan. Behavior under
+  concurrent `append_task` calls for the same plan is **undefined**.
 
 ---
 

--- a/plugins/development-harness/docs/workflow-architecture-diagram.md
+++ b/plugins/development-harness/docs/workflow-architecture-diagram.md
@@ -298,15 +298,15 @@ Readiness rule: a task is ready when `status == not-started` AND all dependency 
 
 ## 4a. Incremental Plan Creation Lifecycle
 
-Plans with 16+ tasks or a `tasks_yaml` payload exceeding ~20 KB should use the incremental
-append workflow instead of a single monolithic `create` call. The plan passes through a
-`drafting` intermediate state that prevents partial plans from being dispatched.
+Plans with 16+ tasks should use the incremental append workflow instead of a single monolithic
+`create` call. The plan passes through a `drafting` intermediate state that prevents partial
+plans from being dispatched.
 
 ```mermaid
 flowchart TD
-    Start([Planner needs large plan]) --> Create["sam_plan(action='create',<br>tasks_yaml='{tasks: []}')"]
+    Start([Planner needs large plan]) --> Create["sam_plan(action='create',<br>tasks=[])"]
     Create --> Drafting["Plan state = drafting<br>Plan ID assigned (e.g. Pd9e0f1a2)"]
-    Drafting --> AppendLoop["sam_plan(plan='P{N}',<br>action='append_task',<br>task_yaml=single_task) × N<br>Single-writer: no concurrent appends<br>state remains drafting throughout"]
+    Drafting --> AppendLoop["sam_plan(plan='P{N}',<br>action='append_task',<br>task=single_task_dict) × N<br>Single-writer: no concurrent appends<br>state remains drafting throughout"]
     AppendLoop --> AppendLoop
     AppendLoop --> Finalize["sam_plan(plan='P{N}', action='finalize')"]
     Finalize --> Ready["Plan state = ready<br>Tasks visible to sam_plan ready/status"]
@@ -319,8 +319,8 @@ flowchart TD
 
 **Key invariants**:
 
-- `state="drafting"` is set by `create` when `tasks_yaml='{tasks: []}'` (empty task list).
-- `state="ready"` is set by `create` when `tasks_yaml` contains at least one task (monolithic path).
+- `state="drafting"` is set by `create` when `tasks=[]` (empty task list).
+- `state="ready"` is set by `create` when `tasks` contains at least one task definition (monolithic path).
 - `append_task` leaves `state` unchanged — it never transitions drafting → ready.
 - `finalize` is the only operation that transitions `drafting` → `ready`.
 - Single-writer assumption: `TaskBackend.append_task` is NOT required to be atomic under
@@ -410,7 +410,7 @@ flowchart TD
     Start(["/complete-implementation<br>invoked"]) --> PrePhase["Pre-phases<br>TN verification, artifact discovery,<br>concern processing"]
     PrePhase --> CheckQG{QG plan<br>exists?}
     CheckQG -->|"No — first run"| GenYAML["build_quality_gate_plan<br>produces 6-task YAML"]
-    GenYAML --> CreatePlan["sam_plan(config={action:create,slug:'qg-{slug}',<br>tasks_yaml:...,issue:N})<br>→ QG{NNN}-qg-{slug}.yaml"]
+    GenYAML --> CreatePlan["sam_plan(config={action:create,slug:'qg-{slug}',<br>tasks:[...],issue:N})<br>→ QG{NNN}-qg-{slug}.yaml"]
     CheckQG -->|"Yes — resume"| ResetBlocked["Reset BLOCKED tasks<br>to NOT_STARTED via sam_task state"]
     CreatePlan --> DispatchLoop
     ResetBlocked --> DispatchLoop

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -21,6 +21,21 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from sam_schema.core.models import Task
 
+# ---------------------------------------------------------------------------
+# Shared base — eliminates 17x repeated model_config boilerplate
+# ---------------------------------------------------------------------------
+
+
+class _ActionConfigBase(BaseModel):
+    """Shared base for all MCP action-config models.
+
+    Sets ``populate_by_name=True`` once so every subclass inherits it without
+    repeating the ``model_config = ConfigDict(populate_by_name=True)`` line.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 __all__ = [
     "ActiveTaskActionConfig",
     "AppendTaskConfig",
@@ -82,26 +97,20 @@ class TaskDefinition(Task):
 # ---------------------------------------------------------------------------
 
 
-class ReadTaskConfig(BaseModel):
+class ReadTaskConfig(_ActionConfigBase):
     """Read a task and return a TaskAssignment (plan context + task fields)."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["read"] = "read"
 
 
-class ClaimTaskConfig(BaseModel):
+class ClaimTaskConfig(_ActionConfigBase):
     """Claim a task (transition from not-started to in-progress)."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["claim"] = "claim"
 
 
-class StateTaskConfig(BaseModel):
+class StateTaskConfig(_ActionConfigBase):
     """Update a task's status field."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["state"] = "state"
     status: str = Field(
@@ -114,13 +123,11 @@ class StateTaskConfig(BaseModel):
     )
 
 
-class UpdateTaskConfig(BaseModel):
+class UpdateTaskConfig(_ActionConfigBase):
     """Update task fields or append a markdown section to the task body.
 
     All three sub-operations are non-exclusive and may be combined in one call.
     """
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["update"] = "update"
     set_fields_json: str | None = Field(
@@ -153,23 +160,19 @@ TaskActionConfig = Annotated[
 # ---------------------------------------------------------------------------
 
 
-class ReadPlanConfig(BaseModel):
+class ReadPlanConfig(_ActionConfigBase):
     """Read a plan and return its Plan fields."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["read"] = "read"
 
 
-class CreatePlanConfig(BaseModel):
+class CreatePlanConfig(_ActionConfigBase):
     """Create a new plan from a typed list of task definitions.
 
     Pass ``tasks=[]`` to create a plan in drafting state for incremental
     building via ``append_task``.  Pass a non-empty list to create a ready
     plan in a single call (monolithic path).
     """
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["create"] = "create"
     slug: str = Field(
@@ -204,10 +207,8 @@ class CreatePlanConfig(BaseModel):
     )
 
 
-class ListPlansConfig(BaseModel):
+class ListPlansConfig(_ActionConfigBase):
     """List all plans with optional search and auto-pagination."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["list"] = "list"
     search: str | None = Field(
@@ -226,18 +227,14 @@ class ListPlansConfig(BaseModel):
     )
 
 
-class StatusPlanConfig(BaseModel):
+class StatusPlanConfig(_ActionConfigBase):
     """Get plan-level progress summary."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["status"] = "status"
 
 
-class ReadyPlanConfig(BaseModel):
+class ReadyPlanConfig(_ActionConfigBase):
     """List tasks ready for dispatch (status=not-started, all dependencies terminal)."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["ready"] = "ready"
     full: bool = Field(
@@ -251,13 +248,11 @@ class ReadyPlanConfig(BaseModel):
     )
 
 
-class UpdatePlanConfig(BaseModel):
+class UpdatePlanConfig(_ActionConfigBase):
     """Update plan-level fields.
 
     Applies field patches and/or sets the plan context field.
     """
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["update"] = "update"
     context: str | None = Field(
@@ -274,7 +269,7 @@ class UpdatePlanConfig(BaseModel):
     )
 
 
-class AppendTaskConfig(BaseModel):
+class AppendTaskConfig(_ActionConfigBase):
     """Append a single task to an existing plan.
 
     Enables incremental plan building — callers emit one task at a time rather than
@@ -291,8 +286,6 @@ class AppendTaskConfig(BaseModel):
     architectural decision record.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
-
     action: Literal["append_task"] = "append_task"
     task: TaskDefinition = Field(
         ...,
@@ -306,7 +299,7 @@ class AppendTaskConfig(BaseModel):
     )
 
 
-class FinalizePlanConfig(BaseModel):
+class FinalizePlanConfig(_ActionConfigBase):
     """Transition a plan out of ``drafting`` state into executable state.
 
     Plans created with an empty ``tasks`` list (the incremental build pattern)
@@ -318,8 +311,6 @@ class FinalizePlanConfig(BaseModel):
 
     See #1770 for the architectural decision record.
     """
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["finalize"] = "finalize"
 
@@ -342,18 +333,14 @@ PlanActionConfig = Annotated[
 # ---------------------------------------------------------------------------
 
 
-class GetActiveTaskConfig(BaseModel):
+class GetActiveTaskConfig(_ActionConfigBase):
     """Retrieve the active task context for a session."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["get"] = "get"
 
 
-class SetActiveTaskConfig(BaseModel):
+class SetActiveTaskConfig(_ActionConfigBase):
     """Store a task address as the active task for a session."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["set"] = "set"
     plan: str = Field(..., description="Plan address to register as the active task's plan (e.g., 'P1').")
@@ -367,14 +354,12 @@ class SetActiveTaskConfig(BaseModel):
     )
 
 
-class UpdateActiveTaskConfig(BaseModel):
+class UpdateActiveTaskConfig(_ActionConfigBase):
     """Update fields on the currently active task without repeating the address.
 
     Delegates to the same backend write path as sam_task(action='update').
     Raises if no active task has been set for this session.
     """
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["update"] = "update"
     set_fields_json: str | None = Field(
@@ -392,10 +377,8 @@ class UpdateActiveTaskConfig(BaseModel):
     )
 
 
-class ClearActiveTaskConfig(BaseModel):
+class ClearActiveTaskConfig(_ActionConfigBase):
     """Clear the active task context for a session."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["clear"] = "clear"
 

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 __all__ = [
     "ActiveTaskActionConfig",
@@ -40,10 +40,135 @@ __all__ = [
     "StatusPlanConfig",
     # Discriminated union type aliases
     "TaskActionConfig",
+    "TaskDefinition",
     "UpdateActiveTaskConfig",
     "UpdatePlanConfig",
     "UpdateTaskConfig",
 ]
+
+# ---------------------------------------------------------------------------
+# MCP input boundary model for task authoring
+# ---------------------------------------------------------------------------
+
+
+class TaskDefinition(BaseModel):
+    """Typed input model for defining a task at the MCP boundary.
+
+    This is the **MCP-input boundary model** — it carries the fields a caller
+    sets when authoring a new task.  It is distinct from two other types with
+    similar names:
+
+    - ``sam_schema.core.models.Task`` — the *persisted entity* model that
+      includes all runtime fields (``created``, ``started``, ``completed``,
+      ``last_activity``, ``body``, ``description``, ``github_issue``, etc.).
+    - ``sam_schema.core.task_backend_types.TaskDefinition`` — the *backend
+      contract* TypedDict used internally between the query layer and backend
+      implementations.
+
+    By using a typed ``BaseModel`` at the MCP boundary, Pydantic handles field
+    validation and alias normalization (kebab-case → snake_case) automatically,
+    eliminating the need for alias-normalization helpers downstream.
+
+    Alias conventions mirror ``Task``: ``populate_by_name=True``,
+    ``AliasChoices("kebab-case", "snake_case")`` for multi-word fields, and
+    ``serialization_alias="kebab-case"`` for round-trip fidelity.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
+
+    # Required fields
+    id: str = Field(..., description="Task identifier (e.g. 'T1').")
+    title: str = Field(..., min_length=1, max_length=200, description="Human-readable task title.")
+    status: str = Field(default="not-started", description="Task status. Defaults to 'not-started'.")
+
+    # Optional structural fields
+    agent: str | None = Field(default=None, description="Agent or specialist responsible for this task.")
+    dependencies: list[str] = Field(default_factory=list, description="List of task IDs this task depends on.")
+    priority: int = Field(default=3, ge=1, le=5, description="Priority (1=highest, 5=lowest). Default: 3 (MEDIUM).")
+    complexity: str = Field(
+        default="medium", pattern=r"^(low|medium|high)$", description="Complexity estimate: 'low', 'medium', or 'high'."
+    )
+    skills: list[str] = Field(default_factory=list, description="Skill tags required to complete this task.")
+    blocked_by: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("blocked-by", "blocked_by"),
+        serialization_alias="blocked-by",
+        description="Task IDs that are blocking this task.",
+    )
+    parallelize_with: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("parallelize-with", "parallelize_with"),
+        serialization_alias="parallelize-with",
+        description="Task IDs that can safely run in parallel with this task.",
+    )
+
+    # Markdown content fields (authoring inputs — no runtime timestamps)
+    body: str = Field(default="", description="Raw markdown body for the task.")
+    description: str = Field(default="", description="Short prose description of the task.")
+    objective: str = Field(default="", description="One-paragraph objective statement.")
+    requirements: str = Field(default="", description="Functional requirements for this task.")
+    constraints: str = Field(default="", description="Constraints and limitations.")
+    expected_outputs: str = Field(
+        default="",
+        validation_alias=AliasChoices("expected-outputs", "expected_outputs"),
+        serialization_alias="expected-outputs",
+        description="Deliverables and success artifacts.",
+    )
+    acceptance_criteria: str = Field(
+        default="",
+        validation_alias=AliasChoices("acceptance-criteria", "acceptance_criteria"),
+        serialization_alias="acceptance-criteria",
+        description="Acceptance criteria for this task.",
+    )
+    verification_steps: str = Field(
+        default="",
+        validation_alias=AliasChoices("verification-steps", "verification_steps"),
+        serialization_alias="verification-steps",
+        description="Steps to verify the task is complete.",
+    )
+    context_notes: str = Field(
+        default="",
+        validation_alias=AliasChoices("context-notes", "context_notes"),
+        serialization_alias="context-notes",
+        description="Additional context notes.",
+    )
+    handoff: str = Field(default="", description="Handoff notes for the next task or agent.")
+    reason: str = Field(default="", description="Reason for this task's inclusion in the plan.")
+
+    # Analytical metadata
+    issue_classification: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("issue-classification", "issue_classification"),
+        serialization_alias="issue-classification",
+        description="Root-cause classification: procedural, defect, recurring-pattern, etc.",
+    )
+    scenario_target: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("scenario-target", "scenario_target"),
+        serialization_alias="scenario-target",
+        description="Target scenario for this task.",
+    )
+    analysis_method: str = Field(
+        default="none",
+        validation_alias=AliasChoices("analysis-method", "analysis_method"),
+        serialization_alias="analysis-method",
+        description="Analysis method applied: none, 5-whys, 6-sigma, design-framing.",
+    )
+
+    # Bookend metadata
+    is_bookend: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("is-bookend", "is_bookend"),
+        serialization_alias="is-bookend",
+        description="True when this task is a bookend (T0 baseline or TN verification).",
+    )
+    bookend_type: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("bookend-type", "bookend_type"),
+        serialization_alias="bookend-type",
+        description="Bookend type: 't0-baseline' or 'tn-verification'.",
+    )
+
 
 # ---------------------------------------------------------------------------
 # Tool 1 — sam_task: single-task operations
@@ -245,6 +370,10 @@ class AppendTaskConfig(BaseModel):
     created with an empty ``tasks_yaml`` enter a ``drafting`` state; ``append_task``
     keeps them in ``drafting`` until ``finalize`` is invoked.
 
+    The ``task`` field accepts a :class:`TaskDefinition` instance. Pydantic validates
+    and alias-normalises the payload at the MCP boundary so backends receive a
+    plain snake_case dict from ``task.model_dump(by_alias=False, exclude_none=True)``.
+
     Single-writer contract: implementations assume a single writer per plan. Backends
     are NOT required to be atomic under concurrent writers. See #1770 for the
     architectural decision record.
@@ -253,16 +382,14 @@ class AppendTaskConfig(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     action: Literal["append_task"] = "append_task"
-    task_yaml: str = Field(
+    task: TaskDefinition = Field(
         ...,
         description=(
-            "YAML string for a single task. Same schema as one element of the "
-            "top-level ``tasks`` list accepted by CreatePlanConfig.tasks_yaml. "
-            "Required fields per Task model: id (str, e.g. 'T1'), title (str), "
-            "and status (any valid TaskStatus value). Optional fields include "
+            "Typed task definition. Required fields: id (str, e.g. 'T1'), "
+            "title (str). Optional fields include status (default 'not-started'), "
             "agent (str), dependencies (list of task IDs), priority (int 1-5), "
-            "and complexity ('low', 'medium', or 'high'); omitted optional fields "
-            "use their model defaults."
+            "and complexity ('low', 'medium', or 'high'). All other TaskDefinition "
+            "fields are optional and use their model defaults when omitted."
         ),
     )
 

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -259,8 +259,10 @@ class AppendTaskConfig(BaseModel):
             "YAML string for a single task. Same schema as one element of the "
             "top-level ``tasks`` list accepted by CreatePlanConfig.tasks_yaml. "
             "Required fields per Task model: id (str, e.g. 'T1'), title (str), "
-            "status ('not-started'), agent (str), dependencies (list of task IDs), "
-            "priority (int 1-5), complexity ('low', 'medium', or 'high')."
+            "and status (any valid TaskStatus value). Optional fields include "
+            "agent (str), dependencies (list of task IDs), priority (int 1-5), "
+            "and complexity ('low', 'medium', or 'high'); omitted optional fields "
+            "use their model defaults."
         ),
     )
 

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -21,9 +21,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = [
     "ActiveTaskActionConfig",
+    "AppendTaskConfig",
     "ClaimTaskConfig",
     "ClearActiveTaskConfig",
     "CreatePlanConfig",
+    "FinalizePlanConfig",
     # Active-task action models
     "GetActiveTaskConfig",
     "ListPlansConfig",
@@ -235,9 +237,62 @@ class UpdatePlanConfig(BaseModel):
     )
 
 
+class AppendTaskConfig(BaseModel):
+    """Append a single task to an existing plan.
+
+    Enables incremental plan building — callers emit one task at a time rather than
+    submitting the full ``tasks_yaml`` payload in a single ``create`` call. Plans
+    created with an empty ``tasks_yaml`` enter a ``drafting`` state; ``append_task``
+    keeps them in ``drafting`` until ``finalize`` is invoked.
+
+    Single-writer contract: implementations assume a single writer per plan. Backends
+    are NOT required to be atomic under concurrent writers. See #1770 for the
+    architectural decision record.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: Literal["append_task"] = "append_task"
+    task_yaml: str = Field(
+        ...,
+        description=(
+            "YAML string for a single task. Same schema as one element of the "
+            "top-level ``tasks`` list accepted by CreatePlanConfig.tasks_yaml. "
+            "Required fields per Task model: id (str, e.g. 'T1'), title (str), "
+            "status ('not-started'), agent (str), dependencies (list of task IDs), "
+            "priority (int 1-5), complexity ('low', 'medium', or 'high')."
+        ),
+    )
+
+
+class FinalizePlanConfig(BaseModel):
+    """Transition a plan out of ``drafting`` state into executable state.
+
+    Plans created with an empty ``tasks_yaml`` (the incremental build pattern)
+    start in ``drafting``. ``sam_plan(action='read')`` returns the tasks and a
+    ``drafting`` marker; ``status`` and ``ready`` return a ``drafting`` marker
+    instead of dispatchable task data. ``finalize`` clears ``drafting`` after
+    plan review completes (no-more-changes), making the plan available for
+    execution by ``sam_plan(action='ready')`` and ``/dh:implement-feature``.
+
+    See #1770 for the architectural decision record.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: Literal["finalize"] = "finalize"
+
+
 # Discriminated union for sam_plan — discriminator is the ``action`` field.
 PlanActionConfig = Annotated[
-    ReadPlanConfig | CreatePlanConfig | ListPlansConfig | StatusPlanConfig | ReadyPlanConfig | UpdatePlanConfig,
+    ReadPlanConfig
+    | CreatePlanConfig
+    | ListPlansConfig
+    | StatusPlanConfig
+    | ReadyPlanConfig
+    | UpdatePlanConfig
+    | AppendTaskConfig
+    | FinalizePlanConfig,
     Field(discriminator="action"),
 ]
 

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -255,7 +255,12 @@ class ReadPlanConfig(BaseModel):
 
 
 class CreatePlanConfig(BaseModel):
-    """Create a new plan from YAML task definitions."""
+    """Create a new plan from a typed list of task definitions.
+
+    Pass ``tasks=[]`` to create a plan in drafting state for incremental
+    building via ``append_task``.  Pass a non-empty list to create a ready
+    plan in a single call (monolithic path).
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -268,16 +273,16 @@ class CreatePlanConfig(BaseModel):
         ),
     )
     goal: str = Field(..., description="Human-readable goal statement for the plan.")
-    tasks_yaml: str = Field(
-        ...,
+    tasks: list[TaskDefinition] = Field(
+        default_factory=list,
         description=(
-            "YAML string with a top-level 'tasks' key containing a list of task dicts. "
-            "Required task fields per Task model: id (str, e.g. 'T1'), title (str), "
-            "status ('not-started'), agent (str, e.g. 'dh:code-reviewer'), "
-            "dependencies (list of task IDs, e.g. ['T1', 'T2']), "
-            "priority (int 1-5, where 1=highest), "
+            "Ordered list of task definitions. "
+            "Required task fields per Task model: id (str, e.g. 'T1'), title (str). "
+            "Optional fields: status (default 'not-started'), agent (str), "
+            "dependencies (list of task IDs), priority (int 1-5, where 1=highest), "
             "complexity ('low', 'medium', or 'high'). "
-            "All other Task fields are optional."
+            "Pass an empty list to create a plan in drafting state for incremental "
+            "building via append_task + finalize."
         ),
     )
     context: str | None = Field(
@@ -366,8 +371,8 @@ class AppendTaskConfig(BaseModel):
     """Append a single task to an existing plan.
 
     Enables incremental plan building — callers emit one task at a time rather than
-    submitting the full ``tasks_yaml`` payload in a single ``create`` call. Plans
-    created with an empty ``tasks_yaml`` enter a ``drafting`` state; ``append_task``
+    submitting the full ``tasks`` list in a single ``create`` call. Plans
+    created with an empty ``tasks`` list enter a ``drafting`` state; ``append_task``
     keeps them in ``drafting`` until ``finalize`` is invoked.
 
     The ``task`` field accepts a :class:`TaskDefinition` instance. Pydantic validates
@@ -397,7 +402,7 @@ class AppendTaskConfig(BaseModel):
 class FinalizePlanConfig(BaseModel):
     """Transition a plan out of ``drafting`` state into executable state.
 
-    Plans created with an empty ``tasks_yaml`` (the incremental build pattern)
+    Plans created with an empty ``tasks`` list (the incremental build pattern)
     start in ``drafting``. ``sam_plan(action='read')`` returns the tasks and a
     ``drafting`` marker; ``status`` and ``ready`` return a ``drafting`` marker
     instead of dispatchable task data. ``finalize`` clears ``drafting`` after

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+from sam_schema.core.models import Task
 
 __all__ = [
     "ActiveTaskActionConfig",
@@ -51,123 +53,28 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-class TaskDefinition(BaseModel):
-    """Typed input model for defining a task at the MCP boundary.
+class TaskDefinition(Task):
+    """MCP-input projection of Task.
 
-    This is the **MCP-input boundary model** — it carries the fields a caller
-    sets when authoring a new task.  It is distinct from two other types with
-    similar names:
+    Inherits all field definitions, alias conventions, and validators from
+    ``sam_schema.core.models.Task``.  The ``extra='ignore'`` config allows
+    callers to submit unknown fields without raising a validation error —
+    unknown fields are silently discarded at the MCP boundary.
 
-    - ``sam_schema.core.models.Task`` — the *persisted entity* model that
-      includes all runtime fields (``created``, ``started``, ``completed``,
-      ``last_activity``, ``body``, ``description``, ``github_issue``, etc.).
-    - ``sam_schema.core.task_backend_types.TaskDefinition`` — the *backend
-      contract* TypedDict used internally between the query layer and backend
-      implementations.
+    Runtime-only fields (``created``, ``started``, ``completed``,
+    ``last_activity``, ``github_issue``) are inherited but default to ``None``;
+    callers should omit them when authoring a new task.
 
-    By using a typed ``BaseModel`` at the MCP boundary, Pydantic handles field
-    validation and alias normalization (kebab-case → snake_case) automatically,
-    eliminating the need for alias-normalization helpers downstream.
+    The ID regex, status enum, priority/complexity enums, and dependency
+    validators are all inherited automatically from ``Task``.
 
-    Alias conventions mirror ``Task``: ``populate_by_name=True``,
-    ``AliasChoices("kebab-case", "snake_case")`` for multi-word fields, and
-    ``serialization_alias="kebab-case"`` for round-trip fidelity.
+    ``status`` is given a default of ``"not-started"`` at the MCP boundary so
+    callers may omit it when submitting a new task.
     """
 
-    model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
+    model_config = ConfigDict(populate_by_name=True, use_enum_values=True, extra="ignore")
 
-    # Required fields
-    id: str = Field(..., description="Task identifier (e.g. 'T1').")
-    title: str = Field(..., min_length=1, max_length=200, description="Human-readable task title.")
     status: str = Field(default="not-started", description="Task status. Defaults to 'not-started'.")
-
-    # Optional structural fields
-    agent: str | None = Field(default=None, description="Agent or specialist responsible for this task.")
-    dependencies: list[str] = Field(default_factory=list, description="List of task IDs this task depends on.")
-    priority: int = Field(default=3, ge=1, le=5, description="Priority (1=highest, 5=lowest). Default: 3 (MEDIUM).")
-    complexity: str = Field(
-        default="medium", pattern=r"^(low|medium|high)$", description="Complexity estimate: 'low', 'medium', or 'high'."
-    )
-    skills: list[str] = Field(default_factory=list, description="Skill tags required to complete this task.")
-    blocked_by: list[str] = Field(
-        default_factory=list,
-        validation_alias=AliasChoices("blocked-by", "blocked_by"),
-        serialization_alias="blocked-by",
-        description="Task IDs that are blocking this task.",
-    )
-    parallelize_with: list[str] = Field(
-        default_factory=list,
-        validation_alias=AliasChoices("parallelize-with", "parallelize_with"),
-        serialization_alias="parallelize-with",
-        description="Task IDs that can safely run in parallel with this task.",
-    )
-
-    # Markdown content fields (authoring inputs — no runtime timestamps)
-    body: str = Field(default="", description="Raw markdown body for the task.")
-    description: str = Field(default="", description="Short prose description of the task.")
-    objective: str = Field(default="", description="One-paragraph objective statement.")
-    requirements: str = Field(default="", description="Functional requirements for this task.")
-    constraints: str = Field(default="", description="Constraints and limitations.")
-    expected_outputs: str = Field(
-        default="",
-        validation_alias=AliasChoices("expected-outputs", "expected_outputs"),
-        serialization_alias="expected-outputs",
-        description="Deliverables and success artifacts.",
-    )
-    acceptance_criteria: str = Field(
-        default="",
-        validation_alias=AliasChoices("acceptance-criteria", "acceptance_criteria"),
-        serialization_alias="acceptance-criteria",
-        description="Acceptance criteria for this task.",
-    )
-    verification_steps: str = Field(
-        default="",
-        validation_alias=AliasChoices("verification-steps", "verification_steps"),
-        serialization_alias="verification-steps",
-        description="Steps to verify the task is complete.",
-    )
-    context_notes: str = Field(
-        default="",
-        validation_alias=AliasChoices("context-notes", "context_notes"),
-        serialization_alias="context-notes",
-        description="Additional context notes.",
-    )
-    handoff: str = Field(default="", description="Handoff notes for the next task or agent.")
-    reason: str = Field(default="", description="Reason for this task's inclusion in the plan.")
-
-    # Analytical metadata
-    issue_classification: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("issue-classification", "issue_classification"),
-        serialization_alias="issue-classification",
-        description="Root-cause classification: procedural, defect, recurring-pattern, etc.",
-    )
-    scenario_target: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("scenario-target", "scenario_target"),
-        serialization_alias="scenario-target",
-        description="Target scenario for this task.",
-    )
-    analysis_method: str = Field(
-        default="none",
-        validation_alias=AliasChoices("analysis-method", "analysis_method"),
-        serialization_alias="analysis-method",
-        description="Analysis method applied: none, 5-whys, 6-sigma, design-framing.",
-    )
-
-    # Bookend metadata
-    is_bookend: bool = Field(
-        default=False,
-        validation_alias=AliasChoices("is-bookend", "is_bookend"),
-        serialization_alias="is-bookend",
-        description="True when this task is a bookend (T0 baseline or TN verification).",
-    )
-    bookend_type: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("bookend-type", "bookend_type"),
-        serialization_alias="bookend-type",
-        description="Bookend type: 't0-baseline' or 'tn-verification'.",
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/sam_schema/core/backends/_utils.py
+++ b/plugins/development-harness/sam_schema/core/backends/_utils.py
@@ -3,8 +3,37 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sam_schema.core.exceptions import TaskValidationError
+
+if TYPE_CHECKING:
+    from sam_schema.core.models import Task
 
 
 def _now_iso() -> str:
     """Return current UTC time as an ISO 8601 string."""
     return datetime.now(tz=UTC).isoformat()
+
+
+def validate_appended_task(task: Task, existing_ids: set[str], plan_id: str) -> None:
+    """Assert that a task can safely be appended to a plan.
+
+    Centralises the duplicate-ID guard that all three backends share.
+    Call before persisting the task to storage.
+
+    Single-writer contract (ADR-1770-1): backends are NOT required to be
+    atomic under concurrent writers. Callers must serialise writes to the
+    same plan. Behavior under concurrent writes is undefined.
+
+    Args:
+        task: Validated Task model to append.
+        existing_ids: Set of task IDs already present in the plan.
+        plan_id: Plan identifier used in the error message.
+
+    Raises:
+        TaskValidationError: When ``task.id`` is already present in
+            ``existing_ids``.
+    """
+    if task.id in existing_ids:
+        raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -69,6 +69,7 @@ _METADATA_END = "<!-- sam-task-metadata:end -->"
 _META_ROW_RE = re.compile(r"^\|\s*(?P<key>[^|]+?)\s*\|\s*(?P<value>[^|]*?)\s*\|$")
 _TASK_TITLE_RE = re.compile(r"^\[(?P<tid>T\d+)\] (?P<title>.+)$")
 _PLAN_SLUG_RE = re.compile(r"<!-- sam-plan-slug: (?P<slug>[^>]+?) -->")
+_DRAFTING_MARKER = "<!-- sam:state=drafting -->"
 _GOAL_RE = re.compile(r"## Goal\n\n(?P<goal>.+?)(?=\n\n##|\Z)", re.DOTALL)
 
 
@@ -534,13 +535,27 @@ class GitHubTaskProvider:
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Transition a plan from drafting state to ready state.
 
+        Clears the ``<!-- sam:state=drafting -->`` marker from the plan issue body
+        and updates the issue via GraphQL. After finalize, the plan is dispatchable.
+
+        Single-writer contract: callers must serialize writes to the same plan.
+        Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
+
         Args:
             plan_id: Plan identifier (GitHub issue number string).
 
+        Returns:
+            Dict with ``finalized`` (True) and ``state`` ("ready").
+
         Raises:
-            NotImplementedError: See #1770 for the green-phase implementation.
+            PlanNotFoundError: When plan_id does not correspond to a SAM plan issue.
         """
-        raise NotImplementedError  # see #1770
+        node = self._fetch_plan_node(plan_id)
+        body = node["body"]
+        new_body = re.sub(r"\n?" + re.escape(_DRAFTING_MARKER), "", body)
+        repo, _, _ = self._get_repo()
+        self._issue_backend._update_issue_graphql(repo, node["id"], body=new_body)  # type: ignore[arg-type]
+        return {"finalized": True, "state": "ready"}
 
     def store_document(
         self, plan_id: str, task_id: str | None, stage: str, doc_type: str, title: str, content: str, fmt: str = "md"

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -287,10 +287,11 @@ class GitHubTaskProvider:
                 raise TaskValidationError(i, "Task must have 'id' and 'title' fields")
 
         repo, _, _ = self._get_repo()
+        plan_body = _render_plan_body(slug, goal, context, acceptance_criteria)
+        if not tasks:
+            plan_body = f"{plan_body}\n{_DRAFTING_MARKER}"
         parent_issue = repo.create_issue(  # type: ignore[attr-defined]
-            title=f"SAM Plan: {slug}",
-            body=_render_plan_body(slug, goal, context, acceptance_criteria),
-            labels=[_SAM_PLAN_LABEL],
+            title=f"SAM Plan: {slug}", body=plan_body, labels=[_SAM_PLAN_LABEL]
         )
         plan_id = str(parent_issue.number)  # type: ignore[attr-defined]
 
@@ -341,7 +342,7 @@ class GitHubTaskProvider:
         node = self._fetch_plan_node(plan_id)
         slug, goal = self._extract_plan_meta(node)
         tasks = [_node_to_task_data(n) for n in self._fetch_task_nodes(plan_id)]
-        return PlanData(
+        plan_data = PlanData(
             plan_id=plan_id,
             feature=slug,
             version="1",
@@ -353,6 +354,9 @@ class GitHubTaskProvider:
             tasks=tasks,
             source_path=None,
         )
+        if _DRAFTING_MARKER in (node.get("body") or ""):
+            plan_data["state"] = "drafting"
+        return plan_data
 
     def list_plans(self, *, search: str | None = None, offset: int = 0, limit: int | None = None) -> list[PlanSummary]:
         """List all SAM plan issues, optionally filtered by search substring."""

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -480,6 +480,29 @@ class GitHubTaskProvider:
             "has_cycles": _has_cycles(tasks),
         }
 
+    def append_task(self, plan_id: str, task_def: TaskDefinition) -> None:
+        """Append a single task to an existing plan.
+
+        Args:
+            plan_id: Plan identifier (GitHub issue number string).
+            task_def: Task definition to append.
+
+        Raises:
+            NotImplementedError: See #1770 for the green-phase implementation.
+        """
+        raise NotImplementedError  # see #1770
+
+    def finalize_plan(self, plan_id: str) -> None:
+        """Transition a plan from drafting state to ready state.
+
+        Args:
+            plan_id: Plan identifier (GitHub issue number string).
+
+        Raises:
+            NotImplementedError: See #1770 for the green-phase implementation.
+        """
+        raise NotImplementedError  # see #1770
+
     def store_document(
         self, plan_id: str, task_id: str | None, stage: str, doc_type: str, title: str, content: str, fmt: str = "md"
     ) -> DocumentHandle:

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -224,6 +224,11 @@ class GitHubTaskProvider:
         """Store the IssueBackend and DocumentBackend dependency instances."""
         self._issue_backend = issue_backend
         self._doc_backend = doc_backend
+        # Per-plan task-ID cache — avoids O(N²) sub-issue fetches during
+        # incremental append_task workflows.  Keyed by plan_id (str).
+        # Populated lazily on first append_task call per plan; invalidated on
+        # finalize_plan to force a fresh read if the plan is re-used.
+        self._task_id_cache: dict[str, set[str]] = {}
 
     def _get_repo(self) -> tuple[Repository, str, str]:
         """Return (repo, owner, repo_name) from the IssueBackend."""
@@ -502,16 +507,22 @@ class GitHubTaskProvider:
         """
         self._fetch_plan_node(plan_id)
 
-        existing_ids: set[str] = set()
-        for n in self._fetch_task_nodes(plan_id):
-            meta_id = _parse_metadata(n["body"]).get("task_id")
-            if meta_id:
-                existing_ids.add(meta_id)
-            else:
-                m = _TASK_TITLE_RE.match(n["title"])
-                if m:
-                    existing_ids.add(m.group("tid"))
-        validate_appended_task(task, existing_ids, plan_id)
+        # Populate cache on first call per plan, then reuse — eliminates O(N²)
+        # GitHub API calls when appending N tasks in sequence.
+        if plan_id not in self._task_id_cache:
+            fetched: set[str] = set()
+            for n in self._fetch_task_nodes(plan_id):
+                meta_id = _parse_metadata(n["body"]).get("task_id")
+                if meta_id:
+                    fetched.add(meta_id)
+                else:
+                    m = _TASK_TITLE_RE.match(n["title"])
+                    if m:
+                        fetched.add(m.group("tid"))
+            self._task_id_cache[plan_id] = fetched
+
+        validate_appended_task(task, self._task_id_cache[plan_id], plan_id)
+        self._task_id_cache[plan_id].add(task.id)
 
         task_body = _render_task_body(task, plan_id)
         status_val = str(task.status)
@@ -541,9 +552,14 @@ class GitHubTaskProvider:
         """
         node = self._fetch_plan_node(plan_id)
         body = node["body"]
+        # No-op guard: already ready — drafting marker absent, nothing to write.
+        if _DRAFTING_MARKER not in body:
+            return {"finalized": True, "state": PlanState.READY}
         new_body = re.sub(r"\n?" + re.escape(_DRAFTING_MARKER), "", body)
         repo, _, _ = self._get_repo()
         self._issue_backend._update_issue_graphql(repo, node["id"], body=new_body)  # type: ignore[arg-type]
+        # Invalidate task-ID cache so subsequent reads pick up the current state.
+        self._task_id_cache.pop(plan_id, None)
         return {"finalized": True, "state": PlanState.READY}
 
     def store_document(

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -464,6 +464,8 @@ class GitHubTaskProvider:
         """Return a summary dict of task status counts for a plan."""
         node = self._fetch_plan_node(plan_id)
         slug, _ = self._extract_plan_meta(node)
+        # Derive plan state from drafting marker in the issue body.
+        state = PlanState.DRAFTING if _DRAFTING_MARKER in (node.get("body") or "") else PlanState.READY
         tasks = [_node_to_task_data(n) for n in self._fetch_task_nodes(plan_id)]
         by_id: dict[str, TaskData] = {t["id"]: t for t in tasks}
         by_status: dict[str, int] = {}
@@ -486,6 +488,7 @@ class GitHubTaskProvider:
             "blocked_tasks": blocked,
             "completion_pct": pct,
             "has_cycles": _has_cycles(tasks),
+            "state": state,
         }
 
     def append_task(self, plan_id: str, task: Task) -> dict[str, Any]:

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -14,7 +14,7 @@ or GraphQL calls are made from this module.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from sam_schema.core.backends._utils import _now_iso
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
@@ -480,7 +480,7 @@ class GitHubTaskProvider:
             "has_cycles": _has_cycles(tasks),
         }
 
-    def append_task(self, plan_id: str, task_def: TaskDefinition) -> None:
+    def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
         """Append a single task to an existing plan.
 
         Args:
@@ -492,7 +492,7 @@ class GitHubTaskProvider:
         """
         raise NotImplementedError  # see #1770
 
-    def finalize_plan(self, plan_id: str) -> None:
+    def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Transition a plan from drafting state to ready state.
 
         Args:

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from sam_schema.core.backends._utils import _now_iso
+from sam_schema.core.backends._utils import _now_iso, validate_appended_task
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
 from sam_schema.core.exceptions import PlanNotFoundError, TaskNotFoundError, TaskValidationError
 from sam_schema.core.models import PlanState, Task
@@ -486,13 +486,8 @@ class GitHubTaskProvider:
     def append_task(self, plan_id: str, task: Task) -> dict[str, Any]:
         """Append a single validated Task to an existing plan as a GitHub sub-issue.
 
-        The task has already been validated at the MCP boundary. This method
-        checks for duplicate IDs and creates the sub-issue on GitHub.
-        Body and label inputs are rendered from ``task.model_dump(mode="python")``
-        so all enum coercions are applied before rendering — no raw dict access.
-
-        Single-writer contract: callers must serialize writes to the same plan.
-        Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
+        Duplicate-ID check via ``validate_appended_task``; see ADR-1770-1 for the
+        single-writer contract (callers must serialise writes to the same plan).
 
         Args:
             plan_id: Plan identifier (GitHub issue number string).
@@ -516,8 +511,7 @@ class GitHubTaskProvider:
                 m = _TASK_TITLE_RE.match(n["title"])
                 if m:
                     existing_ids.add(m.group("tid"))
-        if task.id in existing_ids:
-            raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
+        validate_appended_task(task, existing_ids, plan_id)
 
         task_body = _render_task_body(task, plan_id)
         status_val = str(task.status)
@@ -532,11 +526,9 @@ class GitHubTaskProvider:
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Transition a plan from drafting state to ready state.
 
-        Clears the ``<!-- sam:state=drafting -->`` marker from the plan issue body
-        and updates the issue via GraphQL. After finalize, the plan is dispatchable.
-
-        Single-writer contract: callers must serialize writes to the same plan.
-        Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
+        Clears the ``<!-- sam:state=drafting -->`` marker from the issue body.
+        See ADR-1770-1 for the single-writer contract (callers must serialise
+        writes to the same plan).
 
         Args:
             plan_id: Plan identifier (GitHub issue number string).

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 from sam_schema.core.backends._utils import _now_iso
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
 from sam_schema.core.exceptions import PlanNotFoundError, TaskNotFoundError, TaskValidationError
+from sam_schema.core.models import PlanState
 from sam_schema.core.task_backend_types import (
     DocumentData,
     DocumentHandle,
@@ -355,7 +356,7 @@ class GitHubTaskProvider:
             source_path=None,
         )
         if _DRAFTING_MARKER in (node.get("body") or ""):
-            plan_data["state"] = "drafting"
+            plan_data["state"] = PlanState.DRAFTING
         return plan_data
 
     def list_plans(self, *, search: str | None = None, offset: int = 0, limit: int | None = None) -> list[PlanSummary]:
@@ -559,7 +560,7 @@ class GitHubTaskProvider:
         new_body = re.sub(r"\n?" + re.escape(_DRAFTING_MARKER), "", body)
         repo, _, _ = self._get_repo()
         self._issue_backend._update_issue_graphql(repo, node["id"], body=new_body)  # type: ignore[arg-type]
-        return {"finalized": True, "state": "ready"}
+        return {"finalized": True, "state": PlanState.READY}
 
     def store_document(
         self, plan_id: str, task_id: str | None, stage: str, doc_type: str, title: str, content: str, fmt: str = "md"

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -14,7 +14,7 @@ or GraphQL calls are made from this module.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 from sam_schema.core.backends._utils import _now_iso
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
@@ -481,16 +481,55 @@ class GitHubTaskProvider:
         }
 
     def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
-        """Append a single task to an existing plan.
+        """Append a single task to an existing plan as a GitHub sub-issue.
+
+        Single-writer contract: callers must serialize writes to the same plan.
+        Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
 
         Args:
             plan_id: Plan identifier (GitHub issue number string).
-            task_def: Task definition to append.
+            task_def: Task definition dict or TaskDefinition to append.
+
+        Returns:
+            Dict with ``appended`` (True), ``task_id`` (str), and ``github_issue`` (int).
 
         Raises:
-            NotImplementedError: See #1770 for the green-phase implementation.
+            PlanNotFoundError: When plan_id does not correspond to a SAM plan issue.
+            TaskValidationError: When task_def fails Pydantic validation or the task ID
+                already exists in the plan.
         """
-        raise NotImplementedError  # see #1770
+        import pydantic  # noqa: PLC0415
+
+        from sam_schema.core.models import Task  # noqa: PLC0415
+
+        self._fetch_plan_node(plan_id)
+
+        try:
+            task = Task.model_validate(task_def)
+        except pydantic.ValidationError as exc:
+            raise TaskValidationError(0, str(exc)) from exc
+
+        existing_ids: set[str] = set()
+        for n in self._fetch_task_nodes(plan_id):
+            meta_id = _parse_metadata(n["body"]).get("task_id")
+            if meta_id:
+                existing_ids.add(meta_id)
+            else:
+                m = _TASK_TITLE_RE.match(n["title"])
+                if m:
+                    existing_ids.add(m.group("tid"))
+        if task.id in existing_ids:
+            raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
+
+        task_def_typed = cast("TaskDefinition", task_def)
+        task_body = _render_task_body(task_def_typed, plan_id)
+        status_label = _STATUS_TO_LABEL.get(task_def_typed.get("status", "not-started"), "sam:not-started")
+        repo, _, _ = self._get_repo()
+        task_issue = repo.create_issue(  # type: ignore[attr-defined]
+            title=f"[{task.id}] {task.title}", body=task_body, labels=[_SAM_TASK_LABEL, status_label]
+        )
+
+        return {"appended": True, "task_id": task.id, "github_issue": task_issue.number}  # type: ignore[attr-defined]
 
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Transition a plan from drafting state to ready state.

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -25,7 +25,7 @@ from sam_schema.core.task_backend_types import (
     PlanData,
     PlanSummary,
     TaskData,
-    TaskDefinition,
+    TaskDefinitionDict,
 )
 
 if TYPE_CHECKING:
@@ -82,7 +82,7 @@ def _status_from_labels(labels: list[LabelNode]) -> str:
     return "not-started"
 
 
-def _render_metadata_section(task_def: TaskDefinition, plan_id: str) -> str:
+def _render_metadata_section(task_def: TaskDefinitionDict, plan_id: str) -> str:
     """Render the ``<!-- sam-task-metadata:begin/end -->`` table block."""
     rows: list[tuple[str, str]] = [
         ("task_id", task_def["id"]),
@@ -130,7 +130,7 @@ def _render_plan_body(slug: str, goal: str, context: str | None, ac: str | None)
     return "\n\n".join(parts)
 
 
-def _render_task_body(task_def: TaskDefinition, plan_id: str) -> str:
+def _render_task_body(task_def: TaskDefinitionDict, plan_id: str) -> str:
     """Render the full sub-issue body for a task."""
     parts = [_render_metadata_section(task_def, plan_id)]
     if body := task_def.get("body"):
@@ -275,7 +275,7 @@ class GitHubTaskProvider:
         self,
         slug: str,
         goal: str,
-        tasks: list[TaskDefinition],
+        tasks: list[TaskDefinitionDict],
         *,
         context: str | None = None,
         issue: int | None = None,
@@ -485,7 +485,7 @@ class GitHubTaskProvider:
             "has_cycles": _has_cycles(tasks),
         }
 
-    def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
+    def append_task(self, plan_id: str, task_def: TaskDefinitionDict | dict[str, Any]) -> dict[str, Any]:
         """Append a single task to an existing plan as a GitHub sub-issue.
 
         Single-writer contract: callers must serialize writes to the same plan.
@@ -493,7 +493,7 @@ class GitHubTaskProvider:
 
         Args:
             plan_id: Plan identifier (GitHub issue number string).
-            task_def: Task definition dict or TaskDefinition to append.
+            task_def: Task definition dict or TaskDefinitionDict to append.
 
         Returns:
             Dict with ``appended`` (True), ``task_id`` (str), and ``github_issue`` (int).
@@ -526,7 +526,7 @@ class GitHubTaskProvider:
         if task.id in existing_ids:
             raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
 
-        task_def_typed = cast("TaskDefinition", task_def)
+        task_def_typed = cast("TaskDefinitionDict", task_def)
         task_body = _render_task_body(task_def_typed, plan_id)
         status_label = _STATUS_TO_LABEL.get(task_def_typed.get("status", "not-started"), "sam:not-started")
         repo, _, _ = self._get_repo()

--- a/plugins/development-harness/sam_schema/core/backends/github_task.py
+++ b/plugins/development-harness/sam_schema/core/backends/github_task.py
@@ -14,22 +14,17 @@ or GraphQL calls are made from this module.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from sam_schema.core.backends._utils import _now_iso
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
 from sam_schema.core.exceptions import PlanNotFoundError, TaskNotFoundError, TaskValidationError
-from sam_schema.core.models import PlanState
-from sam_schema.core.task_backend_types import (
-    DocumentData,
-    DocumentHandle,
-    PlanData,
-    PlanSummary,
-    TaskData,
-    TaskDefinitionDict,
-)
+from sam_schema.core.models import PlanState, Task
+from sam_schema.core.task_backend_types import DocumentData, DocumentHandle, PlanData, PlanSummary, TaskData
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from backlog_core.backend_protocol import BacklogBackend, IssueNode, LabelNode
     from github.Repository import Repository
 
@@ -83,19 +78,21 @@ def _status_from_labels(labels: list[LabelNode]) -> str:
     return "not-started"
 
 
-def _render_metadata_section(task_def: TaskDefinitionDict, plan_id: str) -> str:
+def _render_metadata_section(task: Task, plan_id: str) -> str:
     """Render the ``<!-- sam-task-metadata:begin/end -->`` table block."""
+    # Use model_dump to get Python-native values (enum members, not raw strings)
+    td = task.model_dump(mode="python", by_alias=False)
     rows: list[tuple[str, str]] = [
-        ("task_id", task_def["id"]),
+        ("task_id", td["id"]),
         ("plan_id", plan_id),
-        ("agent", task_def.get("agent") or ""),
-        ("priority", str(task_def.get("priority", 0))),
-        ("complexity", task_def.get("complexity", "")),
-        ("dependencies", ",".join(task_def.get("dependencies", []))),
-        ("skills", ",".join(task_def.get("skills", []))),
-        ("created", task_def.get("created") or _now_iso()),
-        ("started", task_def.get("started") or ""),
-        ("completed", task_def.get("completed") or ""),
+        ("agent", td.get("agent") or ""),
+        ("priority", str(td.get("priority", 0))),
+        ("complexity", str(td.get("complexity", ""))),
+        ("dependencies", ",".join(td.get("dependencies") or [])),
+        ("skills", ",".join(td.get("skills") or [])),
+        ("created", str(td.get("created") or _now_iso())),
+        ("started", str(td.get("started") or "")),
+        ("completed", str(td.get("completed") or "")),
     ]
     lines = [_METADATA_BEGIN, "| Field | Value |", "|-------|-------|"]
     lines.extend(f"| {k} | {v} |" for k, v in rows)
@@ -131,15 +128,15 @@ def _render_plan_body(slug: str, goal: str, context: str | None, ac: str | None)
     return "\n\n".join(parts)
 
 
-def _render_task_body(task_def: TaskDefinitionDict, plan_id: str) -> str:
+def _render_task_body(task: Task, plan_id: str) -> str:
     """Render the full sub-issue body for a task."""
-    parts = [_render_metadata_section(task_def, plan_id)]
-    if body := task_def.get("body"):
-        parts.append(body)
-    if ac := task_def.get("acceptance_criteria"):
-        parts.append(f"## Acceptance Criteria\n\n{ac}")
-    if vs := task_def.get("verification_steps"):
-        parts.append(f"## Verification Steps\n\n{vs}")
+    parts = [_render_metadata_section(task, plan_id)]
+    if task.body:
+        parts.append(task.body)
+    if task.acceptance_criteria:
+        parts.append(f"## Acceptance Criteria\n\n{task.acceptance_criteria}")
+    if task.verification_steps:
+        parts.append(f"## Verification Steps\n\n{task.verification_steps}")
     return "\n\n".join(parts)
 
 
@@ -276,15 +273,15 @@ class GitHubTaskProvider:
         self,
         slug: str,
         goal: str,
-        tasks: list[TaskDefinitionDict],
+        tasks: Sequence[Task],
         *,
         context: str | None = None,
         issue: int | None = None,
         acceptance_criteria: str | None = None,
     ) -> PlanData:
         """Create a plan as a parent GitHub Issue with task sub-issues."""
-        for i, task_def in enumerate(tasks):
-            if not task_def.get("id") or not task_def.get("title"):
+        for i, task in enumerate(tasks):
+            if not task.id or not task.title:
                 raise TaskValidationError(i, "Task must have 'id' and 'title' fields")
 
         repo, _, _ = self._get_repo()
@@ -297,24 +294,24 @@ class GitHubTaskProvider:
         plan_id = str(parent_issue.number)  # type: ignore[attr-defined]
 
         task_data_list: list[TaskData] = []
-        for task_def in tasks:
-            task_body = _render_task_body(task_def, plan_id)
-            status_label = _STATUS_TO_LABEL.get(task_def.get("status", "not-started"), "sam:not-started")
+        for task in tasks:
+            task_body = _render_task_body(task, plan_id)
+            status_label = _STATUS_TO_LABEL.get(str(task.status), "sam:not-started")
             task_issue = repo.create_issue(  # type: ignore[attr-defined]
-                title=f"[{task_def['id']}] {task_def['title']}", body=task_body, labels=[_SAM_TASK_LABEL, status_label]
+                title=f"[{task.id}] {task.title}", body=task_body, labels=[_SAM_TASK_LABEL, status_label]
             )
             task_data_list.append(
                 TaskData(
-                    id=task_def["id"],
-                    title=task_def["title"],
-                    status=task_def.get("status", "not-started"),
-                    agent=task_def.get("agent") or None,
-                    dependencies=task_def.get("dependencies", []),
-                    blocked_by=task_def.get("blocked_by", []),
-                    parallelize_with=task_def.get("parallelize_with", []),
-                    priority=task_def.get("priority", 0),
-                    complexity=task_def.get("complexity", ""),
-                    skills=task_def.get("skills", []),
+                    id=task.id,
+                    title=task.title,
+                    status=str(task.status),
+                    agent=task.agent or None,
+                    dependencies=task.dependencies or [],
+                    blocked_by=task.blocked_by or [],
+                    parallelize_with=task.parallelize_with or [],
+                    priority=int(task.priority),
+                    complexity=str(task.complexity),
+                    skills=task.skills or [],
                     created=_now_iso(),
                     started=None,
                     completed=None,
@@ -486,34 +483,29 @@ class GitHubTaskProvider:
             "has_cycles": _has_cycles(tasks),
         }
 
-    def append_task(self, plan_id: str, task_def: TaskDefinitionDict | dict[str, Any]) -> dict[str, Any]:
-        """Append a single task to an existing plan as a GitHub sub-issue.
+    def append_task(self, plan_id: str, task: Task) -> dict[str, Any]:
+        """Append a single validated Task to an existing plan as a GitHub sub-issue.
+
+        The task has already been validated at the MCP boundary. This method
+        checks for duplicate IDs and creates the sub-issue on GitHub.
+        Body and label inputs are rendered from ``task.model_dump(mode="python")``
+        so all enum coercions are applied before rendering — no raw dict access.
 
         Single-writer contract: callers must serialize writes to the same plan.
         Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
 
         Args:
             plan_id: Plan identifier (GitHub issue number string).
-            task_def: Task definition dict or TaskDefinitionDict to append.
+            task: Validated Task model to append.
 
         Returns:
             Dict with ``appended`` (True), ``task_id`` (str), and ``github_issue`` (int).
 
         Raises:
             PlanNotFoundError: When plan_id does not correspond to a SAM plan issue.
-            TaskValidationError: When task_def fails Pydantic validation or the task ID
-                already exists in the plan.
+            TaskValidationError: When the task ID already exists in the plan.
         """
-        import pydantic  # noqa: PLC0415
-
-        from sam_schema.core.models import Task  # noqa: PLC0415
-
         self._fetch_plan_node(plan_id)
-
-        try:
-            task = Task.model_validate(task_def)
-        except pydantic.ValidationError as exc:
-            raise TaskValidationError(0, str(exc)) from exc
 
         existing_ids: set[str] = set()
         for n in self._fetch_task_nodes(plan_id):
@@ -527,9 +519,9 @@ class GitHubTaskProvider:
         if task.id in existing_ids:
             raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
 
-        task_def_typed = cast("TaskDefinitionDict", task_def)
-        task_body = _render_task_body(task_def_typed, plan_id)
-        status_label = _STATUS_TO_LABEL.get(task_def_typed.get("status", "not-started"), "sam:not-started")
+        task_body = _render_task_body(task, plan_id)
+        status_val = str(task.status)
+        status_label = _STATUS_TO_LABEL.get(status_val, "sam:not-started")
         repo, _, _ = self._get_repo()
         task_issue = repo.create_issue(  # type: ignore[attr-defined]
             title=f"[{task.id}] {task.title}", body=task_body, labels=[_SAM_TASK_LABEL, status_label]

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -535,6 +535,33 @@ class LocalYamlTaskProvider:
         except FileNotFoundError as exc:
             raise PlanNotFoundError(plan_id) from exc
 
+    def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
+        """Stub — append_task not yet implemented on LocalYamlTaskProvider.
+
+        See TaskBackend.append_task for the single-writer contract and #1770 for the ADR.
+
+        Args:
+            plan_id: Plan identifier.
+            task_def: Single-task definition dict.
+
+        Raises:
+            NotImplementedError: Always — see #1770 for the green-phase implementation.
+        """
+        raise NotImplementedError("LocalYamlTaskProvider.append_task not yet implemented — see #1770")
+
+    def finalize_plan(self, plan_id: str) -> dict[str, Any]:
+        """Stub — finalize_plan not yet implemented on LocalYamlTaskProvider.
+
+        See TaskBackend.finalize_plan and #1770 for the ADR.
+
+        Args:
+            plan_id: Plan identifier.
+
+        Raises:
+            NotImplementedError: Always — see #1770 for the green-phase implementation.
+        """
+        raise NotImplementedError("LocalYamlTaskProvider.finalize_plan not yet implemented — see #1770")
+
     def get_ready_tasks(self, plan_id: str) -> list[TaskData]:
         """Return all tasks that are ready for dispatch.
 

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -195,6 +195,10 @@ class LocalYamlTaskProvider:
 
             plan_dir = dh_paths.plan_dir()
         self._plan_dir: Path = plan_dir
+        # Per-plan task-ID cache — avoids repeated YAML parse+deserialize when
+        # calling append_task multiple times on the same plan in sequence.
+        # Keyed by plan_id (str); invalidated on finalize_plan.
+        self._task_id_cache: dict[str, set[str]] = {}
 
     def _resolve_path(self, plan_id: str) -> Path:
         """Resolve a plan_id to its filesystem path.
@@ -562,8 +566,12 @@ class LocalYamlTaskProvider:
         result = query.load_plan(path)
         plan = result.plan
 
-        existing_ids = {t.id for t in plan.tasks}
-        validate_appended_task(task, existing_ids, plan_id)
+        # Use cache on subsequent calls; populate from plan on first call.
+        if plan_id not in self._task_id_cache:
+            self._task_id_cache[plan_id] = {t.id for t in plan.tasks}
+
+        validate_appended_task(task, self._task_id_cache[plan_id], plan_id)
+        self._task_id_cache[plan_id].add(task.id)
 
         new_tasks = [*plan.tasks, task]
         updated_plan = plan.model_copy(update={"tasks": new_tasks})
@@ -593,8 +601,14 @@ class LocalYamlTaskProvider:
         result = query.load_plan(path)
         plan = result.plan
 
+        # No-op guard: already ready — skip write, return early.
+        if plan.state == PlanState.READY:
+            return {"finalized": True, "state": PlanState.READY}
+
         updated_plan = plan.model_copy(update={"state": PlanState.READY})
         write_plan(updated_plan, path, force_single=True)
+        # Invalidate task-ID cache so subsequent appends read fresh state.
+        self._task_id_cache.pop(plan_id, None)
 
         return {"finalized": True, "state": PlanState.READY}
 

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -166,6 +166,7 @@ def _plan_to_plan_data(plan: Plan, plan_id: str) -> PlanData:
         data["codebase_patterns"] = plan.codebase_patterns
     if plan.backend_ref is not None:
         data["backend_ref"] = plan.backend_ref
+    data["state"] = plan.state
     return data
 
 

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -583,17 +583,34 @@ class LocalYamlTaskProvider:
         return {"appended": True, "task_id": task.id}
 
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
-        """Stub — finalize_plan not yet implemented on LocalYamlTaskProvider.
+        """Finalize a drafting plan by setting its state to ready.
 
-        See TaskBackend.finalize_plan and #1770 for the ADR.
+        Resolves the plan path, loads the current plan, sets ``state="ready"``,
+        and writes back using ``write_plan`` with ``force_single=True``.
+
+        **Single-writer assumption (ADR-1770-1)**: This method is NOT safe under
+        concurrent writers. Callers must serialize writes to the same plan. Behavior
+        under concurrent ``finalize_plan`` calls for the same plan is **undefined**.
 
         Args:
             plan_id: Plan identifier.
 
+        Returns:
+            ``{"finalized": True, "state": "ready"}``
+
         Raises:
-            NotImplementedError: Always — see #1770 for the green-phase implementation.
+            PlanNotFoundError: When plan_id cannot be resolved to a file.
         """
-        raise NotImplementedError("LocalYamlTaskProvider.finalize_plan not yet implemented — see #1770")
+        from sam_schema.writers.yaml_writer import write_plan  # noqa: PLC0415
+
+        path = self._resolve_path(plan_id)
+        result = query.load_plan(path)
+        plan = result.plan
+
+        updated_plan = plan.model_copy(update={"state": "ready"})
+        write_plan(updated_plan, path, force_single=True)
+
+        return {"finalized": True, "state": "ready"}
 
     def get_ready_tasks(self, plan_id: str) -> list[TaskData]:
         """Return all tasks that are ready for dispatch.

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -23,7 +23,7 @@ from sam_schema.core.exceptions import (
     TaskNotFoundError,
     TaskValidationError,
 )
-from sam_schema.core.models import Plan, Task, TaskStatus
+from sam_schema.core.models import Plan, PlanState, Task, TaskStatus
 from sam_schema.readers.detect import FormatDetectionError
 
 if TYPE_CHECKING:
@@ -272,7 +272,7 @@ class LocalYamlTaskProvider:
         if not tasks:
             from sam_schema.writers.yaml_writer import write_plan  # noqa: PLC0415
 
-            plan = plan.model_copy(update={"state": "drafting"})
+            plan = plan.model_copy(update={"state": PlanState.DRAFTING})
             if plan.source_path is not None:
                 write_plan(plan, plan.source_path, force_single=True)
 
@@ -614,10 +614,10 @@ class LocalYamlTaskProvider:
         result = query.load_plan(path)
         plan = result.plan
 
-        updated_plan = plan.model_copy(update={"state": "ready"})
+        updated_plan = plan.model_copy(update={"state": PlanState.READY})
         write_plan(updated_plan, path, force_single=True)
 
-        return {"finalized": True, "state": "ready"}
+        return {"finalized": True, "state": PlanState.READY}
 
     def get_ready_tasks(self, plan_id: str) -> list[TaskData]:
         """Return all tasks that are ready for dispatch.

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -269,6 +269,13 @@ class LocalYamlTaskProvider:
                 raise TaskValidationError(int(m.group(1)), m.group(2)) from exc
             raise TaskValidationError(0, msg) from exc
 
+        if not tasks:
+            from sam_schema.writers.yaml_writer import write_plan  # noqa: PLC0415
+
+            plan = plan.model_copy(update={"state": "drafting"})
+            if plan.source_path is not None:
+                write_plan(plan, plan.source_path, force_single=True)
+
         plan_id = _plan_id_from_path(plan.source_path) if plan.source_path else slug
         return _plan_to_plan_data(plan, plan_id)
 

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from sam_schema.core import query
 from sam_schema.core.addressing import AddressingError, resolve_plan_address
@@ -27,14 +27,9 @@ from sam_schema.core.models import Plan, PlanState, Task, TaskStatus
 from sam_schema.readers.detect import FormatDetectionError
 
 if TYPE_CHECKING:
-    from sam_schema.core.task_backend_types import (
-        DocumentData,
-        DocumentHandle,
-        PlanData,
-        PlanSummary,
-        TaskData,
-        TaskDefinitionDict,
-    )
+    from collections.abc import Sequence
+
+    from sam_schema.core.task_backend_types import DocumentData, DocumentHandle, PlanData, PlanSummary, TaskData
 
 __all__ = ["LocalYamlTaskProvider"]
 
@@ -225,7 +220,7 @@ class LocalYamlTaskProvider:
         self,
         slug: str,
         goal: str,
-        tasks: list[TaskDefinitionDict],
+        tasks: Sequence[Task],
         *,
         context: str | None = None,
         issue: int | None = None,
@@ -241,7 +236,7 @@ class LocalYamlTaskProvider:
         Args:
             slug: Human-readable identifier slug for the plan.
             goal: One-sentence goal statement.
-            tasks: Ordered list of task definitions.
+            tasks: Ordered list of validated Task models.
             context: Optional plan-level context narrative.
             issue: Optional GitHub issue number.
             acceptance_criteria: Accepted but not written by this backend.
@@ -254,7 +249,7 @@ class LocalYamlTaskProvider:
             PlanExistsError: When a plan with the resolved plan_id already exists.
             TaskValidationError: When any task definition fails validation.
         """
-        task_dicts: list[dict[str, Any]] = [cast("dict[str, Any]", t) for t in tasks]
+        task_dicts: list[dict[str, Any]] = [t.model_dump(by_alias=False, exclude_none=True) for t in tasks]
         try:
             plan = query.create_plan(
                 slug=slug, goal=goal, tasks=task_dicts, plan_dir=self._plan_dir, context=context, issue=issue
@@ -543,12 +538,12 @@ class LocalYamlTaskProvider:
         except FileNotFoundError as exc:
             raise PlanNotFoundError(plan_id) from exc
 
-    def append_task(self, plan_id: str, task_def: TaskDefinitionDict | dict[str, Any]) -> dict[str, Any]:
-        """Append a single task to an existing plan.
+    def append_task(self, plan_id: str, task: Task) -> dict[str, Any]:
+        """Append a single validated Task to an existing plan.
 
-        Resolves the plan path, loads the current plan via ruamel round-trip YAML,
-        validates the task definition, checks for duplicate IDs, appends the task,
-        and writes back using write_plan with force_single=True.
+        The task has already been validated at the MCP boundary. This method
+        checks for duplicate IDs, appends the task, and writes back using
+        write_plan with force_single=True.
 
         **Single-writer assumption (ADR-1770-1)**: This method is NOT safe under
         concurrent writers. Callers must serialize writes to the same plan. Behavior
@@ -556,32 +551,24 @@ class LocalYamlTaskProvider:
 
         Args:
             plan_id: Plan identifier.
-            task_def: Single-task definition dict or TaskDefinitionDict TypedDict.
+            task: Validated Task model to append.
 
         Returns:
             ``{"appended": True, "task_id": task.id}``
 
         Raises:
             PlanNotFoundError: When plan_id cannot be resolved to a file.
-            TaskValidationError: When task_def fails Pydantic validation or the
-                task ID already exists in the plan.
+            TaskValidationError: When the task ID already exists in the plan.
         """
-        import pydantic  # noqa: PLC0415
-
         from sam_schema.writers.yaml_writer import write_plan  # noqa: PLC0415
 
         path = self._resolve_path(plan_id)
         result = query.load_plan(path)
         plan = result.plan
 
-        try:
-            task = Task.model_validate(task_def)
-        except pydantic.ValidationError as exc:
-            raise TaskValidationError(0, str(exc)) from exc
-
         existing_ids = [t.id for t in plan.tasks]
         if task.id in existing_ids:
-            raise TaskValidationError(0, f"Duplicate task ID: {task.id!r} already exists in plan {plan_id!r}")
+            raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
 
         new_tasks = [*plan.tasks, task]
         updated_plan = plan.model_copy(update={"tasks": new_tasks})

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from sam_schema.core import query
 from sam_schema.core.addressing import AddressingError, resolve_plan_address
+from sam_schema.core.backends._utils import validate_appended_task
 from sam_schema.core.exceptions import (
     DocumentNotFoundError,
     PlanExistsError,
@@ -541,13 +542,8 @@ class LocalYamlTaskProvider:
     def append_task(self, plan_id: str, task: Task) -> dict[str, Any]:
         """Append a single validated Task to an existing plan.
 
-        The task has already been validated at the MCP boundary. This method
-        checks for duplicate IDs, appends the task, and writes back using
-        write_plan with force_single=True.
-
-        **Single-writer assumption (ADR-1770-1)**: This method is NOT safe under
-        concurrent writers. Callers must serialize writes to the same plan. Behavior
-        under concurrent ``append_task`` calls for the same plan is **undefined**.
+        Duplicate-ID check via ``validate_appended_task``; see ADR-1770-1 for the
+        single-writer contract (callers must serialise writes to the same plan).
 
         Args:
             plan_id: Plan identifier.
@@ -566,9 +562,8 @@ class LocalYamlTaskProvider:
         result = query.load_plan(path)
         plan = result.plan
 
-        existing_ids = [t.id for t in plan.tasks]
-        if task.id in existing_ids:
-            raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
+        existing_ids = {t.id for t in plan.tasks}
+        validate_appended_task(task, existing_ids, plan_id)
 
         new_tasks = [*plan.tasks, task]
         updated_plan = plan.model_copy(update={"tasks": new_tasks})
@@ -579,12 +574,9 @@ class LocalYamlTaskProvider:
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Finalize a drafting plan by setting its state to ready.
 
-        Resolves the plan path, loads the current plan, sets ``state="ready"``,
-        and writes back using ``write_plan`` with ``force_single=True``.
-
-        **Single-writer assumption (ADR-1770-1)**: This method is NOT safe under
-        concurrent writers. Callers must serialize writes to the same plan. Behavior
-        under concurrent ``finalize_plan`` calls for the same plan is **undefined**.
+        Loads the plan, sets ``state="ready"``, writes back via ``write_plan``.
+        See ADR-1770-1 for the single-writer contract (callers must serialise
+        writes to the same plan).
 
         Args:
             plan_id: Plan identifier.

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         PlanData,
         PlanSummary,
         TaskData,
-        TaskDefinition,
+        TaskDefinitionDict,
     )
 
 __all__ = ["LocalYamlTaskProvider"]
@@ -225,7 +225,7 @@ class LocalYamlTaskProvider:
         self,
         slug: str,
         goal: str,
-        tasks: list[TaskDefinition],
+        tasks: list[TaskDefinitionDict],
         *,
         context: str | None = None,
         issue: int | None = None,
@@ -543,7 +543,7 @@ class LocalYamlTaskProvider:
         except FileNotFoundError as exc:
             raise PlanNotFoundError(plan_id) from exc
 
-    def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
+    def append_task(self, plan_id: str, task_def: TaskDefinitionDict | dict[str, Any]) -> dict[str, Any]:
         """Append a single task to an existing plan.
 
         Resolves the plan path, loads the current plan via ruamel round-trip YAML,
@@ -556,7 +556,7 @@ class LocalYamlTaskProvider:
 
         Args:
             plan_id: Plan identifier.
-            task_def: Single-task definition dict or TaskDefinition TypedDict.
+            task_def: Single-task definition dict or TaskDefinitionDict TypedDict.
 
         Returns:
             ``{"appended": True, "task_id": task.id}``

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -537,18 +537,50 @@ class LocalYamlTaskProvider:
             raise PlanNotFoundError(plan_id) from exc
 
     def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
-        """Stub — append_task not yet implemented on LocalYamlTaskProvider.
+        """Append a single task to an existing plan.
 
-        See TaskBackend.append_task for the single-writer contract and #1770 for the ADR.
+        Resolves the plan path, loads the current plan via ruamel round-trip YAML,
+        validates the task definition, checks for duplicate IDs, appends the task,
+        and writes back using write_plan with force_single=True.
+
+        **Single-writer assumption (ADR-1770-1)**: This method is NOT safe under
+        concurrent writers. Callers must serialize writes to the same plan. Behavior
+        under concurrent ``append_task`` calls for the same plan is **undefined**.
 
         Args:
             plan_id: Plan identifier.
-            task_def: Single-task definition dict.
+            task_def: Single-task definition dict or TaskDefinition TypedDict.
+
+        Returns:
+            ``{"appended": True, "task_id": task.id}``
 
         Raises:
-            NotImplementedError: Always — see #1770 for the green-phase implementation.
+            PlanNotFoundError: When plan_id cannot be resolved to a file.
+            TaskValidationError: When task_def fails Pydantic validation or the
+                task ID already exists in the plan.
         """
-        raise NotImplementedError("LocalYamlTaskProvider.append_task not yet implemented — see #1770")
+        import pydantic  # noqa: PLC0415
+
+        from sam_schema.writers.yaml_writer import write_plan  # noqa: PLC0415
+
+        path = self._resolve_path(plan_id)
+        result = query.load_plan(path)
+        plan = result.plan
+
+        try:
+            task = Task.model_validate(task_def)
+        except pydantic.ValidationError as exc:
+            raise TaskValidationError(0, str(exc)) from exc
+
+        existing_ids = [t.id for t in plan.tasks]
+        if task.id in existing_ids:
+            raise TaskValidationError(0, f"Duplicate task ID: {task.id!r} already exists in plan {plan_id!r}")
+
+        new_tasks = [*plan.tasks, task]
+        updated_plan = plan.model_copy(update={"tasks": new_tasks})
+        write_plan(updated_plan, path, force_single=True)
+
+        return {"appended": True, "task_id": task.id}
 
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Stub — finalize_plan not yet implemented on LocalYamlTaskProvider.

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -649,6 +649,7 @@ class LocalYamlTaskProvider:
         """
         path = self._resolve_path(plan_id)
         try:
+            result = query.load_plan(path)
             status = query.get_plan_status(path)
         except FileNotFoundError as exc:
             raise PlanNotFoundError(plan_id) from exc
@@ -660,6 +661,7 @@ class LocalYamlTaskProvider:
             "blocked_tasks": list(status.blocked_tasks),
             "completion_pct": status.completion_pct,
             "has_cycles": status.has_cycles,
+            "state": result.plan.state,
         }
 
     # ------------------------------------------------------------------

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -30,6 +30,7 @@ from sam_schema.core.exceptions import (
     TaskNotFoundError,
     TaskValidationError,
 )
+from sam_schema.core.models import PlanState
 from sam_schema.core.query import _new_plan_id
 
 if TYPE_CHECKING:
@@ -245,7 +246,7 @@ class InMemoryTaskProvider:
             "issue": str(issue) if issue is not None else None,
             "tasks": task_data_list,
             "source_path": None,
-            "state": "drafting" if not tasks else "ready",
+            "state": PlanState.DRAFTING if not tasks else PlanState.READY,
         }
         self._plans[plan_id] = copy.deepcopy(plan_data)
         return copy.deepcopy(plan_data)
@@ -545,8 +546,8 @@ class InMemoryTaskProvider:
         """
         if plan_id not in self._plans:
             raise PlanNotFoundError(plan_id)
-        self._plans[plan_id]["state"] = "ready"
-        return {"finalized": True, "state": "ready"}
+        self._plans[plan_id]["state"] = PlanState.READY
+        return {"finalized": True, "state": PlanState.READY}
 
     def get_ready_tasks(self, plan_id: str) -> list[TaskData]:
         """Return all tasks that are ready for dispatch.

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -21,7 +21,7 @@ import copy
 import uuid
 from typing import TYPE_CHECKING, Any, cast
 
-from sam_schema.core.backends._utils import _now_iso
+from sam_schema.core.backends._utils import _now_iso, validate_appended_task
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
 from sam_schema.core.exceptions import (
     DocumentNotFoundError,
@@ -486,11 +486,8 @@ class InMemoryTaskProvider:
     def append_task(self, plan_id: str, task: Task) -> dict[str, Any]:
         """Append a single validated Task to an existing plan.
 
-        The task has already been validated at the MCP boundary (TaskDefinition →
-        Task). This method only checks for duplicate task IDs and persists.
-
-        Single-writer contract: callers must serialize writes to the same plan.
-        Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
+        Duplicate-ID check via ``validate_appended_task``; see ADR-1770-1 for the
+        single-writer contract (callers must serialise writes to the same plan).
 
         Args:
             plan_id: Backend-assigned plan identifier.
@@ -507,8 +504,7 @@ class InMemoryTaskProvider:
             raise PlanNotFoundError(plan_id)
 
         existing_ids = {t["id"] for t in self._plans[plan_id]["tasks"]}
-        if task.id in existing_ids:
-            raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
+        validate_appended_task(task, existing_ids, plan_id)
 
         task_data = _task_def_to_task_data(cast("TaskDefinitionDict", task.model_dump(by_alias=False)))
         self._plans[plan_id]["tasks"].append(task_data)
@@ -518,12 +514,8 @@ class InMemoryTaskProvider:
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Finalize a drafting plan, transitioning its state to 'ready'.
 
-        Clears the drafting marker set during create_plan when the tasks list was
-        empty. After finalize, sam_plan status and sam_plan ready return normal
-        progress data instead of a drafting marker.
-
-        Single-writer contract: callers must serialize writes to the same plan.
-        Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
+        Clears the drafting marker set during create_plan. See ADR-1770-1 for the
+        single-writer contract (callers must serialise writes to the same plan).
 
         Args:
             plan_id: Backend-assigned plan identifier.

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -528,6 +528,9 @@ class InMemoryTaskProvider:
         """
         if plan_id not in self._plans:
             raise PlanNotFoundError(plan_id)
+        # No-op guard: already ready — skip write, return early.
+        if self._plans[plan_id].get("state") == PlanState.READY:
+            return {"finalized": True, "state": PlanState.READY}
         self._plans[plan_id]["state"] = PlanState.READY
         return {"finalized": True, "state": PlanState.READY}
 

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -30,11 +30,12 @@ from sam_schema.core.exceptions import (
     TaskNotFoundError,
     TaskValidationError,
 )
-from sam_schema.core.models import PlanState
+from sam_schema.core.models import PlanState, Task
 from sam_schema.core.query import _new_plan_id
 
 if TYPE_CHECKING:
-    from sam_schema.core.models import Task
+    from collections.abc import Sequence
+
     from sam_schema.core.task_backend_types import (
         DocumentData,
         DocumentHandle,
@@ -198,7 +199,7 @@ class InMemoryTaskProvider:
         self,
         slug: str,
         goal: str,
-        tasks: list[TaskDefinitionDict],
+        tasks: Sequence[Task],
         *,
         context: str | None = None,
         issue: int | None = None,
@@ -209,7 +210,7 @@ class InMemoryTaskProvider:
         Args:
             slug: Human-readable identifier slug for the plan.
             goal: One-sentence goal statement.
-            tasks: Ordered list of task definitions.
+            tasks: Ordered list of validated Task models.
             context: Optional plan-level context narrative.
             issue: Optional GitHub issue number. When provided, the plan_id
                 is ``P{issue}``; otherwise an auto-incremented ID is used.
@@ -228,12 +229,12 @@ class InMemoryTaskProvider:
             raise PlanExistsError(plan_id)
 
         task_data_list: list[TaskData] = []
-        for idx, task_def in enumerate(tasks):
-            if not task_def.get("id"):
+        for idx, task in enumerate(tasks):
+            if not task.id:
                 raise TaskValidationError(idx, "Task 'id' is required")
-            if not task_def.get("title"):
+            if not task.title:
                 raise TaskValidationError(idx, "Task 'title' is required")
-            task_data_list.append(_task_def_to_task_data(task_def))
+            task_data_list.append(_task_def_to_task_data(cast("TaskDefinitionDict", task.model_dump(by_alias=False))))
 
         plan_data: PlanData = {
             "plan_id": plan_id,
@@ -482,45 +483,34 @@ class InMemoryTaskProvider:
             new_context = f"{existing}{separator}{heading}\n\n{content}"
         task["context_notes"] = new_context  # type: ignore[typeddict-item]
 
-    def append_task(self, plan_id: str, task_def: TaskDefinitionDict | dict[str, Any]) -> dict[str, Any]:
-        """Append a single task definition to an existing plan.
+    def append_task(self, plan_id: str, task: Task) -> dict[str, Any]:
+        """Append a single validated Task to an existing plan.
 
-        Validates the task definition via the Task Pydantic model, checks for
-        duplicate task IDs, and appends the new task to the plan's task list.
+        The task has already been validated at the MCP boundary (TaskDefinition →
+        Task). This method only checks for duplicate task IDs and persists.
 
         Single-writer contract: callers must serialize writes to the same plan.
         Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
 
         Args:
             plan_id: Backend-assigned plan identifier.
-            task_def: Single-task definition dict. Must contain at minimum ``id``
-                and ``title``. Validated via ``Task.model_validate`` before appending.
+            task: Validated Task model to append.
 
         Returns:
             Dict with ``appended`` (True) and ``task_id`` (the appended task's ID).
 
         Raises:
             PlanNotFoundError: When plan_id is not known.
-            TaskValidationError: When task_def fails Pydantic validation or contains
-                a task ID already present in the plan.
+            TaskValidationError: When the task ID already exists in the plan.
         """
-        import pydantic  # noqa: PLC0415
-
-        from sam_schema.core.models import Task  # noqa: PLC0415
-
         if plan_id not in self._plans:
             raise PlanNotFoundError(plan_id)
-
-        try:
-            task = Task.model_validate(task_def)
-        except pydantic.ValidationError as exc:
-            raise TaskValidationError(0, str(exc)) from exc
 
         existing_ids = {t["id"] for t in self._plans[plan_id]["tasks"]}
         if task.id in existing_ids:
             raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
 
-        task_data = _task_def_to_task_data(cast("TaskDefinitionDict", task_def))
+        task_data = _task_def_to_task_data(cast("TaskDefinitionDict", task.model_dump(by_alias=False)))
         self._plans[plan_id]["tasks"].append(task_data)
 
         return {"appended": True, "task_id": task.id}

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -482,18 +482,47 @@ class InMemoryTaskProvider:
         task["context_notes"] = new_context  # type: ignore[typeddict-item]
 
     def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
-        """Stub — append_task not yet implemented on InMemoryTaskProvider.
+        """Append a single task definition to an existing plan.
 
-        See TaskBackend.append_task for the single-writer contract and #1770 for the ADR.
+        Validates the task definition via the Task Pydantic model, checks for
+        duplicate task IDs, and appends the new task to the plan's task list.
+
+        Single-writer contract: callers must serialize writes to the same plan.
+        Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
 
         Args:
-            plan_id: Plan identifier.
-            task_def: Single-task definition dict.
+            plan_id: Backend-assigned plan identifier.
+            task_def: Single-task definition dict. Must contain at minimum ``id``
+                and ``title``. Validated via ``Task.model_validate`` before appending.
+
+        Returns:
+            Dict with ``appended`` (True) and ``task_id`` (the appended task's ID).
 
         Raises:
-            NotImplementedError: Always — see #1770 for the green-phase implementation.
+            PlanNotFoundError: When plan_id is not known.
+            TaskValidationError: When task_def fails Pydantic validation or contains
+                a task ID already present in the plan.
         """
-        raise NotImplementedError("InMemoryTaskProvider.append_task not yet implemented — see #1770")
+        import pydantic  # noqa: PLC0415
+
+        from sam_schema.core.models import Task  # noqa: PLC0415
+
+        if plan_id not in self._plans:
+            raise PlanNotFoundError(plan_id)
+
+        try:
+            task = Task.model_validate(task_def)
+        except pydantic.ValidationError as exc:
+            raise TaskValidationError(0, str(exc)) from exc
+
+        existing_ids = {t["id"] for t in self._plans[plan_id]["tasks"]}
+        if task.id in existing_ids:
+            raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
+
+        task_data = _task_def_to_task_data(cast("TaskDefinition", task_def))
+        self._plans[plan_id]["tasks"].append(task_data)
+
+        return {"appended": True, "task_id": task.id}
 
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Stub — finalize_plan not yet implemented on InMemoryTaskProvider.

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -245,6 +245,7 @@ class InMemoryTaskProvider:
             "issue": str(issue) if issue is not None else None,
             "tasks": task_data_list,
             "source_path": None,
+            "state": "drafting" if not tasks else "ready",
         }
         self._plans[plan_id] = copy.deepcopy(plan_data)
         return copy.deepcopy(plan_data)

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -525,17 +525,28 @@ class InMemoryTaskProvider:
         return {"appended": True, "task_id": task.id}
 
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
-        """Stub — finalize_plan not yet implemented on InMemoryTaskProvider.
+        """Finalize a drafting plan, transitioning its state to 'ready'.
 
-        See TaskBackend.finalize_plan and #1770 for the ADR.
+        Clears the drafting marker set during create_plan when tasks_yaml was
+        empty. After finalize, sam_plan status and sam_plan ready return normal
+        progress data instead of a drafting marker.
+
+        Single-writer contract: callers must serialize writes to the same plan.
+        Behavior under concurrent writes to the same plan is undefined. See ADR-1770-1.
 
         Args:
-            plan_id: Plan identifier.
+            plan_id: Backend-assigned plan identifier.
+
+        Returns:
+            Dict with ``finalized`` (True) and ``state`` ('ready').
 
         Raises:
-            NotImplementedError: Always — see #1770 for the green-phase implementation.
+            PlanNotFoundError: When plan_id is not known.
         """
-        raise NotImplementedError("InMemoryTaskProvider.finalize_plan not yet implemented — see #1770")
+        if plan_id not in self._plans:
+            raise PlanNotFoundError(plan_id)
+        self._plans[plan_id]["state"] = "ready"
+        return {"finalized": True, "state": "ready"}
 
     def get_ready_tasks(self, plan_id: str) -> list[TaskData]:
         """Return all tasks that are ready for dispatch.

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
         PlanData,
         PlanSummary,
         TaskData,
-        TaskDefinition,
+        TaskDefinitionDict,
     )
 
 __all__ = ["InMemoryTaskProvider"]
@@ -56,8 +56,8 @@ _VALID_STATUSES: frozenset[str] = frozenset({
 })
 
 
-def _task_def_to_task_data(task_def: TaskDefinition) -> TaskData:
-    """Convert a TaskDefinition input TypedDict to a TaskData output TypedDict.
+def _task_def_to_task_data(task_def: TaskDefinitionDict) -> TaskData:
+    """Convert a TaskDefinitionDict input TypedDict to a TaskData output TypedDict.
 
     Applies defaults for all optional fields absent from the input.
 
@@ -197,7 +197,7 @@ class InMemoryTaskProvider:
         self,
         slug: str,
         goal: str,
-        tasks: list[TaskDefinition],
+        tasks: list[TaskDefinitionDict],
         *,
         context: str | None = None,
         issue: int | None = None,
@@ -481,7 +481,7 @@ class InMemoryTaskProvider:
             new_context = f"{existing}{separator}{heading}\n\n{content}"
         task["context_notes"] = new_context  # type: ignore[typeddict-item]
 
-    def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
+    def append_task(self, plan_id: str, task_def: TaskDefinitionDict | dict[str, Any]) -> dict[str, Any]:
         """Append a single task definition to an existing plan.
 
         Validates the task definition via the Task Pydantic model, checks for
@@ -519,7 +519,7 @@ class InMemoryTaskProvider:
         if task.id in existing_ids:
             raise TaskValidationError(0, f"Task ID {task.id!r} already exists in plan {plan_id!r}")
 
-        task_data = _task_def_to_task_data(cast("TaskDefinition", task_def))
+        task_data = _task_def_to_task_data(cast("TaskDefinitionDict", task_def))
         self._plans[plan_id]["tasks"].append(task_data)
 
         return {"appended": True, "task_id": task.id}
@@ -527,7 +527,7 @@ class InMemoryTaskProvider:
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Finalize a drafting plan, transitioning its state to 'ready'.
 
-        Clears the drafting marker set during create_plan when tasks_yaml was
+        Clears the drafting marker set during create_plan when the tasks list was
         empty. After finalize, sam_plan status and sam_plan ready return normal
         progress data instead of a drafting marker.
 

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import copy
 import uuid
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from sam_schema.core.backends._utils import _now_iso
 from sam_schema.core.dependencies import TERMINAL_STATUSES as _TERMINAL_STATUSES
@@ -479,6 +479,33 @@ class InMemoryTaskProvider:
             separator = "\n" if existing else ""
             new_context = f"{existing}{separator}{heading}\n\n{content}"
         task["context_notes"] = new_context  # type: ignore[typeddict-item]
+
+    def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
+        """Stub — append_task not yet implemented on InMemoryTaskProvider.
+
+        See TaskBackend.append_task for the single-writer contract and #1770 for the ADR.
+
+        Args:
+            plan_id: Plan identifier.
+            task_def: Single-task definition dict.
+
+        Raises:
+            NotImplementedError: Always — see #1770 for the green-phase implementation.
+        """
+        raise NotImplementedError("InMemoryTaskProvider.append_task not yet implemented — see #1770")
+
+    def finalize_plan(self, plan_id: str) -> dict[str, Any]:
+        """Stub — finalize_plan not yet implemented on InMemoryTaskProvider.
+
+        See TaskBackend.finalize_plan and #1770 for the ADR.
+
+        Args:
+            plan_id: Plan identifier.
+
+        Raises:
+            NotImplementedError: Always — see #1770 for the green-phase implementation.
+        """
+        raise NotImplementedError("InMemoryTaskProvider.finalize_plan not yet implemented — see #1770")
 
     def get_ready_tasks(self, plan_id: str) -> list[TaskData]:
         """Return all tasks that are ready for dispatch.

--- a/plugins/development-harness/sam_schema/core/backends/memory.py
+++ b/plugins/development-harness/sam_schema/core/backends/memory.py
@@ -611,6 +611,7 @@ class InMemoryTaskProvider:
             "blocked_tasks": blocked_tasks,
             "completion_pct": completion_pct,
             "has_cycles": _has_cycle(tasks),
+            "state": plan.get("state", PlanState.READY),
         }
 
     # ------------------------------------------------------------------

--- a/plugins/development-harness/sam_schema/core/models.py
+++ b/plugins/development-harness/sam_schema/core/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from enum import IntEnum, StrEnum
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
@@ -102,6 +102,13 @@ class BookendType(StrEnum):
 
     T0_BASELINE = "t0-baseline"
     TN_VERIFICATION = "tn-verification"
+
+
+class PlanState(StrEnum):
+    """Lifecycle state for a SAM plan."""
+
+    DRAFTING = "drafting"
+    READY = "ready"
 
 
 class Task(BaseModel):
@@ -271,7 +278,7 @@ class Plan(BaseModel):
     feature: str
     version: str = "1.0"
     description: str = ""
-    state: Literal["drafting", "ready"] = "ready"
+    state: PlanState = PlanState.READY
 
     # Plan-level context fields (multiline markdown)
     goal: str | None = None

--- a/plugins/development-harness/sam_schema/core/models.py
+++ b/plugins/development-harness/sam_schema/core/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from enum import IntEnum, StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
@@ -271,6 +271,7 @@ class Plan(BaseModel):
     feature: str
     version: str = "1.0"
     description: str = ""
+    state: Literal["drafting", "ready"] = "ready"
 
     # Plan-level context fields (multiline markdown)
     goal: str | None = None

--- a/plugins/development-harness/sam_schema/core/task_backend.py
+++ b/plugins/development-harness/sam_schema/core/task_backend.py
@@ -22,15 +22,10 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sam_schema.core.models import Task
-    from sam_schema.core.task_backend_types import (
-        DocumentData,
-        DocumentHandle,
-        PlanData,
-        PlanSummary,
-        TaskData,
-        TaskDefinitionDict,
-    )
+    from sam_schema.core.task_backend_types import DocumentData, DocumentHandle, PlanData, PlanSummary, TaskData
 
 __all__ = ["TaskBackend"]
 
@@ -57,7 +52,7 @@ class TaskBackend(Protocol):
         self,
         slug: str,
         goal: str,
-        tasks: list[TaskDefinitionDict],
+        tasks: Sequence[Task],
         *,
         context: str | None = None,
         issue: int | None = None,
@@ -68,7 +63,7 @@ class TaskBackend(Protocol):
         Args:
             slug: Human-readable identifier slug for the plan.
             goal: One-sentence goal statement for the plan.
-            tasks: Ordered list of task definitions to create.
+            tasks: Ordered sequence of validated Task models to create.
             context: Optional plan-level context narrative.
             issue: Optional GitHub issue number to associate with this plan.
             acceptance_criteria: Optional plan-level acceptance criteria markdown.
@@ -234,24 +229,26 @@ class TaskBackend(Protocol):
         """
         ...
 
-    def append_task(self, plan_id: str, task_def: TaskDefinitionDict | dict[str, Any]) -> dict[str, Any]:
+    def append_task(self, plan_id: str, task: Task) -> dict[str, Any]:
         """Append a single task to an existing plan.
 
         **Concurrency — single-writer assumption**: ``TaskBackend.append_task`` is NOT
         required to be atomic under concurrent writers. Callers MUST serialize writes to
         the same plan. Behavior under concurrent writes is undefined — backends are not
-        required to detect, reject, or recover from it. See #1770 / ADR-1770-1.
+        required to detect, reject, or recover from it. See ADR-1770-1.
 
         Args:
             plan_id: Plan identifier returned by create_plan.
-            task_def: Single-task dict matching one element of the tasks_yaml list.
+            task: Validated Task model to append. The caller (server layer) is
+                responsible for validation via Pydantic before calling this method.
+                Backends use ``task.model_dump()`` for format-specific serialization.
 
         Returns:
-            Dict with append result (e.g. appended=True, task_id=...).
+            Dict with append result: ``{"appended": True, "task_id": task.id}``.
 
         Raises:
             PlanNotFoundError: If plan_id does not exist.
-            TaskValidationError: If task_def is malformed or duplicates an existing task ID.
+            TaskValidationError: If the task ID duplicates an existing task in the plan.
         """
         ...
 

--- a/plugins/development-harness/sam_schema/core/task_backend.py
+++ b/plugins/development-harness/sam_schema/core/task_backend.py
@@ -17,7 +17,7 @@ Dependency direction (must remain acyclic):
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Protocol, runtime_checkable
 
@@ -231,6 +231,43 @@ class TaskBackend(Protocol):
         Raises:
             PlanNotFoundError: When plan_id does not resolve to a known plan.
             TaskNotFoundError: When task_id does not exist within the plan.
+        """
+        ...
+
+    def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
+        """Append a single task to an existing plan.
+
+        Single-writer contract: callers MUST NOT invoke append_task concurrently on
+        the same plan_id. Backends are NOT required to provide atomicity under
+        concurrent writers. See #1770.
+
+        Args:
+            plan_id: Plan identifier returned by create_plan.
+            task_def: Single-task dict matching one element of the tasks_yaml list.
+
+        Returns:
+            Dict with append result (e.g. appended=True, task_id=...).
+
+        Raises:
+            PlanNotFoundError: If plan_id does not exist.
+            TaskValidationError: If task_def is malformed or duplicates an existing task ID.
+        """
+        ...
+
+    def finalize_plan(self, plan_id: str) -> dict[str, Any]:
+        """Transition a plan from drafting state to ready state.
+
+        After finalize, the plan is available for execution via
+        sam_plan(action='ready') and /dh:implement-feature. See #1770.
+
+        Args:
+            plan_id: Plan identifier.
+
+        Returns:
+            Dict with finalized=True and the new state.
+
+        Raises:
+            PlanNotFoundError: If plan_id does not exist.
         """
         ...
 

--- a/plugins/development-harness/sam_schema/core/task_backend.py
+++ b/plugins/development-harness/sam_schema/core/task_backend.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
         PlanData,
         PlanSummary,
         TaskData,
-        TaskDefinition,
+        TaskDefinitionDict,
     )
 
 __all__ = ["TaskBackend"]
@@ -57,7 +57,7 @@ class TaskBackend(Protocol):
         self,
         slug: str,
         goal: str,
-        tasks: list[TaskDefinition],
+        tasks: list[TaskDefinitionDict],
         *,
         context: str | None = None,
         issue: int | None = None,
@@ -234,7 +234,7 @@ class TaskBackend(Protocol):
         """
         ...
 
-    def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
+    def append_task(self, plan_id: str, task_def: TaskDefinitionDict | dict[str, Any]) -> dict[str, Any]:
         """Append a single task to an existing plan.
 
         **Concurrency — single-writer assumption**: ``TaskBackend.append_task`` is NOT

--- a/plugins/development-harness/sam_schema/core/task_backend.py
+++ b/plugins/development-harness/sam_schema/core/task_backend.py
@@ -237,9 +237,10 @@ class TaskBackend(Protocol):
     def append_task(self, plan_id: str, task_def: TaskDefinition | dict[str, Any]) -> dict[str, Any]:
         """Append a single task to an existing plan.
 
-        Single-writer contract: callers MUST NOT invoke append_task concurrently on
-        the same plan_id. Backends are NOT required to provide atomicity under
-        concurrent writers. See #1770.
+        **Concurrency — single-writer assumption**: ``TaskBackend.append_task`` is NOT
+        required to be atomic under concurrent writers. Callers MUST serialize writes to
+        the same plan. Behavior under concurrent writes is undefined — backends are not
+        required to detect, reject, or recover from it. See #1770 / ADR-1770-1.
 
         Args:
             plan_id: Plan identifier returned by create_plan.
@@ -257,8 +258,14 @@ class TaskBackend(Protocol):
     def finalize_plan(self, plan_id: str) -> dict[str, Any]:
         """Transition a plan from drafting state to ready state.
 
-        After finalize, the plan is available for execution via
-        sam_plan(action='ready') and /dh:implement-feature. See #1770.
+        **Concurrency — single-writer assumption**: ``TaskBackend.finalize_plan`` is NOT
+        required to be atomic under concurrent writers. Callers MUST serialize writes to
+        the same plan. Behavior under concurrent writes is undefined — backends are not
+        required to detect, reject, or recover from it. See #1770 / ADR-1770-1.
+
+        After finalize, the plan transitions from ``state="drafting"`` to
+        ``state="ready"`` and becomes available for execution via
+        ``sam_plan(action='ready')`` and ``/dh:implement-feature``. See #1770.
 
         Args:
             plan_id: Plan identifier.

--- a/plugins/development-harness/sam_schema/core/task_backend_types.py
+++ b/plugins/development-harness/sam_schema/core/task_backend_types.py
@@ -12,11 +12,14 @@ All types follow the pattern established in backlog_core/backend_protocol.py:
 
 from __future__ import annotations
 
-from typing import Literal, NotRequired
+from typing import TYPE_CHECKING, NotRequired
 
 from typing_extensions import TypedDict
 
-__all__ = ["DocumentData", "DocumentHandle", "PlanData", "PlanSummary", "TaskData", "TaskDefinitionDict"]
+if TYPE_CHECKING:
+    from sam_schema.core.models import PlanState
+
+__all__ = ["DocumentData", "DocumentHandle", "PlanData", "PlanSummary", "TaskData"]
 
 
 class TaskDefinitionDict(TypedDict):
@@ -165,7 +168,7 @@ class PlanData(TypedDict):
     source_path: str | None
 
     # Drafting state (see #1770)
-    state: NotRequired[Literal["drafting", "ready"]]
+    state: NotRequired[PlanState]
 
     # Optional reference fields
     architecture: NotRequired[str | None]

--- a/plugins/development-harness/sam_schema/core/task_backend_types.py
+++ b/plugins/development-harness/sam_schema/core/task_backend_types.py
@@ -16,14 +16,20 @@ from typing import Literal, NotRequired
 
 from typing_extensions import TypedDict
 
-__all__ = ["DocumentData", "DocumentHandle", "PlanData", "PlanSummary", "TaskData", "TaskDefinition"]
+__all__ = ["DocumentData", "DocumentHandle", "PlanData", "PlanSummary", "TaskData", "TaskDefinitionDict"]
 
 
-class TaskDefinition(TypedDict):
-    """Input type for creating tasks in a plan.
+class TaskDefinitionDict(TypedDict):
+    """Internal backend-contract type for creating tasks in a plan.
 
     Passed as elements of the ``tasks`` list in
     :meth:`~sam_schema.core.task_backend.TaskBackend.create_plan`.
+
+    This is the *backend-contract* TypedDict used between the query layer and
+    backend implementations.  It is distinct from
+    ``sam_schema.core.action_models.TaskDefinition``, which is the
+    *MCP-boundary* Pydantic model.  The server layer converts the Pydantic model
+    to this dict via ``TaskDefinition.model_dump(by_alias=False, exclude_none=True)``.
 
     Required fields define the minimum viable task; all other fields
     are optional and default to empty/None in the backend implementation.

--- a/plugins/development-harness/sam_schema/core/task_backend_types.py
+++ b/plugins/development-harness/sam_schema/core/task_backend_types.py
@@ -21,68 +21,11 @@ if TYPE_CHECKING:
 
 __all__ = ["DocumentData", "DocumentHandle", "PlanData", "PlanSummary", "TaskData"]
 
-
-class TaskDefinitionDict(TypedDict):
-    """Internal backend-contract type for creating tasks in a plan.
-
-    Passed as elements of the ``tasks`` list in
-    :meth:`~sam_schema.core.task_backend.TaskBackend.create_plan`.
-
-    This is the *backend-contract* TypedDict used between the query layer and
-    backend implementations.  It is distinct from
-    ``sam_schema.core.action_models.TaskDefinition``, which is the
-    *MCP-boundary* Pydantic model.  The server layer converts the Pydantic model
-    to this dict via ``TaskDefinition.model_dump(by_alias=False, exclude_none=True)``.
-
-    Required fields define the minimum viable task; all other fields
-    are optional and default to empty/None in the backend implementation.
-    """
-
-    # Required fields
-    id: str
-    title: str
-    status: str
-
-    # Optional structural fields
-    agent: NotRequired[str | None]
-    dependencies: NotRequired[list[str]]
-    blocked_by: NotRequired[list[str]]
-    parallelize_with: NotRequired[list[str]]
-    priority: NotRequired[int]
-    complexity: NotRequired[str]
-    skills: NotRequired[list[str]]
-
-    # Timestamp fields (ISO 8601 strings)
-    created: NotRequired[str | None]
-    started: NotRequired[str | None]
-    completed: NotRequired[str | None]
-    last_activity: NotRequired[str | None]
-
-    # Markdown content fields
-    body: NotRequired[str]
-    description: NotRequired[str]
-    objective: NotRequired[str]
-    requirements: NotRequired[str]
-    constraints: NotRequired[str]
-    expected_outputs: NotRequired[str]
-    acceptance_criteria: NotRequired[str]
-    verification_steps: NotRequired[str]
-    context_notes: NotRequired[str]
-    handoff: NotRequired[str]
-
-    # Analytical metadata
-    issue_classification: NotRequired[str | None]
-    analysis_method: NotRequired[str]
-    divergence_notes: NotRequired[int]
-    accuracy_risk: NotRequired[str]
-    reason: NotRequired[str]
-
-    # Bookend metadata
-    is_bookend: NotRequired[bool]
-    bookend_type: NotRequired[str | None]
-
-    # GitHub integration
-    github_issue: NotRequired[int | None]
+# TaskDefinitionDict was removed in the RC1 refactor (PR #1773).
+# Backends now accept Task instances or plain dicts directly via append_task.
+# This backwards-compat alias allows existing TYPE_CHECKING imports to resolve
+# without errors during the migration period.
+TaskDefinitionDict = dict  # backwards-compat alias; use Task or dict[str, Any] instead
 
 
 class TaskData(TypedDict):

--- a/plugins/development-harness/sam_schema/core/task_backend_types.py
+++ b/plugins/development-harness/sam_schema/core/task_backend_types.py
@@ -12,7 +12,7 @@ All types follow the pattern established in backlog_core/backend_protocol.py:
 
 from __future__ import annotations
 
-from typing import NotRequired
+from typing import Literal, NotRequired
 
 from typing_extensions import TypedDict
 
@@ -157,6 +157,9 @@ class PlanData(TypedDict):
     issue: str | None
     tasks: list[TaskData]
     source_path: str | None
+
+    # Drafting state (see #1770)
+    state: NotRequired[Literal["drafting", "ready"]]
 
     # Optional reference fields
     architecture: NotRequired[str | None]

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -58,6 +58,10 @@ _PLAN_DIR_SENTINEL = "plan"
 # Single-agent scenarios do not require explicit session isolation.
 _DEFAULT_SESSION_ID = "_default"
 
+# Returned by _sam_plan_status and _sam_plan_ready when the plan is in drafting state.
+# Defined once here to ensure both handlers return an identical shape.
+_DRAFTING_MARKER_RESPONSE: dict[str, object] = {"drafting": True, "state": PlanState.DRAFTING}
+
 # Stem parsing thresholds used in _build_task_assignment.
 _STEM_MIN_PARTS_FOR_NUMBER: int = 2
 _STEM_MIN_PARTS_FOR_SLUG: int = 3
@@ -317,25 +321,33 @@ def _sam_plan_list(config: ListPlansConfig, plan_dir: str) -> dict:
 
 
 def _sam_plan_status(plan: str, plan_dir: str) -> dict:
-    """Return plan-level progress summary."""
+    """Return plan-level progress summary.
+
+    Uses a single backend call — ``get_plan_status`` now includes ``state``
+    so no separate ``read_plan`` is needed for the drafting check.
+    """
     backend = _get_backend(plan_dir)
-    plan_data = backend.read_plan(plan)
-    if plan_data.get("state") == PlanState.DRAFTING:
-        return {"drafting": True, "state": PlanState.DRAFTING}
-    return dict(backend.get_plan_status(plan))
+    status = backend.get_plan_status(plan)
+    if status.get("state") == PlanState.DRAFTING:
+        return dict(_DRAFTING_MARKER_RESPONSE)
+    return dict(status)
 
 
 def _sam_plan_ready(plan: str, config: ReadyPlanConfig, plan_dir: str) -> dict:
     """List tasks ready for dispatch.
 
+    Calls ``get_plan_status`` first for the drafting check (single backend call),
+    then ``get_ready_tasks`` only when the plan is not in drafting state.
+
     Returns:
         Dict with ``ready_tasks``, ``count``, ``feature``, and ``issue`` keys.
     """
     backend = _get_backend(plan_dir)
-    plan_data = backend.read_plan(plan)
-    if plan_data.get("state") == PlanState.DRAFTING:
-        return {"drafting": True, "state": PlanState.DRAFTING}
+    status = backend.get_plan_status(plan)
+    if status.get("state") == PlanState.DRAFTING:
+        return dict(_DRAFTING_MARKER_RESPONSE)
     tasks_data = backend.get_ready_tasks(plan)
+    plan_data = backend.read_plan(plan)  # needed for plan_data["issue"]
     if config.full:
         ready_tasks: list[dict[str, Any]] = [Task.model_validate(t).model_dump(mode="json") for t in tasks_data]
     else:
@@ -354,7 +366,7 @@ def _sam_plan_ready(plan: str, config: ReadyPlanConfig, plan_dir: str) -> dict:
     return {
         "ready_tasks": ready_tasks,
         "count": len(tasks_data),
-        "feature": plan_data["feature"],
+        "feature": cast("str", status["feature"]),
         "issue": plan_data["issue"],
     }
 

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -48,7 +48,6 @@ from sam_schema.core.task_config import TaskConfig, create_task_backend, get_tas
 
 if TYPE_CHECKING:
     from sam_schema.core.task_backend import TaskBackend
-    from sam_schema.core.task_backend_types import TaskDefinitionDict
 
 _log = logging.getLogger(__name__)
 _artifact_registry = _ArtifactRegistry()
@@ -277,12 +276,9 @@ def _sam_plan_create(config: CreatePlanConfig, plan_dir: str) -> dict:
         when an issue number is present, or just ``plan_id`` otherwise.
         It is not stored in the Plan model.
     """
-    task_defs = cast(
-        "list[TaskDefinitionDict]", [t.model_dump(by_alias=False, exclude_none=True) for t in config.tasks]
-    )
     backend = _get_backend(plan_dir)
     plan_data = backend.create_plan(
-        slug=config.slug, goal=config.goal, tasks=task_defs, context=config.context, issue=config.issue
+        slug=config.slug, goal=config.goal, tasks=config.tasks, context=config.context, issue=config.issue
     )
     plan_id_str = plan_data["plan_id"]
     plan_ref: str | None = (
@@ -402,9 +398,8 @@ def _sam_plan_append_task(plan: str, config: AppendTaskConfig, plan_dir: str) ->
         PlanNotFoundError: When the plan address cannot be resolved.
         TaskValidationError: When the task definition fails model validation.
     """
-    task_dict: dict[str, Any] = config.task.model_dump(by_alias=False, exclude_none=True)
     backend = _get_backend(plan_dir)
-    return backend.append_task(plan, task_dict)
+    return backend.append_task(plan, config.task)
 
 
 def _sam_plan_finalize(plan: str, plan_dir: str) -> dict:

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -43,7 +43,7 @@ from sam_schema.core.action_models import (
 )
 from sam_schema.core.context_config import ContextConfig, create_context_backend, get_context_config, set_context_config
 from sam_schema.core.exceptions import PlanNotFoundError, SamError, TaskNotFoundError
-from sam_schema.core.models import Plan, Task, TaskAssignment
+from sam_schema.core.models import Plan, PlanState, Task, TaskAssignment
 from sam_schema.core.task_config import TaskConfig, create_task_backend, get_task_config, set_task_config
 
 if TYPE_CHECKING:
@@ -324,8 +324,8 @@ def _sam_plan_status(plan: str, plan_dir: str) -> dict:
     """Return plan-level progress summary."""
     backend = _get_backend(plan_dir)
     plan_data = backend.read_plan(plan)
-    if plan_data.get("state") == "drafting":
-        return {"drafting": True, "state": "drafting"}
+    if plan_data.get("state") == PlanState.DRAFTING:
+        return {"drafting": True, "state": PlanState.DRAFTING}
     return dict(backend.get_plan_status(plan))
 
 
@@ -337,8 +337,8 @@ def _sam_plan_ready(plan: str, config: ReadyPlanConfig, plan_dir: str) -> dict:
     """
     backend = _get_backend(plan_dir)
     plan_data = backend.read_plan(plan)
-    if plan_data.get("state") == "drafting":
-        return {"drafting": True, "state": "drafting"}
+    if plan_data.get("state") == PlanState.DRAFTING:
+        return {"drafting": True, "state": PlanState.DRAFTING}
     tasks_data = backend.get_ready_tasks(plan)
     if config.full:
         ready_tasks: list[dict[str, Any]] = [Task.model_validate(t).model_dump(mode="json") for t in tasks_data]

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -30,6 +30,7 @@ from ruamel.yaml import YAML
 
 from sam_schema.core.action_models import (
     ActiveTaskActionConfig,
+    AppendTaskConfig,
     CreatePlanConfig,
     ListPlansConfig,
     PlanActionConfig,
@@ -256,7 +257,7 @@ def _validated_task_patch(backend: TaskBackend, plan_id: str, task_id: str, raw_
 
 
 # Actions that require the ``plan`` parameter to be supplied.
-_SAM_PLAN_REQUIRED_ACTIONS: frozenset[str] = frozenset({"read", "status", "ready", "update"})
+_SAM_PLAN_REQUIRED_ACTIONS: frozenset[str] = frozenset({"read", "status", "ready", "update", "append_task", "finalize"})
 
 
 def _sam_plan_read(plan: str, plan_dir: str) -> dict:
@@ -377,6 +378,22 @@ def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict
     return {"updated": True, "address": plan}
 
 
+def _sam_plan_append_task(plan: str, config: AppendTaskConfig, plan_dir: str) -> dict:
+    """Append a single task to an existing plan.
+
+    See AppendTaskConfig for the single-writer contract and #1770 for the ADR.
+    """
+    raise NotImplementedError("sam_plan action='append_task' not yet implemented — see #1770")
+
+
+def _sam_plan_finalize(plan: str, plan_dir: str) -> dict:
+    """Transition a plan from drafting state to ready state.
+
+    See FinalizePlanConfig and #1770 for the ADR.
+    """
+    raise NotImplementedError("sam_plan action='finalize' not yet implemented — see #1770")
+
+
 @mcp.tool(
     annotations=ToolAnnotations(
         title="SAM Plan Operations", readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
@@ -445,6 +462,10 @@ def sam_plan(
             return _sam_plan_ready(cast("str", plan), cast("ReadyPlanConfig", config), plan_dir)
         case "update":
             return _sam_plan_update(cast("str", plan), cast("UpdatePlanConfig", config), plan_dir)
+        case "append_task":
+            return _sam_plan_append_task(cast("str", plan), cast("AppendTaskConfig", config), plan_dir)
+        case "finalize":
+            return _sam_plan_finalize(cast("str", plan), plan_dir)
         case _:  # pragma: no cover
             raise ValueError(f"sam_plan: unhandled action '{config.action}'")
 

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -404,8 +404,13 @@ def _sam_plan_append_task(plan: str, config: AppendTaskConfig, plan_dir: str) ->
         PlanNotFoundError: When the plan address cannot be resolved.
         TaskValidationError: When the task definition fails model validation.
     """
+    import collections.abc  # noqa: PLC0415
+
     yaml_parser: Any = YAML()
-    task_dict: dict[str, Any] = yaml_parser.load(config.task_yaml)
+    parsed: Any = yaml_parser.load(config.task_yaml)
+    if not isinstance(parsed, collections.abc.Mapping):
+        raise TypeError("task_yaml must parse to a YAML mapping with task fields")
+    task_dict: dict[str, Any] = dict(parsed)
     backend = _get_backend(plan_dir)
     return backend.append_task(plan, task_dict)
 

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -409,8 +409,12 @@ def _sam_plan_finalize(plan: str, plan_dir: str) -> dict:
     """Transition a plan from drafting state to ready state.
 
     See FinalizePlanConfig and #1770 for the ADR.
+
+    Returns:
+        Result dict from ``backend.finalize_plan`` — shape: ``{"finalized": True, "state": "ready"}``.
     """
-    raise NotImplementedError("sam_plan action='finalize' not yet implemented — see #1770")
+    backend = _get_backend(plan_dir)
+    return backend.finalize_plan(plan)
 
 
 @mcp.tool(

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -326,6 +326,9 @@ def _sam_plan_list(config: ListPlansConfig, plan_dir: str) -> dict:
 def _sam_plan_status(plan: str, plan_dir: str) -> dict:
     """Return plan-level progress summary."""
     backend = _get_backend(plan_dir)
+    plan_data = backend.read_plan(plan)
+    if plan_data.get("state") == "drafting":
+        return {"drafting": True, "state": "drafting"}
     return dict(backend.get_plan_status(plan))
 
 
@@ -337,6 +340,8 @@ def _sam_plan_ready(plan: str, config: ReadyPlanConfig, plan_dir: str) -> dict:
     """
     backend = _get_backend(plan_dir)
     plan_data = backend.read_plan(plan)
+    if plan_data.get("state") == "drafting":
+        return {"drafting": True, "state": "drafting"}
     tasks_data = backend.get_ready_tasks(plan)
     if config.full:
         ready_tasks: list[dict[str, Any]] = [Task.model_validate(t).model_dump(mode="json") for t in tasks_data]

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -117,7 +117,7 @@ mcp: FastMCP = FastMCP(
         "set config.action to: read | claim | state | update. "
         "Use sam_plan to read a plan, create a plan, list all plans, get progress status, "
         "or list ready-to-dispatch tasks — "
-        "set config.action to: read | create | list | status | ready | update. "
+        "set config.action to: read | create | list | status | ready | update | append_task | finalize. "
         "Use sam_active_task to park and retrieve the task currently being worked on "
         "within an agent session — "
         "set config.action to: get | set | update | clear."
@@ -402,7 +402,9 @@ def _sam_plan_finalize(plan: str, plan_dir: str) -> dict:
 def sam_plan(
     config: Annotated[
         PlanActionConfig,
-        Field(description="Action config. Set 'action' to: read | create | list | status | ready | update"),
+        Field(
+            description="Action config. Set 'action' to: read | create | list | status | ready | update | append_task | finalize"
+        ),
     ],
     plan_dir: Annotated[str, Field(description="Plan directory path")] = "plan",
     plan: Annotated[
@@ -410,7 +412,7 @@ def sam_plan(
         Field(
             description=(
                 "Plan address (e.g., 'P1' or slug). "
-                "Required for: read, status, ready, update. "
+                "Required for: read, status, ready, update, append_task, finalize. "
                 "Not used for: list, create."
             )
         ),
@@ -426,6 +428,8 @@ def sam_plan(
     - ``status``: Return plan-level progress summary (task counts, completion %).
     - ``ready``: List tasks ready for dispatch (not-started, all deps resolved).
     - ``update``: Set plan-level context and/or patch plan fields.
+    - ``append_task``: Append a single task to an existing plan (incremental build; see #1770).
+    - ``finalize``: Transition a plan from drafting state to ready state (see #1770).
 
     Actions that do not use ``plan``:
 
@@ -435,7 +439,7 @@ def sam_plan(
     Args:
         config: Discriminated union config. The ``action`` field selects the operation.
         plan_dir: Path to the directory containing plan files.
-        plan: Plan address component. Required for read, status, ready, update actions.
+        plan: Plan address component. Required for read, status, ready, update, append_task, finalize actions.
 
     Returns:
         Response dict whose shape depends on the action (see individual action docs).

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -381,9 +381,28 @@ def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict
 def _sam_plan_append_task(plan: str, config: AppendTaskConfig, plan_dir: str) -> dict:
     """Append a single task to an existing plan.
 
+    Parses ``config.task_yaml`` via ruamel round-trip YAML and delegates to
+    ``backend.append_task``.  The server is the YAML-parse boundary; the
+    backend receives a plain dict.
+
     See AppendTaskConfig for the single-writer contract and #1770 for the ADR.
+
+    Args:
+        plan: Plan address (e.g., ``P1`` or slug).
+        config: AppendTaskConfig carrying the single-task YAML string.
+        plan_dir: Plan directory path passed through to ``_get_backend``.
+
+    Returns:
+        Result dict from ``backend.append_task`` — shape: ``{"appended": True, "task_id": ...}``.
+
+    Raises:
+        PlanNotFoundError: When the plan address cannot be resolved.
+        TaskValidationError: When the task definition fails model validation.
     """
-    raise NotImplementedError("sam_plan action='append_task' not yet implemented — see #1770")
+    yaml_parser: Any = YAML()
+    task_dict: dict[str, Any] = yaml_parser.load(config.task_yaml)
+    backend = _get_backend(plan_dir)
+    return backend.append_task(plan, task_dict)
 
 
 def _sam_plan_finalize(plan: str, plan_dir: str) -> dict:

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -386,15 +386,16 @@ def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict
 def _sam_plan_append_task(plan: str, config: AppendTaskConfig, plan_dir: str) -> dict:
     """Append a single task to an existing plan.
 
-    Parses ``config.task_yaml`` via ruamel round-trip YAML and delegates to
-    ``backend.append_task``.  The server is the YAML-parse boundary; the
-    backend receives a plain dict.
+    Converts ``config.task`` (a validated :class:`TaskDefinition` model) to a
+    snake_case dict via ``model_dump`` and delegates to ``backend.append_task``.
+    Pydantic handles alias normalisation (kebab-case → snake_case) at the MCP
+    boundary; no YAML parsing or re-normalisation is required downstream.
 
     See AppendTaskConfig for the single-writer contract and #1770 for the ADR.
 
     Args:
         plan: Plan address (e.g., ``P1`` or slug).
-        config: AppendTaskConfig carrying the single-task YAML string.
+        config: AppendTaskConfig carrying the validated TaskDefinition.
         plan_dir: Plan directory path passed through to ``_get_backend``.
 
     Returns:
@@ -404,13 +405,7 @@ def _sam_plan_append_task(plan: str, config: AppendTaskConfig, plan_dir: str) ->
         PlanNotFoundError: When the plan address cannot be resolved.
         TaskValidationError: When the task definition fails model validation.
     """
-    import collections.abc  # noqa: PLC0415
-
-    yaml_parser: Any = YAML()
-    parsed: Any = yaml_parser.load(config.task_yaml)
-    if not isinstance(parsed, collections.abc.Mapping):
-        raise TypeError("task_yaml must parse to a YAML mapping with task fields")
-    task_dict: dict[str, Any] = dict(parsed)
+    task_dict: dict[str, Any] = config.task.model_dump(by_alias=False, exclude_none=True)
     backend = _get_backend(plan_dir)
     return backend.append_task(plan, task_dict)
 

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -26,7 +26,6 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from pydantic import Field
-from ruamel.yaml import YAML
 
 from sam_schema.core.action_models import (
     ActiveTaskActionConfig,
@@ -49,7 +48,7 @@ from sam_schema.core.task_config import TaskConfig, create_task_backend, get_tas
 
 if TYPE_CHECKING:
     from sam_schema.core.task_backend import TaskBackend
-    from sam_schema.core.task_backend_types import TaskDefinition
+    from sam_schema.core.task_backend_types import TaskDefinitionDict
 
 _log = logging.getLogger(__name__)
 _artifact_registry = _ArtifactRegistry()
@@ -270,7 +269,7 @@ def _sam_plan_read(plan: str, plan_dir: str) -> dict:
 
 
 def _sam_plan_create(config: CreatePlanConfig, plan_dir: str) -> dict:
-    """Create a new plan from YAML task definitions.
+    """Create a new plan from a typed list of task definitions.
 
     Returns:
         Dict with ``plan_id``, ``plan_ref``, and ``task_count`` keys.
@@ -278,11 +277,9 @@ def _sam_plan_create(config: CreatePlanConfig, plan_dir: str) -> dict:
         when an issue number is present, or just ``plan_id`` otherwise.
         It is not stored in the Plan model.
     """
-    yaml_parser: Any = YAML()
-    parsed: dict[str, Any] = yaml_parser.load(config.tasks_yaml)
-    if not isinstance(parsed, dict) or "tasks" not in parsed:
-        raise ValueError("tasks_yaml must be a YAML string with a top-level 'tasks' key")
-    task_defs = cast("list[TaskDefinition]", parsed["tasks"])
+    task_defs = cast(
+        "list[TaskDefinitionDict]", [t.model_dump(by_alias=False, exclude_none=True) for t in config.tasks]
+    )
     backend = _get_backend(plan_dir)
     plan_data = backend.create_plan(
         slug=config.slug, goal=config.goal, tasks=task_defs, context=config.context, issue=config.issue
@@ -461,7 +458,7 @@ def sam_plan(
 
     Actions that do not use ``plan``:
 
-    - ``create``: Create a new plan from YAML task definitions.
+    - ``create``: Create a new plan from a typed list of task definitions.
     - ``list``: List all plans with optional search and auto-pagination.
 
     Args:

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -112,7 +112,24 @@ artifact_read(issue_number={issue}, artifact_type="research") before starting
 discovery — they contain prior investigation findings that should be incorporated.
 Produce feature-context-{slug}.md content with WHAT/WHY analysis — problem space, desired
 outcome, stakeholders, risks, open questions.
-Return the full markdown content in your response. Do NOT write to disk.
+
+MCP-NATIVE ARTIFACT STORAGE — REQUIRED:
+As your FINAL step, call `mcp__plugin_dh_backlog__artifact_register` directly with the
+markdown content:
+
+    mcp__plugin_dh_backlog__artifact_register(
+        issue_number={issue},
+        artifact_type="feature-context",
+        artifact_id="plan/feature-context-{slug}.md",
+        content="<your full markdown content>",
+        agent="feature-researcher",
+    )
+
+The `content=` parameter stores the document as a GitHub issue comment, retrievable by
+downstream agents via `artifact_read(issue_number={issue}, artifact_type="feature-context")`.
+Do NOT write the file to disk. Do NOT return the markdown content inline in your response.
+Your STATUS: DONE report should confirm the artifact was registered (character count,
+action="added" or "updated" from the return value) and include your <concerns> block.
 Do NOT prescribe HOW to build it.
 If the feature involves replacing or migrating a local module to an external tool,
 you MUST perform a Replacement Coverage Analysis: enumerate all capabilities of the
@@ -121,16 +138,16 @@ local module, enumerate the replacement's capabilities, and produce a coverage m
 document. Surface any PARTIAL or MISSING capabilities as questions.
 ```
 
-After the agent writes the feature-context file, register it as an artifact on the GitHub Issue:
+After the agent completes, verify the artifact was registered:
 
 ```text
-mcp__plugin_dh_backlog__artifact_register(
-    issue_number={issue},
-    artifact_type="feature-context",
-    path="plan/feature-context-{slug}.md",  # state-relative path
-    agent="feature-researcher"
-)
+mcp__plugin_dh_backlog__artifact_list(issue_number={issue}, artifact_type="feature-context")
 ```
+
+If `count == 0`, the agent did not register the artifact. Re-dispatch with an explicit
+reminder that `artifact_register(content=...)` is the agent's responsibility, not the
+orchestrator's. The orchestrator MUST NOT call `artifact_register` as a workaround —
+the MCP-native rule is that agents own their artifact storage.
 
 ---
 
@@ -164,20 +181,40 @@ statements of fact without citation, code smells, missing documentation.
 Analyze {focus_area} for #{issue}: "{title}".
 Produce {focus_area}.md content documenting what exists today — patterns,
 conventions, constraints.
-Return the full markdown content in your response. Do NOT write to disk.
 Do NOT prescribe changes.
+
+MCP-NATIVE ARTIFACT STORAGE — REQUIRED:
+As your FINAL step, call `mcp__plugin_dh_backlog__artifact_register` directly with the
+markdown content:
+
+    mcp__plugin_dh_backlog__artifact_register(
+        issue_number={issue},
+        artifact_type="codebase-analysis",
+        artifact_id="plan/codebase/{FOCUS}.md",
+        content="<your full markdown content>",
+        agent="codebase-analyzer",
+    )
+
+The `content=` parameter stores the document as a GitHub issue comment, retrievable by
+downstream agents via `artifact_read(issue_number={issue}, artifact_type="codebase-analysis")`.
+Do NOT write the file to disk. Do NOT return the markdown content inline in your response.
+A single invocation covering multiple focus areas issues one `artifact_register` call per
+focus area with a distinct `artifact_id` per focus (e.g., `plan/codebase/PATTERNS.md`,
+`plan/codebase/ARCHITECTURE.md`).
+Your STATUS: DONE report should confirm each artifact was registered (character count,
+action="added" or "updated" from the return value) and include your <concerns> block.
 ```
 
-After the agent writes each codebase analysis file, register it as an artifact:
+After the agent completes, verify the artifact was registered:
 
 ```text
-mcp__plugin_dh_backlog__artifact_register(
-    issue_number={issue},
-    artifact_type="codebase-analysis",
-    path="plan/codebase/{FOCUS}.md",  # state-relative path
-    agent="codebase-analyzer"
-)
+mcp__plugin_dh_backlog__artifact_list(issue_number={issue}, artifact_type="codebase-analysis")
 ```
+
+If `count == 0`, the agent did not register the artifact. Re-dispatch with an explicit
+reminder that `artifact_register(content=...)` is the agent's responsibility, not the
+orchestrator's. The orchestrator MUST NOT call `artifact_register` as a workaround —
+the MCP-native rule is that agents own their artifact storage.
 
 ---
 
@@ -324,20 +361,37 @@ If research artifacts exist for this issue, read them via
 artifact_read(issue_number={issue}, artifact_type="research") for prior research
 findings that should inform the architecture.
 Produce architect-{slug}.md content with interfaces, contracts, data models, module boundaries.
-Return the full markdown content in your response. Do NOT write to disk.
 Do NOT implement — define WHAT to build, not the code.
+
+MCP-NATIVE ARTIFACT STORAGE — REQUIRED:
+As your FINAL step, call `mcp__plugin_dh_backlog__artifact_register` directly with the
+markdown content:
+
+    mcp__plugin_dh_backlog__artifact_register(
+        issue_number={issue},
+        artifact_type="architect",
+        artifact_id="plan/architect-{slug}.md",
+        content="<your full markdown content>",
+        agent="python-cli-design-spec",
+    )
+
+The `content=` parameter stores the document as a GitHub issue comment, retrievable by
+downstream agents via `artifact_read(issue_number={issue}, artifact_type="architect")`.
+Do NOT write the file to disk. Do NOT return the markdown content inline in your response.
+Your STATUS: DONE report should confirm the artifact was registered (character count,
+action="added" or "updated" from the return value) and include your <concerns> block.
 ```
 
-After the agent writes the architect spec, register it as an artifact:
+After the agent completes, verify the artifact was registered:
 
 ```text
-mcp__plugin_dh_backlog__artifact_register(
-    issue_number={issue},
-    artifact_type="architect",
-    path="plan/architect-{slug}.md",  # state-relative path
-    agent="python-cli-design-spec"
-)
+mcp__plugin_dh_backlog__artifact_list(issue_number={issue}, artifact_type="architect")
 ```
+
+If `count == 0`, the agent did not register the artifact. Re-dispatch with an explicit
+reminder that `artifact_register(content=...)` is the agent's responsibility, not the
+orchestrator's. The orchestrator MUST NOT call `artifact_register` as a workaround —
+the MCP-native rule is that agents own their artifact storage.
 
 ---
 
@@ -390,22 +444,18 @@ into each implementation agent's prompt. Omitting it means implementation agents
 without domain schema context.
 ```
 
-After the agent writes the task plan, register it as an artifact and write the plan path
-back to the backlog item:
+After the agent completes, write the plan path back to the backlog item:
 
 ```text
-mcp__plugin_dh_backlog__artifact_register(
-    issue_number={issue},
-    artifact_type="task-plan",
-    path="plan/P{id}-{slug}.yaml",  # state-relative path; auto-registered by sam_plan when issue is set
-    agent="swarm-task-planner"
-)
-
 mcp__plugin_dh_backlog__backlog_update(
     selector="{title}",
     plan="P{id}"
 )
 ```
+
+Note: `sam_plan(action='create', issue={issue})` already auto-registers the `task-plan`
+artifact. Do NOT call `artifact_register` for the `task-plan` type — it is redundant and
+would create a duplicate entry.
 
 The `backlog_update(plan=...)` call writes the plan address into the backlog item's `metadata.plan`
 field. This is a backend signal — it records that a plan exists and its address, not a filesystem

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -119,11 +119,7 @@ local module, enumerate the replacement's capabilities, and produce a coverage m
 (COVERED/PARTIAL/MISSING for each capability). Include the matrix in the feature-context
 document. Surface any PARTIAL or MISSING capabilities as questions.
 
-Before storing your output, load the artifact storage skill:
-
-    Skill(skill="dh:create-artifact")
-
-Then register your deliverable with:
+Register your deliverable with:
     artifact_type="feature-context"
     artifact_id="plan/feature-context-{slug}.md"
     issue_number={issue}
@@ -175,13 +171,9 @@ Produce {focus_area}.md content documenting what exists today — patterns,
 conventions, constraints.
 Do NOT prescribe changes.
 
-Before storing your output, load the artifact storage skill:
-
-    Skill(skill="dh:create-artifact")
-
-Then register each document with:
+Register each document with:
     artifact_type="codebase-analysis"
-    artifact_id="plan/codebase/PATTERNS.md"  (use the actual focus-area filename, e.g. PATTERNS.md, ARCHITECTURE.md)
+    artifact_id="codebase-{focus}-{slug}"  (logical id — use lowercase focus area, e.g. codebase-patterns-{slug})
     issue_number={issue}
     agent="codebase-analyzer"
 
@@ -347,11 +339,7 @@ findings that should inform the architecture.
 Produce architect-{slug}.md content with interfaces, contracts, data models, module boundaries.
 Do NOT implement — define WHAT to build, not the code.
 
-Before storing your output, load the artifact storage skill:
-
-    Skill(skill="dh:create-artifact")
-
-Then register your deliverable with:
+Register your deliverable with:
     artifact_type="architect"
     artifact_id="plan/architect-{slug}.md"
     issue_number={issue}

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -112,30 +112,22 @@ artifact_read(issue_number={issue}, artifact_type="research") before starting
 discovery — they contain prior investigation findings that should be incorporated.
 Produce feature-context-{slug}.md content with WHAT/WHY analysis — problem space, desired
 outcome, stakeholders, risks, open questions.
-
-MCP-NATIVE ARTIFACT STORAGE — REQUIRED:
-As your FINAL step, call `mcp__plugin_dh_backlog__artifact_register` directly with the
-markdown content:
-
-    mcp__plugin_dh_backlog__artifact_register(
-        issue_number={issue},
-        artifact_type="feature-context",
-        artifact_id="plan/feature-context-{slug}.md",
-        content="<your full markdown content>",
-        agent="feature-researcher",
-    )
-
-The `content=` parameter stores the document as a GitHub issue comment, retrievable by
-downstream agents via `artifact_read(issue_number={issue}, artifact_type="feature-context")`.
-Do NOT write the file to disk. Do NOT return the markdown content inline in your response.
-Your STATUS: DONE report should confirm the artifact was registered (character count,
-action="added" or "updated" from the return value) and include your <concerns> block.
 Do NOT prescribe HOW to build it.
 If the feature involves replacing or migrating a local module to an external tool,
 you MUST perform a Replacement Coverage Analysis: enumerate all capabilities of the
 local module, enumerate the replacement's capabilities, and produce a coverage matrix
 (COVERED/PARTIAL/MISSING for each capability). Include the matrix in the feature-context
 document. Surface any PARTIAL or MISSING capabilities as questions.
+
+Before storing your output, load the artifact storage skill:
+
+    Skill(skill="dh:create-artifact")
+
+Then register your deliverable with:
+    artifact_type="feature-context"
+    artifact_id="plan/feature-context-{slug}.md"
+    issue_number={issue}
+    agent="feature-researcher"
 ```
 
 After the agent completes, verify the artifact was registered:
@@ -183,26 +175,18 @@ Produce {focus_area}.md content documenting what exists today — patterns,
 conventions, constraints.
 Do NOT prescribe changes.
 
-MCP-NATIVE ARTIFACT STORAGE — REQUIRED:
-As your FINAL step, call `mcp__plugin_dh_backlog__artifact_register` directly with the
-markdown content:
+Before storing your output, load the artifact storage skill:
 
-    mcp__plugin_dh_backlog__artifact_register(
-        issue_number={issue},
-        artifact_type="codebase-analysis",
-        artifact_id="plan/codebase/{FOCUS}.md",
-        content="<your full markdown content>",
-        agent="codebase-analyzer",
-    )
+    Skill(skill="dh:create-artifact")
 
-The `content=` parameter stores the document as a GitHub issue comment, retrievable by
-downstream agents via `artifact_read(issue_number={issue}, artifact_type="codebase-analysis")`.
-Do NOT write the file to disk. Do NOT return the markdown content inline in your response.
-A single invocation covering multiple focus areas issues one `artifact_register` call per
-focus area with a distinct `artifact_id` per focus (e.g., `plan/codebase/PATTERNS.md`,
-`plan/codebase/ARCHITECTURE.md`).
-Your STATUS: DONE report should confirm each artifact was registered (character count,
-action="added" or "updated" from the return value) and include your <concerns> block.
+Then register each document with:
+    artifact_type="codebase-analysis"
+    artifact_id="plan/codebase/PATTERNS.md"  (use the actual focus-area filename, e.g. PATTERNS.md, ARCHITECTURE.md)
+    issue_number={issue}
+    agent="codebase-analyzer"
+
+A single invocation covering multiple focus areas issues one artifact_register call per
+focus area with a distinct artifact_id per focus.
 ```
 
 After the agent completes, verify the artifact was registered:
@@ -363,23 +347,15 @@ findings that should inform the architecture.
 Produce architect-{slug}.md content with interfaces, contracts, data models, module boundaries.
 Do NOT implement — define WHAT to build, not the code.
 
-MCP-NATIVE ARTIFACT STORAGE — REQUIRED:
-As your FINAL step, call `mcp__plugin_dh_backlog__artifact_register` directly with the
-markdown content:
+Before storing your output, load the artifact storage skill:
 
-    mcp__plugin_dh_backlog__artifact_register(
-        issue_number={issue},
-        artifact_type="architect",
-        artifact_id="plan/architect-{slug}.md",
-        content="<your full markdown content>",
-        agent="python-cli-design-spec",
-    )
+    Skill(skill="dh:create-artifact")
 
-The `content=` parameter stores the document as a GitHub issue comment, retrievable by
-downstream agents via `artifact_read(issue_number={issue}, artifact_type="architect")`.
-Do NOT write the file to disk. Do NOT return the markdown content inline in your response.
-Your STATUS: DONE report should confirm the artifact was registered (character count,
-action="added" or "updated" from the return value) and include your <concerns> block.
+Then register your deliverable with:
+    artifact_type="architect"
+    artifact_id="plan/architect-{slug}.md"
+    issue_number={issue}
+    agent="python-cli-design-spec"
 ```
 
 After the agent completes, verify the artifact was registered:

--- a/plugins/development-harness/skills/complete-implementation/SKILL.md
+++ b/plugins/development-harness/skills/complete-implementation/SKILL.md
@@ -260,13 +260,13 @@ Before invoking Phase 1, check for a TN verification report produced by `tn-veri
 
 Extract `{slug}` from the task file path (`plan/P{id}-{slug}.yaml` — strip the `P{id}-` prefix and `.yaml` suffix).
 
-Read the TN-verification artifact via `artifact_read(issue_number={N}, artifact_type="TN-verification")`. Fallback: if no artifact is registered, read `dh_paths.plan_dir() / "TN-verification-{slug}.yaml"`.
+Read the TN-verification artifact via `artifact_read(issue_number={N}, artifact_type="TN-verification")`.
 
 The file contains a list of per-criterion `BookendVerification` records — one per `acceptance-criteria-structured` entry. There is no top-level `verdict` field. Aggregate the verdict by scanning all records: the overall result is FAIL if any record has `status: regressed`; otherwise PASS.
 
 ```mermaid
 flowchart TD
-    Read["artifact_read(issue_number, 'TN-verification')<br>Fallback: dh_paths.plan_dir() / TN-verification-{slug}.yaml"] --> Exists{Artifact exists?}
+    Read["artifact_read(issue_number, 'TN-verification')"] --> Exists{Artifact exists?}
     Exists -->|No| Proceed["No structured criteria — proceed to Phase 1"]
     Exists -->|Yes| Scan["Scan all per-criterion records<br>for status: regressed"]
     Scan --> AnyRegressed{Any criterion<br>has status: regressed?}

--- a/plugins/development-harness/skills/create-artifact/SKILL.md
+++ b/plugins/development-harness/skills/create-artifact/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: create-artifact
+description: Register a plan artifact via the MCP backlog server. Use when you produce a document or report that downstream agents or worktree-isolated environments need to retrieve — feature-context, codebase-analysis, architect, task-plan, T0-baseline, TN-verification, or research artifacts. Triggers include "store an artifact", "register a plan artifact", "write a report to the backlog", "upload artifact content".
+---
+
+# Create Artifact (MCP-native storage)
+
+Register your deliverable using `mcp__plugin_dh_backlog__artifact_register`. This is the ONLY
+correct storage path for plan artifacts. Do NOT use `Write` to disk and do NOT return content
+inline.
+
+## Why disk writes and inline returns are wrong
+
+- **Disk writes** produce a file only accessible from the root worktree. Worktree-isolated agents
+  and CI environments cannot reach `~/.dh/...` paths via filesystem — they must use
+  `artifact_read(issue_number, artifact_type)` over MCP.
+- **Inline returns** are truncated by the task-notification summary when the agent runs as a
+  background-dispatched task. The orchestrator receives a partial summary, not the full document.
+
+MCP-native storage uploads content to a GitHub issue comment where any agent — regardless of
+worktree or environment — can retrieve it via `artifact_read`.
+
+## Correct invocation (verified against `backlog_core/server.py:2385`)
+
+```python
+mcp__plugin_dh_backlog__artifact_register(
+    issue_number=<int>,           # GitHub issue number — REQUIRED
+    artifact_type=<str>,          # Artifact type string — REQUIRED (see table below)
+    artifact_id=<str>,            # Logical identifier — REQUIRED (see path format below)
+    status="current",             # Lifecycle status: draft | current | superseded | archived
+    agent=<str>,                  # Name of the producing agent (default: "")
+    content=<str | None>,         # Full artifact content — include this to store in GitHub
+)
+```
+
+**Return value**: dict with keys `registered` (bool), `artifact_count` (int), `action`
+("added" or "updated"), `content_stored` (bool), `messages`, `warnings`. Check `action`
+in your STATUS: DONE report — do NOT paste the full content.
+
+## Parameters
+
+### `artifact_type`
+
+One of the recognized type strings:
+
+| artifact_type | Producing agent | When to use |
+|---|---|---|
+| `feature-context` | feature-researcher | Discovery document: WHO/WHAT/WHEN/WHY analysis |
+| `codebase-analysis` | codebase-analyzer | Codebase pattern/architecture/testing documents |
+| `architect` | python-cli-design-spec | Architecture spec with interfaces and contracts |
+| `task-plan` | swarm-task-planner | SAM task plan — auto-registered by `sam_plan(action='create', issue=N)`, do NOT register manually |
+| `T0-baseline` | t0-baseline-capture | Pre-implementation baseline of acceptance criteria |
+| `TN-verification` | tn-verification-gate | Post-implementation verification results |
+| `research` | any research agent | Investigation findings, coverage analysis, rationale |
+
+### `artifact_id`
+
+Logical identifier for the artifact. Two valid formats:
+
+- **Repo-relative path** for file artifacts: `plan/feature-context-{slug}.md`,
+  `plan/architect-{slug}.md`, `plan/codebase/PATTERNS.md`
+- **Logical id** for content-only artifacts: `T0-baseline-{slug}`, `TN-verification-{slug}`
+
+Do NOT use `~/.dh/...` paths — these are MCP-server internals, not stable agent interfaces.
+
+### `content`
+
+Pass the full markdown string. When `content` is provided, it is stored as a structured GitHub
+issue comment retrievable via `artifact_read(issue_number, artifact_type)` from any environment.
+
+When `content` is `None`: the server attempts to read a local file at `artifact_id` (resolved
+against the root worktree). If no file exists, a manifest-only entry is registered and a warning
+is emitted. For background-dispatched agents, always pass `content=` explicitly.
+
+## Examples by artifact type
+
+### feature-context
+
+```python
+mcp__plugin_dh_backlog__artifact_register(
+    issue_number=1770,
+    artifact_type="feature-context",
+    artifact_id="plan/feature-context-my-feature.md",
+    content=feature_context_markdown,
+    agent="feature-researcher",
+)
+```
+
+### codebase-analysis (one call per focus area)
+
+```python
+mcp__plugin_dh_backlog__artifact_register(
+    issue_number=1770,
+    artifact_type="codebase-analysis",
+    artifact_id="plan/codebase/PATTERNS.md",
+    content=patterns_markdown,
+    agent="codebase-analyzer",
+)
+
+mcp__plugin_dh_backlog__artifact_register(
+    issue_number=1770,
+    artifact_type="codebase-analysis",
+    artifact_id="plan/codebase/ARCHITECTURE.md",
+    content=architecture_markdown,
+    agent="codebase-analyzer",
+)
+```
+
+### architect
+
+```python
+mcp__plugin_dh_backlog__artifact_register(
+    issue_number=1770,
+    artifact_type="architect",
+    artifact_id="plan/architect-my-feature.md",
+    content=architect_markdown,
+    agent="python-cli-design-spec",
+)
+```
+
+### task-plan
+
+`sam_plan(action='create', issue=N)` auto-registers this artifact. Do NOT call
+`artifact_register` for `task-plan` — it creates a duplicate entry.
+
+### research (secondary documents, rationale, coverage analysis)
+
+```python
+mcp__plugin_dh_backlog__artifact_register(
+    issue_number=1770,
+    artifact_type="research",
+    artifact_id="plan/swarm-rationale-my-feature.md",
+    content=rationale_markdown,
+    agent="swarm-task-planner",
+)
+```
+
+## STATUS: DONE report format
+
+Do NOT paste the full document content. Report only:
+
+```text
+STATUS: DONE
+ARTIFACT: type={artifact_type}, action={action}, content_stored={content_stored}, chars={len(content)}
+```
+
+Include a `<concerns>` block if quality issues were found during the work.

--- a/plugins/development-harness/skills/create-artifact/SKILL.md
+++ b/plugins/development-harness/skills/create-artifact/SKILL.md
@@ -57,9 +57,14 @@ One of the recognized type strings:
 
 Logical identifier for the artifact. Two valid formats:
 
-- **Repo-relative path** for file artifacts: `plan/feature-context-{slug}.md`,
-  `plan/architect-{slug}.md`, `plan/codebase/PATTERNS.md`
-- **Logical id** for content-only artifacts: `T0-baseline-{slug}`, `TN-verification-{slug}`
+- **Repo-relative path** for file artifacts that exist on disk in the root worktree:
+  `plan/feature-context-{slug}.md`, `plan/architect-{slug}.md`
+- **Logical id** for artifacts that do NOT write a repo file: `codebase-patterns-{slug}`,
+  `codebase-architecture-{slug}`, `T0-baseline-{slug}`, `TN-verification-{slug}`
+
+Use a logical id (not a path) when the agent stores content via `content=` without writing
+a file to disk. Using a path that doesn't exist on disk causes a warning when `content=None`
+and is misleading to artifact consumers.
 
 Do NOT use `~/.dh/...` paths — these are MCP-server internals, not stable agent interfaces.
 
@@ -86,13 +91,13 @@ mcp__plugin_dh_backlog__artifact_register(
 )
 ```
 
-### codebase-analysis (one call per focus area)
+### codebase-analysis (one call per focus area, logical id — no filesystem path)
 
 ```python
 mcp__plugin_dh_backlog__artifact_register(
     issue_number=1770,
     artifact_type="codebase-analysis",
-    artifact_id="plan/codebase/PATTERNS.md",
+    artifact_id="codebase-patterns-my-feature",  # logical id: codebase-{focus}-{slug}
     content=patterns_markdown,
     agent="codebase-analyzer",
 )
@@ -100,7 +105,7 @@ mcp__plugin_dh_backlog__artifact_register(
 mcp__plugin_dh_backlog__artifact_register(
     issue_number=1770,
     artifact_type="codebase-analysis",
-    artifact_id="plan/codebase/ARCHITECTURE.md",
+    artifact_id="codebase-architecture-my-feature",  # logical id: codebase-{focus}-{slug}
     content=architecture_markdown,
     agent="codebase-analyzer",
 )

--- a/plugins/development-harness/skills/development-harness/references/artifact-conventions.md
+++ b/plugins/development-harness/skills/development-harness/references/artifact-conventions.md
@@ -61,7 +61,7 @@ Artifact types used in the S1–S7 pipeline:
 
 Task plans and task-level state are managed by the SAM MCP server:
 
-- **Create:** `sam_plan(config={"action": "create", "slug": slug, "goal": goal, "tasks_yaml": tasks_yaml, "issue": issue_number})` — creates a task plan YAML and auto-registers it as `artifact_type="task-plan"`.
+- **Create:** `sam_plan(config={"action": "create", "slug": slug, "goal": goal, "tasks": [task_dict, ...], "issue": issue_number})` — creates a task plan and auto-registers it as `artifact_type="task-plan"`. Pass `tasks=[]` to create a drafting plan for incremental append.
 - **Read:** `sam_task(plan, task, config={"action": "read"})` — returns a `TaskAssignment` dict with plan-level context and task fields.
 - **Update:** `sam_task(plan, task, config={"action": "update", "append_section": ..., "section_content": ...})` — appends sections to task bodies. Used by S5 Execution, S6 Forensic Review, and S7 Final Verification to store results within the task structure.
 

--- a/plugins/development-harness/skills/development-harness/references/sdlc-stage-taxonomy.md
+++ b/plugins/development-harness/skills/development-harness/references/sdlc-stage-taxonomy.md
@@ -65,7 +65,7 @@ skill_activation: /dh:task-decomposition
 purpose: Break the validated plan into executable, independently-delegatable task files with acceptance criteria and dependency ordering.
 inputs: Amended PLAN artifact
 outputs: One TASK file per work unit, with acceptance criteria, agent routing, and dependency graph
-artifact_access: sam_plan(action=create, slug, goal, tasks_yaml, issue=issue_number) / sam_task(plan, task, config={action:read})
+artifact_access: sam_plan(action=create, slug, goal, tasks=[...], issue=issue_number) / sam_task(plan, task, config={action:read})
 ```
 
 #### S5 — `execution`

--- a/plugins/development-harness/skills/dispatch/SKILL.md
+++ b/plugins/development-harness/skills/dispatch/SKILL.md
@@ -92,7 +92,7 @@ When all workers return:
 3. Run verification (tests, linter) across the full changeset
 4. Relay synthesis findings to user or feed into next wave
 
-File pointer pattern: instruct workers to write findings to `~/.dh/projects/{slug}/reports/` (resolved via `dh_paths.reports_dir()`) and return the path. Read reports, not inline summaries, to keep orchestrator context lean.
+File pointer pattern: instruct workers to write findings to `.tmp/scratch/reports/` and return the path, or register artifacts via `artifact_register` and return the artifact type. Read reports, not inline summaries, to keep orchestrator context lean.
 
 ### 6 — Clean Up
 

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -220,7 +220,7 @@ When the plan contains `acceptance-criteria-structured` entries, `swarm-task-pla
 - **T0** has `priority: 1` and `dependencies: []`, so it is the first ready task and dispatches before any implementation task.
 - **TN** has `dependencies: [all non-bookend task IDs]`, so it becomes ready only after all implementation tasks complete and dispatches last.
 
-T0 runs agent `t0-baseline-capture`. TN runs agent `tn-verification-gate`. Both agents write YAML result files to `~/.dh/projects/{project-slug}/plan/T0-baseline-{slug}.yaml` and `~/.dh/projects/{project-slug}/plan/TN-verification-{slug}.yaml` (resolved via `dh_paths.plan_dir()`). These files are read by `/complete-implementation` in its pre-Phase 1 check.
+T0 runs agent `t0-baseline-capture`. TN runs agent `tn-verification-gate`. Both agents register their results as artifacts via `artifact_register` (types `T0-baseline` and `TN-verification`). These artifacts are read by `/complete-implementation` in its pre-Phase 1 check via `artifact_read`.
 
 ### Bookend Artifact Registration
 

--- a/plugins/development-harness/skills/interop/SKILL.md
+++ b/plugins/development-harness/skills/interop/SKILL.md
@@ -122,41 +122,30 @@ plan file path as a note in the prompt (e.g., "Plan file for context: {plan-file
 `work-backlog-item` skill does not accept a second positional argument, so the path is passed
 as contextual prose in the delegation prompt, not as an arg.
 
-This step runs: groom → RT-ICA → SAM planning and produces `~/.dh/projects/{project-slug}/plan/tasks-N-slug.md` (resolved via `dh_paths.plan_dir()`).
+This step runs: groom → RT-ICA → SAM planning and produces a SAM task plan. The plan address is returned in the `/work-backlog-item` output.
 
-Wait for `/work-backlog-item` to complete. The task file path it produces is required for Steps
+Wait for `/work-backlog-item` to complete. The plan address it produces is required for Steps
 5 and 6.
 
 ---
 
-## Step 5 — Capture the task file path
+## Step 5 — Capture the plan address
 
-After `/work-backlog-item` completes, identify the task file it produced. Plan files are stored under `~/.dh/projects/{slug}/plan/` (resolved via `dh_paths.plan_dir()`). Use Glob with the resolved path:
+After `/work-backlog-item` completes, identify the plan address it produced. The plan address is included in the `/work-backlog-item` output (e.g., `Pc7d8e9f0` or `tasks-N-slug`).
 
-```python
-from dh_paths import plan_dir
-plan_root = plan_dir()
-# Find the specific plan file:
-Glob(pattern=str(plan_root / "tasks-N-*.md"))
-```
-
-Where `N` is the backlog item number from Step 3. If the item number is unknown or the glob
-returns no results, broaden to:
-
-```python
-Glob(pattern=str(plan_dir() / "tasks-*.md"))
-```
-
-Compare results against any task file paths mentioned in the `/work-backlog-item` output. Select
-the file whose slug matches the backlog item title.
-
-If no matching file exists after the Glob check, abort:
+If the plan address is not stated in the output, use `sam_list` via MCP to find the plan whose slug matches the backlog item title:
 
 ```text
-ERROR: /work-backlog-item did not produce a task file. Cannot write back-references.
+mcp__plugin_dh_sam__sam_plan(config={"action": "list"})
 ```
 
-Record the exact filename (e.g., `tasks-3-oauth-token-refresh.md`) for use in Steps 6 and 7.
+If no matching plan exists, abort:
+
+```text
+ERROR: /work-backlog-item did not produce a task plan. Cannot write back-references.
+```
+
+Record the plan address for use in Steps 6 and 7.
 
 ---
 
@@ -173,13 +162,13 @@ flowchart TD
     Insert --> Done
 ```
 
-The exact text to write (substituting the real task filename and full state path):
+The exact text to write (substituting the real plan address):
 
 ```markdown
-**SAM tasks:** ~/.dh/projects/{project-slug}/plan/tasks-N-slug.md
+**SAM tasks:** {plan-address}
 ```
 
-Plan files live outside the repository under `~/.dh/projects/{project-slug}/plan/` (resolved via `dh_paths.plan_dir()`). Use the absolute path — relative paths from `docs/superpowers/plans/` cannot reach state files outside the repo.
+Where `{plan-address}` is the plan identifier returned in Step 5 (e.g., `Pc7d8e9f0` or `tasks-N-slug`). The address is resolved by MCP tools — do not construct filesystem paths.
 
 Use the Edit tool to make this change. Do not rewrite the file.
 
@@ -196,17 +185,17 @@ flowchart TD
     ForEach([For each Chunk N captured]) --> HasTask{Does chunk number N<br>have a corresponding SAM task T{N}?}
     HasTask -->|No — chunk count exceeds task count| Skip[Skip this chunk — no annotation]
     HasTask -->|Yes| CheckExisting{Does the line immediately<br>following this heading already<br>contain a SAM annotation comment?}
-    CheckExisting -->|Yes — re-run scenario| ReplaceAnnotation["Replace existing annotation in-place<br><!-- SAM: T{N} in ~/.dh/projects/{project-slug}/plan/tasks-N-slug.md -->"]
-    CheckExisting -->|No| InsertAnnotation["Insert on the line immediately<br>after the ## Chunk N: heading<br><!-- SAM: T{N} in ~/.dh/projects/{project-slug}/plan/tasks-N-slug.md -->"]
+    CheckExisting -->|Yes — re-run scenario| ReplaceAnnotation["Replace existing annotation in-place<br><!-- SAM: T{N} in {plan-address} -->"]
+    CheckExisting -->|No| InsertAnnotation["Insert on the line immediately<br>after the ## Chunk N: heading<br><!-- SAM: T{N} in {plan-address} -->"]
     ReplaceAnnotation --> Next([Next chunk])
     InsertAnnotation --> Next
     Skip --> Next
 ```
 
-Annotation format — substitute the real chunk number and task filename:
+Annotation format — substitute the real chunk number and plan address from Step 5:
 
 ```markdown
-<!-- SAM: T3 in ~/.dh/projects/{project-slug}/plan/tasks-N-slug.md -->
+<!-- SAM: T3 in {plan-address} -->
 ```
 
 The task number `T{N}` matches the chunk number `N` by position. Chunk 1 → T1, chunk 2 → T2.

--- a/plugins/development-harness/skills/start-task/SKILL.md
+++ b/plugins/development-harness/skills/start-task/SKILL.md
@@ -71,7 +71,7 @@ $ARGUMENTS
 
    Use the returned content as context for implementation instead of reading filesystem paths directly. This is especially important for worktree-isolated agents that cannot access uncommitted plan files from the root worktree.
 
-   **Fallback**: If `artifact_list` returns an empty manifest (no `artifacts` entries) or an error, fall back to filesystem path conventions (`dh_paths.plan_dir() / "architect-{slug}.md"` and `dh_paths.plan_dir() / "feature-context-{slug}.md"`). This ensures backward compatibility with issues that predate the artifact manifest system.
+   **Fallback**: If `artifact_list` returns an empty manifest (no `artifacts` entries) or an error, try `artifact_read` with types `architect` and `feature-context` directly. These artifact types are registered by the agents that produce them.
 
 2. Select the task:
    - If `--task` provided, use that ID

--- a/plugins/development-harness/skills/task-decomposition/SKILL.md
+++ b/plugins/development-harness/skills/task-decomposition/SKILL.md
@@ -123,27 +123,29 @@ field contains the full contextualized ARTIFACT:PLAN markdown.
 
 | Plan size | Preferred path |
 |-----------|----------------|
-| Small (fewer than 16 tasks, `tasks_yaml` under 20 KB) | Monolithic — single `sam_plan create` call |
-| Large (16+ tasks or `tasks_yaml` exceeds 20 KB) | Incremental — `create` → N × `append_task` → `finalize` |
+| Small (fewer than 16 tasks) | Monolithic — single `sam_plan create` call |
+| Large (16+ tasks) | Incremental — `create` → N × `append_task` → `finalize` |
 
 #### Monolithic path (small plans)
 
 ```text
-sam_plan(config={"action": "create", "slug": "{feature-slug}", "goal": "{plan goal}", "tasks_yaml": "{YAML task list}", "issue": {issue_number}})
+sam_plan(config={"action": "create", "slug": "{feature-slug}", "goal": "{plan goal}", "tasks": [{task_dict}, ...], "issue": {issue_number}})
 ```
+
+`tasks` is a list of task definition objects. Required fields: `id` (str), `title` (str). Optional: `status`, `agent`, `dependencies`, `priority`, `complexity`.
 
 Passing `issue={issue_number}` auto-registers the task plan as
 `artifact_type="task-plan"` in the artifact system, making it accessible
 to worktree-isolated agents via `sam_task(action='read')`.
 
-#### Incremental path (large plans — preferred when 16+ tasks or >20 KB)
+#### Incremental path (large plans — preferred when 16+ tasks)
 
-Use three calls to avoid payload limits:
+Use three calls to avoid large single-call payloads:
 
 1. Create a drafting plan (empty tasks list enters `state="drafting"`):
 
    ```text
-   sam_plan(config={"action": "create", "slug": "{feature-slug}", "goal": "{plan goal}", "tasks_yaml": "{tasks: []}", "issue": {issue_number}})
+   sam_plan(config={"action": "create", "slug": "{feature-slug}", "goal": "{plan goal}", "tasks": [], "issue": {issue_number}})
    ```
 
    The response includes the assigned plan number `P{N}`. While `state="drafting"`,
@@ -153,7 +155,7 @@ Use three calls to avoid payload limits:
 2. Append each task one at a time (repeat for every task):
 
    ```text
-   sam_plan(plan="P{N}", config={"action": "append_task", "task_yaml": "{single task YAML}"})
+   sam_plan(plan="P{N}", config={"action": "append_task", "task": {single_task_dict}})
    ```
 
 3. Finalize — clears `state="drafting"` and makes the plan ready for dispatch:

--- a/plugins/development-harness/skills/task-decomposition/SKILL.md
+++ b/plugins/development-harness/skills/task-decomposition/SKILL.md
@@ -119,7 +119,14 @@ field contains the full contextualized ARTIFACT:PLAN markdown.
 
 ## Output
 
-Create a SAM task plan via MCP:
+### Choosing a plan-creation path
+
+| Plan size | Preferred path |
+|-----------|----------------|
+| Small (fewer than 16 tasks, `tasks_yaml` under 20 KB) | Monolithic — single `sam_plan create` call |
+| Large (16+ tasks or `tasks_yaml` exceeds 20 KB) | Incremental — `create` → N × `append_task` → `finalize` |
+
+#### Monolithic path (small plans)
 
 ```text
 sam_plan(config={"action": "create", "slug": "{feature-slug}", "goal": "{plan goal}", "tasks_yaml": "{YAML task list}", "issue": {issue_number}})
@@ -128,6 +135,37 @@ sam_plan(config={"action": "create", "slug": "{feature-slug}", "goal": "{plan go
 Passing `issue={issue_number}` auto-registers the task plan as
 `artifact_type="task-plan"` in the artifact system, making it accessible
 to worktree-isolated agents via `sam_task(action='read')`.
+
+#### Incremental path (large plans — preferred when 16+ tasks or >20 KB)
+
+Use three calls to avoid payload limits:
+
+1. Create a drafting plan (empty tasks list enters `state="drafting"`):
+
+   ```text
+   sam_plan(config={"action": "create", "slug": "{feature-slug}", "goal": "{plan goal}", "tasks_yaml": "{tasks: []}", "issue": {issue_number}})
+   ```
+
+   The response includes the assigned plan number `P{N}`. While `state="drafting"`,
+   `sam_plan status` and `sam_plan ready` return a drafting marker instead of task
+   counts — the plan is not visible to the dispatch loop.
+
+2. Append each task one at a time (repeat for every task):
+
+   ```text
+   sam_plan(plan="P{N}", config={"action": "append_task", "task_yaml": "{single task YAML}"})
+   ```
+
+3. Finalize — clears `state="drafting"` and makes the plan ready for dispatch:
+
+   ```text
+   sam_plan(plan="P{N}", config={"action": "finalize"})
+   ```
+
+**Single-writer constraint**: `append_task` is NOT safe under concurrent writers. Do not
+call `append_task` for the same plan from multiple agents or sessions simultaneously. For
+the full single-writer contract, see the `CLAUDE.md` gotcha note in
+`plugins/development-harness/CLAUDE.md`.
 
 Each file contains YAML frontmatter followed by CLEAR-ordered sections:
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md
@@ -16,7 +16,7 @@
        "action": "create",
        "slug": "quick-{slug}",
        "goal": "{goal from description or acceptance_criteria}",
-       "tasks_yaml": "tasks:\n  - id: T1\n    title: \"{description}\"\n    status: not-started\n    agent: task-worker\n    dependencies: []\n    priority: 1\n    complexity: low\n    accuracy-risk: low\n    skills: []\n    reason: \"Quick fix task\"\n    handoff: \"Done when acceptance criteria met\""
+       "tasks": [{"id": "T1", "title": "{description}", "status": "not-started", "agent": "task-worker", "dependencies": [], "priority": 1, "complexity": "low"}]
      }
    )
    ```

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/sam-definition.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/sam-definition.md
@@ -70,18 +70,20 @@ Each artifact type uses the token pattern `ARTIFACT:{TYPE}({SCOPE_OR_ID})`. Stor
    - Use `ARTIFACT:{TYPE}({ID})` tokens in artifact headers; cross-reference predecessor/successor.
    - In claude_skills: Register via MCP — `artifact_register(issue_number, artifact_type, path, agent, content)` for discovery and plan artifacts. For task plans, choose a creation path based on plan size:
 
-     **Monolithic path** (fewer than 16 tasks, `tasks_yaml` under 20 KB):
+     **Monolithic path** (fewer than 16 tasks):
 
      ```text
-     sam_plan(action='create', slug, goal, tasks_yaml=<full YAML>, issue)
+     sam_plan(action='create', slug, goal, tasks=[{task_dict}, ...], issue)
      ```
 
-     **Incremental path** (16+ tasks or `tasks_yaml` exceeds 20 KB — preferred for large plans):
+     `tasks` is a list of task definition objects. Required fields: `id`, `title`. Optional: `status`, `agent`, `dependencies`, `priority`, `complexity`.
+
+     **Incremental path** (16+ tasks — preferred for large plans):
 
      1. Create a drafting plan — passing an empty task list enters `state="drafting"`:
 
         ```text
-        sam_plan(action='create', slug, goal, tasks_yaml='{tasks: []}', issue)
+        sam_plan(action='create', slug, goal, tasks=[], issue)
         ```
 
         While `state="drafting"`, `sam_plan status` and `sam_plan ready` return a drafting
@@ -90,7 +92,7 @@ Each artifact type uses the token pattern `ARTIFACT:{TYPE}({SCOPE_OR_ID})`. Stor
      2. Append tasks one at a time:
 
         ```text
-        sam_plan(plan='P{N}', action='append_task', task_yaml=<single task YAML>)
+        sam_plan(plan='P{N}', action='append_task', task={single_task_dict})
         ```
 
      3. Finalize — clears `state="drafting"` → `state="ready"`:

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/sam-definition.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/sam-definition.md
@@ -68,7 +68,41 @@ Each artifact type uses the token pattern `ARTIFACT:{TYPE}({SCOPE_OR_ID})`. Stor
 
 2. **Produce artifacts at every stage**
    - Use `ARTIFACT:{TYPE}({ID})` tokens in artifact headers; cross-reference predecessor/successor.
-   - In claude_skills: Register via MCP — `artifact_register(issue_number, artifact_type, path, agent, content)` for discovery and plan artifacts, `sam_plan(action='create', slug, goal, tasks_yaml, issue)` for task plans. Artifacts are stored in the artifact manifest and accessible to all agents including worktree-isolated sessions.
+   - In claude_skills: Register via MCP — `artifact_register(issue_number, artifact_type, path, agent, content)` for discovery and plan artifacts. For task plans, choose a creation path based on plan size:
+
+     **Monolithic path** (fewer than 16 tasks, `tasks_yaml` under 20 KB):
+
+     ```text
+     sam_plan(action='create', slug, goal, tasks_yaml=<full YAML>, issue)
+     ```
+
+     **Incremental path** (16+ tasks or `tasks_yaml` exceeds 20 KB — preferred for large plans):
+
+     1. Create a drafting plan — passing an empty task list enters `state="drafting"`:
+
+        ```text
+        sam_plan(action='create', slug, goal, tasks_yaml='{tasks: []}', issue)
+        ```
+
+        While `state="drafting"`, `sam_plan status` and `sam_plan ready` return a drafting
+        marker rather than task counts; the plan is not visible to the dispatch loop.
+
+     2. Append tasks one at a time:
+
+        ```text
+        sam_plan(plan='P{N}', action='append_task', task_yaml=<single task YAML>)
+        ```
+
+     3. Finalize — clears `state="drafting"` → `state="ready"`:
+
+        ```text
+        sam_plan(plan='P{N}', action='finalize')
+        ```
+
+     `append_task` is single-writer only — do not call it concurrently for the same plan.
+     For the full contract, see the gotcha note in `plugins/development-harness/CLAUDE.md`.
+
+   Artifacts are stored in the artifact manifest and accessible to all agents including worktree-isolated sessions.
 
 3. **Apply structural gates, not instructions**
    - Run quality gates (format, lint, typecheck, test) after each stage.

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -107,16 +107,17 @@ _PLAN_SUMMARY: dict = {
     "source_path": "/tmp/P001-test.yaml",
 }
 
-_MINIMAL_TASKS_YAML = (
-    "tasks:\n"
-    "  - task: T1\n"
-    "    title: Do something\n"
-    "    status: not-started\n"
-    "    agent: test-agent\n"
-    "    dependencies: []\n"
-    "    priority: 2\n"
-    "    complexity: simple\n"
-)
+_MINIMAL_TASKS_LIST = [
+    {
+        "id": "T1",
+        "title": "Do something",
+        "status": "not-started",
+        "agent": "test-agent",
+        "dependencies": [],
+        "priority": 2,
+        "complexity": "low",
+    }
+]
 
 
 # ---------------------------------------------------------------------------
@@ -295,7 +296,7 @@ async def test_sam_create_routes_through_backend_create_plan(backend_mock: Magic
     # Act
     await _call(
         "sam_plan",
-        {"config": {"action": "create", "slug": "test-slug", "goal": "test goal", "tasks_yaml": _MINIMAL_TASKS_YAML}},
+        {"config": {"action": "create", "slug": "test-slug", "goal": "test goal", "tasks": _MINIMAL_TASKS_LIST}},
     )
 
     # Assert
@@ -613,7 +614,7 @@ def test_update_task_round_trips_list_fields_without_coercion(tmp_path: Path) ->
     from pathlib import Path as _Path
 
     from ruamel.yaml import YAML
-    from sam_schema.core.action_models import CreatePlanConfig
+    from sam_schema.core.action_models import CreatePlanConfig, TaskDefinition
     from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
     from sam_schema.core.models import Task as _Task
     from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
@@ -622,21 +623,14 @@ def test_update_task_round_trips_list_fields_without_coercion(tmp_path: Path) ->
     # Arrange: create plan via LocalYamlTaskProvider so the file is real YAML
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    minimal_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Task One\n"
-        "    status: not-started\n"
-        "    agent: a\n"
-        "    dependencies: []\n"
-        "    priority: 2\n"
-        "    complexity: low\n"
+    minimal_task = TaskDefinition(
+        id="T01", title="Task One", status="not-started", agent="a", priority=2, complexity="low"
     )
     backend = LocalYamlTaskProvider(p_dir)
     set_task_config(TaskConfig(backend=backend))
     try:
         result = sam_plan(
-            config=CreatePlanConfig(slug="roundtrip", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
+            config=CreatePlanConfig(slug="roundtrip", goal="Goal", tasks=[minimal_task]), plan_dir=str(p_dir)
         )
         assert "error" not in result, f"sam_create failed: {result}"
         plan_id = result["plan_id"]

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 import pytest
+from sam_schema.core.action_models import TaskDefinition
 from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
 from sam_schema.core.backends.memory import InMemoryTaskProvider
 from sam_schema.core.exceptions import DocumentNotFoundError, PlanNotFoundError, TaskNotFoundError, TaskValidationError
@@ -24,8 +25,6 @@ from sam_schema.core.task_backend import TaskBackend
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from sam_schema.core.task_backend_types import TaskDefinitionDict
 
 
 # ---------------------------------------------------------------------------
@@ -44,13 +43,16 @@ def _make_task_def(
     skills: list[str] | None = None,
     body: str = "",
     description: str = "",
-) -> TaskDefinitionDict:
-    """Construct a minimal TaskDefinitionDict for test data.
+) -> TaskDefinition:
+    """Construct a minimal TaskDefinition for test data.
+
+    Uses model_validate to accept raw test values (int priority, str complexity)
+    without triggering ty type errors on enum fields.
 
     All parameters have sensible defaults so callers only need to supply
     the fields relevant to the test under execution.
     """
-    td: TaskDefinitionDict = {
+    return TaskDefinition.model_validate({
         "id": task_id,
         "title": title,
         "status": status,
@@ -58,14 +60,10 @@ def _make_task_def(
         "complexity": complexity,
         "body": body,
         "description": description,
-    }
-    if dependencies is not None:
-        td["dependencies"] = dependencies
-    if agent is not None:
-        td["agent"] = agent
-    if skills is not None:
-        td["skills"] = skills
-    return td
+        "dependencies": dependencies or [],
+        "agent": agent,
+        "skills": skills or [],
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -499,7 +497,7 @@ class TestTaskBackendConformance:
         created = backend.create_plan("my-slug", "Do the thing", [])
         plan_id = created["plan_id"]
 
-        task_def: TaskDefinitionDict = _make_task_def("T01", "First appended task")
+        task_def = _make_task_def("T01", "First appended task")
 
         # Act
         backend.append_task(plan_id, task_def)

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -25,7 +25,7 @@ from sam_schema.core.task_backend import TaskBackend
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from sam_schema.core.task_backend_types import TaskDefinition
+    from sam_schema.core.task_backend_types import TaskDefinitionDict
 
 
 # ---------------------------------------------------------------------------
@@ -44,13 +44,13 @@ def _make_task_def(
     skills: list[str] | None = None,
     body: str = "",
     description: str = "",
-) -> TaskDefinition:
-    """Construct a minimal TaskDefinition for test data.
+) -> TaskDefinitionDict:
+    """Construct a minimal TaskDefinitionDict for test data.
 
     All parameters have sensible defaults so callers only need to supply
     the fields relevant to the test under execution.
     """
-    td: TaskDefinition = {
+    td: TaskDefinitionDict = {
         "id": task_id,
         "title": title,
         "status": status,
@@ -492,14 +492,14 @@ class TestTaskBackendConformance:
         and make it visible on the subsequent read_plan call.
 
         Arrange: create a plan with zero tasks.
-        Act: call backend.append_task with a TaskDefinition for T01.
+        Act: call backend.append_task with a TaskDefinitionDict for T01.
         Assert: read_plan returns a plan with exactly one task; task fields match.
         """
         # Arrange
         created = backend.create_plan("my-slug", "Do the thing", [])
         plan_id = created["plan_id"]
 
-        task_def: TaskDefinition = _make_task_def("T01", "First appended task")
+        task_def: TaskDefinitionDict = _make_task_def("T01", "First appended task")
 
         # Act
         backend.append_task(plan_id, task_def)

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -564,7 +564,7 @@ class TestTaskBackendConformance:
         plan_id = created["plan_id"]
 
         # Act / Assert — appending a duplicate ID must be rejected
-        with pytest.raises((TaskValidationError, ValueError)):
+        with pytest.raises(TaskValidationError):
             backend.append_task(plan_id, _make_task_def("T01", "Duplicate"))
 
     def test_append_multiple_tasks_preserves_order(self, backend: TaskBackend) -> None:

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -550,12 +550,12 @@ class TestTaskBackendConformance:
     def test_append_task_duplicate_task_id_raises(self, backend: TaskBackend) -> None:
         """append_task raises an error when a duplicate task ID is appended.
 
-        AC #6: each backend must raise an appropriate error (TaskValidationError
-        or ValueError) when a task with an already-existing ID is appended.
+        AC #6: each backend must raise TaskValidationError when a task with an
+        already-existing ID is appended.
 
         Arrange: create a plan with T01; append T01 again.
         Act: second append_task call with the same task ID.
-        Assert: TaskValidationError (or ValueError) is raised.
+        Assert: TaskValidationError is raised.
         """
         from sam_schema.core.exceptions import TaskValidationError
 

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -485,6 +485,7 @@ class TestTaskBackendConformance:
     # tests must pass for ALL parametrized variants.
     # ------------------------------------------------------------------
 
+    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_task_adds_task_to_plan(self, backend: TaskBackend) -> None:
         """append_task adds a single task to a plan with empty task list.
 
@@ -510,6 +511,7 @@ class TestTaskBackendConformance:
         assert plan["tasks"][0]["id"] == "T01"
         assert plan["tasks"][0]["title"] == "First appended task"
 
+    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_task_preserves_existing_tasks(self, backend: TaskBackend) -> None:
         """append_task adds a task without disturbing existing tasks.
 
@@ -533,6 +535,7 @@ class TestTaskBackendConformance:
         assert plan["tasks"][0]["id"] == "T01"
         assert plan["tasks"][1]["id"] == "T02"
 
+    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_task_plan_not_found_raises(self, backend: TaskBackend) -> None:
         """append_task raises PlanNotFoundError when plan_id does not exist.
 
@@ -549,6 +552,7 @@ class TestTaskBackendConformance:
         with pytest.raises(PlanNotFoundError):
             backend.append_task("P99999", _make_task_def("T01", "Task"))
 
+    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_task_duplicate_task_id_raises(self, backend: TaskBackend) -> None:
         """append_task raises an error when a duplicate task ID is appended.
 
@@ -569,6 +573,7 @@ class TestTaskBackendConformance:
         with pytest.raises((TaskValidationError, ValueError)):
             backend.append_task(plan_id, _make_task_def("T01", "Duplicate"))
 
+    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_multiple_tasks_preserves_order(self, backend: TaskBackend) -> None:
         """N sequential append_task calls preserve insertion order.
 

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -485,7 +485,6 @@ class TestTaskBackendConformance:
     # tests must pass for ALL parametrized variants.
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_task_adds_task_to_plan(self, backend: TaskBackend) -> None:
         """append_task adds a single task to a plan with empty task list.
 
@@ -511,7 +510,6 @@ class TestTaskBackendConformance:
         assert plan["tasks"][0]["id"] == "T01"
         assert plan["tasks"][0]["title"] == "First appended task"
 
-    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_task_preserves_existing_tasks(self, backend: TaskBackend) -> None:
         """append_task adds a task without disturbing existing tasks.
 
@@ -535,7 +533,6 @@ class TestTaskBackendConformance:
         assert plan["tasks"][0]["id"] == "T01"
         assert plan["tasks"][1]["id"] == "T02"
 
-    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_task_plan_not_found_raises(self, backend: TaskBackend) -> None:
         """append_task raises PlanNotFoundError when plan_id does not exist.
 
@@ -552,7 +549,6 @@ class TestTaskBackendConformance:
         with pytest.raises(PlanNotFoundError):
             backend.append_task("P99999", _make_task_def("T01", "Task"))
 
-    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_task_duplicate_task_id_raises(self, backend: TaskBackend) -> None:
         """append_task raises an error when a duplicate task ID is appended.
 
@@ -573,7 +569,6 @@ class TestTaskBackendConformance:
         with pytest.raises((TaskValidationError, ValueError)):
             backend.append_task(plan_id, _make_task_def("T01", "Duplicate"))
 
-    @pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
     def test_append_multiple_tasks_preserves_order(self, backend: TaskBackend) -> None:
         """N sequential append_task calls preserve insertion order.
 

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -14,7 +14,7 @@ Coverage targets:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
@@ -371,7 +371,7 @@ class TestTaskBackendConformance:
 
         # Assert
         assert status["total_tasks"] == 3
-        by_status = status["by_status"]
+        by_status = cast("dict[str, int]", status["by_status"])
         assert isinstance(by_status, dict)
         assert by_status.get("complete") == 1
         assert by_status.get("not-started") == 2
@@ -474,3 +474,121 @@ class TestTaskBackendConformance:
     def test_isinstance_check(self, backend: TaskBackend) -> None:
         """Backend instance should satisfy the runtime-checkable TaskBackend Protocol."""
         assert isinstance(backend, TaskBackend)
+
+    # ------------------------------------------------------------------
+    # append_task — #1770 RED-PHASE conformance case
+    # ------------------------------------------------------------------
+    # These tests FAIL in the red phase with:
+    #   AttributeError: object has no attribute 'append_task'
+    # or NotImplementedError if the Protocol stub is added without implementation.
+    # The green phase implements append_task on all three backends and these
+    # tests must pass for ALL parametrized variants.
+    # ------------------------------------------------------------------
+
+    def test_append_task_adds_task_to_plan(self, backend: TaskBackend) -> None:
+        """append_task adds a single task to a plan with empty task list.
+
+        AC #2/#5: TaskBackend.append_task must append a single task to the plan
+        and make it visible on the subsequent read_plan call.
+
+        Arrange: create a plan with zero tasks.
+        Act: call backend.append_task with a TaskDefinition for T01.
+        Assert: read_plan returns a plan with exactly one task; task fields match.
+        """
+        # Arrange
+        created = backend.create_plan("my-slug", "Do the thing", [])
+        plan_id = created["plan_id"]
+
+        task_def: TaskDefinition = _make_task_def("T01", "First appended task")
+
+        # Act
+        backend.append_task(plan_id, task_def)
+
+        # Assert
+        plan = backend.read_plan(plan_id)
+        assert len(plan["tasks"]) == 1
+        assert plan["tasks"][0]["id"] == "T01"
+        assert plan["tasks"][0]["title"] == "First appended task"
+
+    def test_append_task_preserves_existing_tasks(self, backend: TaskBackend) -> None:
+        """append_task adds a task without disturbing existing tasks.
+
+        AC #3/#5: appending to a plan with existing tasks must not overwrite or
+        reorder the existing task list.
+
+        Arrange: create a plan with one task (T01); append a second task (T02).
+        Act: call backend.append_task(plan_id, T02_def).
+        Assert: read_plan returns two tasks in insertion order: T01 then T02.
+        """
+        # Arrange
+        created = backend.create_plan("two-task-plan", "Two tasks", [_make_task_def("T01", "Original task")])
+        plan_id = created["plan_id"]
+
+        # Act
+        backend.append_task(plan_id, _make_task_def("T02", "Appended task"))
+
+        # Assert
+        plan = backend.read_plan(plan_id)
+        assert len(plan["tasks"]) == 2
+        assert plan["tasks"][0]["id"] == "T01"
+        assert plan["tasks"][1]["id"] == "T02"
+
+    def test_append_task_plan_not_found_raises(self, backend: TaskBackend) -> None:
+        """append_task raises PlanNotFoundError when plan_id does not exist.
+
+        AC #6: each backend must raise PlanNotFoundError (not a silent no-op)
+        when append_task is called for an unknown plan_id.
+
+        Arrange: backend has no plans.
+        Act: call backend.append_task with plan_id 'P99999'.
+        Assert: PlanNotFoundError is raised containing 'P99999'.
+        """
+        # Arrange — backend starts empty; no plans exist
+
+        # Act / Assert
+        with pytest.raises(PlanNotFoundError):
+            backend.append_task("P99999", _make_task_def("T01", "Task"))
+
+    def test_append_task_duplicate_task_id_raises(self, backend: TaskBackend) -> None:
+        """append_task raises an error when a duplicate task ID is appended.
+
+        AC #6: each backend must raise an appropriate error (TaskValidationError
+        or ValueError) when a task with an already-existing ID is appended.
+
+        Arrange: create a plan with T01; append T01 again.
+        Act: second append_task call with the same task ID.
+        Assert: TaskValidationError (or ValueError) is raised.
+        """
+        from sam_schema.core.exceptions import TaskValidationError
+
+        # Arrange
+        created = backend.create_plan("dup-plan", "Goal", [_make_task_def("T01", "Original")])
+        plan_id = created["plan_id"]
+
+        # Act / Assert — appending a duplicate ID must be rejected
+        with pytest.raises((TaskValidationError, ValueError)):
+            backend.append_task(plan_id, _make_task_def("T01", "Duplicate"))
+
+    def test_append_multiple_tasks_preserves_order(self, backend: TaskBackend) -> None:
+        """N sequential append_task calls preserve insertion order.
+
+        AC #3: after N sequential append_task calls, read_plan must return tasks
+        in the same order they were appended.
+
+        Arrange: create empty plan; append T01..T05 sequentially.
+        Act: read plan.
+        Assert: tasks are ordered T01, T02, T03, T04, T05.
+        """
+        # Arrange
+        created = backend.create_plan("ordered-plan", "Order test", [])
+        plan_id = created["plan_id"]
+
+        # Act
+        for i in range(1, 6):
+            backend.append_task(plan_id, _make_task_def(f"T{i:02d}", f"Task {i}"))
+
+        # Assert
+        plan = backend.read_plan(plan_id)
+        assert len(plan["tasks"]) == 5
+        task_ids = [t["id"] for t in plan["tasks"]]
+        assert task_ids == ["T01", "T02", "T03", "T04", "T05"], f"Expected ordered IDs T01..T05, got: {task_ids}"

--- a/plugins/development-harness/tests_sam/conftest.py
+++ b/plugins/development-harness/tests_sam/conftest.py
@@ -10,10 +10,16 @@ Fixture design follows AAA pattern with full type annotations and pytest-mock
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from sam_schema.core.action_models import TaskDefinition
+from sam_schema.core.backends.memory import InMemoryTaskProvider
 from sam_schema.core.models import Complexity, Plan, Priority, Task, TaskStatus
+from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 # ---------------------------------------------------------------------------
 # Path constants
@@ -72,6 +78,26 @@ def make_task_def(
         "priority": 1,
         "complexity": "low",
     })
+
+
+# ---------------------------------------------------------------------------
+# Backend fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memory_backend() -> Generator[InMemoryTaskProvider, None, None]:
+    """Inject a fresh InMemoryTaskProvider via set_task_config.
+
+    Calls reset_task_config() in teardown to prevent cross-test contamination.
+
+    Yields:
+        Configured InMemoryTaskProvider instance.
+    """
+    backend = InMemoryTaskProvider()
+    set_task_config(TaskConfig(backend=backend))
+    yield backend
+    reset_task_config()
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests_sam/conftest.py
+++ b/plugins/development-harness/tests_sam/conftest.py
@@ -10,9 +10,13 @@ Fixture design follows AAA pattern with full type annotations and pytest-mock
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from sam_schema.core.models import Complexity, Plan, Priority, Task, TaskStatus
+
+if TYPE_CHECKING:
+    from sam_schema.core.task_backend_types import TaskDefinitionDict
 
 # ---------------------------------------------------------------------------
 # Path constants
@@ -54,7 +58,7 @@ def make_task_def(
     status: str = "not-started",
     deps: list[str] | None = None,
     agent: str = "test-agent",
-) -> dict[str, object]:
+) -> TaskDefinitionDict:
     """Return a minimal task definition dict suitable for InMemoryTaskProvider.create_plan.
 
     Used by test_consolidated_tools.  Centralised here to eliminate duplication.

--- a/plugins/development-harness/tests_sam/conftest.py
+++ b/plugins/development-harness/tests_sam/conftest.py
@@ -10,13 +10,10 @@ Fixture design follows AAA pattern with full type annotations and pytest-mock
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
+from sam_schema.core.action_models import TaskDefinition
 from sam_schema.core.models import Complexity, Plan, Priority, Task, TaskStatus
-
-if TYPE_CHECKING:
-    from sam_schema.core.task_backend_types import TaskDefinitionDict
 
 # ---------------------------------------------------------------------------
 # Path constants
@@ -58,12 +55,15 @@ def make_task_def(
     status: str = "not-started",
     deps: list[str] | None = None,
     agent: str = "test-agent",
-) -> TaskDefinitionDict:
-    """Return a minimal task definition dict suitable for InMemoryTaskProvider.create_plan.
+) -> TaskDefinition:
+    """Return a minimal TaskDefinition suitable for TaskBackend.create_plan and append_task.
+
+    Uses model_validate to accept raw test values (int priority, str complexity)
+    without triggering ty type errors on enum fields.
 
     Used by test_consolidated_tools.  Centralised here to eliminate duplication.
     """
-    return {
+    return TaskDefinition.model_validate({
         "id": task_id,
         "title": title,
         "status": status,
@@ -71,7 +71,7 @@ def make_task_def(
         "dependencies": deps if deps is not None else [],
         "priority": 1,
         "complexity": "low",
-    }
+    })
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests_sam/test_consolidated_tools.py
+++ b/plugins/development-harness/tests_sam/test_consolidated_tools.py
@@ -27,35 +27,39 @@ if TYPE_CHECKING:
 # Helpers
 # ---------------------------------------------------------------------------
 
-# YAML for sam_plan(action="create") tests — uses "id:" key for InMemoryTaskProvider.
-_TWO_TASK_YAML = (
-    "tasks:\n"
-    "  - id: T01\n"
-    "    title: First task\n"
-    "    status: not-started\n"
-    "    agent: test-agent\n"
-    "    dependencies: []\n"
-    "    priority: 1\n"
-    "    complexity: low\n"
-    "  - id: T02\n"
-    "    title: Second task\n"
-    "    status: not-started\n"
-    "    agent: test-agent\n"
-    "    dependencies: [T01]\n"
-    "    priority: 2\n"
-    "    complexity: medium\n"
-)
+# Task lists for sam_plan(action="create") tests.
+_TWO_TASK_LIST = [
+    {
+        "id": "T01",
+        "title": "First task",
+        "status": "not-started",
+        "agent": "test-agent",
+        "dependencies": [],
+        "priority": 1,
+        "complexity": "low",
+    },
+    {
+        "id": "T02",
+        "title": "Second task",
+        "status": "not-started",
+        "agent": "test-agent",
+        "dependencies": ["T01"],
+        "priority": 2,
+        "complexity": "medium",
+    },
+]
 
-_SINGLE_TASK_YAML = (
-    "tasks:\n"
-    "  - id: T01\n"
-    "    title: Only task\n"
-    "    status: not-started\n"
-    "    agent: test-agent\n"
-    "    dependencies: []\n"
-    "    priority: 1\n"
-    "    complexity: low\n"
-)
+_SINGLE_TASK_LIST = [
+    {
+        "id": "T01",
+        "title": "Only task",
+        "status": "not-started",
+        "agent": "test-agent",
+        "dependencies": [],
+        "priority": 1,
+        "complexity": "low",
+    }
+]
 
 
 from tests_sam.conftest import make_task_def as _task_def
@@ -420,7 +424,7 @@ async def test_sam_plan_create_returns_plan_number_and_task_count(client: Client
     # Act
     result = await client.call_tool(
         "sam_plan",
-        {"config": {"action": "create", "slug": "new-plan", "goal": "Build something", "tasks_yaml": _TWO_TASK_YAML}},
+        {"config": {"action": "create", "slug": "new-plan", "goal": "Build something", "tasks": _TWO_TASK_LIST}},
     )
 
     # Assert
@@ -444,7 +448,7 @@ async def test_sam_plan_create_sets_plan_goal(client: Client) -> None:
                 "action": "create",
                 "slug": "goal-plan",
                 "goal": "Specific goal string",
-                "tasks_yaml": _SINGLE_TASK_YAML,
+                "tasks": _SINGLE_TASK_LIST,
             }
         },
     )
@@ -456,12 +460,12 @@ async def test_sam_plan_create_sets_plan_goal(client: Client) -> None:
     assert read_result.data.get("goal") == "Specific goal string"
 
 
-async def test_sam_plan_create_invalid_yaml_raises_tool_error(client: Client) -> None:
-    """sam_plan action=create raises ToolError when tasks_yaml lacks a 'tasks' key.
+async def test_sam_plan_create_invalid_task_missing_id_raises_tool_error(client: Client) -> None:
+    """sam_plan action=create raises ToolError when a task dict lacks required 'id' field.
 
-    Tests: sam_plan create YAML validation.
-    How: Pass YAML with no 'tasks' top-level key.
-    Why: The server validates the parsed YAML structure before calling the backend.
+    Tests: sam_plan create task validation.
+    How: Pass a task dict missing the required 'id' field.
+    Why: Pydantic validates task fields at the MCP boundary; missing required fields raise ToolError.
     """
     # Act / Assert
     with pytest.raises(ToolError):
@@ -472,7 +476,7 @@ async def test_sam_plan_create_invalid_yaml_raises_tool_error(client: Client) ->
                     "action": "create",
                     "slug": "bad",
                     "goal": "Bad plan",
-                    "tasks_yaml": "not_tasks: true\nother: value",
+                    "tasks": [{"title": "Task without id"}],
                 }
             },
         )

--- a/plugins/development-harness/tests_sam/test_drafting_state.py
+++ b/plugins/development-harness/tests_sam/test_drafting_state.py
@@ -1,58 +1,14 @@
-"""Tests for drafting-state semantics introduced by #1770.
+"""Tests for drafting-state lifecycle introduced by #1770.
 
-DESIGN DECISIONS (binding for the green phase implementer)
-==========================================================
+Covers the create-empty → drafting → append_task → finalize → ready lifecycle:
 
-1. Drafting-state representation
-   --------------------------------
-   CHOICE: ``state: Literal["drafting", "ready"]`` field on the Plan Pydantic model
-   (option b from the backlog item).
+- Test D: ``status`` and ``ready`` return a drafting marker for a mid-append plan.
+- Test E: ``read`` returns the task list plus a drafting marker for a mid-append plan.
+- Test F: after ``finalize``, ``status`` and ``ready`` return normal dispatchable data.
 
-   Rationale: A two-value StrEnum-style field is more explicit than a bare bool
-   and maps cleanly to the existing Plan model pattern (see ``TaskStatus``,
-   ``Complexity`` etc.).  A ``state`` field also allows additional future states
-   without a breaking field rename.
-
-   Consequence: ``Plan.state`` must exist and default to ``"ready"`` so all
-   existing tests continue to pass without change.  Plans created with an empty
-   ``tasks_yaml='{tasks: []}'`` payload receive ``state="drafting"`` from
-   ``create_plan``.  ``append_task`` calls do NOT change ``state`` — it stays
-   ``"drafting"`` until ``finalize`` is called.
-
-2. Finalize mechanism
-   --------------------
-   CHOICE: New ``sam_plan(action='finalize', plan=P)`` routing (option a from
-   the backlog item).
-
-   Rationale: A dedicated action is self-documenting at the MCP call-site,
-   makes the state transition explicit in server logs, and avoids the risk of
-   a raw ``set_fields_json='{"state": "ready"}'`` call accidentally clearing
-   a drafting plan before the review step.
-
-   Consequence: A new ``FinalizePlanConfig`` model with ``action: Literal["finalize"]``
-   must be added to ``action_models.py`` and wired into the ``sam_plan`` match
-   block in ``server.py``.
-
-3. AppendTaskConfig shape
-   -----------------------
-   CHOICE: New ``AppendTaskConfig(action="append_task", plan_id=..., task_yaml=...)``
-   where:
-   - ``action: Literal["append_task"]``
-   - ``task_yaml: str`` — single-task YAML string with the same schema as one
-     element of the ``tasks`` list in ``CreatePlanConfig.tasks_yaml``.
-     Example: ``"id: T3\\ntitle: My task\\nstatus: not-started\\n..."``
-   - The ``plan`` parameter on the MCP tool wrapper carries the plan address
-     (same pattern as ``read``, ``status``, ``ready``).
-
-   ``task_yaml`` mirrors the ``tasks_yaml`` naming convention of ``CreatePlanConfig``
-   (singular form for a single task).
-
-AC coverage
------------
-Test D — ``status`` and ``ready`` return ``drafting`` marker for mid-append plan
-Test E — ``read`` returns task list plus ``drafting`` marker for mid-append plan
-Test F — after ``finalize``, ``status`` and ``ready`` return normal dispatchable data
-Test G — (deferred to agent plan-validator tests; plan-validator is out of scope here)
+For the single-writer concurrency contract and the architectural rationale behind
+the ``state`` field and ``finalize`` action, see
+``plugins/development-harness/docs/adrs/ADR-1770-1-single-writer-task-backend.md``.
 """
 
 from __future__ import annotations

--- a/plugins/development-harness/tests_sam/test_drafting_state.py
+++ b/plugins/development-harness/tests_sam/test_drafting_state.py
@@ -119,7 +119,6 @@ def memory_backend() -> Generator[InMemoryTaskProvider, None, None]:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_status_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='status') returns a drafting marker while plan is mid-append.
 
@@ -144,7 +143,6 @@ def test_status_returns_drafting_marker_on_mid_append_plan(memory_backend: InMem
     assert _is_drafting(status), f"Expected drafting marker in status response for a mid-append plan, got: {status!r}"
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_ready_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='ready') returns a drafting marker while plan is mid-append.
 
@@ -175,7 +173,6 @@ def test_ready_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemo
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_read_returns_tasks_and_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='read') returns tasks plus drafting marker on a drafting plan.
 
@@ -213,7 +210,6 @@ def test_read_returns_tasks_and_drafting_marker_on_mid_append_plan(memory_backen
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_status_returns_normal_data_after_finalize(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='status') returns normal task data after finalize clears drafting.
 
@@ -240,7 +236,6 @@ def test_status_returns_normal_data_after_finalize(memory_backend: InMemoryTaskP
     assert status.get("total_tasks") == 1
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_ready_returns_normal_data_after_finalize(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='ready') returns ready tasks after finalize clears drafting.
 

--- a/plugins/development-harness/tests_sam/test_drafting_state.py
+++ b/plugins/development-harness/tests_sam/test_drafting_state.py
@@ -71,23 +71,13 @@ if TYPE_CHECKING:
 # Helpers
 # ---------------------------------------------------------------------------
 
-from sam_schema.core.action_models import TaskDefinition
-
-_MINIMAL_TASK_DEF = {
-    "id": "T1",
-    "title": "First task",
-    "status": "not-started",
-    "agent": "test-agent",
-    "dependencies": [],
-    "priority": 2,
-    "complexity": "low",
-}
+from sam_schema.core.action_models import CreatePlanConfig, TaskDefinition
 
 _MINIMAL_TASK = TaskDefinition(
     id="T1", title="First task", status="not-started", agent="test-agent", dependencies=[], priority=2, complexity="low"
 )
 
-_EMPTY_TASKS_YAML = "tasks: []"
+_DRAFTING_PLAN_CONFIG = CreatePlanConfig(slug="test-plan", goal="Test goal", tasks=[])
 
 
 # ---------------------------------------------------------------------------
@@ -121,15 +111,15 @@ def test_status_returns_drafting_marker_on_mid_append_plan(memory_backend: InMem
     AC #12: status returns a drafting marker instead of dispatchable task data
     when the plan is in drafting state.
 
-    Arrange: create a plan with empty tasks_yaml so it enters drafting state.
+    Arrange: create a plan with empty tasks list so it enters drafting state.
     Act: call sam_plan(action='status', plan=P).
     Assert: response contains a 'drafting' key that is truthy, or a 'state'
             key with value 'drafting'.
     """
-    from sam_schema.core.action_models import CreatePlanConfig, StatusPlanConfig
+    from sam_schema.core.action_models import StatusPlanConfig
 
     # Arrange — create plan in drafting state
-    result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    result = sam_plan(config=_DRAFTING_PLAN_CONFIG)
     plan_id = result["plan_id"]
 
     # Act
@@ -149,10 +139,10 @@ def test_ready_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemo
     Act: call sam_plan(action='ready', plan=P).
     Assert: response contains 'drafting' marker; 'ready_tasks' is absent or empty.
     """
-    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, ReadyPlanConfig
+    from sam_schema.core.action_models import AppendTaskConfig, ReadyPlanConfig
 
     # Arrange
-    create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    create_result = sam_plan(config=_DRAFTING_PLAN_CONFIG)
     plan_id = create_result["plan_id"]
 
     sam_plan(config=AppendTaskConfig(task=_MINIMAL_TASK), plan=plan_id)
@@ -179,10 +169,10 @@ def test_read_returns_tasks_and_drafting_marker_on_mid_append_plan(memory_backen
     Act: call sam_plan(action='read', plan=P).
     Assert: response includes the appended task AND a 'drafting' or 'state' marker.
     """
-    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, ReadPlanConfig
+    from sam_schema.core.action_models import AppendTaskConfig, ReadPlanConfig
 
     # Arrange
-    create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    create_result = sam_plan(config=_DRAFTING_PLAN_CONFIG)
     plan_id = create_result["plan_id"]
 
     sam_plan(config=AppendTaskConfig(task=_MINIMAL_TASK), plan=plan_id)
@@ -215,10 +205,10 @@ def test_status_returns_normal_data_after_finalize(memory_backend: InMemoryTaskP
     Act: call sam_plan(action='status', plan=P).
     Assert: response does NOT contain drafting marker; total_tasks == 1.
     """
-    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, FinalizePlanConfig, StatusPlanConfig
+    from sam_schema.core.action_models import AppendTaskConfig, FinalizePlanConfig, StatusPlanConfig
 
     # Arrange
-    create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    create_result = sam_plan(config=_DRAFTING_PLAN_CONFIG)
     plan_id = create_result["plan_id"]
     sam_plan(config=AppendTaskConfig(task=_MINIMAL_TASK), plan=plan_id)
     sam_plan(config=FinalizePlanConfig(), plan=plan_id)
@@ -241,10 +231,10 @@ def test_ready_returns_normal_data_after_finalize(memory_backend: InMemoryTaskPr
     Act: call sam_plan(action='ready', plan=P).
     Assert: response does NOT contain drafting marker; ready_tasks contains T1.
     """
-    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, FinalizePlanConfig, ReadyPlanConfig
+    from sam_schema.core.action_models import AppendTaskConfig, FinalizePlanConfig, ReadyPlanConfig
 
     # Arrange
-    create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    create_result = sam_plan(config=_DRAFTING_PLAN_CONFIG)
     plan_id = create_result["plan_id"]
     sam_plan(config=AppendTaskConfig(task=_MINIMAL_TASK), plan=plan_id)
     sam_plan(config=FinalizePlanConfig(), plan=plan_id)

--- a/plugins/development-harness/tests_sam/test_drafting_state.py
+++ b/plugins/development-harness/tests_sam/test_drafting_state.py
@@ -59,45 +59,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-from sam_schema.core.backends.memory import InMemoryTaskProvider
-from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
-from sam_schema.server import sam_plan
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
 from sam_schema.core.action_models import CreatePlanConfig, TaskDefinition
+from sam_schema.server import sam_plan
+
+if TYPE_CHECKING:
+    from sam_schema.core.backends.memory import InMemoryTaskProvider
 
 _MINIMAL_TASK = TaskDefinition(
     id="T1", title="First task", status="not-started", agent="test-agent", dependencies=[], priority=2, complexity="low"
 )
 
 _DRAFTING_PLAN_CONFIG = CreatePlanConfig(slug="test-plan", goal="Test goal", tasks=[])
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def memory_backend() -> Generator[InMemoryTaskProvider, None, None]:
-    """Inject a fresh InMemoryTaskProvider via set_task_config.
-
-    Calls reset_task_config() in teardown to prevent cross-test contamination.
-
-    Yields:
-        Configured InMemoryTaskProvider instance.
-    """
-    backend = InMemoryTaskProvider()
-    set_task_config(TaskConfig(backend=backend))
-    yield backend
-    reset_task_config()
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests_sam/test_drafting_state.py
+++ b/plugins/development-harness/tests_sam/test_drafting_state.py
@@ -1,0 +1,284 @@
+"""Tests for drafting-state semantics introduced by #1770.
+
+DESIGN DECISIONS (binding for the green phase implementer)
+==========================================================
+
+1. Drafting-state representation
+   --------------------------------
+   CHOICE: ``state: Literal["drafting", "ready"]`` field on the Plan Pydantic model
+   (option b from the backlog item).
+
+   Rationale: A two-value StrEnum-style field is more explicit than a bare bool
+   and maps cleanly to the existing Plan model pattern (see ``TaskStatus``,
+   ``Complexity`` etc.).  A ``state`` field also allows additional future states
+   without a breaking field rename.
+
+   Consequence: ``Plan.state`` must exist and default to ``"ready"`` so all
+   existing tests continue to pass without change.  Plans created with an empty
+   ``tasks_yaml='{tasks: []}'`` payload receive ``state="drafting"`` from
+   ``create_plan``.  ``append_task`` calls do NOT change ``state`` — it stays
+   ``"drafting"`` until ``finalize`` is called.
+
+2. Finalize mechanism
+   --------------------
+   CHOICE: New ``sam_plan(action='finalize', plan=P)`` routing (option a from
+   the backlog item).
+
+   Rationale: A dedicated action is self-documenting at the MCP call-site,
+   makes the state transition explicit in server logs, and avoids the risk of
+   a raw ``set_fields_json='{"state": "ready"}'`` call accidentally clearing
+   a drafting plan before the review step.
+
+   Consequence: A new ``FinalizePlanConfig`` model with ``action: Literal["finalize"]``
+   must be added to ``action_models.py`` and wired into the ``sam_plan`` match
+   block in ``server.py``.
+
+3. AppendTaskConfig shape
+   -----------------------
+   CHOICE: New ``AppendTaskConfig(action="append_task", plan_id=..., task_yaml=...)``
+   where:
+   - ``action: Literal["append_task"]``
+   - ``task_yaml: str`` — single-task YAML string with the same schema as one
+     element of the ``tasks`` list in ``CreatePlanConfig.tasks_yaml``.
+     Example: ``"id: T3\\ntitle: My task\\nstatus: not-started\\n..."``
+   - The ``plan`` parameter on the MCP tool wrapper carries the plan address
+     (same pattern as ``read``, ``status``, ``ready``).
+
+   ``task_yaml`` mirrors the ``tasks_yaml`` naming convention of ``CreatePlanConfig``
+   (singular form for a single task).
+
+AC coverage
+-----------
+Test D — ``status`` and ``ready`` return ``drafting`` marker for mid-append plan
+Test E — ``read`` returns task list plus ``drafting`` marker for mid-append plan
+Test F — after ``finalize``, ``status`` and ``ready`` return normal dispatchable data
+Test G — (deferred to agent plan-validator tests; plan-validator is out of scope here)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sam_schema.core.backends.memory import InMemoryTaskProvider
+from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
+from sam_schema.server import sam_plan
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_TASK_DEF = {
+    "id": "T1",
+    "title": "First task",
+    "status": "not-started",
+    "agent": "test-agent",
+    "dependencies": [],
+    "priority": 2,
+    "complexity": "low",
+}
+
+_MINIMAL_TASK_YAML = (
+    "id: T1\n"
+    "title: First task\n"
+    "status: not-started\n"
+    "agent: test-agent\n"
+    "dependencies: []\n"
+    "priority: 2\n"
+    "complexity: low\n"
+)
+
+_EMPTY_TASKS_YAML = "tasks: []"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memory_backend() -> Generator[InMemoryTaskProvider, None, None]:
+    """Inject a fresh InMemoryTaskProvider via set_task_config.
+
+    Calls reset_task_config() in teardown to prevent cross-test contamination.
+
+    Yields:
+        Configured InMemoryTaskProvider instance.
+    """
+    backend = InMemoryTaskProvider()
+    set_task_config(TaskConfig(backend=backend))
+    yield backend
+    reset_task_config()
+
+
+# ---------------------------------------------------------------------------
+# Test D — status and ready return drafting marker for mid-append plan
+# ---------------------------------------------------------------------------
+
+
+def test_status_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
+    """sam_plan(action='status') returns a drafting marker while plan is mid-append.
+
+    AC #12: status returns a drafting marker instead of dispatchable task data
+    when the plan is in drafting state.
+
+    Arrange: create a plan with empty tasks_yaml so it enters drafting state.
+    Act: call sam_plan(action='status', plan=P).
+    Assert: response contains a 'drafting' key that is truthy, or a 'state'
+            key with value 'drafting'.
+    """
+    # Arrange — create plan in drafting state
+    result = sam_plan(
+        config=__import__("sam_schema.core.action_models", fromlist=["CreatePlanConfig"]).CreatePlanConfig(
+            slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML
+        )
+    )
+    plan_id = result["plan_id"]
+
+    # Act
+    from sam_schema.core.action_models import StatusPlanConfig
+
+    status = sam_plan(config=StatusPlanConfig(), plan=plan_id)
+
+    # Assert — drafting marker must be present
+    assert _is_drafting(status), f"Expected drafting marker in status response for a mid-append plan, got: {status!r}"
+
+
+def test_ready_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
+    """sam_plan(action='ready') returns a drafting marker while plan is mid-append.
+
+    AC #12: ready returns a drafting marker instead of dispatchable task data
+    when the plan is in drafting state.
+
+    Arrange: create empty plan; append one task so plan has content.
+    Act: call sam_plan(action='ready', plan=P).
+    Assert: response contains 'drafting' marker; 'ready_tasks' is absent or empty.
+    """
+    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, ReadyPlanConfig
+
+    # Arrange
+    create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    plan_id = create_result["plan_id"]
+
+    sam_plan(config=AppendTaskConfig(task_yaml=_MINIMAL_TASK_YAML), plan=plan_id)
+
+    # Act
+    ready = sam_plan(config=ReadyPlanConfig(), plan=plan_id)
+
+    # Assert
+    assert _is_drafting(ready), f"Expected drafting marker in ready response for a mid-append plan, got: {ready!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test E — read returns task list plus drafting marker
+# ---------------------------------------------------------------------------
+
+
+def test_read_returns_tasks_and_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
+    """sam_plan(action='read') returns tasks plus drafting marker on a drafting plan.
+
+    AC #11: read on a drafting plan returns the plan body including all tasks
+    appended so far, and includes the drafting marker in the response.
+
+    Arrange: create empty plan; append one task.
+    Act: call sam_plan(action='read', plan=P).
+    Assert: response includes the appended task AND a 'drafting' or 'state' marker.
+    """
+    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, ReadPlanConfig
+
+    # Arrange
+    create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    plan_id = create_result["plan_id"]
+
+    sam_plan(config=AppendTaskConfig(task_yaml=_MINIMAL_TASK_YAML), plan=plan_id)
+
+    # Act
+    read_result = sam_plan(config=ReadPlanConfig(), plan=plan_id)
+
+    # Assert — tasks present
+    tasks = read_result.get("tasks", [])
+    assert len(tasks) == 1, f"Expected 1 task after append, got: {len(tasks)}"
+    assert tasks[0]["id"] == "T1"
+
+    # Assert — drafting marker present
+    assert _is_drafting(read_result), (
+        f"Expected drafting marker in read response for a mid-append plan, got: {read_result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test F — after finalize, status and ready return normal data
+# ---------------------------------------------------------------------------
+
+
+def test_status_returns_normal_data_after_finalize(memory_backend: InMemoryTaskProvider) -> None:
+    """sam_plan(action='status') returns normal task data after finalize clears drafting.
+
+    AC #13/#14: after finalize (or equivalent), status returns real dispatchable data.
+
+    Arrange: create empty plan, append a task, then call finalize.
+    Act: call sam_plan(action='status', plan=P).
+    Assert: response does NOT contain drafting marker; total_tasks == 1.
+    """
+    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, FinalizePlanConfig, StatusPlanConfig
+
+    # Arrange
+    create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    plan_id = create_result["plan_id"]
+    sam_plan(config=AppendTaskConfig(task_yaml=_MINIMAL_TASK_YAML), plan=plan_id)
+    sam_plan(config=FinalizePlanConfig(), plan=plan_id)
+
+    # Act
+    status = sam_plan(config=StatusPlanConfig(), plan=plan_id)
+
+    # Assert — no drafting marker
+    assert not _is_drafting(status), f"Expected no drafting marker in status after finalize, got: {status!r}"
+    # Assert — normal data present
+    assert status.get("total_tasks") == 1
+
+
+def test_ready_returns_normal_data_after_finalize(memory_backend: InMemoryTaskProvider) -> None:
+    """sam_plan(action='ready') returns ready tasks after finalize clears drafting.
+
+    AC #13/#14: after finalize, ready lists dispatchable tasks.
+
+    Arrange: create empty plan, append a not-started task with no deps, finalize.
+    Act: call sam_plan(action='ready', plan=P).
+    Assert: response does NOT contain drafting marker; ready_tasks contains T1.
+    """
+    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, FinalizePlanConfig, ReadyPlanConfig
+
+    # Arrange
+    create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
+    plan_id = create_result["plan_id"]
+    sam_plan(config=AppendTaskConfig(task_yaml=_MINIMAL_TASK_YAML), plan=plan_id)
+    sam_plan(config=FinalizePlanConfig(), plan=plan_id)
+
+    # Act
+    ready = sam_plan(config=ReadyPlanConfig(), plan=plan_id)
+
+    # Assert — no drafting marker
+    assert not _is_drafting(ready), f"Expected no drafting marker in ready response after finalize, got: {ready!r}"
+    # Assert — T1 is ready
+    ready_ids = [t["id"] for t in ready.get("ready_tasks", [])]
+    assert "T1" in ready_ids, f"Expected T1 in ready tasks after finalize, got: {ready_ids}"
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+
+def _is_drafting(response: dict) -> bool:
+    """Return True when the response carries a drafting marker.
+
+    Accepts either:
+    - ``{"drafting": True, ...}``
+    - ``{"state": "drafting", ...}``
+    """
+    if response.get("drafting") is True:
+        return True
+    return response.get("state") == "drafting"

--- a/plugins/development-harness/tests_sam/test_drafting_state.py
+++ b/plugins/development-harness/tests_sam/test_drafting_state.py
@@ -119,6 +119,7 @@ def memory_backend() -> Generator[InMemoryTaskProvider, None, None]:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_status_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='status') returns a drafting marker while plan is mid-append.
 
@@ -130,23 +131,20 @@ def test_status_returns_drafting_marker_on_mid_append_plan(memory_backend: InMem
     Assert: response contains a 'drafting' key that is truthy, or a 'state'
             key with value 'drafting'.
     """
+    from sam_schema.core.action_models import CreatePlanConfig, StatusPlanConfig
+
     # Arrange — create plan in drafting state
-    result = sam_plan(
-        config=__import__("sam_schema.core.action_models", fromlist=["CreatePlanConfig"]).CreatePlanConfig(
-            slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML
-        )
-    )
+    result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
     plan_id = result["plan_id"]
 
     # Act
-    from sam_schema.core.action_models import StatusPlanConfig
-
     status = sam_plan(config=StatusPlanConfig(), plan=plan_id)
 
     # Assert — drafting marker must be present
     assert _is_drafting(status), f"Expected drafting marker in status response for a mid-append plan, got: {status!r}"
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_ready_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='ready') returns a drafting marker while plan is mid-append.
 
@@ -177,6 +175,7 @@ def test_ready_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemo
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_read_returns_tasks_and_drafting_marker_on_mid_append_plan(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='read') returns tasks plus drafting marker on a drafting plan.
 
@@ -214,6 +213,7 @@ def test_read_returns_tasks_and_drafting_marker_on_mid_append_plan(memory_backen
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_status_returns_normal_data_after_finalize(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='status') returns normal task data after finalize clears drafting.
 
@@ -240,6 +240,7 @@ def test_status_returns_normal_data_after_finalize(memory_backend: InMemoryTaskP
     assert status.get("total_tasks") == 1
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_ready_returns_normal_data_after_finalize(memory_backend: InMemoryTaskProvider) -> None:
     """sam_plan(action='ready') returns ready tasks after finalize clears drafting.
 

--- a/plugins/development-harness/tests_sam/test_drafting_state.py
+++ b/plugins/development-harness/tests_sam/test_drafting_state.py
@@ -71,6 +71,8 @@ if TYPE_CHECKING:
 # Helpers
 # ---------------------------------------------------------------------------
 
+from sam_schema.core.action_models import TaskDefinition
+
 _MINIMAL_TASK_DEF = {
     "id": "T1",
     "title": "First task",
@@ -81,14 +83,8 @@ _MINIMAL_TASK_DEF = {
     "complexity": "low",
 }
 
-_MINIMAL_TASK_YAML = (
-    "id: T1\n"
-    "title: First task\n"
-    "status: not-started\n"
-    "agent: test-agent\n"
-    "dependencies: []\n"
-    "priority: 2\n"
-    "complexity: low\n"
+_MINIMAL_TASK = TaskDefinition(
+    id="T1", title="First task", status="not-started", agent="test-agent", dependencies=[], priority=2, complexity="low"
 )
 
 _EMPTY_TASKS_YAML = "tasks: []"
@@ -159,7 +155,7 @@ def test_ready_returns_drafting_marker_on_mid_append_plan(memory_backend: InMemo
     create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
     plan_id = create_result["plan_id"]
 
-    sam_plan(config=AppendTaskConfig(task_yaml=_MINIMAL_TASK_YAML), plan=plan_id)
+    sam_plan(config=AppendTaskConfig(task=_MINIMAL_TASK), plan=plan_id)
 
     # Act
     ready = sam_plan(config=ReadyPlanConfig(), plan=plan_id)
@@ -189,7 +185,7 @@ def test_read_returns_tasks_and_drafting_marker_on_mid_append_plan(memory_backen
     create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
     plan_id = create_result["plan_id"]
 
-    sam_plan(config=AppendTaskConfig(task_yaml=_MINIMAL_TASK_YAML), plan=plan_id)
+    sam_plan(config=AppendTaskConfig(task=_MINIMAL_TASK), plan=plan_id)
 
     # Act
     read_result = sam_plan(config=ReadPlanConfig(), plan=plan_id)
@@ -224,7 +220,7 @@ def test_status_returns_normal_data_after_finalize(memory_backend: InMemoryTaskP
     # Arrange
     create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
     plan_id = create_result["plan_id"]
-    sam_plan(config=AppendTaskConfig(task_yaml=_MINIMAL_TASK_YAML), plan=plan_id)
+    sam_plan(config=AppendTaskConfig(task=_MINIMAL_TASK), plan=plan_id)
     sam_plan(config=FinalizePlanConfig(), plan=plan_id)
 
     # Act
@@ -250,7 +246,7 @@ def test_ready_returns_normal_data_after_finalize(memory_backend: InMemoryTaskPr
     # Arrange
     create_result = sam_plan(config=CreatePlanConfig(slug="test-plan", goal="Test goal", tasks_yaml=_EMPTY_TASKS_YAML))
     plan_id = create_result["plan_id"]
-    sam_plan(config=AppendTaskConfig(task_yaml=_MINIMAL_TASK_YAML), plan=plan_id)
+    sam_plan(config=AppendTaskConfig(task=_MINIMAL_TASK), plan=plan_id)
     sam_plan(config=FinalizePlanConfig(), plan=plan_id)
 
     # Act

--- a/plugins/development-harness/tests_sam/test_large_document_write.py
+++ b/plugins/development-harness/tests_sam/test_large_document_write.py
@@ -172,7 +172,6 @@ def test_A_monolithic_50_task_create_round_trips(memory_backend: InMemoryTaskPro
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_B_incremental_50_append_matches_monolithic_create(memory_backend: InMemoryTaskProvider) -> None:
     """50 sequential append_task calls produce plan with identical content to monolithic create.
 
@@ -233,7 +232,6 @@ def test_B_incremental_50_append_matches_monolithic_create(memory_backend: InMem
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_C_mixed_5_create_45_append_preserves_order_and_fields(memory_backend: InMemoryTaskProvider) -> None:
     """Create with 5 tasks then append 45 more: total 50 tasks in correct order.
 

--- a/plugins/development-harness/tests_sam/test_large_document_write.py
+++ b/plugins/development-harness/tests_sam/test_large_document_write.py
@@ -53,30 +53,29 @@ def _make_task_yaml(task_id: str, idx: int, deps: list[str] | None = None) -> Ta
     )
 
 
-def _make_tasks_yaml(count: int, start: int = 1) -> str:
-    """Build a multi-task tasks_yaml block for CreatePlanConfig.
+def _make_tasks_list(count: int, start: int = 1) -> list[TaskDefinition]:
+    """Build a list of TaskDefinition instances for CreatePlanConfig.
 
     Args:
         count: Number of tasks to generate.
         start: Starting sequential index (default 1).
 
     Returns:
-        YAML string with a top-level ``tasks:`` key containing ``count`` tasks.
+        List of TaskDefinition instances with deterministic content.
     """
-    task_lines = []
-    for i in range(start, start + count):
-        task_id = f"T{i:02d}"
-        task_lines.extend((
-            f"  - id: {task_id}",
-            f"    title: Task {i:02d} title text",
-            "    status: not-started",
-            "    agent: test-agent",
-            "    dependencies: []",
-            "    priority: 2",
-            "    complexity: low",
-            f"    description: Description for task {i:02d}.",
-        ))
-    return "tasks:\n" + "\n".join(task_lines) + "\n"
+    return [
+        TaskDefinition(
+            id=f"T{i:02d}",
+            title=f"Task {i:02d} title text",
+            status="not-started",
+            agent="test-agent",
+            dependencies=[],
+            priority=2,
+            complexity="low",
+            description=f"Description for task {i:02d}.",
+        )
+        for i in range(start, start + count)
+    ]
 
 
 def _extract_task_fields(task: Mapping[str, Any]) -> dict[str, Any]:
@@ -145,10 +144,10 @@ def test_A_monolithic_50_task_create_round_trips(memory_backend: InMemoryTaskPro
 
     # Arrange
     n = 50
-    tasks_yaml = _make_tasks_yaml(n)
+    tasks = _make_tasks_list(n)
 
     # Act
-    result = sam_plan(config=CreatePlanConfig(slug="large-plan", goal="Large plan goal", tasks_yaml=tasks_yaml))
+    result = sam_plan(config=CreatePlanConfig(slug="large-plan", goal="Large plan goal", tasks=tasks))
     assert "error" not in result, f"create failed: {result}"
     plan_id = result["plan_id"]
 
@@ -189,19 +188,13 @@ def test_B_incremental_50_append_matches_monolithic_create(memory_backend: InMem
 
     # Arrange — monolithic reference
     mono_result = sam_plan(
-        config=CreatePlanConfig(slug="mono-plan", goal="Monolithic reference", tasks_yaml=_make_tasks_yaml(n))
+        config=CreatePlanConfig(slug="mono-plan", goal="Monolithic reference", tasks=_make_tasks_list(n))
     )
     assert "error" not in mono_result
     mono_id = mono_result["plan_id"]
 
     # Arrange — incremental subject: create empty, then append 50 tasks
-    incr_result = sam_plan(
-        config=CreatePlanConfig(
-            slug="incr-plan",
-            goal="Monolithic reference",  # same goal for comparability
-            tasks_yaml="tasks: []",
-        )
-    )
+    incr_result = sam_plan(config=CreatePlanConfig(slug="incr-plan", goal="Monolithic reference", tasks=[]))
     assert "error" not in incr_result
     incr_id = incr_result["plan_id"]
 
@@ -251,9 +244,7 @@ def test_C_mixed_5_create_45_append_preserves_order_and_fields(memory_backend: I
 
     # Arrange — create with first 5 tasks
     create_result = sam_plan(
-        config=CreatePlanConfig(
-            slug="mixed-plan", goal="Mixed create goal", tasks_yaml=_make_tasks_yaml(initial, start=1)
-        )
+        config=CreatePlanConfig(slug="mixed-plan", goal="Mixed create goal", tasks=_make_tasks_list(initial, start=1))
     )
     assert "error" not in create_result
     plan_id = create_result["plan_id"]

--- a/plugins/development-harness/tests_sam/test_large_document_write.py
+++ b/plugins/development-harness/tests_sam/test_large_document_write.py
@@ -17,20 +17,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import pytest
 from sam_schema.core.action_models import TaskDefinition
-from sam_schema.core.backends.memory import InMemoryTaskProvider
-from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping
+    from collections.abc import Mapping
+
+    from sam_schema.core.backends.memory import InMemoryTaskProvider
 
 # ---------------------------------------------------------------------------
 # Task generation helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_task_yaml(task_id: str, idx: int, deps: list[str] | None = None) -> TaskDefinition:
+def _make_task_def(task_id: str, idx: int, deps: list[str] | None = None) -> TaskDefinition:
     """Produce a single TaskDefinition for use with append_task.
 
     Args:
@@ -101,26 +100,6 @@ def _extract_task_fields(task: Mapping[str, Any]) -> dict[str, Any]:
         "complexity": task.get("complexity"),
         "description": task.get("description", ""),
     }
-
-
-# ---------------------------------------------------------------------------
-# Fixture
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def memory_backend() -> Generator[InMemoryTaskProvider, None, None]:
-    """Inject a fresh InMemoryTaskProvider via set_task_config.
-
-    Calls reset_task_config() in teardown to prevent cross-test contamination.
-
-    Yields:
-        Configured InMemoryTaskProvider instance.
-    """
-    backend = InMemoryTaskProvider()
-    set_task_config(TaskConfig(backend=backend))
-    yield backend
-    reset_task_config()
 
 
 # ---------------------------------------------------------------------------
@@ -200,7 +179,7 @@ def test_B_incremental_50_append_matches_monolithic_create(memory_backend: InMem
 
     for i in range(1, n + 1):
         task_id = f"T{i:02d}"
-        append_result = sam_plan(config=AppendTaskConfig(task=_make_task_yaml(task_id, i)), plan=incr_id)
+        append_result = sam_plan(config=AppendTaskConfig(task=_make_task_def(task_id, i)), plan=incr_id)
         assert "error" not in append_result, f"append_task failed at T{i:02d}: {append_result}"
 
     # Act — read both plans
@@ -252,7 +231,7 @@ def test_C_mixed_5_create_45_append_preserves_order_and_fields(memory_backend: I
     # Arrange — append remaining 45 tasks
     for i in range(initial + 1, total + 1):
         task_id = f"T{i:02d}"
-        append_result = sam_plan(config=AppendTaskConfig(task=_make_task_yaml(task_id, i)), plan=plan_id)
+        append_result = sam_plan(config=AppendTaskConfig(task=_make_task_def(task_id, i)), plan=plan_id)
         assert "error" not in append_result, f"append_task failed at T{i:02d}: {append_result}"
 
     # Act

--- a/plugins/development-harness/tests_sam/test_large_document_write.py
+++ b/plugins/development-harness/tests_sam/test_large_document_write.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from sam_schema.core.action_models import TaskDefinition
 from sam_schema.core.backends.memory import InMemoryTaskProvider
 from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
 
@@ -29,8 +30,8 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _make_task_yaml(task_id: str, idx: int, deps: list[str] | None = None) -> str:
-    """Produce a single-task YAML string for use with append_task.
+def _make_task_yaml(task_id: str, idx: int, deps: list[str] | None = None) -> TaskDefinition:
+    """Produce a single TaskDefinition for use with append_task.
 
     Args:
         task_id: Identifier for the task (e.g. ``'T01'``).
@@ -38,18 +39,17 @@ def _make_task_yaml(task_id: str, idx: int, deps: list[str] | None = None) -> st
         deps: Optional list of dependency task IDs.
 
     Returns:
-        YAML string for a single task compatible with AppendTaskConfig.task_yaml.
+        TaskDefinition instance compatible with AppendTaskConfig.task.
     """
-    deps_yaml = ", ".join(f'"{d}"' for d in (deps or []))
-    return (
-        f"id: {task_id}\n"
-        f"title: Task {idx:02d} title text\n"
-        "status: not-started\n"
-        "agent: test-agent\n"
-        f"dependencies: [{deps_yaml}]\n"
-        "priority: 2\n"
-        "complexity: low\n"
-        f"description: Description for task {idx:02d}.\n"
+    return TaskDefinition(
+        id=task_id,
+        title=f"Task {idx:02d} title text",
+        status="not-started",
+        agent="test-agent",
+        dependencies=list(deps or []),
+        priority=2,
+        complexity="low",
+        description=f"Description for task {idx:02d}.",
     )
 
 
@@ -207,7 +207,7 @@ def test_B_incremental_50_append_matches_monolithic_create(memory_backend: InMem
 
     for i in range(1, n + 1):
         task_id = f"T{i:02d}"
-        append_result = sam_plan(config=AppendTaskConfig(task_yaml=_make_task_yaml(task_id, i)), plan=incr_id)
+        append_result = sam_plan(config=AppendTaskConfig(task=_make_task_yaml(task_id, i)), plan=incr_id)
         assert "error" not in append_result, f"append_task failed at T{i:02d}: {append_result}"
 
     # Act — read both plans
@@ -261,7 +261,7 @@ def test_C_mixed_5_create_45_append_preserves_order_and_fields(memory_backend: I
     # Arrange — append remaining 45 tasks
     for i in range(initial + 1, total + 1):
         task_id = f"T{i:02d}"
-        append_result = sam_plan(config=AppendTaskConfig(task_yaml=_make_task_yaml(task_id, i)), plan=plan_id)
+        append_result = sam_plan(config=AppendTaskConfig(task=_make_task_yaml(task_id, i)), plan=plan_id)
         assert "error" not in append_result, f"append_task failed at T{i:02d}: {append_result}"
 
     # Act

--- a/plugins/development-harness/tests_sam/test_large_document_write.py
+++ b/plugins/development-harness/tests_sam/test_large_document_write.py
@@ -172,6 +172,7 @@ def test_A_monolithic_50_task_create_round_trips(memory_backend: InMemoryTaskPro
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_B_incremental_50_append_matches_monolithic_create(memory_backend: InMemoryTaskProvider) -> None:
     """50 sequential append_task calls produce plan with identical content to monolithic create.
 
@@ -232,6 +233,7 @@ def test_B_incremental_50_append_matches_monolithic_create(memory_backend: InMem
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_C_mixed_5_create_45_append_preserves_order_and_fields(memory_backend: InMemoryTaskProvider) -> None:
     """Create with 5 tasks then append 45 more: total 50 tasks in correct order.
 

--- a/plugins/development-harness/tests_sam/test_large_document_write.py
+++ b/plugins/development-harness/tests_sam/test_large_document_write.py
@@ -1,0 +1,287 @@
+"""Regression tests for large-plan write correctness — AC #18 from #1770.
+
+Tests A, B, C verify that a 50-task plan round-trips correctly regardless of
+whether it is written monolithically (create) or incrementally (append_task).
+
+All three tests share the same canonical task generator so the 50-task input is
+reproducible and the byte-round-trip assertion is deterministic.
+
+AC coverage
+-----------
+Test A: monolithic create with ~50 tasks completes and round-trips
+Test B: incremental create + 50 append_task calls produces identical field content
+Test C: mixed — create with 5 tasks, append 45 more, verify order and field preservation
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from sam_schema.core.backends.memory import InMemoryTaskProvider
+from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Mapping
+
+# ---------------------------------------------------------------------------
+# Task generation helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task_yaml(task_id: str, idx: int, deps: list[str] | None = None) -> str:
+    """Produce a single-task YAML string for use with append_task.
+
+    Args:
+        task_id: Identifier for the task (e.g. ``'T01'``).
+        idx: Sequential index used to generate deterministic title/body content.
+        deps: Optional list of dependency task IDs.
+
+    Returns:
+        YAML string for a single task compatible with AppendTaskConfig.task_yaml.
+    """
+    deps_yaml = ", ".join(f'"{d}"' for d in (deps or []))
+    return (
+        f"id: {task_id}\n"
+        f"title: Task {idx:02d} title text\n"
+        "status: not-started\n"
+        "agent: test-agent\n"
+        f"dependencies: [{deps_yaml}]\n"
+        "priority: 2\n"
+        "complexity: low\n"
+        f"description: Description for task {idx:02d}.\n"
+    )
+
+
+def _make_tasks_yaml(count: int, start: int = 1) -> str:
+    """Build a multi-task tasks_yaml block for CreatePlanConfig.
+
+    Args:
+        count: Number of tasks to generate.
+        start: Starting sequential index (default 1).
+
+    Returns:
+        YAML string with a top-level ``tasks:`` key containing ``count`` tasks.
+    """
+    task_lines = []
+    for i in range(start, start + count):
+        task_id = f"T{i:02d}"
+        task_lines.extend((
+            f"  - id: {task_id}",
+            f"    title: Task {i:02d} title text",
+            "    status: not-started",
+            "    agent: test-agent",
+            "    dependencies: []",
+            "    priority: 2",
+            "    complexity: low",
+            f"    description: Description for task {i:02d}.",
+        ))
+    return "tasks:\n" + "\n".join(task_lines) + "\n"
+
+
+def _extract_task_fields(task: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the subset of task fields used for round-trip equality.
+
+    Only structural and content fields are compared; backend timestamps
+    (``created``, ``started``, ``completed``) are excluded.
+
+    Args:
+        task: TaskData dict from a read_plan call.
+
+    Returns:
+        Dict with id, title, status, agent, dependencies, priority, complexity,
+        description fields.
+    """
+    return {
+        "id": task.get("id"),
+        "title": task.get("title"),
+        "status": task.get("status"),
+        "agent": task.get("agent"),
+        "dependencies": task.get("dependencies", []),
+        "priority": task.get("priority"),
+        "complexity": task.get("complexity"),
+        "description": task.get("description", ""),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memory_backend() -> Generator[InMemoryTaskProvider, None, None]:
+    """Inject a fresh InMemoryTaskProvider via set_task_config.
+
+    Calls reset_task_config() in teardown to prevent cross-test contamination.
+
+    Yields:
+        Configured InMemoryTaskProvider instance.
+    """
+    backend = InMemoryTaskProvider()
+    set_task_config(TaskConfig(backend=backend))
+    yield backend
+    reset_task_config()
+
+
+# ---------------------------------------------------------------------------
+# Test A — monolithic 50-task create round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_A_monolithic_50_task_create_round_trips(memory_backend: InMemoryTaskProvider) -> None:
+    """Monolithic create with 50 tasks completes and round-trips field content correctly.
+
+    AC #18 Test A: sam_plan(action='create', tasks_yaml=<50 tasks>) must succeed
+    and all task fields must survive the round-trip through the backend.
+
+    Arrange: build a 50-task tasks_yaml string.
+    Act: create the plan; read it back.
+    Assert: plan contains exactly 50 tasks; each task ID, title, and description
+            matches the generated input.
+    """
+    from sam_schema.core.action_models import CreatePlanConfig
+    from sam_schema.server import sam_plan
+
+    # Arrange
+    n = 50
+    tasks_yaml = _make_tasks_yaml(n)
+
+    # Act
+    result = sam_plan(config=CreatePlanConfig(slug="large-plan", goal="Large plan goal", tasks_yaml=tasks_yaml))
+    assert "error" not in result, f"create failed: {result}"
+    plan_id = result["plan_id"]
+
+    plan_data = memory_backend.read_plan(plan_id)
+    tasks = plan_data["tasks"]
+
+    # Assert — count
+    assert len(tasks) == n, f"Expected {n} tasks, got {len(tasks)}"
+
+    # Assert — field content for each task
+    for i in range(1, n + 1):
+        task = tasks[i - 1]
+        fields = _extract_task_fields(task)
+        assert fields["id"] == f"T{i:02d}", f"Task {i}: id mismatch: {fields['id']!r}"
+        assert fields["title"] == f"Task {i:02d} title text", f"Task {i}: title mismatch"
+        assert fields["status"] == "not-started", f"Task {i}: status mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Test B — incremental 50-task append produces identical content to monolithic create
+# ---------------------------------------------------------------------------
+
+
+def test_B_incremental_50_append_matches_monolithic_create(memory_backend: InMemoryTaskProvider) -> None:
+    """50 sequential append_task calls produce plan with identical content to monolithic create.
+
+    AC #18 Test B: the plan produced by create({tasks:[]}) + 50 x append_task
+    must have field content identical to a monolithic create with the same 50 tasks.
+
+    Arrange: build a monolithic plan (reference) and an incremental plan (subject).
+    Act: read both plans back; compare extracted fields for each task.
+    Assert: both plans have 50 tasks; each task's structural fields are equal.
+    """
+    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig
+    from sam_schema.server import sam_plan
+
+    n = 50
+
+    # Arrange — monolithic reference
+    mono_result = sam_plan(
+        config=CreatePlanConfig(slug="mono-plan", goal="Monolithic reference", tasks_yaml=_make_tasks_yaml(n))
+    )
+    assert "error" not in mono_result
+    mono_id = mono_result["plan_id"]
+
+    # Arrange — incremental subject: create empty, then append 50 tasks
+    incr_result = sam_plan(
+        config=CreatePlanConfig(
+            slug="incr-plan",
+            goal="Monolithic reference",  # same goal for comparability
+            tasks_yaml="tasks: []",
+        )
+    )
+    assert "error" not in incr_result
+    incr_id = incr_result["plan_id"]
+
+    for i in range(1, n + 1):
+        task_id = f"T{i:02d}"
+        append_result = sam_plan(config=AppendTaskConfig(task_yaml=_make_task_yaml(task_id, i)), plan=incr_id)
+        assert "error" not in append_result, f"append_task failed at T{i:02d}: {append_result}"
+
+    # Act — read both plans
+    mono_data = memory_backend.read_plan(mono_id)
+    incr_data = memory_backend.read_plan(incr_id)
+
+    # Assert — same task count
+    assert len(incr_data["tasks"]) == n, f"Expected {n} tasks in incremental plan, got {len(incr_data['tasks'])}"
+    assert len(mono_data["tasks"]) == n
+
+    # Assert — field-by-field equality
+    for idx in range(n):
+        mono_fields = _extract_task_fields(mono_data["tasks"][idx])
+        incr_fields = _extract_task_fields(incr_data["tasks"][idx])
+        assert mono_fields == incr_fields, (
+            f"Task at index {idx} differs:\n  monolithic: {mono_fields!r}\n  incremental: {incr_fields!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test C — mixed: create with 5 tasks, append 45 more, verify order and field
+# ---------------------------------------------------------------------------
+
+
+def test_C_mixed_5_create_45_append_preserves_order_and_fields(memory_backend: InMemoryTaskProvider) -> None:
+    """Create with 5 tasks then append 45 more: total 50 tasks in correct order.
+
+    AC #18 Test C: mixed approach must produce correct task ordering (T01 first,
+    T50 last) with all fields preserved.
+
+    Arrange: create plan with T01..T05; append T06..T50.
+    Act: read plan back.
+    Assert: 50 tasks; IDs are T01..T50 in order; all titles and descriptions match.
+    """
+    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig
+    from sam_schema.server import sam_plan
+
+    initial = 5
+    remaining = 45
+    total = initial + remaining
+
+    # Arrange — create with first 5 tasks
+    create_result = sam_plan(
+        config=CreatePlanConfig(
+            slug="mixed-plan", goal="Mixed create goal", tasks_yaml=_make_tasks_yaml(initial, start=1)
+        )
+    )
+    assert "error" not in create_result
+    plan_id = create_result["plan_id"]
+
+    # Arrange — append remaining 45 tasks
+    for i in range(initial + 1, total + 1):
+        task_id = f"T{i:02d}"
+        append_result = sam_plan(config=AppendTaskConfig(task_yaml=_make_task_yaml(task_id, i)), plan=plan_id)
+        assert "error" not in append_result, f"append_task failed at T{i:02d}: {append_result}"
+
+    # Act
+    plan_data = memory_backend.read_plan(plan_id)
+    tasks = plan_data["tasks"]
+
+    # Assert — count
+    assert len(tasks) == total, f"Expected {total} tasks, got {len(tasks)}"
+
+    # Assert — ordering: T01 first, T50 last
+    assert tasks[0]["id"] == "T01", f"Expected first task to be T01, got {tasks[0]['id']!r}"
+    assert tasks[-1]["id"] == "T50", f"Expected last task to be T50, got {tasks[-1]['id']!r}"
+
+    # Assert — all task IDs are present in order
+    task_ids = [t["id"] for t in tasks]
+    expected_ids = [f"T{i:02d}" for i in range(1, total + 1)]
+    assert task_ids == expected_ids, f"Task order mismatch:\n  got:      {task_ids}\n  expected: {expected_ids}"
+
+    # Assert — field content for a sample task in the appended range
+    t30 = next((t for t in tasks if t["id"] == "T30"), None)
+    assert t30 is not None, "Expected to find T30 in plan tasks"
+    assert t30["title"] == "Task 30 title text"
+    assert t30["description"] == "Description for task 30."

--- a/plugins/development-harness/tests_sam/test_large_document_write.py
+++ b/plugins/development-harness/tests_sam/test_large_document_write.py
@@ -110,7 +110,7 @@ def _extract_task_fields(task: Mapping[str, Any]) -> dict[str, Any]:
 def test_A_monolithic_50_task_create_round_trips(memory_backend: InMemoryTaskProvider) -> None:
     """Monolithic create with 50 tasks completes and round-trips field content correctly.
 
-    AC #18 Test A: sam_plan(action='create', tasks_yaml=<50 tasks>) must succeed
+    AC #18 Test A: sam_plan(action='create', tasks=<50 TaskDefinition objects>) must succeed
     and all task fields must survive the round-trip through the backend.
 
     Arrange: build a 50-task tasks_yaml string.

--- a/plugins/development-harness/tests_sam/test_large_document_write.py
+++ b/plugins/development-harness/tests_sam/test_large_document_write.py
@@ -113,7 +113,7 @@ def test_A_monolithic_50_task_create_round_trips(memory_backend: InMemoryTaskPro
     AC #18 Test A: sam_plan(action='create', tasks=<50 TaskDefinition objects>) must succeed
     and all task fields must survive the round-trip through the backend.
 
-    Arrange: build a 50-task tasks_yaml string.
+    Arrange: build a list of 50 TaskDefinition objects.
     Act: create the plan; read it back.
     Assert: plan contains exactly 50 tasks; each task ID, title, and description
             matches the generated input.

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -23,6 +23,7 @@ from sam_schema.core.action_models import (
     ReadyPlanConfig,
     StateTaskConfig,
     StatusPlanConfig,
+    TaskDefinition,
     UpdatePlanConfig,
     UpdateTaskConfig,
 )
@@ -513,30 +514,21 @@ def test_sam_read_with_missing_plan_returns_error(tmp_path: Path) -> None:
 
 
 def test_sam_create_valid_tasks_yaml_returns_path_and_counts(tmp_path: Path) -> None:
-    """sam_plan(create) with valid tasks_yaml creates a plan file and returns metadata.
+    """sam_plan(create) with typed task list creates a plan file and returns metadata.
 
     Tests: sam_plan create happy path.
-    How: Pass a minimal tasks_yaml string; verify returned dict has path, plan_number, task_count.
+    How: Pass a minimal tasks list; verify returned dict has path, plan_number, task_count.
     Why: sam_plan create is the MCP entry point for swarm-task-planner to persist new plans.
     """
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    tasks_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: First task\n"
-        "    status: not-started\n"
-        "    agent: test-agent\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
+    task = TaskDefinition(
+        id="T01", title="First task", status="not-started", agent="test-agent", priority=1, complexity="low"
     )
 
     # Act
-    result = sam_plan(
-        config=CreatePlanConfig(slug="test-create", goal="Test goal", tasks_yaml=tasks_yaml), plan_dir=str(p_dir)
-    )
+    result = sam_plan(config=CreatePlanConfig(slug="test-create", goal="Test goal", tasks=[task]), plan_dir=str(p_dir))
 
     import re
 
@@ -556,19 +548,12 @@ def test_sam_create_file_is_readable_by_sam_task(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    tasks_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Round-trip task\n"
-        "    status: not-started\n"
-        "    agent: test-agent\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
+    task = TaskDefinition(
+        id="T01", title="Round-trip task", status="not-started", agent="test-agent", priority=1, complexity="low"
     )
 
     create_result = sam_plan(
-        config=CreatePlanConfig(slug="round-trip", goal="Round-trip goal", tasks_yaml=tasks_yaml), plan_dir=str(p_dir)
+        config=CreatePlanConfig(slug="round-trip", goal="Round-trip goal", tasks=[task]), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
 
@@ -582,21 +567,26 @@ def test_sam_create_file_is_readable_by_sam_task(tmp_path: Path) -> None:
     assert read_result["task"]["title"] == "Round-trip task"
 
 
-def test_sam_create_invalid_tasks_yaml_returns_error(tmp_path: Path) -> None:
-    """sam_plan(create) raises ValueError when tasks_yaml lacks 'tasks' key.
+def test_sam_create_empty_tasks_creates_drafting_plan(tmp_path: Path) -> None:
+    """sam_plan(create) with empty tasks list creates a drafting plan.
 
-    Tests: sam_plan create input validation.
-    How: Pass YAML without 'tasks' key.
-    Why: Invalid input raises ValueError. FastMCP converts it to isError=true;
-         direct callers must handle it.
+    Tests: sam_plan create with empty tasks list enters drafting state.
+    How: Pass tasks=[] and verify plan_id returned; plan is in drafting state.
+    Why: Drafting plans support incremental building via append_task + finalize.
     """
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
 
-    # Act / Assert
-    with pytest.raises(ValueError, match="tasks"):
-        sam_plan(config=CreatePlanConfig(slug="bad", goal="Bad goal", tasks_yaml="not_tasks: []"), plan_dir=str(p_dir))
+    # Act
+    result = sam_plan(config=CreatePlanConfig(slug="empty-plan", goal="Drafting goal", tasks=[]), plan_dir=str(p_dir))
+
+    # Assert
+    import re
+
+    assert "error" not in result
+    assert re.match(r"^P[0-9a-f]{8}$", result["plan_id"]), f"Expected UUID plan_id, got: {result['plan_id']!r}"
+    assert result["task_count"] == 0
 
 
 def test_sam_create_assigns_unique_plan_ids(tmp_path: Path) -> None:
@@ -611,20 +601,11 @@ def test_sam_create_assigns_unique_plan_ids(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    minimal_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Task\n"
-        "    status: not-started\n"
-        "    agent: a\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    minimal_task = TaskDefinition(id="T01", title="Task", status="not-started", agent="a", priority=1, complexity="low")
 
     # Act
-    r1 = sam_plan(config=CreatePlanConfig(slug="first", goal="First", tasks_yaml=minimal_yaml), plan_dir=str(p_dir))
-    r2 = sam_plan(config=CreatePlanConfig(slug="second", goal="Second", tasks_yaml=minimal_yaml), plan_dir=str(p_dir))
+    r1 = sam_plan(config=CreatePlanConfig(slug="first", goal="First", tasks=[minimal_task]), plan_dir=str(p_dir))
+    r2 = sam_plan(config=CreatePlanConfig(slug="second", goal="Second", tasks=[minimal_task]), plan_dir=str(p_dir))
 
     # Assert
     assert "error" not in r1
@@ -649,19 +630,10 @@ def test_sam_update_context_sets_plan_context(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    minimal_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Task\n"
-        "    status: not-started\n"
-        "    agent: a\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    minimal_task = TaskDefinition(id="T01", title="Task", status="not-started", agent="a", priority=1, complexity="low")
 
     create_result = sam_plan(
-        config=CreatePlanConfig(slug="update-ctx", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
+        config=CreatePlanConfig(slug="update-ctx", goal="Goal", tasks=[minimal_task]), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
     plan_id = create_result["plan_id"]
@@ -691,19 +663,10 @@ def test_sam_update_append_section_adds_to_task_body(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    minimal_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Task\n"
-        "    status: not-started\n"
-        "    agent: a\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    minimal_task = TaskDefinition(id="T01", title="Task", status="not-started", agent="a", priority=1, complexity="low")
 
     create_result = sam_plan(
-        config=CreatePlanConfig(slug="append-sec", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
+        config=CreatePlanConfig(slug="append-sec", goal="Goal", tasks=[minimal_task]), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
     plan_id = create_result["plan_id"]
@@ -759,19 +722,10 @@ def test_sam_claim_not_started_task_returns_claimed_true(tmp_path: Path) -> None
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    minimal_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Task\n"
-        "    status: not-started\n"
-        "    agent: a\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    minimal_task = TaskDefinition(id="T01", title="Task", status="not-started", agent="a", priority=1, complexity="low")
 
     create_result = sam_plan(
-        config=CreatePlanConfig(slug="claim-test", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
+        config=CreatePlanConfig(slug="claim-test", goal="Goal", tasks=[minimal_task]), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
     plan_id = create_result["plan_id"]
@@ -795,19 +749,10 @@ def test_sam_claim_already_claimed_returns_claimed_false(tmp_path: Path) -> None
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    minimal_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Task\n"
-        "    status: not-started\n"
-        "    agent: a\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    minimal_task = TaskDefinition(id="T01", title="Task", status="not-started", agent="a", priority=1, complexity="low")
 
     create_result = sam_plan(
-        config=CreatePlanConfig(slug="double-claim", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
+        config=CreatePlanConfig(slug="double-claim", goal="Goal", tasks=[minimal_task]), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
     plan_id = create_result["plan_id"]
@@ -834,19 +779,10 @@ def test_sam_claim_missing_task_returns_claimed_false(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    minimal_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Task\n"
-        "    status: not-started\n"
-        "    agent: a\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    minimal_task = TaskDefinition(id="T01", title="Task", status="not-started", agent="a", priority=1, complexity="low")
 
     create_result = sam_plan(
-        config=CreatePlanConfig(slug="missing-task", goal="Goal", tasks_yaml=minimal_yaml), plan_dir=str(p_dir)
+        config=CreatePlanConfig(slug="missing-task", goal="Goal", tasks=[minimal_task]), plan_dir=str(p_dir)
     )
     assert "error" not in create_result
     plan_id = create_result["plan_id"]
@@ -885,21 +821,12 @@ def test_sam_create_returns_plan_ref_without_issue(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    tasks_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: First task\n"
-        "    status: not-started\n"
-        "    agent: test-agent\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
+    task = TaskDefinition(
+        id="T01", title="First task", status="not-started", agent="test-agent", priority=1, complexity="low"
     )
 
     # Act
-    result = sam_plan(
-        config=CreatePlanConfig(slug="ref-no-issue", goal="Test goal", tasks_yaml=tasks_yaml), plan_dir=str(p_dir)
-    )
+    result = sam_plan(config=CreatePlanConfig(slug="ref-no-issue", goal="Test goal", tasks=[task]), plan_dir=str(p_dir))
 
     # Assert
     assert "error" not in result
@@ -918,21 +845,13 @@ def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    tasks_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: First task\n"
-        "    status: not-started\n"
-        "    agent: test-agent\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
+    task = TaskDefinition(
+        id="T01", title="First task", status="not-started", agent="test-agent", priority=1, complexity="low"
     )
 
     # Act
     result = sam_plan(
-        config=CreatePlanConfig(slug="ref-with-issue", goal="Test goal", tasks_yaml=tasks_yaml, issue=42),
-        plan_dir=str(p_dir),
+        config=CreatePlanConfig(slug="ref-with-issue", goal="Test goal", tasks=[task], issue=42), plan_dir=str(p_dir)
     )
 
     # Assert — plan_ref includes issue number and UUID plan_id
@@ -1000,8 +919,6 @@ def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> N
     set_task_config(TaskConfig(backend=mock_backend))
 
     try:
-        from sam_schema.core.action_models import TaskDefinition
-
         task_def = TaskDefinition(
             id="T1",
             title="First task",
@@ -1043,12 +960,8 @@ def test_sam_append_task_returns_success_acknowledgment(tmp_path: Path) -> None:
     set_task_config(TaskConfig(backend=backend))
 
     try:
-        create_result = sam_plan(
-            config=CreatePlanConfig(slug="append-test", goal="Append goal", tasks_yaml="tasks: []")
-        )
+        create_result = sam_plan(config=CreatePlanConfig(slug="append-test", goal="Append goal", tasks=[]))
         plan_id = create_result["plan_id"]
-
-        from sam_schema.core.action_models import TaskDefinition
 
         task_def = TaskDefinition(
             id="T1",
@@ -1090,8 +1003,6 @@ def test_sam_append_task_plan_not_found_raises(tmp_path: Path) -> None:
     set_task_config(TaskConfig(backend=backend))
 
     try:
-        from sam_schema.core.action_models import TaskDefinition
-
         task_def = TaskDefinition(id="T1", title="Task", agent="a")
 
         # Act / Assert
@@ -1120,10 +1031,8 @@ def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
     set_task_config(TaskConfig(backend=backend))
 
     try:
-        create_result = sam_plan(config=CreatePlanConfig(slug="dup-task", goal="Goal", tasks_yaml="tasks: []"))
+        create_result = sam_plan(config=CreatePlanConfig(slug="dup-task", goal="Goal", tasks=[]))
         plan_id = create_result["plan_id"]
-
-        from sam_schema.core.action_models import TaskDefinition
 
         task_def = TaskDefinition(id="T1", title="Task", agent="a")
 

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -867,7 +867,7 @@ def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
 def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> None:
     """sam_plan action=append_task calls backend.append_task for the given plan.
 
-    AC #2: sam_plan(action='append_task', plan=P, task_yaml=...) must append
+    AC #2: sam_plan(action='append_task', plan=P, task=<TaskDefinition>) must append
     a single task and return a success acknowledgment.
 
     Arrange: create a plan with empty tasks_yaml; inject mock backend.
@@ -942,7 +942,7 @@ def test_sam_append_task_returns_success_acknowledgment(tmp_path: Path) -> None:
     success indicator (e.g. 'appended': True or 'task_id': 'T1').
 
     Arrange: create plan via InMemoryTaskProvider; append one task.
-    Act: call sam_plan(action='append_task', plan=P, task_yaml=...).
+    Act: call sam_plan(action='append_task', plan=P, task=<TaskDefinition>).
     Assert: result contains 'appended': True or 'task_id': 'T1' and no 'error' key.
     """
     from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -1000,18 +1000,20 @@ def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> N
     set_task_config(TaskConfig(backend=mock_backend))
 
     try:
-        task_yaml = (
-            "id: T1\n"
-            "title: First task\n"
-            "status: not-started\n"
-            "agent: test-agent\n"
-            "dependencies: []\n"
-            "priority: 2\n"
-            "complexity: low\n"
+        from sam_schema.core.action_models import TaskDefinition
+
+        task_def = TaskDefinition(
+            id="T1",
+            title="First task",
+            status="not-started",
+            agent="test-agent",
+            dependencies=[],
+            priority=2,
+            complexity="low",
         )
 
         # Act
-        result = sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan="P1")
+        result = sam_plan(config=AppendTaskConfig(task=task_def), plan="P1")
 
         # Assert — backend.append_task called once
         assert "error" not in result, f"append_task returned error: {result}"
@@ -1046,18 +1048,20 @@ def test_sam_append_task_returns_success_acknowledgment(tmp_path: Path) -> None:
         )
         plan_id = create_result["plan_id"]
 
-        task_yaml = (
-            "id: T1\n"
-            "title: First task\n"
-            "status: not-started\n"
-            "agent: test-agent\n"
-            "dependencies: []\n"
-            "priority: 2\n"
-            "complexity: low\n"
+        from sam_schema.core.action_models import TaskDefinition
+
+        task_def = TaskDefinition(
+            id="T1",
+            title="First task",
+            status="not-started",
+            agent="test-agent",
+            dependencies=[],
+            priority=2,
+            complexity="low",
         )
 
         # Act
-        result = sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan=plan_id)
+        result = sam_plan(config=AppendTaskConfig(task=task_def), plan=plan_id)
 
         # Assert
         assert "error" not in result, f"Expected success but got error: {result}"
@@ -1086,13 +1090,13 @@ def test_sam_append_task_plan_not_found_raises(tmp_path: Path) -> None:
     set_task_config(TaskConfig(backend=backend))
 
     try:
-        task_yaml = (
-            "id: T1\ntitle: Task\nstatus: not-started\nagent: a\ndependencies: []\npriority: 2\ncomplexity: low\n"
-        )
+        from sam_schema.core.action_models import TaskDefinition
+
+        task_def = TaskDefinition(id="T1", title="Task", agent="a")
 
         # Act / Assert
         with pytest.raises(PlanNotFoundError, match="P99999"):
-            sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan="P99999")
+            sam_plan(config=AppendTaskConfig(task=task_def), plan="P99999")
     finally:
         reset_task_config()
 
@@ -1119,16 +1123,16 @@ def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
         create_result = sam_plan(config=CreatePlanConfig(slug="dup-task", goal="Goal", tasks_yaml="tasks: []"))
         plan_id = create_result["plan_id"]
 
-        task_yaml = (
-            "id: T1\ntitle: Task\nstatus: not-started\nagent: a\ndependencies: []\npriority: 2\ncomplexity: low\n"
-        )
+        from sam_schema.core.action_models import TaskDefinition
+
+        task_def = TaskDefinition(id="T1", title="Task", agent="a")
 
         # First append succeeds
-        sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan=plan_id)
+        sam_plan(config=AppendTaskConfig(task=task_def), plan=plan_id)
 
         # Act / Assert — second append with same ID must raise
         with pytest.raises((TaskValidationError, ValueError)):
-            sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan=plan_id)
+            sam_plan(config=AppendTaskConfig(task=task_def), plan=plan_id)
     finally:
         reset_task_config()
 

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -870,7 +870,7 @@ def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> N
     AC #2: sam_plan(action='append_task', plan=P, task=<TaskDefinition>) must append
     a single task and return a success acknowledgment.
 
-    Arrange: create a plan with empty tasks_yaml; inject mock backend.
+    Arrange: create a plan with empty tasks list; inject mock backend.
     Act: call sam_plan with action=append_task.
     Assert: backend.append_task was called exactly once with the plan_id and a
             parsed task definition.

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -952,7 +952,6 @@ def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> None:
     """sam_plan action=append_task calls backend.append_task for the given plan.
 
@@ -984,7 +983,7 @@ def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> N
         "source_path": None,
         "state": "drafting",
     }
-    mock_backend.append_task.return_value = None
+    mock_backend.append_task.return_value = {"appended": True, "task_id": "T1"}
     mock_backend.create_plan.return_value = {
         "plan_id": "P1",
         "feature": "test-plan",
@@ -1024,7 +1023,6 @@ def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> N
         reset_task_config()
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_append_task_returns_success_acknowledgment(tmp_path: Path) -> None:
     """sam_plan action=append_task returns a success acknowledgment dict.
 
@@ -1069,7 +1067,6 @@ def test_sam_append_task_returns_success_acknowledgment(tmp_path: Path) -> None:
         reset_task_config()
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_append_task_plan_not_found_raises(tmp_path: Path) -> None:
     """sam_plan action=append_task raises PlanNotFoundError when plan does not exist.
 
@@ -1100,7 +1097,6 @@ def test_sam_append_task_plan_not_found_raises(tmp_path: Path) -> None:
         reset_task_config()
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
     """sam_plan action=append_task raises an error when duplicate task ID is appended.
 
@@ -1145,7 +1141,6 @@ def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_finalize_routes_through_backend_finalize_plan(tmp_path: Path) -> None:
     """sam_plan action=finalize calls backend.finalize_plan (or update_plan_fields).
 
@@ -1161,8 +1156,8 @@ def test_sam_finalize_routes_through_backend_finalize_plan(tmp_path: Path) -> No
     from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
 
     mock_backend = MagicMock()
-    mock_backend.finalize_plan.return_value = None
-    mock_backend.update_plan_fields.return_value = None
+    mock_backend.finalize_plan.return_value = {"finalized": True, "state": "ready"}
+    mock_backend.update_plan_fields.return_value = {"updated": True}
     set_task_config(TaskConfig(backend=mock_backend))
 
     try:

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -860,14 +860,7 @@ def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# sam_plan — append_task action (#1770 RED-PHASE tests)
-# ---------------------------------------------------------------------------
-# These tests target the new append_task routing added by #1770.
-# They are expected to FAIL in the red phase with:
-#   - Pydantic discriminator error for unknown action 'append_task', OR
-#   - ValueError: sam_plan: unhandled action 'append_task'
-# The green phase will add AppendTaskConfig to action_models.py and wire
-# the server.py match block.
+# sam_plan — append_task action (#1770)
 # ---------------------------------------------------------------------------
 
 
@@ -1015,12 +1008,11 @@ def test_sam_append_task_plan_not_found_raises(tmp_path: Path) -> None:
 def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
     """sam_plan action=append_task raises an error when duplicate task ID is appended.
 
-    AC #6: backend must raise an error (TaskValidationError or ValueError) when
-    a task with an ID that already exists in the plan is appended.
+    AC #6: backend raises TaskValidationError when a duplicate task ID is appended.
 
     Arrange: create a plan with T1; append T1 a second time.
     Act: second append_task call.
-    Assert: an exception is raised (TaskValidationError or ValueError or similar).
+    Assert: TaskValidationError is raised.
     """
     from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig
     from sam_schema.core.backends.memory import InMemoryTaskProvider
@@ -1039,18 +1031,15 @@ def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
         # First append succeeds
         sam_plan(config=AppendTaskConfig(task=task_def), plan=plan_id)
 
-        # Act / Assert — second append with same ID must raise
-        with pytest.raises((TaskValidationError, ValueError)):
+        # Act / Assert — second append with same ID must raise TaskValidationError
+        with pytest.raises(TaskValidationError):
             sam_plan(config=AppendTaskConfig(task=task_def), plan=plan_id)
     finally:
         reset_task_config()
 
 
 # ---------------------------------------------------------------------------
-# sam_plan — finalize action (#1770 RED-PHASE tests)
-# ---------------------------------------------------------------------------
-# These tests target the new finalize routing.
-# They FAIL in the red phase with Pydantic discriminator error or ValueError.
+# sam_plan — finalize action (#1770)
 # ---------------------------------------------------------------------------
 
 

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -938,3 +938,237 @@ def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
     # Assert — plan_ref includes issue number and UUID plan_id
     assert "error" not in result
     assert re.match(r"^#42,P[0-9a-f]{8}$", result["plan_ref"]), f"Expected '#42,P<hex8>', got: {result['plan_ref']!r}"
+
+
+# ---------------------------------------------------------------------------
+# sam_plan — append_task action (#1770 RED-PHASE tests)
+# ---------------------------------------------------------------------------
+# These tests target the new append_task routing added by #1770.
+# They are expected to FAIL in the red phase with:
+#   - Pydantic discriminator error for unknown action 'append_task', OR
+#   - ValueError: sam_plan: unhandled action 'append_task'
+# The green phase will add AppendTaskConfig to action_models.py and wire
+# the server.py match block.
+# ---------------------------------------------------------------------------
+
+
+def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> None:
+    """sam_plan action=append_task calls backend.append_task for the given plan.
+
+    AC #2: sam_plan(action='append_task', plan=P, task_yaml=...) must append
+    a single task and return a success acknowledgment.
+
+    Arrange: create a plan with empty tasks_yaml; inject mock backend.
+    Act: call sam_plan with action=append_task.
+    Assert: backend.append_task was called exactly once with the plan_id and a
+            parsed task definition.
+    """
+    from unittest.mock import MagicMock
+
+    from sam_schema.core.action_models import AppendTaskConfig
+    from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
+
+    # Arrange
+    mock_backend = MagicMock()
+    mock_backend.read_plan.return_value = {
+        "plan_id": "P1",
+        "feature": "test-plan",
+        "version": "1",
+        "description": "",
+        "goal": "Test goal",
+        "context": "",
+        "acceptance_criteria": "",
+        "issue": None,
+        "tasks": [],
+        "source_path": None,
+        "state": "drafting",
+    }
+    mock_backend.append_task.return_value = None
+    mock_backend.create_plan.return_value = {
+        "plan_id": "P1",
+        "feature": "test-plan",
+        "version": "1",
+        "description": "",
+        "goal": "Test goal",
+        "context": "",
+        "acceptance_criteria": "",
+        "issue": None,
+        "tasks": [],
+        "source_path": str(tmp_path / "P1-test-plan.yaml"),
+        "state": "drafting",
+    }
+    set_task_config(TaskConfig(backend=mock_backend))
+
+    try:
+        task_yaml = (
+            "id: T1\n"
+            "title: First task\n"
+            "status: not-started\n"
+            "agent: test-agent\n"
+            "dependencies: []\n"
+            "priority: 2\n"
+            "complexity: low\n"
+        )
+
+        # Act
+        result = sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan="P1")
+
+        # Assert — backend.append_task called once
+        assert "error" not in result, f"append_task returned error: {result}"
+        mock_backend.append_task.assert_called_once()
+        call_args = mock_backend.append_task.call_args
+        plan_id_arg = call_args.args[0] if call_args.args else call_args.kwargs.get("plan_id")
+        assert plan_id_arg == "P1"
+    finally:
+        reset_task_config()
+
+
+def test_sam_append_task_returns_success_acknowledgment(tmp_path: Path) -> None:
+    """sam_plan action=append_task returns a success acknowledgment dict.
+
+    AC #2: the response must not be an error dict; it must contain a truthy
+    success indicator (e.g. 'appended': True or 'task_id': 'T1').
+
+    Arrange: create plan via InMemoryTaskProvider; append one task.
+    Act: call sam_plan(action='append_task', plan=P, task_yaml=...).
+    Assert: result contains 'appended': True or 'task_id': 'T1' and no 'error' key.
+    """
+    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig
+    from sam_schema.core.backends.memory import InMemoryTaskProvider
+    from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
+
+    backend = InMemoryTaskProvider()
+    set_task_config(TaskConfig(backend=backend))
+
+    try:
+        create_result = sam_plan(
+            config=CreatePlanConfig(slug="append-test", goal="Append goal", tasks_yaml="tasks: []")
+        )
+        plan_id = create_result["plan_id"]
+
+        task_yaml = (
+            "id: T1\n"
+            "title: First task\n"
+            "status: not-started\n"
+            "agent: test-agent\n"
+            "dependencies: []\n"
+            "priority: 2\n"
+            "complexity: low\n"
+        )
+
+        # Act
+        result = sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan=plan_id)
+
+        # Assert
+        assert "error" not in result, f"Expected success but got error: {result}"
+        success = result.get("appended") is True or result.get("task_id") is not None
+        assert success, f"Expected success indicator in append_task response, got: {result!r}"
+    finally:
+        reset_task_config()
+
+
+def test_sam_append_task_plan_not_found_raises(tmp_path: Path) -> None:
+    """sam_plan action=append_task raises PlanNotFoundError when plan does not exist.
+
+    AC #6: backend must raise PlanNotFoundError for unknown plan_id.
+    FastMCP converts this to a ToolError (isError=true) at the MCP transport.
+
+    Arrange: inject fresh InMemoryTaskProvider (no plans).
+    Act: call sam_plan(action='append_task', plan='P99999').
+    Assert: PlanNotFoundError or ToolError is raised containing 'P99999'.
+    """
+    from sam_schema.core.action_models import AppendTaskConfig
+    from sam_schema.core.backends.memory import InMemoryTaskProvider
+    from sam_schema.core.exceptions import PlanNotFoundError
+    from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
+
+    backend = InMemoryTaskProvider()
+    set_task_config(TaskConfig(backend=backend))
+
+    try:
+        task_yaml = (
+            "id: T1\ntitle: Task\nstatus: not-started\nagent: a\ndependencies: []\npriority: 2\ncomplexity: low\n"
+        )
+
+        # Act / Assert
+        with pytest.raises(PlanNotFoundError, match="P99999"):
+            sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan="P99999")
+    finally:
+        reset_task_config()
+
+
+def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
+    """sam_plan action=append_task raises an error when duplicate task ID is appended.
+
+    AC #6: backend must raise an error (TaskValidationError or ValueError) when
+    a task with an ID that already exists in the plan is appended.
+
+    Arrange: create a plan with T1; append T1 a second time.
+    Act: second append_task call.
+    Assert: an exception is raised (TaskValidationError or ValueError or similar).
+    """
+    from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig
+    from sam_schema.core.backends.memory import InMemoryTaskProvider
+    from sam_schema.core.exceptions import TaskValidationError
+    from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
+
+    backend = InMemoryTaskProvider()
+    set_task_config(TaskConfig(backend=backend))
+
+    try:
+        create_result = sam_plan(config=CreatePlanConfig(slug="dup-task", goal="Goal", tasks_yaml="tasks: []"))
+        plan_id = create_result["plan_id"]
+
+        task_yaml = (
+            "id: T1\ntitle: Task\nstatus: not-started\nagent: a\ndependencies: []\npriority: 2\ncomplexity: low\n"
+        )
+
+        # First append succeeds
+        sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan=plan_id)
+
+        # Act / Assert — second append with same ID must raise
+        with pytest.raises((TaskValidationError, ValueError)):
+            sam_plan(config=AppendTaskConfig(task_yaml=task_yaml), plan=plan_id)
+    finally:
+        reset_task_config()
+
+
+# ---------------------------------------------------------------------------
+# sam_plan — finalize action (#1770 RED-PHASE tests)
+# ---------------------------------------------------------------------------
+# These tests target the new finalize routing.
+# They FAIL in the red phase with Pydantic discriminator error or ValueError.
+# ---------------------------------------------------------------------------
+
+
+def test_sam_finalize_routes_through_backend_finalize_plan(tmp_path: Path) -> None:
+    """sam_plan action=finalize calls backend.finalize_plan (or update_plan_fields).
+
+    AC #14: finalize must clear the drafting state via a dedicated backend call.
+
+    Arrange: inject mock backend.
+    Act: call sam_plan(action='finalize', plan='P1').
+    Assert: backend.finalize_plan (or update_plan_fields with state='ready') called once.
+    """
+    from unittest.mock import MagicMock
+
+    from sam_schema.core.action_models import FinalizePlanConfig
+    from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
+
+    mock_backend = MagicMock()
+    mock_backend.finalize_plan.return_value = None
+    mock_backend.update_plan_fields.return_value = None
+    set_task_config(TaskConfig(backend=mock_backend))
+
+    try:
+        # Act
+        result = sam_plan(config=FinalizePlanConfig(), plan="P1")
+
+        # Assert — either finalize_plan OR update_plan_fields called to transition state
+        assert "error" not in result, f"Expected success, got: {result!r}"
+        state_transitioned = mock_backend.finalize_plan.called or mock_backend.update_plan_fields.called
+        assert state_transitioned, (
+            "Expected either backend.finalize_plan or backend.update_plan_fields to be called to clear drafting state"
+        )
+    finally:
+        reset_task_config()

--- a/plugins/development-harness/tests_sam/test_server.py
+++ b/plugins/development-harness/tests_sam/test_server.py
@@ -952,6 +952,7 @@ def test_sam_create_returns_plan_ref_with_issue(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> None:
     """sam_plan action=append_task calls backend.append_task for the given plan.
 
@@ -1023,6 +1024,7 @@ def test_sam_append_task_routes_through_backend_append_task(tmp_path: Path) -> N
         reset_task_config()
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_append_task_returns_success_acknowledgment(tmp_path: Path) -> None:
     """sam_plan action=append_task returns a success acknowledgment dict.
 
@@ -1067,6 +1069,7 @@ def test_sam_append_task_returns_success_acknowledgment(tmp_path: Path) -> None:
         reset_task_config()
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_append_task_plan_not_found_raises(tmp_path: Path) -> None:
     """sam_plan action=append_task raises PlanNotFoundError when plan does not exist.
 
@@ -1097,6 +1100,7 @@ def test_sam_append_task_plan_not_found_raises(tmp_path: Path) -> None:
         reset_task_config()
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
     """sam_plan action=append_task raises an error when duplicate task ID is appended.
 
@@ -1141,6 +1145,7 @@ def test_sam_append_task_duplicate_task_id_raises(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(strict=True, reason="red-phase — awaits #1770 green implementation")
 def test_sam_finalize_routes_through_backend_finalize_plan(tmp_path: Path) -> None:
     """sam_plan action=finalize calls backend.finalize_plan (or update_plan_fields).
 

--- a/plugins/development-harness/tests_sam/test_server_mcp.py
+++ b/plugins/development-harness/tests_sam/test_server_mcp.py
@@ -274,34 +274,30 @@ async def test_mcp_sam_create_creates_plan_file(tmp_path: Path) -> None:
     """sam_plan create creates a plan file and returns metadata via MCP protocol.
 
     Tests: sam_plan create MCP protocol happy path.
-    How: Pass valid tasks_yaml string via call_tool with config={"action": "create", ...}.
-    Why: Verifies YAML string argument passes MCP serialization unchanged.
+    How: Pass valid typed task list via call_tool with config={"action": "create", ...}.
+    Why: Verifies typed task list passes MCP serialization unchanged.
     """
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    tasks_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: MCP test task\n"
-        "    status: not-started\n"
-        "    agent: test-agent\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    tasks = [
+        {
+            "id": "T01",
+            "title": "MCP test task",
+            "status": "not-started",
+            "agent": "test-agent",
+            "dependencies": [],
+            "priority": 1,
+            "complexity": "low",
+        }
+    ]
 
     # Act
     async with Client(mcp) as client:
         result = await client.call_tool(
             "sam_plan",
             {
-                "config": {
-                    "action": "create",
-                    "slug": "mcp-create",
-                    "goal": "MCP create goal",
-                    "tasks_yaml": tasks_yaml,
-                },
+                "config": {"action": "create", "slug": "mcp-create", "goal": "MCP create goal", "tasks": tasks},
                 "plan_dir": str(p_dir),
             },
         )
@@ -331,22 +327,23 @@ async def test_mcp_sam_claim_returns_claimed_true(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    tasks_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Claim test task\n"
-        "    status: not-started\n"
-        "    agent: test-agent\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    tasks = [
+        {
+            "id": "T01",
+            "title": "Claim test task",
+            "status": "not-started",
+            "agent": "test-agent",
+            "dependencies": [],
+            "priority": 1,
+            "complexity": "low",
+        }
+    ]
 
     async with Client(mcp) as client:
         create_result = await client.call_tool(
             "sam_plan",
             {
-                "config": {"action": "create", "slug": "claim-mcp", "goal": "Claim goal", "tasks_yaml": tasks_yaml},
+                "config": {"action": "create", "slug": "claim-mcp", "goal": "Claim goal", "tasks": tasks},
                 "plan_dir": str(p_dir),
             },
         )
@@ -375,22 +372,23 @@ async def test_mcp_sam_claim_double_claim_returns_claimed_false(tmp_path: Path) 
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    tasks_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Double claim task\n"
-        "    status: not-started\n"
-        "    agent: test-agent\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    tasks = [
+        {
+            "id": "T01",
+            "title": "Double claim task",
+            "status": "not-started",
+            "agent": "test-agent",
+            "dependencies": [],
+            "priority": 1,
+            "complexity": "low",
+        }
+    ]
 
     async with Client(mcp) as client:
         create_result = await client.call_tool(
             "sam_plan",
             {
-                "config": {"action": "create", "slug": "double-claim-mcp", "goal": "Goal", "tasks_yaml": tasks_yaml},
+                "config": {"action": "create", "slug": "double-claim-mcp", "goal": "Goal", "tasks": tasks},
                 "plan_dir": str(p_dir),
             },
         )
@@ -426,22 +424,23 @@ async def test_mcp_sam_update_sets_context(tmp_path: Path) -> None:
     # Arrange
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
-    tasks_yaml = (
-        "tasks:\n"
-        "  - task: T01\n"
-        "    title: Update test\n"
-        "    status: not-started\n"
-        "    agent: test-agent\n"
-        "    dependencies: []\n"
-        "    priority: 1\n"
-        "    complexity: low\n"
-    )
+    tasks = [
+        {
+            "id": "T01",
+            "title": "Update test",
+            "status": "not-started",
+            "agent": "test-agent",
+            "dependencies": [],
+            "priority": 1,
+            "complexity": "low",
+        }
+    ]
 
     async with Client(mcp) as client:
         create_result = await client.call_tool(
             "sam_plan",
             {
-                "config": {"action": "create", "slug": "update-mcp", "goal": "Update goal", "tasks_yaml": tasks_yaml},
+                "config": {"action": "create", "slug": "update-mcp", "goal": "Update goal", "tasks": tasks},
                 "plan_dir": str(p_dir),
             },
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,9 @@ unfixable = ["F401"]
 # parameter types (PlanActionConfig, TaskActionConfig, ActiveTaskActionConfig, etc.) must be
 # present in the module's global namespace even with `from __future__ import annotations`.
 # TC001/TC002 would move these to TYPE_CHECKING, making them unavailable at runtime.
-"**/sam_schema/server.py" = ["TC001", "TC002"]
+# TC001/TC002 — action model types must be present at runtime for discriminated union dispatch (from __future__ import annotations bypasses this)
+# PLR0911 — match-case action dispatch in sam_plan/sam_task produces one return per case; guard-clause refactoring would obscure intent
+"**/sam_schema/server.py" = ["TC001", "TC002", "PLR0911"]
 # GitHubBackend implements every method of BacklogBackend — PLR0904 does not apply to protocol implementations
 # SLF001 — protocol surface includes _-prefixed methods that delegate to _-prefixed gh_client functions by design
 "**/backlog_core/backends/github_backend.py" = ["PLR0904", "SLF001"]


### PR DESCRIPTION
## Summary

Completes the full implementation of incremental plan building for #1770, resolving 7 root causes identified during a structural refactor audit. All implementations are green; all red-phase stubs have been replaced.

## Root Causes Addressed

| RC | Description | Key change |
|----|-------------|------------|
| RC3 | `"drafting"`/`"ready"` stringly-typed literals | Replaced with `PlanState` StrEnum |
| RC1 | `TaskDefinition` duplicated 100 lines of `Task` as a TypedDict | `TaskDefinition` now subclasses `Task`; removed `TaskDefinitionDict` TypedDict |
| RC2 | `model_config = ConfigDict(populate_by_name=True)` repeated 17x | Introduced `_ActionConfigBase` shared base class |
| RC4 | Triplicated validate-then-check-unique block across 3 backends | Extracted `validate_appended_task` into `backends/_utils.py`; added ADR-1770-1 |
| RC5 | O(N²) `append_task` — full task list re-fetched on every call | Per-instance `_task_id_cache` on all 3 backends; `finalize_plan` no-op guard |
| RC6 | Drafting-guard in `server.py` duplicated `read_plan` + `get_plan_status` calls | `get_plan_status` extended to return `state`; single call replaces two |
| RC7 | Stale red-phase test artifacts and comment blocks | Fixture promoted, name corrected, raises tightened, comments removed |

## Key Changes

**`action_models.py`** (RC1 + RC2)
- `TaskDefinition` subclasses `Task` instead of duplicating its fields as a TypedDict
- `_ActionConfigBase` carries shared `model_config`; all 17 action-config models inherit it

**`task_backend.py`** (RC1)
- `create_plan` signature updated to `Sequence[Task]` (covariant) to accept `list[TaskDefinition]`

**`backends/_utils.py`** (RC4)
- New module: `validate_appended_task(task, existing_ids, plan_id)` — centralised duplicate-ID guard with ADR-1770-1 single-writer contract

**`backends/memory.py`, `local_yaml.py`, `github_task.py`** (RC1 + RC4 + RC5 + RC6)
- All 3 backends: attribute access on `task.id`/`task.title`, `validate_appended_task` call, `_task_id_cache`, `finalize_plan` no-op guard, `state` in `get_plan_status` return

**`server.py`** (RC1 + RC6)
- `_DRAFTING_MARKER_RESPONSE` constant replaces inline dict literals
- `_sam_plan_status` and `_sam_plan_ready` use single `backend.get_plan_status` call

**`tests_sam/conftest.py`** (RC7)
- `memory_backend` fixture promoted from `test_drafting_state.py` and `test_large_document_write.py`
- `_make_task_yaml` renamed to `_make_task_def` in `test_large_document_write.py`
- `pytest.raises((TaskValidationError, ValueError))` tightened to `pytest.raises(TaskValidationError)`

**`docs/adrs/ADR-1770-1-single-writer-task-backend.md`** (RC4)
- Documents the single-writer concurrency contract for `append_task` and `finalize_plan`

## Test Results

2934 passed, 81 skipped — all green across `tests/` and `tests_sam/`.

https://claude.ai/code/session_01LAsWgqccJPxyw8XDj7382Y