### PR TITLE
fix(tests): remove dual-patch conflict and SystemExit swallow in test_migrate_tasks_to_github

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.297"
+    "version": "6.3.298"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.311"
+    "version": "6.3.314"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.298"
+    "version": "6.3.299"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.299"
+    "version": "6.3.311"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.45",
+  "version": "7.11.48",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.33",
+  "version": "7.11.34",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.34",
+  "version": "7.11.35",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.35",
+  "version": "7.11.45",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,7 +183,7 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # Act: invoke without dry-run; the task should still be skipped
+        # Act: invoke in dry-run mode; the already-migrated task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
     # Assert
@@ -287,6 +287,7 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
         patch("migrate_tasks_to_github.SamTask") as mock_sam_cls,
         patch("migrate_tasks_to_github.get_github") as mock_gh,
         patch("migrate_tasks_to_github.create_task_issue", side_effect=_side_effect),
+        patch("migrate_tasks_to_github._write_cache"),
     ):
         mock_gh.return_value = MagicMock()
         mock_sam_cls.side_effect = lambda **kw: MagicMock(task_id=kw["task_id"])

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,13 +183,6 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # We don't enter the live path because all tasks are skipped.
-        # But we need the import to succeed — monkeypatch the module namespace.
-        import migrate_tasks_to_github as mod
-
-        mod.create_task_issue = mock_create  # type: ignore[attr-defined]
-        mod.get_github = mock_gh  # type: ignore[attr-defined]
-
         # Act: invoke without dry-run; the task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
@@ -286,8 +279,11 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
             raise RuntimeError(msg)
         return success_issue
 
+    fake_bc = tmp_path / "bc"
+    fake_bc.mkdir()
+
     with (
-        patch("migrate_tasks_to_github._BACKLOG_CORE", tmp_path / "bc"),
+        patch("migrate_tasks_to_github._BACKLOG_CORE", fake_bc),
         patch("migrate_tasks_to_github.SamTask") as mock_sam_cls,
         patch("migrate_tasks_to_github.get_github") as mock_gh,
         patch("migrate_tasks_to_github.create_task_issue", side_effect=_side_effect),
@@ -295,21 +291,9 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
         mock_gh.return_value = MagicMock()
         mock_sam_cls.side_effect = lambda **kw: MagicMock(task_id=kw["task_id"])
 
-        # Patch _BACKLOG_CORE.exists() to return True so we proceed.
-        import migrate_tasks_to_github as mod
+        result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480"])
 
-        orig_bc = mod._BACKLOG_CORE
-        mod._BACKLOG_CORE = MagicMock()
-        mod._BACKLOG_CORE.exists.return_value = True
-        mod.create_task_issue = _side_effect  # type: ignore[attr-defined]
-        mod.get_github = mock_gh  # type: ignore[attr-defined]
-
-        try:
-            runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480"], catch_exceptions=False)
-        except SystemExit:
-            pass
-        finally:
-            mod._BACKLOG_CORE = orig_bc
+    assert result.exit_code == 0, result.output
 
     # The second task's github_issue field should be written (issue 482).
     updated_content = task_file.read_text()

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,7 +183,7 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # Act: invoke in dry-run mode; the already-migrated task should still be skipped
+        # Act: invoke with --dry-run; the task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
     # Assert

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,7 +183,7 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # Act: invoke with --dry-run; the task should still be skipped
+        # Act: invoke in dry-run mode; the already-migrated task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
     # Assert
@@ -287,6 +287,7 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
         patch("migrate_tasks_to_github.SamTask") as mock_sam_cls,
         patch("migrate_tasks_to_github.get_github") as mock_gh,
         patch("migrate_tasks_to_github.create_task_issue", side_effect=_side_effect),
+        patch("migrate_tasks_to_github._write_cache"),
     ):
         mock_gh.return_value = MagicMock()
         mock_sam_cls.side_effect = lambda **kw: MagicMock(task_id=kw["task_id"])

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,7 +183,7 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # Act: invoke in dry-run mode; the already-migrated task should still be skipped
+        # Act: invoke with --dry-run; the task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
     # Assert
@@ -287,7 +287,6 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
         patch("migrate_tasks_to_github.SamTask") as mock_sam_cls,
         patch("migrate_tasks_to_github.get_github") as mock_gh,
         patch("migrate_tasks_to_github.create_task_issue", side_effect=_side_effect),
-        patch("migrate_tasks_to_github._write_cache"),
     ):
         mock_gh.return_value = MagicMock()
         mock_sam_cls.side_effect = lambda **kw: MagicMock(task_id=kw["task_id"])


### PR DESCRIPTION
## Summary

- **Fixes #1122**: Two anti-patterns in `test_migrate_tasks_to_github.py` that could hide test failures.

**`test_skips_already_migrated`**: Removes redundant direct attribute assignments (`mod.create_task_issue = mock_create`, `mod.get_github = mock_gh`) made while `patch()` context managers were already active. The dual-patch created ambiguity about which patch was actually in effect.

**`test_partial_failure_continues`**:
- Creates `fake_bc` directory so `_BACKLOG_CORE.exists()` returns `True` naturally, eliminating the fragile manual `MagicMock` save/restore (`orig_bc = mod._BACKLOG_CORE` / `finally: mod._BACKLOG_CORE = orig_bc`)
- Removes duplicate `mod.create_task_issue` and `mod.get_github` direct assignments inside the existing `patch()` context
- Removes `try/except SystemExit: pass` that was swallowing CLI crashes while `catch_exceptions=False` was active; replaces with default `catch_exceptions=True` and explicit `assert result.exit_code == 0`

Note: `test_frontmatter_validator.py:452` and the other test files mentioned in #1121 (`test_complexity_validator.py`, `test_plugin_structure_validator.py`, etc.) do not exist in this repository — those are tracked separately.

## Test plan

- [ ] `uv run pytest plugins/development-harness/tests/test_migrate_tasks_to_github.py -v` exits 0
- [ ] All pre-commit hooks pass (verified locally)

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_