### PR TITLE
fix(orchestrator-discipline): strip quoted strings before matching diagnostic patterns

### DIFF
--- a/plugins/orchestrator-discipline/.claude-plugin/plugin.json
+++ b/plugins/orchestrator-discipline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrator-discipline",
   "description": "Enforces orchestrator context window discipline via PreToolUse hooks and rules. Prevents the orchestrator from reading source files it will not edit, running diagnostic commands that should be delegated, and bypassing delegation with 'small change' rationalizations. Install to structurally prevent investigation escalation anti-patterns.",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"


### PR DESCRIPTION
## Summary

- `matchesDiagnosticCommand` was matching patterns against the full raw command string, including content inside single-quoted and double-quoted shell arguments
- False positives occurred when spawning kage-bunshin sessions with prompts mentioning diagnostic commands — e.g. `uv run spawn.py spawn 'run ruff check on foo'` triggered the warning
- Adds `stripQuotedStrings()` helper that removes `'single'` and `"double"` quoted substrings before the regex loop
- `prevent-bash-tool-misuse.cjs` is unaffected — its patterns are start-anchored and do not match inside quoted arguments

Closes #1024

## Test plan

All 7 acceptance criteria verified by inline test:

| Case | Result |
|------|--------|
| `'run ruff check on foo'` (single-quoted) | PASS — no warning |
| `"run pytest and report"` (double-quoted) | PASS — no warning |
| `ruff check src/` (bare) | PASS — warning fires |
| `uv run ruff check plugins/` (bare) | PASS — warning fires |
| `pytest tests/ -x` (bare) | PASS — warning fires |
| `uv run prek run --files src/foo.py` (bare) | PASS — warning fires |
| `'prek run --files foo.py'` (single-quoted) | PASS — no warning |

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_