### PR TITLE
fix(dh): emit metadata-only message from task-notification hook (#1044)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.297"
+    "version": "6.3.298"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.311"
+    "version": "6.3.314"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.298"
+    "version": "6.3.311"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.45",
+  "version": "7.11.48",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.33",
+  "version": "7.11.34",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.34",
+  "version": "7.11.45",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/hooks/task-completed-kage-bunshin-reminder.cjs
+++ b/plugins/development-harness/hooks/task-completed-kage-bunshin-reminder.cjs
@@ -126,34 +126,9 @@ process.stdin.on('end', () => {
     process.exit(0);
   }
 
-  // Build reminder message
-  const spawn = `${process.env.CLAUDE_PLUGIN_ROOT || '.'}/skills/kage-bunshin/scripts/spawn.py`;
-  const sessionList = sessions.map((s) => `  - ${s}`).join('\n');
-  const commands = sessions
-    .map((s) => {
-      const match = s.match(/_worktree-(.+)$/);
-      const name = match ? match[1] : s;
-      return `  uv run ${spawn} read --name ${name}  # check if idle (❯) or working\n  uv run ${spawn} stop --name ${name}  # graceful Ctrl-C shutdown`;
-    })
-    .join('\n');
-  const fullMessage = [
-    `Kage-bunshin worktree sessions still running (${sessions.length}):`,
-    sessionList,
-    '',
-    'Check state then gracefully stop:',
-    commands,
-    '',
-    `List all sessions: uv run ${spawn} list`,
-  ].join('\n');
-
-  // Truncate to 500 chars — injected on every task completion; 51 firings × full message
-  // consumed 105K+ chars. The orchestrator needs session count and registry path only;
-  // full command listings can be found in the registry file.
-  const MAX_CHARS = 500;
-  const message =
-    fullMessage.length > MAX_CHARS
-      ? `${fullMessage.slice(0, MAX_CHARS)}\u2026[truncated \u2014 full details at: ${registryPath}]`
-      : fullMessage;
+  // Emit metadata-only: session count + registry path.
+  // Full session details (tmux names, commands) are in the registry file.
+  const message = `${sessions.length} kage-bunshin session(s) still running. Registry: ${registryPath}`;
 
   const output = {
     systemMessage: message,

--- a/plugins/development-harness/hooks/task-completed-kage-bunshin-reminder.cjs
+++ b/plugins/development-harness/hooks/task-completed-kage-bunshin-reminder.cjs
@@ -128,7 +128,30 @@ process.stdin.on('end', () => {
 
   // Emit metadata-only: session count + registry path.
   // Full session details (tmux names, commands) are in the registry file.
-  const message = `${sessions.length} kage-bunshin session(s) still running. Registry: ${registryPath}`;
+  // Bound the message to MAX_MESSAGE_LEN — long deep-checkout repoRoots can
+  // otherwise push the message past the documented limit. Filename is kept
+  // intact; the directory portion is elided from the front when needed.
+  const MAX_MESSAGE_LEN = 200;
+  const ELLIPSIS = '\u2026';
+  const prefix = `${sessions.length} kage-bunshin session(s) still running. Registry: `;
+  const pathBudget = MAX_MESSAGE_LEN - prefix.length;
+  let displayPath = registryPath;
+  if (displayPath.length > pathBudget) {
+    if (pathBudget <= ELLIPSIS.length) {
+      displayPath = ELLIPSIS;
+    } else {
+      const filename = path.basename(displayPath);
+      const sep = path.sep;
+      const room = pathBudget - filename.length - ELLIPSIS.length - sep.length;
+      if (room <= 0) {
+        displayPath = ELLIPSIS + filename.slice(-(pathBudget - ELLIPSIS.length));
+      } else {
+        const dir = path.dirname(displayPath);
+        displayPath = ELLIPSIS + dir.slice(-room) + sep + filename;
+      }
+    }
+  }
+  const message = prefix + displayPath;
 
   const output = {
     systemMessage: message,


### PR DESCRIPTION
## Summary

- Replaces the verbose tmux session listing + spawn.py command block with a single metadata line: session count + registry path
- Removes the `MAX_CHARS = 500` truncation workaround — the correct fix is never building verbose content in the first place
- Output is consistently under 200 chars regardless of session count or path length

## Root cause

The hook built a `fullMessage` containing tmux session names and `uv run spawn.py` command strings, then tried to limit damage with a 500-char truncation. This violates the \"check state = metadata only\" rule and still injected ~500 chars of unnecessary detail per TaskCompleted event. 51 firings × full message consumed 105K+ chars per session.

## Acceptance criteria verification

```
echo '{\"hook_event_name\":\"TaskCompleted\",\"session_id\":\"test123\"}' | node ./hooks/task-completed-kage-bunshin-reminder.cjs
# → {\"systemMessage\":\"2 kage-bunshin session(s) still running. Registry: /path/to/registry-test123.json\"}
```

- [x] `systemMessage` under 200 chars
- [x] Contains registry file path
- [x] Contains session count
- [x] No `_worktree-` pattern in message
- [x] No `uv run` strings in message
- [x] `MAX_CHARS = 500` block removed
- [x] `uv run prek run --files ...` exits 0

Closes #1044

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_