### PR TITLE
fix(tests): strengthen typing — replace suppressions with proper enum and TypedDict usage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.306"
+    "version": "6.3.307"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.311"
+    "version": "6.3.314"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.307"
+    "version": "6.3.308"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.308"
+    "version": "6.3.311"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.45",
+  "version": "7.11.48",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.42",
+  "version": "7.11.43",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.41",
+  "version": "7.11.42",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.43",
+  "version": "7.11.45",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,13 +183,6 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # We don't enter the live path because all tasks are skipped.
-        # But we need the import to succeed — monkeypatch the module namespace.
-        import migrate_tasks_to_github as mod
-
-        mod.create_task_issue = mock_create  # type: ignore[attr-defined]
-        mod.get_github = mock_gh  # type: ignore[attr-defined]
-
         # Act: invoke without dry-run; the task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
@@ -301,8 +294,6 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
         orig_bc = mod._BACKLOG_CORE
         mod._BACKLOG_CORE = MagicMock()
         mod._BACKLOG_CORE.exists.return_value = True
-        mod.create_task_issue = _side_effect  # type: ignore[attr-defined]
-        mod.get_github = mock_gh  # type: ignore[attr-defined]
 
         try:
             runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480"], catch_exceptions=False)

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,7 +183,7 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # Act: invoke without dry-run; the task should still be skipped
+        # Act: invoke with --dry-run; the task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
     # Assert

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -279,28 +279,22 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
             raise RuntimeError(msg)
         return success_issue
 
+    fake_bc = tmp_path / "bc"
+    fake_bc.mkdir()
+
     with (
-        patch("migrate_tasks_to_github._BACKLOG_CORE", tmp_path / "bc"),
+        patch("migrate_tasks_to_github._BACKLOG_CORE", fake_bc),
         patch("migrate_tasks_to_github.SamTask") as mock_sam_cls,
         patch("migrate_tasks_to_github.get_github") as mock_gh,
         patch("migrate_tasks_to_github.create_task_issue", side_effect=_side_effect),
+        patch("migrate_tasks_to_github._write_cache"),
     ):
         mock_gh.return_value = MagicMock()
         mock_sam_cls.side_effect = lambda **kw: MagicMock(task_id=kw["task_id"])
 
-        # Patch _BACKLOG_CORE.exists() to return True so we proceed.
-        import migrate_tasks_to_github as mod
+        result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480"])
 
-        orig_bc = mod._BACKLOG_CORE
-        mod._BACKLOG_CORE = MagicMock()
-        mod._BACKLOG_CORE.exists.return_value = True
-
-        try:
-            runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480"], catch_exceptions=False)
-        except SystemExit:
-            pass
-        finally:
-            mod._BACKLOG_CORE = orig_bc
+    assert result.exit_code == 0, result.output
 
     # The second task's github_issue field should be written (issue 482).
     updated_content = task_file.read_text()

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -656,7 +656,7 @@ def test_update_task_round_trips_list_fields_without_coercion(tmp_path: Path) ->
     from ruamel.yaml import YAML
     from sam_schema.core.action_models import CreatePlanConfig, TaskDefinition
     from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
-    from sam_schema.core.models import Task as _Task
+    from sam_schema.core.models import Complexity, Priority, Task as _Task
     from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
     from sam_schema.server import sam_plan
 
@@ -664,7 +664,7 @@ def test_update_task_round_trips_list_fields_without_coercion(tmp_path: Path) ->
     p_dir = tmp_path / "plan"
     p_dir.mkdir()
     minimal_task = TaskDefinition(
-        id="T01", title="Task One", status="not-started", agent="a", priority=2, complexity="low"
+        id="T01", title="Task One", status="not-started", agent="a", priority=Priority.HIGH, complexity=Complexity.LOW
     )
     backend = LocalYamlTaskProvider(p_dir)
     set_task_config(TaskConfig(backend=backend))

--- a/plugins/development-harness/tests/test_task_backend_conformance.py
+++ b/plugins/development-harness/tests/test_task_backend_conformance.py
@@ -26,6 +26,8 @@ from sam_schema.core.task_backend import TaskBackend
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from sam_schema.core.task_backend_types import DocumentHandle
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -423,11 +425,19 @@ class TestTaskBackendConformance:
         handle = backend.store_document(
             plan_id=plan_id, task_id=None, stage="context", doc_type="notes", title="Notes", content="content"
         )
-        bad_handle = {**handle, "content_ref": "nonexistent://fake-ref"}
+        bad_handle: DocumentHandle = {
+            "content_ref": "nonexistent://fake-ref",
+            "owner_type": handle["owner_type"],
+            "owner_id": handle["owner_id"],
+            "stage": handle["stage"],
+            "doc_type": handle["doc_type"],
+            "title": handle["title"],
+            "fmt": handle["fmt"],
+        }
 
         # Act / Assert
         with pytest.raises(DocumentNotFoundError):
-            backend.read_document(bad_handle)  # type: ignore[arg-type]
+            backend.read_document(bad_handle)
 
     # ------------------------------------------------------------------
     # plan_id durability


### PR DESCRIPTION
## Summary

Three type-boundary violations in the test suite, each suppressed with `# type: ignore` or `# type: ignore[attr-defined]` instead of being fixed properly. This PR replaces each suppression with a correct construction.

### Root cause (design level)

Tests bypassed enum and TypedDict constructors by passing raw literals or assigning through untyped module attributes. The suppressions hid the violations rather than enforcing the contract.

### Fixes

**`test_server_sam_taskbackend.py`**
- `TaskDefinition(priority=2, complexity="low")` used raw literals, bypassing the `Priority(IntEnum)` and `Complexity(StrEnum)` contracts
- Fixed: `Priority.HIGH` and `Complexity.LOW`

**`test_task_backend_conformance.py`**
- `bad_handle = {**handle, "content_ref": "..."}` created a plain `dict` instead of a `DocumentHandle`, requiring `# type: ignore[arg-type]` on the `read_document()` call
- Fixed: explicit `DocumentHandle` literal with all required keys copied from the valid handle
- `DocumentHandle` import placed under `TYPE_CHECKING` (ruff autofix — correct because all annotations are lazy under `from __future__ import annotations`)

**`test_migrate_tasks_to_github.py`**
- Two tests directly assigned `mock_create` / `mock_gh` / `_side_effect` to module attributes after `patch()` had already installed the same mocks, requiring `# type: ignore[attr-defined]` on each
- The assignments were redundant — `patch()` already replaces the attributes
- Fixed: removed the redundant direct assignments

## Test plan

- [ ] `uv run pytest tests/test_task_backend_conformance.py -k "read_document_missing"` — 2 passed (local_yaml + memory)
- [ ] `uv run pytest tests/test_migrate_tasks_to_github.py` — 21 passed
- [ ] `uv run pytest tests/test_server_sam_taskbackend.py::test_update_task_round_trips_list_fields_without_coercion` — passed
- [ ] `uv run ty check plugins/development-harness/tests/test_server_sam_taskbackend.py tests/test_task_backend_conformance.py tests/test_migrate_tasks_to_github.py` — All checks passed
- [ ] Pre-commit hooks (ruff, ty, prek) — all passed

https://claude.ai/code/session_01EgjjGZGvzjmaqmFUTsDHia

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgjjGZGvzjmaqmFUTsDHia)_