### PR TITLE
fix(tests): remove sys.path mutation and add asyncio_mode for silent async tests

### DIFF
--- a/plugins/frustration-analyzer/.claude-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs the triggering assistant output, and renders a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/summarizer/.claude-plugin/plugin.json
+++ b/plugins/summarizer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "summarizer",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Faithful information summarization with fidelity preservation, structured output, and anti-hallucination methodology. Provides skills for file, URL, and image summarization; agents for autonomous summarization tasks; and hooks for validating agent output structure.",
   "author": {
     "name": "jamie-bitflight-skills",

--- a/plugins/summarizer/tests/test_file_metrics.py
+++ b/plugins/summarizer/tests/test_file_metrics.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 import file_metrics
 
 


### PR DESCRIPTION
## Summary

- **Fixes #1123**: Removes `sys.path.insert(0, ...)` module-level mutation from `plugins/summarizer/tests/test_file_metrics.py`. `conftest.py` already seeds `sys.modules["file_metrics"]` via `importlib`, making the `sys.path` mutation redundant and unsafe under parallel or randomised test ordering.

- **Fixes #1120**: Creates `plugins/frustration-analyzer/pyproject.toml` with `asyncio_mode = "auto"` and `pytest-asyncio` as a dev dependency. Without this, the 10 `async def` test methods in `test_extract_user_messages.py` were collected by pytest as coroutine objects and reported PASSED without ever executing — zero real coverage behind a green CI signal. Also adds `frustration-analyzer` to uv workspace members per repo policy.

## Test plan

- [ ] `grep -n 'sys.path.insert' plugins/summarizer/tests/test_file_metrics.py` returns no matches
- [ ] `uv run pytest plugins/summarizer/tests/ -v` exits 0 with all tests passing
- [ ] `uv run pytest plugins/frustration-analyzer/tests/test_extract_user_messages.py -v` exits 0 with 10 async tests executing their bodies (not silently passing)
- [ ] Linting and ty checks pass (verified locally)

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_