### PR TITLE
fix(backlog_core): raise AmbiguousSelectorError on ambiguous title match; remove invented truncation limits

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.298"
+    "version": "6.3.299"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.33",
+  "version": "7.11.34",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -514,6 +514,32 @@ class ItemNotFoundError(BacklogError):
         super().__init__(f"No item found for: {selector}")
 
 
+_AMBIGUOUS_TITLE_PREVIEW_LIMIT = 10
+
+
+class AmbiguousSelectorError(BacklogError):
+    """Raised when a title substring selector matches multiple backlog items.
+
+    The caller must use a more specific selector (e.g. ``#N`` issue number).
+    """
+
+    def __init__(self, selector: str, matches: list[BacklogItem]) -> None:
+        """Initialize with the ambiguous selector and the items it matched."""
+        self.selector = selector
+        self.matches = matches
+        preview = matches[:_AMBIGUOUS_TITLE_PREVIEW_LIMIT]
+        titles = ", ".join(f'"{it.title}" ({it.issue or "no issue"})' for it in preview)
+        suffix = (
+            f" (showing first {_AMBIGUOUS_TITLE_PREVIEW_LIMIT} of {len(matches)})"
+            if len(matches) > _AMBIGUOUS_TITLE_PREVIEW_LIMIT
+            else ""
+        )
+        super().__init__(
+            f"Ambiguous selector {selector!r} matches {len(matches)} items{suffix}: {titles}. "
+            "Use an issue number (#N) or a more specific title substring."
+        )
+
+
 class DuplicateItemError(BacklogError):
     """Raised when a fuzzy duplicate is detected during item creation."""
 

--- a/plugins/development-harness/backlog_core/parsing.py
+++ b/plugins/development-harness/backlog_core/parsing.py
@@ -32,6 +32,7 @@ from .models import (
     ROLE_MAP,
     SECTION_HEADING_ALIAS,
     SKIP_STATUS,
+    AmbiguousSelectorError,
     BacklogItem,
     Entry,
     GroomedData,
@@ -470,7 +471,11 @@ def find_item(items: list[BacklogItem], selector: str) -> BacklogItem | None:
     # Title substring match (case-insensitive)
     selector_lower = selector.lower()
     matches = [it for it in items if selector_lower in it.title.lower()]
-    return matches[0] if len(matches) == 1 else (matches[0] if matches else None)
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise AmbiguousSelectorError(selector, matches)
+    return None
 
 
 def find_fuzzy_duplicates(

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -4232,9 +4232,7 @@ async def _poll_until_done(
                     item_cost = float(rj.get("cost", 0)) or None
                 except (ValueError, KeyError, TypeError):
                     pass
-                await asyncio.to_thread(
-                    mgr.set_item_complete, milestone, wave_num, issue_num, content[:4096], item_cost
-                )
+                await asyncio.to_thread(mgr.set_item_complete, milestone, wave_num, issue_num, content, item_cost)
                 return True, item_cost
 
         pid_alive = True
@@ -4303,7 +4301,7 @@ async def _run_spawn_item(
                 pid = int(spawn_data.get("pid", -1))
                 result_file = str(spawn_data.get("result_file", ""))
             except (ValueError, KeyError):
-                error_msg = f"spawn.py non-JSON output: {stdout_text[:200]}"
+                error_msg = f"spawn.py non-JSON output: {stdout_text}"
                 await asyncio.to_thread(mgr.set_item_failed, milestone, wave_num, issue_num, error_msg)
                 counters.failed += 1
                 counters.total_done += 1

--- a/plugins/development-harness/backlog_core/tests/test_find_item.py
+++ b/plugins/development-harness/backlog_core/tests/test_find_item.py
@@ -1,0 +1,91 @@
+"""Tests for find_item selector resolution in backlog_core.parsing.
+
+Regression guard for #1721 — find_item previously silently returned the first
+match when a title substring matched multiple items.  The fix raises
+AmbiguousSelectorError, forcing callers to supply a more specific selector.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backlog_core.models import AmbiguousSelectorError, BacklogItem
+from backlog_core.parsing import find_item
+
+
+def _item(title: str, issue: str = "") -> BacklogItem:
+    return BacklogItem(title=title, issue=issue)
+
+
+class TestFindItemByIssueNumber:
+    """Issue-number selectors (#N, bare N, GitHub URL) are unambiguous."""
+
+    def test_finds_item_by_hash_prefix(self) -> None:
+        items = [_item("Fix auth bug", "#42"), _item("Fix cache bug", "#43")]
+        result = find_item(items, "#42")
+        assert result is not None
+        assert result.title == "Fix auth bug"
+
+    def test_finds_item_by_bare_number(self) -> None:
+        items = [_item("Fix auth bug", "#42"), _item("Fix cache bug", "#43")]
+        result = find_item(items, "42")
+        assert result is not None
+        assert result.title == "Fix auth bug"
+
+    def test_returns_none_when_issue_number_not_found(self) -> None:
+        items = [_item("Fix auth bug", "#42")]
+        assert find_item(items, "#99") is None
+
+    def test_returns_none_when_list_is_empty(self) -> None:
+        assert find_item([], "#1") is None
+
+
+class TestFindItemByTitleSubstring:
+    """Title-substring selectors must be unambiguous or raise."""
+
+    def test_returns_single_matching_item(self) -> None:
+        items = [_item("Fix authentication timeout"), _item("Refactor cache layer")]
+        result = find_item(items, "authentication")
+        assert result is not None
+        assert result.title == "Fix authentication timeout"
+
+    def test_title_match_is_case_insensitive(self) -> None:
+        items = [_item("Fix Authentication Timeout"), _item("Refactor cache layer")]
+        result = find_item(items, "AUTHENTICATION")
+        assert result is not None
+        assert result.title == "Fix Authentication Timeout"
+
+    def test_returns_none_when_no_title_matches(self) -> None:
+        items = [_item("Fix auth bug"), _item("Refactor cache")]
+        assert find_item(items, "nonexistent-keyword") is None
+
+    def test_raises_ambiguous_when_multiple_titles_match(self) -> None:
+        items = [_item("Fix auth login bug", "#10"), _item("Fix auth signup bug", "#11")]
+        with pytest.raises(AmbiguousSelectorError) as exc_info:
+            find_item(items, "auth")
+        err = exc_info.value
+        assert err.selector == "auth"
+        assert len(err.matches) == 2
+        assert "2 items" in str(err)
+
+    def test_ambiguous_error_lists_matched_titles_in_message(self) -> None:
+        items = [_item("Fix auth login bug", "#10"), _item("Fix auth signup bug", "#11")]
+        with pytest.raises(AmbiguousSelectorError) as exc_info:
+            find_item(items, "auth")
+        msg = str(exc_info.value)
+        assert "Fix auth login bug" in msg
+        assert "Fix auth signup bug" in msg
+
+    def test_ambiguous_error_captures_all_matches(self) -> None:
+        items = [_item(f"Feature {i} auth flow", f"#{i}") for i in range(5)]
+        with pytest.raises(AmbiguousSelectorError) as exc_info:
+            find_item(items, "auth")
+        assert len(exc_info.value.matches) == 5
+
+    def test_ambiguous_error_is_subclass_of_backlog_error(self) -> None:
+        from backlog_core.models import BacklogError
+
+        items = [_item("auth feature A"), _item("auth feature B")]
+        with pytest.raises(AmbiguousSelectorError) as exc_info:
+            find_item(items, "auth")
+        assert isinstance(exc_info.value, BacklogError)


### PR DESCRIPTION
## Summary

Fixes two P0 design bugs identified in the backlog: #1721 and #1720.

### Bug #1721 — `find_item` silent ambiguity (design bug, not symptom)

**Root cause:** `find_item` in `parsing.py` contained a dead-code ternary that was structurally equivalent to always returning `matches[0]` — both the single-match and multi-match branches did the same thing. When a title substring matched N>1 items, the function silently returned whichever item happened to sort first with no error, no warning, and no signal to the caller.

**Fix:**
- Added `AmbiguousSelectorError(BacklogError)` to `models.py` with `selector` and `matches` attributes and a message listing matched titles
- Replaced the dead-code ternary in `find_item` with explicit branches: single match → return it, multiple matches → raise `AmbiguousSelectorError`, no match → return `None`
- `server.py`'s existing `BacklogError` catch converts the error to a structured `{"error": ...}` dict automatically — no caller changes needed

### Bug #1720 — Invented truncation limits silently drop content

**Root cause:** Two call sites in `server.py` sliced content that operators need in full:
- `content[:4096]` in `set_item_complete` — SQLite `TEXT` is unbounded; the limit was arbitrary and silently dropped wave item completion payloads beyond 4 KB
- `stdout_text[:200]` in the spawn non-JSON error handler — only the first 200 chars of a `spawn.py` failure were surfaced; the actual error was often past that point

**Fix:** Both slices removed. Full content is now stored and surfaced.

## Test plan

- [ ] 11 new tests in `test_find_item.py` cover all selector paths (issue number, bare number, no match, single match, multiple matches) and the `AmbiguousSelectorError` contract (selector attribute, matches list, message content, `BacklogError` inheritance)
- [ ] All 45 existing `backlog_core` tests pass
- [ ] All pre-commit hooks pass (ruff, ruff-format, ty, conventional-pre-commit)

https://claude.ai/code/session_01JAuMxVY2AjNaxrSPDLGEdR