### PR TITLE
fix(backlog-core): dedup MIN_CONFLICT_GROUP_SIZE — define once in operations, import in validator

### DIFF
--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -4933,7 +4933,7 @@ def create_project(
 # Impact Radius conflict analysis (pure — no GitHub calls)
 # ---------------------------------------------------------------------------
 
-_MIN_CONFLICT_GROUP_SIZE = 2
+MIN_CONFLICT_GROUP_SIZE = 2
 
 
 class _UnionFind:
@@ -5045,7 +5045,7 @@ def _build_conflict_groups(titles: list[str], path_sets: list[set[str]]) -> list
     group_id = 1
     for root in sorted(components):
         members = components[root]
-        if len(members) < _MIN_CONFLICT_GROUP_SIZE:
+        if len(members) < MIN_CONFLICT_GROUP_SIZE:
             continue
         member_titles = sorted(titles[i] for i in members)
         shared = group_shared.get(root, set())
@@ -5104,6 +5104,6 @@ def analyze_impact_radius_conflicts(items: list[ImpactRadiusItem]) -> list[Confl
         conflicts are found.
     """
     titles, path_sets = _collect_items_with_paths(items)
-    if len(titles) < _MIN_CONFLICT_GROUP_SIZE:
+    if len(titles) < MIN_CONFLICT_GROUP_SIZE:
         return []
     return _build_conflict_groups(titles, path_sets)

--- a/plugins/development-harness/dispatch_schema/core/validator.py
+++ b/plugins/development-harness/dispatch_schema/core/validator.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from backlog_core.operations import MIN_CONFLICT_GROUP_SIZE
+
 if TYPE_CHECKING:
     from dispatch_schema.core.models import DispatchPlan
-
-_MIN_CONFLICT_GROUP_SIZE = 2
 
 
 @dataclass(frozen=True)
@@ -215,7 +215,7 @@ def _check_conflict_group_wave_placement(plan: DispatchPlan) -> list[str]:
             wave_to_issues.setdefault(wave_idx, []).append(issue_num)
 
         for wave_idx, issues_in_wave in wave_to_issues.items():
-            if len(issues_in_wave) < _MIN_CONFLICT_GROUP_SIZE:
+            if len(issues_in_wave) < MIN_CONFLICT_GROUP_SIZE:
                 continue
             actual_wave = plan.waves[wave_idx]
             if not actual_wave.parallel:


### PR DESCRIPTION
## Summary

- Removes the duplicate `_MIN_CONFLICT_GROUP_SIZE = 2` definition from `dispatch_schema/core/validator.py`
- Renames the constant to public `MIN_CONFLICT_GROUP_SIZE` in `backlog_core/operations.py` (canonical owner)
- Adds `from backlog_core.operations import MIN_CONFLICT_GROUP_SIZE` import in `validator.py`
- Updates all 3 usages across both files to the public name

## Root Cause

T01 of #938 (simplify review fixes) planned to consolidate the duplicate but never completed the change. The private `_` prefix on the constant discouraged cross-module import (ruff PLC2701 private-name-import error), so each module independently defined its own copy.

## Test Plan

- [x] `ruff` lint passes (no PLC2701 private-name-import error)
- [x] `ty` type check passes
- [x] Pre-commit hooks pass clean
- [x] No circular import risk — `dispatch_schema` does not import `backlog_core` at package level

Closes #952

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_