### PR TITLE
fix(#1625): correct sam_active_task action verb in hook error message

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.297"
+    "version": "6.3.298"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.311"
+    "version": "6.3.314"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.298"
+    "version": "6.3.299"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.300"
+    "version": "6.3.301"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.302"
+    "version": "6.3.311"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.301"
+    "version": "6.3.302"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.299"
+    "version": "6.3.300"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.45",
+  "version": "7.11.48",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.33",
+  "version": "7.11.34",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.37",
+  "version": "7.11.38",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.34",
+  "version": "7.11.35",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.36",
+  "version": "7.11.37",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.35",
+  "version": "7.11.36",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.38",
+  "version": "7.11.45",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/hooks/block-context-direct-writes.cjs
+++ b/plugins/development-harness/hooks/block-context-direct-writes.cjs
@@ -88,7 +88,7 @@ function isBlockedWrite(command) {
 const BLOCK_REASON =
   'Direct writes to active-task context files are prohibited. ' +
   'Use the sam_active_task MCP tool instead: ' +
-  'mcp__plugin_dh_sam__sam_active_task({"action": "write", ...})';
+  'mcp__plugin_dh_sam__sam_active_task({"action": "set", "plan": "P{N}", "task": "T{M}"}).';
 
 let input = '';
 process.stdin.setEncoding('utf8');

--- a/plugins/development-harness/hooks/block-context-direct-writes.cjs
+++ b/plugins/development-harness/hooks/block-context-direct-writes.cjs
@@ -88,7 +88,7 @@ function isBlockedWrite(command) {
 const BLOCK_REASON =
   'Direct writes to active-task context files are prohibited. ' +
   'Use the sam_active_task MCP tool instead: ' +
-  'mcp__plugin_dh_sam__sam_active_task({"action": "set", "plan": "P{N}", "task": "T{M}"}).';
+  'mcp__plugin_dh_sam__sam_active_task(config={"action": "set", "plan": "P{N}", "task": "T{M}"})';
 
 let input = '';
 process.stdin.setEncoding('utf8');

--- a/plugins/development-harness/tests/test_dispatch_schema/test_gates.py
+++ b/plugins/development-harness/tests/test_dispatch_schema/test_gates.py
@@ -847,3 +847,62 @@ class TestSubprocessTimeoutContract:
         # Assert
         _, kwargs = mock_run.call_args
         assert kwargs["timeout"] == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# {files} template variable pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestFilesTemplateVariable:
+    """{files} placeholder in commands is NOT substituted by run_quality_gates.
+
+    The function is a pass-through executor: callers must expand {files}
+    before invoking run_quality_gates. This class documents and enforces
+    that contract.
+    """
+
+    def test_files_template_passed_verbatim_to_subprocess(self, mocker: MockerFixture) -> None:
+        """{files} appears literally in the subprocess.run call args.
+
+        Tests: that run_quality_gates does not substitute {files} before
+               passing the tokenised command to subprocess.run.
+        How: Patch shutil.which; patch subprocess.run; call with a command
+             containing {files}; inspect the positional args received by
+             subprocess.run.
+        Why: Callers pre-expand {files} with the actual file list. If
+             run_quality_gates substituted it too, a double-expansion bug
+             would silently corrupt commands.
+        """
+        # Arrange
+        mocker.patch("dispatch_schema.gates.shutil.which", return_value="/usr/bin/ruff")
+        mock_run = mocker.patch(
+            "dispatch_schema.gates.subprocess.run", return_value=_make_completed_process(returncode=0)
+        )
+
+        # Act
+        run_quality_gates(["ruff check {files}"])
+
+        # Assert: {files} was forwarded as a literal token
+        call_args, _ = mock_run.call_args
+        assert "{files}" in call_args[0]
+
+    def test_files_template_result_recorded_in_command_field(self, mocker: MockerFixture) -> None:
+        """CommandResult.command preserves the original {files} command string.
+
+        Tests: CommandResult.command field when input contains {files}.
+        How: Call with 'ruff check {files}'; assert result.results[0].command
+             equals the original string unchanged.
+        Why: The command field is the caller-visible record of what was run.
+             If it were modified, callers could not correlate results back to
+             their original pre-expanded command template.
+        """
+        # Arrange
+        mocker.patch("dispatch_schema.gates.shutil.which", return_value="/usr/bin/ruff")
+        mocker.patch("dispatch_schema.gates.subprocess.run", return_value=_make_completed_process(returncode=0))
+
+        # Act
+        result = run_quality_gates(["ruff check {files}"])
+
+        # Assert
+        assert result.results[0].command == "ruff check {files}"

--- a/plugins/development-harness/tests/test_manifest_merge.py
+++ b/plugins/development-harness/tests/test_manifest_merge.py
@@ -256,6 +256,23 @@ class TestResolveExtendsChain:
         with pytest.raises(CircularExtendsError):
             resolve_extends_chain(a_dir / "language-manifest.yaml", search_paths=[("test", tmp_path / "manifests")])
 
+    def test_resolve_extends_chain_when_parent_not_found_then_raises(self, tmp_path: Path) -> None:
+        child_dir = tmp_path / "manifests" / "child"
+        child_dir.mkdir(parents=True)
+        child_file = child_dir / "language-manifest.yaml"
+        child_file.write_text(
+            dedent("""\
+            name: child
+            extends: missing-plugin:nonexistent
+            language: python
+            version: "1.0"
+            project_detection:
+              markers: [pyproject.toml]
+        """)
+        )
+        with pytest.raises(FileNotFoundError):
+            resolve_extends_chain(child_file, search_paths=[("other-plugin", tmp_path / "manifests")])
+
     def test_two_level_chain(self, tmp_path: Path) -> None:
         gp_dir = tmp_path / "manifests" / "gp"
         p_dir = tmp_path / "manifests" / "parent"

--- a/plugins/development-harness/tests/test_manifest_merge.py
+++ b/plugins/development-harness/tests/test_manifest_merge.py
@@ -270,8 +270,11 @@ class TestResolveExtendsChain:
               markers: [pyproject.toml]
         """)
         )
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError) as exc_info:
             resolve_extends_chain(child_file, search_paths=[("other-plugin", tmp_path / "manifests")])
+        message = str(exc_info.value)
+        assert "missing-plugin:nonexistent" in message
+        assert "other-plugin" in message
 
     def test_two_level_chain(self, tmp_path: Path) -> None:
         gp_dir = tmp_path / "manifests" / "gp"

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,7 +183,7 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # Act: invoke without dry-run; the task should still be skipped
+        # Act: invoke with --dry-run; the task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
     # Assert

--- a/plugins/development-harness/tests/test_migrate_tasks_to_github.py
+++ b/plugins/development-harness/tests/test_migrate_tasks_to_github.py
@@ -183,13 +183,6 @@ def test_skips_already_migrated(tmp_path: Path) -> None:
         # Provide a mock repo so the live-mode path doesn't fail on import.
         mock_gh.return_value = MagicMock()
 
-        # We don't enter the live path because all tasks are skipped.
-        # But we need the import to succeed — monkeypatch the module namespace.
-        import migrate_tasks_to_github as mod
-
-        mod.create_task_issue = mock_create  # type: ignore[attr-defined]
-        mod.get_github = mock_gh  # type: ignore[attr-defined]
-
         # Act: invoke without dry-run; the task should still be skipped
         result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480", "--dry-run"])
 
@@ -286,8 +279,11 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
             raise RuntimeError(msg)
         return success_issue
 
+    fake_bc = tmp_path / "bc"
+    fake_bc.mkdir()
+
     with (
-        patch("migrate_tasks_to_github._BACKLOG_CORE", tmp_path / "bc"),
+        patch("migrate_tasks_to_github._BACKLOG_CORE", fake_bc),
         patch("migrate_tasks_to_github.SamTask") as mock_sam_cls,
         patch("migrate_tasks_to_github.get_github") as mock_gh,
         patch("migrate_tasks_to_github.create_task_issue", side_effect=_side_effect),
@@ -295,21 +291,9 @@ def test_partial_failure_continues(tmp_path: Path) -> None:
         mock_gh.return_value = MagicMock()
         mock_sam_cls.side_effect = lambda **kw: MagicMock(task_id=kw["task_id"])
 
-        # Patch _BACKLOG_CORE.exists() to return True so we proceed.
-        import migrate_tasks_to_github as mod
+        result = runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480"])
 
-        orig_bc = mod._BACKLOG_CORE
-        mod._BACKLOG_CORE = MagicMock()
-        mod._BACKLOG_CORE.exists.return_value = True
-        mod.create_task_issue = _side_effect  # type: ignore[attr-defined]
-        mod.get_github = mock_gh  # type: ignore[attr-defined]
-
-        try:
-            runner.invoke(app, ["--task-file", str(task_file), "--parent-issue", "480"], catch_exceptions=False)
-        except SystemExit:
-            pass
-        finally:
-            mod._BACKLOG_CORE = orig_bc
+    assert result.exit_code == 0, result.output
 
     # The second task's github_issue field should be written (issue 482).
     updated_content = task_file.read_text()


### PR DESCRIPTION
## Summary

- Fixes `plugins/development-harness/hooks/block-context-direct-writes.cjs` line 91
- `BLOCK_REASON` said `"action": "write"` but the correct action is `"set"` per `TASK_FILE_FORMAT.md` lines 55-66
- An agent reading the old error would call `sam_active_task` with the wrong action and fail again, making the error actively misleading
- Updated to include a complete usage example: `{"action": "set", "plan": "P{N}", "task": "T{M}"}`

## Test plan

- [ ] `biome check` passes on the `.cjs` file
- [ ] `BLOCK_REASON` string now matches `TASK_FILE_FORMAT.md` spec for `action: "set"`

Closes #1625

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_