### PR TITLE
fix(tests): add global try_get_github mock to test_batch_section_writes autouse fixture (#1610)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.297"
+    "version": "6.3.298"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.311"
+    "version": "6.3.314"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.298"
+    "version": "6.3.311"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.45",
+  "version": "7.11.48",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.33",
+  "version": "7.11.34",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.34",
+  "version": "7.11.45",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/tests/test_batch_section_writes.py
+++ b/plugins/development-harness/tests/test_batch_section_writes.py
@@ -92,6 +92,11 @@ def _isolate_backlog_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
         ),
     )
 
+    # Prevent any operation that calls try_get_github from reaching the live
+    # API and creating real GitHub issues.  Tests that need GitHub-touching
+    # behaviour mock _write_groomed_to_github or try_get_github individually.
+    monkeypatch.setattr(ops, "try_get_github", lambda repo="": None)
+
 
 # ---------------------------------------------------------------------------
 # _handle_batch_groomed: Phase 1 — local writes


### PR DESCRIPTION
## Summary

- `test_batch_section_writes.py` autouse fixture lacked a global `try_get_github` mock, leaving any code path that reaches `try_get_github` without a per-test mock exposed to the live GitHub API
- `test_backlog_core_operations.py` already had this protection — added the identical guard to `test_batch_section_writes.py`'s `_isolate_backlog_dir` autouse fixture

## Root cause

The per-test approach (each test patching `try_get_github` individually) is fragile — a new test or changed call path can slip through. The autouse fixture provides a non-bypassable boundary matching the principle used in the sibling test file.

## Test plan

- [ ] `test_batch_section_writes.py`: 24/24 passing (no regressions — tests that mock `_write_groomed_to_github` still work because the global mock only blocks `try_get_github`, not `_write_groomed_to_github`)

Closes #1610

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_