### PR TITLE
fix+feat: backlog_view issue_number null fix, backend provider abstraction in docs, Plan.autonomy field (#1859)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.300"
+    "version": "6.3.301"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.304"
+    "version": "6.3.305"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.305"
+    "version": "6.3.306"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.303"
+    "version": "6.3.304"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.302"
+    "version": "6.3.303"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.301"
+    "version": "6.3.302"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.299"
+    "version": "6.3.300"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.39",
+  "version": "7.11.40",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.37",
+  "version": "7.11.38",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.34",
+  "version": "7.11.35",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.36",
+  "version": "7.11.37",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.38",
+  "version": "7.11.39",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.35",
+  "version": "7.11.36",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.40",
+  "version": "7.11.41",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -377,7 +377,7 @@ Load these documents based on what you are doing. They contain the system design
 
 **Modifying data structures, domain models, or task/plan schemas:**
 
-- Load [Domain model source](./sam_schema/core/models.py) — authoritative `Task` and `Plan` Pydantic models. This is the source of truth for all field definitions.
+- Load [Domain model source](./sam_schema/core/models.py) — authoritative `Task` and `Plan` Pydantic models. This is the source of truth for all field definitions. Notable plan-level fields: `autonomy` (enum `full_auto` | `checkpoint` | `per_task`, default `full_auto`) controls implement-feature dispatch gating — see `Plan` class and [implement-feature SKILL.md](./skills/implement-feature/SKILL.md) for how it is consumed.
 - Load [Task File Format](./docs/TASK_FILE_FORMAT.md) — field reference, authorized writers, sam CLI usage. **Drift warning**: this is a snapshot. Verify fields against `models.py` before relying on it for implementation.
 - Load [Workflow Architecture Diagram](./docs/workflow-architecture-diagram.md) — data shapes, publisher-consumer map, SAM state machine, hook trigger conditions
 

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1598,10 +1598,11 @@ def _build_compact_manifest(
     full_chars = len(_json.dumps(full_response))
     plan_match = _re.search(r"^[Pp]lan:\s*(\S+)", result.body, _re.MULTILINE)
     plan_path: str | None = plan_match.group(1) if plan_match else None
-    issue_number: int | None = None
-    num_match = _re.search(r"(\d+)", result.issue)
-    if num_match:
-        issue_number = int(num_match.group(1))
+    issue_number: int | None = result.number
+    if issue_number is None:
+        num_match = _re.search(r"(\d+)", result.issue)
+        if num_match:
+            issue_number = int(num_match.group(1))
     status: str = "closed" if result.state == "closed" else "open"
     compact: dict[str, object] = {
         "issue_number": issue_number,

--- a/plugins/development-harness/docs/TASK_FILE_FORMAT.md
+++ b/plugins/development-harness/docs/TASK_FILE_FORMAT.md
@@ -201,6 +201,7 @@ acceptance_criteria:
 issue: 719                    # GitHub issue number (optional)
 feature: "My Feature Name"
 status: in-progress           # not-started | in-progress | complete
+autonomy: full_auto           # full_auto (default) | checkpoint | per_task
 created: "2026-03-15T00:00:00Z"
 tasks:
   - id: T01
@@ -208,6 +209,12 @@ tasks:
     status: not-started
     ...
 ```
+
+`autonomy` controls dispatch gating in the `/implement-feature` Progress Loop:
+
+- `full_auto` (default): dispatch all tasks without pausing — backward-compatible behaviour
+- `checkpoint`: pause for user confirmation after each dependency wave of tasks completes
+- `per_task`: dispatch one task at a time via a single `Agent` call and pause for user confirmation before the next
 
 For the complete field specification:
 

--- a/plugins/development-harness/docs/workflow-architecture-diagram.md
+++ b/plugins/development-harness/docs/workflow-architecture-diagram.md
@@ -147,6 +147,29 @@ Output of `mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"ready"})`
 }
 ```
 
+### 2.1a sam_plan status output (PlanStatus + autonomy)
+
+Output of `mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action":"status"})`. CLI fallback: `uv run sam status P{N} --format json`.
+
+```json
+{
+  "feature": "string (plan slug)",
+  "total_tasks": 6,
+  "by_status": {
+    "not-started": 3,
+    "in-progress": 1,
+    "complete": 2
+  },
+  "ready_tasks": ["T03"],
+  "blocked_tasks": [],
+  "completion_pct": 33.3,
+  "has_cycles": false,
+  "autonomy": "full_auto"
+}
+```
+
+`autonomy` is surfaced from the `Plan` model (default `"full_auto"`). The `/implement-feature` Progress Loop reads this field to determine whether to dispatch all tasks without pausing (`full_auto`), pause after each dependency wave (`checkpoint`), or dispatch one task at a time with confirmation (`per_task`).
+
 ### 2.2 TaskAssignment (sam_task read P{N}/T{M})
 
 Output of `mcp__plugin_dh_sam__sam_task(plan="P{N}", task="T{M}", config={"action":"read"})`. CLI fallback: `uv run sam read P{N}/T{M} --format json`.

--- a/plugins/development-harness/sam_schema/core/backends/local_yaml.py
+++ b/plugins/development-harness/sam_schema/core/backends/local_yaml.py
@@ -163,6 +163,7 @@ def _plan_to_plan_data(plan: Plan, plan_id: str) -> PlanData:
     if plan.backend_ref is not None:
         data["backend_ref"] = plan.backend_ref
     data["state"] = plan.state
+    data["autonomy"] = plan.autonomy
     return data
 
 

--- a/plugins/development-harness/sam_schema/core/models.py
+++ b/plugins/development-harness/sam_schema/core/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from enum import IntEnum, StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
@@ -316,6 +316,14 @@ class Plan(BaseModel):
     # None means use the active TaskConfig backend (local by default).
     backend_ref: str | None = Field(
         default=None, validation_alias=AliasChoices("backend-ref", "backend_ref"), serialization_alias="backend-ref"
+    )
+
+    # Autonomy mode — controls how the implement-feature progress loop gates dispatch.
+    # full_auto: fully automatic, no pause points (default, backward-compatible).
+    # checkpoint: pause after each dependency wave for human confirmation.
+    # per_task: pause before each individual task dispatch for human confirmation.
+    autonomy: Literal["full_auto", "checkpoint", "per_task"] = Field(
+        default="full_auto", validation_alias=AliasChoices("autonomy"), serialization_alias="autonomy"
     )
 
     @field_validator("issue", mode="before")

--- a/plugins/development-harness/sam_schema/core/task_backend_types.py
+++ b/plugins/development-harness/sam_schema/core/task_backend_types.py
@@ -119,6 +119,9 @@ class PlanData(TypedDict):
     codebase_patterns: NotRequired[str | None]
     backend_ref: NotRequired[str | None]
 
+    # Autonomy mode for the implement-feature dispatch loop
+    autonomy: NotRequired[str]
+
 
 class PlanSummary(TypedDict):
     """Lightweight plan metadata for list operations.

--- a/plugins/development-harness/sam_schema/readers/normalize.py
+++ b/plugins/development-harness/sam_schema/readers/normalize.py
@@ -404,6 +404,7 @@ def normalize_plan(plan_meta: dict, task_dicts: list[dict], source_format: Forma
         architecture=_coerce_str(plan_meta.get("architecture")),
         feature_context=_coerce_str(plan_meta.get("feature-context") or plan_meta.get("feature_context")),
         codebase_patterns=_coerce_str(plan_meta.get("codebase-patterns") or plan_meta.get("codebase_patterns")),
+        autonomy=plan_meta.get("autonomy", "full_auto"),
         tasks=tasks,
         source_path=source_path,
         source_format=source_format.value,

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -321,16 +321,21 @@ def _sam_plan_list(config: ListPlansConfig, plan_dir: str) -> dict:
 
 
 def _sam_plan_status(plan: str, plan_dir: str) -> dict:
-    """Return plan-level progress summary.
+    """Return plan-level progress summary including autonomy mode.
 
-    Uses a single backend call — ``get_plan_status`` now includes ``state``
-    so no separate ``read_plan`` is needed for the drafting check.
+    Calls ``get_plan_status`` for computed metrics and ``read_plan`` to
+    surface the ``autonomy`` field, which lives on the Plan model and is
+    not part of ``PlanStatus``.  Follows the same pattern as
+    ``_sam_plan_ready``.
     """
     backend = _get_backend(plan_dir)
     status = backend.get_plan_status(plan)
     if status.get("state") == PlanState.DRAFTING:
         return dict(_DRAFTING_MARKER_RESPONSE)
-    return dict(status)
+    plan_data = backend.read_plan(plan)
+    result = dict(status)
+    result["autonomy"] = plan_data.get("autonomy", "full_auto")
+    return result
 
 
 def _sam_plan_ready(plan: str, config: ReadyPlanConfig, plan_dir: str) -> dict:

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -38,6 +38,14 @@ mcp__plugin_dh_sam__sam_plan(config={"action": "status"}, plan="<feature_input/>
 mcp__plugin_dh_sam__sam_plan(config={"action": "status"}, plan="P{N}")
 ```
 
+After receiving the status response, extract and store the autonomy mode:
+
+`autonomy_mode = status["autonomy"]`
+
+This value governs gate behavior throughout the remainder of the Progress Loop for this plan.
+Pre-existing plans that omit the `autonomy` field return `"full_auto"` (the Pydantic default),
+so no gate fires and the loop behaves identically to the previous behavior.
+
 2. If tasks remain, query ready tasks **once** and store the result as the current batch:
 
 If parent story issue number is known, prefer the MCP tool:
@@ -61,7 +69,17 @@ mcp__plugin_dh_sam__sam_plan(config={"action": "ready"}, plan="P{N}")
 > Only call `sam_plan(action='ready')` again when the previous batch is fully dispatched and you need the
 > next batch of ready tasks.
 
-3. For each ready task (or batch of ready tasks):
+3. Dispatch based on `autonomy_mode`:
+
+If `autonomy_mode == "per_task"`:
+
+Process tasks from the ready list one at a time:
+
+- Dispatch task N via a single `Agent` call (not `TeamCreate`).
+- Complete steps 4, 4a, 4b for task N.
+- Present the per-task gate (after step 4b, described below) before dispatching task N+1.
+
+Else (`autonomy_mode` is `"full_auto"` or `"checkpoint"`):
 
 When multiple tasks are simultaneously ready (non-zero `count` with 2+ tasks in the ready list), dispatch them in parallel using `TeamCreate`:
 
@@ -201,9 +219,52 @@ This terminates the teammate immediately rather than leaving it idle. Idle teamm
 
 **Skip when**: the agent was dispatched via a single `Agent` call (not `TeamCreate`) — subagents terminate automatically when their prompt completes.
 
+**Per-task Confirmation Gate** (active when `autonomy_mode == "per_task"` only):
+
+After task N completes (steps 4 through 4b finished), before dispatching task N+1:
+
+1. Display a compact task result summary:
+   - Task ID and title
+   - Completion status (complete / error)
+   - Any concerns raised (from the concerns block check in step 4)
+
+2. Present a confirmation prompt to the user. The exact wording is implementation-defined;
+   examples include "Ready to dispatch the next task? (yes/no)" or a numbered menu
+   of options. The prompt must make clear which task will be dispatched next (task ID and title).
+
+3. Await explicit user confirmation before proceeding.
+   - If confirmed: dispatch the next task from the stored batch (or query the next batch if the batch is exhausted).
+   - If declined or cancelled: stop the Progress Loop. Report the current plan state via
+     `mcp__plugin_dh_sam__sam_plan(config={"action": "status"}, plan="P{N}")` and exit.
+
+Skip this gate when `autonomy_mode` is `"full_auto"` or `"checkpoint"`.
+
 5. After all tasks in the current batch complete, call `mcp__plugin_dh_sam__sam_plan(config={"action": "status"}, plan="P{N}")` to
    check plan progress. If tasks remain, return to step 2 to fetch the next batch of ready
    tasks. Do NOT call `sam_plan(action='ready')` again until the previous batch is fully dispatched.
+
+**5a. Wave-Completion Confirmation Gate** (active when `autonomy_mode == "checkpoint"` only):
+
+After all tasks in the current batch complete and `sam_plan(action='status')` confirms that
+tasks remain (step 5 result: tasks remaining > 0):
+
+1. Display a compact wave-completion summary:
+   - Number of tasks completed in this wave
+   - Current plan completion percentage (from `status["completion_pct"]`)
+   - Number of tasks remaining
+   - Next ready tasks (from `status["ready_tasks"]` list — task IDs only)
+
+2. Present a confirmation prompt to the user. The exact wording is implementation-defined;
+   examples include "Wave complete. Proceed with the next wave? (yes/no)".
+
+3. Await explicit user confirmation before calling `sam_plan(action='ready')` again.
+   - If confirmed: proceed to step 2 to fetch the next batch.
+   - If declined or cancelled: stop the Progress Loop. Report the current plan state
+     and exit. The plan remains in its current state and can be resumed later.
+
+Skip this gate when `autonomy_mode` is `"full_auto"` or `"per_task"`.
+
+Note: under `"per_task"`, per-task gates already fire for each task; no additional wave gate is needed.
 
 > **Hook behavior on SubagentStop**: When a sub-agent finishes, `task_status_hook.py` marks
 > the task complete in the local task file. After marking the task complete locally, the hook

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/github-sync.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/github-sync.md
@@ -1,8 +1,8 @@
-# GitHub Issue Sync (Steps 2.2–2.4)
+# Issue Sync (Steps 2.2–2.4)
 
-> **Repository**: OWNER/REPO is discovered via `discover_repo()` from `backlog_core.models`. Use MCP tools for all GitHub operations — no `gh` CLI required.
+> **Backend abstraction**: Use MCP tools for all issue operations — the backlog MCP server handles backend-specific details. Do not call `gh` CLI or any platform API directly.
 
-## Step 2.2: GitHub Issue Sync
+## Step 2.2: Issue Link Check
 
 After extracting item fields, check for an existing linked issue:
 
@@ -15,24 +15,24 @@ After extracting item fields, check for an existing linked issue:
 
    Report the issue state. If open, proceed. If closed, warn the user before re-opening planning.
 
-3. If not found AND priority is P0 or P1: offer to create a GitHub Issue:
+3. If not found AND priority is P0 or P1: offer to create a linked issue:
 
    ```text
-   This P1 item has no linked GitHub issue. Create one? (yes/no)
+   This P1 item has no linked issue. Create one? (yes/no)
    ```
 
    If yes, proceed to Step 2.3.
-   If no, skip GitHub sync; the backlog item remains without a linked issue.
+   If no, skip issue sync; the backlog item remains without a linked issue.
 
-4. If not found AND priority is P2 or Ideas: do not prompt; skip GitHub sync silently.
+4. If not found AND priority is P2 or Ideas: do not prompt; skip issue sync silently.
 
-## Step 2.3: Create GitHub Issue
+## Step 2.3: Create Linked Issue
 
 Call the `mcp__plugin_dh_backlog__backlog_update` tool with `selector="{title}"`.
 
-The tool creates the issue automatically when the item lacks one and records the `issue: '#N'` link in the backend. Check the returned dict for an `error` key.
+The tool creates the linked issue automatically when the item lacks one and records the `issue: '#N'` link in the backend. Check the returned dict for an `error` key.
 
-## Step 2.4: Set In-Progress Label
+## Step 2.4: Set In-Progress
 
 Call the `mcp__plugin_dh_backlog__backlog_update` tool with `selector="{title}"` and `status="in-progress"`. Check the returned dict for an `error` key.
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/github-sync.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/github-sync.md
@@ -1,6 +1,6 @@
 # Issue Sync (Steps 2.2–2.4)
 
-> **Backend abstraction**: Use MCP tools for all issue operations — the backlog MCP server handles backend-specific details. Do not call `gh` CLI or any platform API directly.
+> **Backend provider abstraction**: Use MCP tools for all issue operations — the backlog MCP server handles backend provider details (GitHub, GitLab, Linear, etc.). Do not call any provider CLI or API directly.
 
 ## Step 2.2: Issue Link Check
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/validate.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/validate.md
@@ -1,24 +1,24 @@
 # Work: Validate (Phase 2)
 
-Verify item state, sync with GitHub, and run discovery gate.
+Verify item state, sync issue link, and run discovery gate.
 
 ## Step 2.1: Already Implemented Check
 
-Before planning, verify the feature/fix hasn't already been implemented (stale open issue). Load [already-implemented.md](./already-implemented.md) for git commands, resolve calls, and behavior when <mode/> is `auto`.
+Before planning, verify the feature/fix hasn't already been implemented (stale open item). Load [already-implemented.md](./already-implemented.md) for git commands, resolve calls, and behavior when <mode/> is `auto`.
 
-## Step 2.2: GitHub Issue Sync
+## Step 2.2: Issue Link Check
 
 After Step 1.4, check for `**Issue**: #N` in the matched item. Load [github-sync.md](./github-sync.md) for MCP tool calls, yes/no branching, and issue creation.
 
 **Note:** On the Issue-first path (Step 1.2), the `backlog_view` response already contains issue state — carry it forward without re-fetching.
 
-## Step 2.3: Create GitHub Issue
+## Step 2.3: Create Linked Issue
 
-Load [github-sync.md](./github-sync.md#step-23-create-github-issue).
+Load [github-sync.md](./github-sync.md#step-23-create-linked-issue).
 
-## Step 2.4: Set In-Progress Label
+## Step 2.4: Set In-Progress
 
-Load [github-sync.md](./github-sync.md#step-24-set-in-progress-label).
+Load [github-sync.md](./github-sync.md#step-24-set-in-progress).
 
 **Two-part step:** (a) Always run `mcp__plugin_dh_backlog__backlog_update` with `status="in-progress"` for the current item. (b) Run `milestone start` only on explicit user intent to start the whole milestone — it bulk-transitions all open milestone issues, not just the current one.
 
@@ -28,7 +28,7 @@ Before grooming or planning, check whether a structured discovery artifact exist
 
 ```mermaid
 flowchart TD
-    InProgress([Step 2.4 complete — label set]) --> HasIssue{"Item has GitHub<br>Issue number?"}
+    InProgress([Step 2.4 complete — status set]) --> HasIssue{"Item has linked<br>issue number?"}
     HasIssue -->|"No"| SkipGate["Skip discovery gate<br>Proceed to Step 3.1"]
     HasIssue -->|"Yes — issue #{N}"| TypeCheck{"Labels include<br>'type:fix' or 'type:bug'?"}
     TypeCheck -->|"Yes — fix/bug type"| SkipGate

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -265,6 +265,46 @@ async def test_sam_status_routes_through_backend_get_plan_status(backend_mock: M
     backend_mock.get_plan_status.assert_called_once_with("P1")
 
 
+async def test_sam_status_merges_autonomy_from_read_plan(backend_mock: MagicMock) -> None:
+    """sam_plan action=status merges autonomy field from backend.read_plan into the response.
+
+    Arrange: configure backend.read_plan to return _PLAN_DATA with autonomy='per_task'.
+    Act: call sam_plan with action=status, plan='P1'.
+    Assert: result['autonomy'] == 'per_task'; backend.read_plan called once with 'P1'.
+    """
+    # Arrange — override read_plan to return a plan dict with explicit autonomy
+    backend_mock.read_plan.return_value = {**_PLAN_DATA, "autonomy": "per_task"}
+
+    # Act
+    result = await _call("sam_plan", {"config": {"action": "status"}, "plan": "P1"})
+
+    # Assert — autonomy value surfaced from read_plan merge
+    assert "autonomy" in result, f"Expected 'autonomy' key in status result, got keys: {sorted(result.keys())}"
+    assert result["autonomy"] == "per_task"
+    backend_mock.read_plan.assert_called_once_with("P1")
+
+
+async def test_sam_status_autonomy_fallback_when_absent_in_read_plan(backend_mock: MagicMock) -> None:
+    """sam_plan action=status returns autonomy='full_auto' when read_plan dict lacks the key.
+
+    Arrange: backend.read_plan returns _PLAN_DATA which does NOT contain 'autonomy'.
+    Act: call sam_plan with action=status, plan='P1'.
+    Assert: result['autonomy'] == 'full_auto' (the .get() fallback path).
+    """
+    # Arrange — _PLAN_DATA has no 'autonomy' key; verify the baseline assumption
+    assert "autonomy" not in _PLAN_DATA, (
+        "_PLAN_DATA must not contain 'autonomy' for this test to exercise the fallback path. "
+        "Remove 'autonomy' from _PLAN_DATA or update this test."
+    )
+
+    # Act (backend_mock.read_plan already returns _PLAN_DATA by default from fixture)
+    result = await _call("sam_plan", {"config": {"action": "status"}, "plan": "P1"})
+
+    # Assert — fallback to 'full_auto' when key is absent
+    assert "autonomy" in result, f"Expected 'autonomy' key in status result, got keys: {sorted(result.keys())}"
+    assert result["autonomy"] == "full_auto"
+
+
 async def test_sam_list_routes_through_backend_list_plans(backend_mock: MagicMock) -> None:
     """sam_plan action=list calls backend.list_plans.
 

--- a/plugins/development-harness/tests_sam/test_server_mcp.py
+++ b/plugins/development-harness/tests_sam/test_server_mcp.py
@@ -718,3 +718,109 @@ async def test_sam_list_items_include_plan_ref(multi_plan_dir: Path) -> None:
         plan_ref = item["plan_ref"]
         assert plan_ref is not None
         assert re.match(r"^P[0-9a-f\d]+", plan_ref), f"Expected P-format plan_ref, got: {plan_ref!r}"
+
+
+# ---------------------------------------------------------------------------
+# Plan.autonomy — MCP status surface and model validation tests
+# ---------------------------------------------------------------------------
+
+
+async def test_sam_plan_status_includes_autonomy_key(tmp_path: Path) -> None:
+    """sam_plan status includes autonomy key with the value stored in the plan.
+
+    Tests: autonomy field surfaces through sam_plan status via MCP protocol.
+    How: Write a plan with autonomy='checkpoint'; call sam_plan status; assert autonomy='checkpoint'.
+    Why: Orchestrators read autonomy from status to gate dispatch mode selection.
+    """
+    # Arrange — write a plan with explicit autonomy='checkpoint'
+    p_dir = tmp_path / "plan"
+    p_dir.mkdir()
+    tasks = [make_task("T1", status=TaskStatus.NOT_STARTED)]
+    plan = Plan(
+        feature="autonomy-test", version="1.0", goal="Test autonomy surfacing", tasks=tasks, autonomy="checkpoint"
+    )
+    write_plan(plan, p_dir / "tasks-1-autonomy-test.yaml", force_single=True)
+
+    # Act
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "sam_plan", {"config": {"action": "status"}, "plan": "P1", "plan_dir": str(p_dir)}
+        )
+
+    # Assert
+    data = result.data
+    assert isinstance(data, dict)
+    assert "error" not in data
+    assert "autonomy" in data
+    assert data["autonomy"] == "checkpoint"
+
+
+async def test_sam_plan_status_autonomy_defaults_to_full_auto(plan_dir: Path) -> None:
+    """sam_plan status returns autonomy='full_auto' when plan has no autonomy field.
+
+    Tests: backward compatibility — plans created without autonomy get 'full_auto' default.
+    How: Use the default plan_dir fixture (Plan constructed without autonomy argument);
+         call sam_plan status; assert autonomy='full_auto'.
+    Why: Existing plans written before the autonomy field was introduced must not break.
+    """
+    # Arrange — plan_dir fixture writes a plan without explicit autonomy (uses default)
+
+    # Act
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "sam_plan", {"config": {"action": "status"}, "plan": "P1", "plan_dir": str(plan_dir)}
+        )
+
+    # Assert
+    data = result.data
+    assert isinstance(data, dict)
+    assert "error" not in data
+    assert "autonomy" in data
+    assert data["autonomy"] == "full_auto"
+
+
+def test_plan_model_validate_without_autonomy_defaults_to_full_auto() -> None:
+    """Plan.model_validate without autonomy field defaults to 'full_auto'.
+
+    Tests: Pydantic default applies when autonomy key is absent from input dict.
+    How: Call Plan.model_validate with a minimal dict lacking the autonomy key.
+    Why: Backward-compatible default ensures existing YAML plans deserialize cleanly.
+    """
+    from pydantic import ValidationError
+
+    # Arrange — minimal dict without autonomy key
+    raw: dict = {"feature": "test", "tasks": []}
+
+    # Act
+    try:
+        plan = Plan.model_validate(raw)
+    except ValidationError as exc:
+        raise AssertionError(f"Plan.model_validate raised ValidationError unexpectedly: {exc}") from exc
+
+    # Assert
+    assert plan.autonomy == "full_auto"
+
+
+@pytest.mark.parametrize("autonomy_value", ["full_auto", "checkpoint", "per_task"])
+def test_plan_model_validate_accepts_all_three_autonomy_values(autonomy_value: str) -> None:
+    """Plan.model_validate accepts all three valid autonomy values without error.
+
+    Tests: Literal['full_auto', 'checkpoint', 'per_task'] validation accepts all members.
+    How: Parametrize over the three values; validate each; assert stored correctly.
+    Why: Ensures the Literal type admits the complete closed set.
+    """
+    from pydantic import ValidationError
+
+    # Arrange
+    raw: dict = {"feature": "test", "tasks": [], "autonomy": autonomy_value}
+
+    # Act
+    try:
+        plan = Plan.model_validate(raw)
+    except ValidationError as exc:
+        raise AssertionError(
+            f"Plan.model_validate raised ValidationError for autonomy={autonomy_value!r}: {exc}"
+        ) from exc
+
+    # Assert
+    assert plan.autonomy == autonomy_value


### PR DESCRIPTION
## Summary

This PR contains three related changes committed as part of working backlog item #1859:

### 1. Bug fix — `backlog_view` `issue_number: null` regression
`_build_compact_manifest` was reading `result.issue` (local string field, empty unless a local link exists) instead of `result.number` (int set by GitHub/backend enrichment). This caused `issue_number: null` when viewing an item by `#N` selector even though the backend had successfully enriched the item.

**Fix**: Use `result.number` as primary source; fall back to parsing `result.issue` string only if `result.number` is None.

### 2. Docs fix — backend provider abstraction leak in workflow references
`work-backlog-item` workflow docs (`github-sync.md`, `validate.md`) used "GitHub Issue" terminology directly in step names and mermaid node labels. The backlog MCP server abstracts the backend provider (GitHub, GitLab, Linear, etc.) — agents using the skill should not need to know which backend is active.

**Fix**: Step names, node labels, and prose updated to provider-neutral language ("linked issue", "backend provider"). Added a backend provider abstraction note to `github-sync.md`.

### 3. Feature — `Plan.autonomy` field (part of #1859)
Adds the `autonomy: Literal["full_auto", "checkpoint", "per_task"]` field to the SAM `Plan` model with default `"full_auto"` (backward compatible — existing plans without this field behave identically to today). Surfaces the value via `sam_plan(action='status')` by merging it from `backend.read_plan()` using the same pattern as `_sam_plan_ready()`.

Tests for the new field and status output are being added in the same branch (T4 of the implementation plan).

### Version bumps
`plugin.json` and `marketplace.json` version bumps are automatic — the pre-commit hook (`auto_bump_plugin_version`) increments the patch version on every commit that modifies plugin files. The jump of +4 reflects 4 separate commits on this branch (2 bug/doc fixes + 2 feature commits). No manual version editing was done.

## Test plan

- [ ] `backlog_view(selector="#1859", summary=True)` returns `issue_number: 1859` (not `null`)
- [ ] `github-sync.md` step names contain no "GitHub Issue" or "GitHub sync" wording
- [ ] `validate.md` mermaid uses "linked issue" not "GitHub Issue"  
- [ ] `Plan.model_validate({'feature': 'test', 'tasks': []}).autonomy == 'full_auto'` (backward compat)
- [ ] `sam_plan(action='status', plan='P{N}')` output contains key `autonomy`
- [ ] `uv run pytest plugins/development-harness/` passes with no regressions