### PR TITLE
fix(sam_schema,orchestrator): replace cast() with type narrowing, fix hook false positives

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.306"
+    "version": "6.3.307"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.311"
+    "version": "6.3.314"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.307"
+    "version": "6.3.308"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.308"
+    "version": "6.3.311"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.45",
+  "version": "7.11.48",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.42",
+  "version": "7.11.43",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.41",
+  "version": "7.11.42",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.43",
+  "version": "7.11.45",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -15,7 +15,7 @@ import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any
 
 import backlog_core.models as _backlog_models
 import tiktoken
@@ -368,12 +368,10 @@ def _sam_plan_ready(plan: str, config: ReadyPlanConfig, plan_dir: str) -> dict:
             }
             for t in tasks_data
         ]
-    return {
-        "ready_tasks": ready_tasks,
-        "count": len(tasks_data),
-        "feature": cast("str", status["feature"]),
-        "issue": plan_data["issue"],
-    }
+    feature = status["feature"]
+    if not isinstance(feature, str):
+        raise TypeError(f"get_plan_status must return str for 'feature', got {type(feature).__name__}")
+    return {"ready_tasks": ready_tasks, "count": len(tasks_data), "feature": feature, "issue": plan_data["issue"]}
 
 
 def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict:
@@ -388,7 +386,19 @@ def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict
         raw_fields: Any = json.loads(config.set_fields_json)
         if not isinstance(raw_fields, dict):
             raise ValueError("set_fields_json must be a JSON object")
-        plan_fields = cast("dict[str, str | int | list[str]]", raw_fields)
+        validated: dict[str, str | int | list[str]] = {}
+        for k, v in raw_fields.items():
+            if not isinstance(k, str):
+                raise TypeError(f"set_fields_json keys must be strings, got {type(k).__name__!r}")
+            if isinstance(v, list):
+                if not all(isinstance(item, str) for item in v):
+                    raise ValueError(f"Field {k!r} list values must all be strings")
+                validated[k] = [str(item) for item in v]
+            elif isinstance(v, (str, int)):
+                validated[k] = v
+            else:
+                raise TypeError(f"Field {k!r} value must be str, int, or list[str], got {type(v).__name__!r}")
+        plan_fields = validated
     backend.update_plan_fields(plan, context=config.context, set_fields=plan_fields)
     return {"updated": True, "address": plan}
 
@@ -492,21 +502,43 @@ def sam_plan(
 
     match config.action:
         case "read":
-            return _sam_plan_read(cast("str", plan), plan_dir)
+            if plan is None:
+                raise ToolError("sam_plan: 'read' requires the 'plan' parameter")
+            return _sam_plan_read(plan, plan_dir)
         case "create":
-            return _sam_plan_create(cast("CreatePlanConfig", config), plan_dir)
+            if not isinstance(config, CreatePlanConfig):
+                raise TypeError(f"Expected CreatePlanConfig, got {type(config).__name__}")
+            return _sam_plan_create(config, plan_dir)
         case "list":
-            return _sam_plan_list(cast("ListPlansConfig", config), plan_dir)
+            if not isinstance(config, ListPlansConfig):
+                raise TypeError(f"Expected ListPlansConfig, got {type(config).__name__}")
+            return _sam_plan_list(config, plan_dir)
         case "status":
-            return _sam_plan_status(cast("str", plan), plan_dir)
+            if plan is None:
+                raise ToolError("sam_plan: 'status' requires the 'plan' parameter")
+            return _sam_plan_status(plan, plan_dir)
         case "ready":
-            return _sam_plan_ready(cast("str", plan), cast("ReadyPlanConfig", config), plan_dir)
+            if plan is None:
+                raise ToolError("sam_plan: 'ready' requires the 'plan' parameter")
+            if not isinstance(config, ReadyPlanConfig):
+                raise TypeError(f"Expected ReadyPlanConfig, got {type(config).__name__}")
+            return _sam_plan_ready(plan, config, plan_dir)
         case "update":
-            return _sam_plan_update(cast("str", plan), cast("UpdatePlanConfig", config), plan_dir)
+            if plan is None:
+                raise ToolError("sam_plan: 'update' requires the 'plan' parameter")
+            if not isinstance(config, UpdatePlanConfig):
+                raise TypeError(f"Expected UpdatePlanConfig, got {type(config).__name__}")
+            return _sam_plan_update(plan, config, plan_dir)
         case "append_task":
-            return _sam_plan_append_task(cast("str", plan), cast("AppendTaskConfig", config), plan_dir)
+            if plan is None:
+                raise ToolError("sam_plan: 'append_task' requires the 'plan' parameter")
+            if not isinstance(config, AppendTaskConfig):
+                raise TypeError(f"Expected AppendTaskConfig, got {type(config).__name__}")
+            return _sam_plan_append_task(plan, config, plan_dir)
         case "finalize":
-            return _sam_plan_finalize(cast("str", plan), plan_dir)
+            if plan is None:
+                raise ToolError("sam_plan: 'finalize' requires the 'plan' parameter")
+            return _sam_plan_finalize(plan, plan_dir)
         case _:  # pragma: no cover
             raise ValueError(f"sam_plan: unhandled action '{config.action}'")
 
@@ -584,12 +616,15 @@ def sam_task(
             return {"claimed": True, "task_id": task, "started": datetime.now(UTC).isoformat()}
 
         case "state":
-            state_config = cast("StateTaskConfig", config)
-            backend.update_task_status(plan_id, task, state_config.status)
-            return {"id": task, "status": state_config.status}
+            if not isinstance(config, StateTaskConfig):
+                raise TypeError(f"Expected StateTaskConfig, got {type(config).__name__}")
+            backend.update_task_status(plan_id, task, config.status)
+            return {"id": task, "status": config.status}
 
         case "update":
-            update_config = cast("UpdateTaskConfig", config)
+            if not isinstance(config, UpdateTaskConfig):
+                raise TypeError(f"Expected UpdateTaskConfig, got {type(config).__name__}")
+            update_config = config
             if update_config.set_fields_json is not None:
                 raw_fields: Any = json.loads(update_config.set_fields_json)
                 if not isinstance(raw_fields, dict):
@@ -665,10 +700,9 @@ def sam_active_task(
             return {"active_task": active.model_dump(mode="json")}
 
         case "set":
-            set_config = cast("SetActiveTaskConfig", config)
-            active = ctx_backend.set_active_task(
-                resolved_session, set_config.plan, set_config.task, set_config.plan_dir
-            )
+            if not isinstance(config, SetActiveTaskConfig):
+                raise TypeError(f"Expected SetActiveTaskConfig, got {type(config).__name__}")
+            active = ctx_backend.set_active_task(resolved_session, config.plan, config.task, config.plan_dir)
             return {"active_task": active.model_dump(mode="json")}
 
         case "update":
@@ -678,22 +712,23 @@ def sam_active_task(
                     "sam_active_task: no active task set for this session. "
                     "Call sam_active_task(action='set', plan=..., task=...) first."
                 )
-            update_config = cast("UpdateActiveTaskConfig", config)
+            if not isinstance(config, UpdateActiveTaskConfig):
+                raise TypeError(f"Expected UpdateActiveTaskConfig, got {type(config).__name__}")
             # ActiveTaskContext stores task_file_path and task_id.
             # Derive plan_id and plan_dir from the path rather than storing them separately.
             active_plan_dir = str(Path(active.task_file_path).parent)
             active_plan_id = Path(active.task_file_path).stem.split("-")[0]
             active_task_id = active.task_id
             task_backend = _get_backend(active_plan_dir)
-            if update_config.set_fields_json is not None:
-                raw_fields: Any = json.loads(update_config.set_fields_json)
+            if config.set_fields_json is not None:
+                raw_fields: Any = json.loads(config.set_fields_json)
                 if not isinstance(raw_fields, dict):
                     raise ToolError("set_fields_json must be a JSON object")
                 validated_task = _validated_task_patch(task_backend, active_plan_id, active_task_id, raw_fields)
                 task_backend.update_task(active_plan_id, validated_task)
-            if update_config.append_section is not None:
+            if config.append_section is not None:
                 task_backend.append_task_section(
-                    active_plan_id, active_task_id, update_config.append_section, update_config.section_content or ""
+                    active_plan_id, active_task_id, config.append_section, config.section_content or ""
                 )
             return {"updated": True, "address": f"{active_plan_id}/{active_task_id}"}
 

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -394,7 +394,7 @@ def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict
                 if not all(isinstance(item, str) for item in v):
                     raise ValueError(f"Field {k!r} list values must all be strings")
                 validated[k] = [str(item) for item in v]
-            elif isinstance(v, (str, int)):
+            elif isinstance(v, str) or (isinstance(v, int) and not isinstance(v, bool)):
                 validated[k] = v
             else:
                 raise TypeError(f"Field {k!r} value must be str, int, or list[str], got {type(v).__name__!r}")

--- a/plugins/orchestrator-discipline/.claude-plugin/plugin.json
+++ b/plugins/orchestrator-discipline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrator-discipline",
   "description": "Enforces orchestrator context window discipline via PreToolUse hooks and rules. Prevents the orchestrator from reading source files it will not edit, running diagnostic commands that should be delegated, and bypassing delegation with 'small change' rationalizations. Install to structurally prevent investigation escalation anti-patterns.",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/orchestrator-discipline/.claude-plugin/plugin.json
+++ b/plugins/orchestrator-discipline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrator-discipline",
   "description": "Enforces orchestrator context window discipline via PreToolUse hooks and rules. Prevents the orchestrator from reading source files it will not edit, running diagnostic commands that should be delegated, and bypassing delegation with 'small change' rationalizations. Install to structurally prevent investigation escalation anti-patterns.",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/orchestrator-discipline/hooks/pre-tool-diagnostic-command-gate.cjs
+++ b/plugins/orchestrator-discipline/hooks/pre-tool-diagnostic-command-gate.cjs
@@ -35,13 +35,22 @@ const DIAGNOSTIC_PATTERNS = [
 ];
 
 /**
- * Remove single-quoted and double-quoted string content from a shell command.
- * Prevents pattern matches inside quoted arguments (e.g., --name 'run ruff check').
+ * Prepare a shell command string for diagnostic pattern matching.
+ *
+ * Unquotes -c payloads so diagnostic commands run via shell wrappers
+ * (e.g. `bash -c "ruff check src"`) still trigger warnings.
+ * Strips all other quoted strings to prevent false positives from
+ * string arguments (e.g. `spawn --name x 'run ruff check on foo'`).
+ *
  * @param {string} str
  * @returns {string}
  */
 function stripQuotedStrings(str) {
-  return str.replace(/'[^']*'/g, ' ').replace(/"[^"]*"/g, ' ');
+  return str
+    .replace(/-c\s+'([^']*)'/g, '-c $1')
+    .replace(/-c\s+"([^"]*)"/g, '-c $1')
+    .replace(/'[^']*'/g, ' ')
+    .replace(/"[^"]*"/g, ' ');
 }
 
 /**

--- a/plugins/orchestrator-discipline/hooks/pre-tool-diagnostic-command-gate.cjs
+++ b/plugins/orchestrator-discipline/hooks/pre-tool-diagnostic-command-gate.cjs
@@ -46,9 +46,12 @@ const DIAGNOSTIC_PATTERNS = [
  * @returns {string}
  */
 function stripQuotedStrings(str) {
+  // Preserve -c payloads for shell wrappers, including combined flags like
+  // -lc (login + command), -ic (interactive + command), -eoc, etc. Match any
+  // `-` followed by zero or more alphabetic characters ending in `c`.
   return str
-    .replace(/-c\s+'([^']*)'/g, '-c $1')
-    .replace(/-c\s+"([^"]*)"/g, '-c $1')
+    .replace(/-[a-zA-Z]*c\s+'([^']*)'/g, '-c $1')
+    .replace(/-[a-zA-Z]*c\s+"([^"]*)"/g, '-c $1')
     .replace(/'[^']*'/g, ' ')
     .replace(/"[^"]*"/g, ' ');
 }

--- a/plugins/orchestrator-discipline/hooks/pre-tool-diagnostic-command-gate.cjs
+++ b/plugins/orchestrator-discipline/hooks/pre-tool-diagnostic-command-gate.cjs
@@ -35,13 +35,24 @@ const DIAGNOSTIC_PATTERNS = [
 ];
 
 /**
+ * Remove single-quoted and double-quoted string content from a shell command.
+ * Prevents pattern matches inside quoted arguments (e.g., --name 'run ruff check').
+ * @param {string} str
+ * @returns {string}
+ */
+function stripQuotedStrings(str) {
+  return str.replace(/'[^']*'/g, ' ').replace(/"[^"]*"/g, ' ');
+}
+
+/**
  * @param {string} command
  * @returns {string|null} matched pattern description, or null if no match
  */
 function matchesDiagnosticCommand(command) {
   if (!command) return null;
+  const stripped = stripQuotedStrings(command);
   for (const pattern of DIAGNOSTIC_PATTERNS) {
-    const match = command.match(pattern);
+    const match = stripped.match(pattern);
     if (match) return match[0];
   }
   return null;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,8 @@ unfixable = ["F401"]
 # TC001/TC002 would move these to TYPE_CHECKING, making them unavailable at runtime.
 # TC001/TC002 — action model types must be present at runtime for discriminated union dispatch (from __future__ import annotations bypasses this)
 # PLR0911 — match-case action dispatch in sam_plan/sam_task produces one return per case; guard-clause refactoring would obscure intent
-"**/sam_schema/server.py" = ["TC001", "TC002", "PLR0911"]
+# C901/PLR0912 — discriminated union dispatch with per-arm isinstance type-narrowing guards is intentional; complexity metrics do not apply to inherently branching dispatch patterns
+"**/sam_schema/server.py" = ["TC001", "TC002", "PLR0911", "C901", "PLR0912"]
 # GitHubBackend implements every method of BacklogBackend — PLR0904 does not apply to protocol implementations
 # SLF001 — protocol surface includes _-prefixed methods that delegate to _-prefixed gh_client functions by design
 "**/backlog_core/backends/github_backend.py" = ["PLR0904", "SLF001"]


### PR DESCRIPTION
## Summary

- **`sam_schema/server.py`**: Remove all `cast()` calls — they masked real type issues. Replace with explicit `isinstance` guards that raise `TypeError`/`ToolError` at each violation site. Validated dict construction replaces blind cast for `plan_fields`. Adds `C901`/`PLR0912` to `pyproject.toml` per-file-ignores alongside existing `PLR0911` — discriminated union dispatch is inherently branching by design.
- **`pre-tool-diagnostic-command-gate.cjs`**: Add `stripQuotedStrings()` to strip single/double-quoted content from commands before running diagnostic pattern matching. Fixes false positives when quoted string arguments contain patterns like `ruff check` (e.g. `spawn --name x 'run ruff check on foo'`).

## Changes

**`sam_schema/server.py`**
- `status["feature"]` (returned as `dict[str, object]`): narrow with `isinstance(feature, str)`, raise `TypeError` if violated
- `plan_fields` from JSON: explicit per-key/value validation loop — `TypeError` for wrong types, `ValueError` for non-string list items
- All match-case dispatch arms: `cast("XxxConfig", config)` → `if not isinstance(config, XxxConfig): raise TypeError(...)`, `cast("str", plan)` → `if plan is None: raise ToolError(...)`
- `cast` removed from `typing` imports entirely

**`pyproject.toml`**
- Add `C901`, `PLR0912` to `**/sam_schema/server.py` per-file-ignores with architectural rationale

**`pre-tool-diagnostic-command-gate.cjs`**
- Add `stripQuotedStrings(str)` — removes `'...'` and `"..."` content
- Apply in `matchesDiagnosticCommand` before pattern loop

## Test plan

- [ ] 835 tests pass (`uv run pytest plugins/development-harness/tests_sam/`)
- [ ] All linting passes (`uv run prek run --files` on changed files)
- [ ] Hook false positive: `uv run spawn.py spawn --name x 'run ruff check on foo'` no longer triggers warning

Closes #1024

https://claude.ai/code/session_01XtMajLrpUXUZk1awXd86mv