### PR TITLE
fix(#1014,#1624): fix stale skill reference and add parent_issue_number to SetActiveTaskConfig

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.297"
+    "version": "6.3.298"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.311"
+    "version": "6.3.314"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.298"
+    "version": "6.3.299"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.299"
+    "version": "6.3.311"
   },
   "plugins": [
     {

--- a/.claude/skills/group-items-to-milestone/SKILL.md
+++ b/.claude/skills/group-items-to-milestone/SKILL.md
@@ -110,7 +110,7 @@ Assigned {count} items:
 
 Per-item files updated with {created_count} new issue numbers.
 
-Next step: /start-milestone {number}
+Next step: /dh:groom-milestone {number}
 ```
 
 ## Error Handling

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.45",
+  "version": "7.11.48",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.33",
+  "version": "7.11.34",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.34",
+  "version": "7.11.35",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.35",
+  "version": "7.11.45",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -354,7 +354,7 @@ class SetActiveTaskConfig(_ActionConfigBase):
     )
     parent_issue_number: int | None = Field(
         default=None,
-        description="Optional GitHub issue number for the parent story. Used by the SubagentStop hook to create sub-issues.",
+        description="Optional GitHub issue number for the parent story. Used by the SubagentStop hook for GitHub sync and issue linking.",
     )
 
 

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -352,6 +352,10 @@ class SetActiveTaskConfig(_ActionConfigBase):
             "Stored alongside plan/task so retrieval uses the same backend."
         ),
     )
+    parent_issue_number: int | None = Field(
+        default=None,
+        description="Optional GitHub issue number for the parent story. Used by the SubagentStop hook to create sub-issues.",
+    )
 
 
 class UpdateActiveTaskConfig(_ActionConfigBase):

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -662,7 +662,7 @@ def sam_active_task(
         case "set":
             set_config = cast("SetActiveTaskConfig", config)
             active = ctx_backend.set_active_task(
-                resolved_session, set_config.plan, set_config.task, set_config.plan_dir
+                resolved_session, set_config.plan, set_config.task, set_config.plan_dir, set_config.parent_issue_number
             )
             return {"active_task": active.model_dump(mode="json")}
 

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -685,3 +685,39 @@ async def test_sam_update_set_fields_json_writes_via_update_task(backend_mock: M
     # Assert: update_task called, update_task_fields NOT called
     backend_mock.update_task.assert_called_once()
     backend_mock.update_task_fields.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# sam_active_task: set→get round-trip with parent_issue_number
+# ---------------------------------------------------------------------------
+
+
+async def test_sam_active_task_set_get_round_trip_persists_parent_issue_number(backend_mock: MagicMock) -> None:
+    """sam_active_task set→get round-trip persists parent_issue_number.
+
+    SetActiveTaskConfig gained parent_issue_number to thread it into the
+    context backend so the SubagentStop hook can link sub-issues.  Verify
+    that a value set via action='set' is returned by action='get'.
+
+    Arrange: inject in-memory context backend; inject mock task backend.
+    Act 1: sam_active_task(action='set', plan='P1', task='T1', parent_issue_number=42).
+    Act 2: sam_active_task(action='get').
+    Assert: get response includes parent_issue_number=42.
+    """
+    from sam_schema.core.backends.memory_context_backend import InMemoryContextBackend
+    from sam_schema.core.context_config import ContextConfig, reset_context_config, set_context_config
+
+    ctx_backend = InMemoryContextBackend()
+    set_context_config(ContextConfig(backend=ctx_backend))
+    try:
+        # Act 1 — set with parent_issue_number
+        await _call(
+            "sam_active_task", {"config": {"action": "set", "plan": "P1", "task": "T1", "parent_issue_number": 42}}
+        )
+
+        # Act 2 — get and verify round-trip
+        result = await _call("sam_active_task", {"config": {"action": "get"}})
+        active_task = result.get("active_task") or {}
+        assert active_task.get("parent_issue_number") == 42
+    finally:
+        reset_context_config()


### PR DESCRIPTION
## Summary

### #1014 — Stale skill reference in `group-items-to-milestone`
- `SKILL.md` Step 7 said `Next step: /start-milestone {number}` but the correct workflow next step is `/dh:groom-milestone`
- `/start-milestone` bulk-transitions labels to `in-progress` — it runs after grooming, not before it

### #1624 — `SetActiveTaskConfig` missing `parent_issue_number`
- `SetActiveTaskConfig` had no `parent_issue_number` field; Pydantic silently dropped it (no `extra='forbid'`)
- `ActiveTaskContext.parent_issue_number` was always `None`, breaking the SubagentStop hook's GitHub sub-issue sync
- Added `parent_issue_number: int | None = None` to `SetActiveTaskConfig` with description matching `TASK_FILE_FORMAT.md`
- Wired through `server.py` `case "set":` to `ctx_backend.set_active_task()`
- Backend already accepted the parameter (`context_backend.py` line 53)

## Test plan

- [ ] `uv run pytest tests/ -q --ignore=tests/test_live_validation.py` → 2108 passed
- [ ] `ty check` passes on modified files
- [ ] `ruff check` passes

Closes #1014
Closes #1624

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_