### PR TITLE
fix(skills): update milestone workflow next-step references to /dh:groom-milestone

### DIFF
--- a/.claude/skills/create-milestone/SKILL.md
+++ b/.claude/skills/create-milestone/SKILL.md
@@ -106,6 +106,7 @@ Milestone created.
 
 Next steps:
   Assign items:  /group-items-to-milestone {number}
+  Groom for execution: /dh:groom-milestone {number}
   Start work:    /start-milestone {number}
 ```
 

--- a/.claude/skills/group-items-to-milestone/SKILL.md
+++ b/.claude/skills/group-items-to-milestone/SKILL.md
@@ -110,7 +110,7 @@ Assigned {count} items:
 
 Per-item files updated with {created_count} new issue numbers.
 
-Next step: /start-milestone {number}
+Next step: /dh:groom-milestone {number}
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Summary

- Updates `group-items-to-milestone/SKILL.md` Step 7 from `Next step: /start-milestone {number}` to `Next step: /dh:groom-milestone {number}`
- Adds `/dh:groom-milestone` to `create-milestone/SKILL.md` next-steps list to reflect the full workflow chain

## Root Cause

The `group-items-to-milestone` skill referenced `/start-milestone` as the next step, but `/dh:groom-milestone` now exists in the development-harness plugin and is the correct automated next step (group → groom → work-milestone). The `/start-milestone` reference was written before `/dh:groom-milestone` was created.

Old grooming from 2026-03-30 had this BLOCKED because `/groom-milestone` didn't exist at the time — that blocker is now resolved.

## Workflow sequence after fix

```
/create-milestone → /group-items-to-milestone → /dh:groom-milestone → /dh:work-milestone
```

`/start-milestone` remains listed in `create-milestone` for teams doing manual sprint label management.

## Test Plan

- [x] `markdownlint-cli2` passes
- [x] `skilllint` validation passes
- [x] `/dh:groom-milestone` skill confirmed at `plugins/development-harness/skills/groom-milestone/SKILL.md` with description "Requires milestone items assigned via /group-items-to-milestone"

Closes #1014

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_