### PR TITLE
fix(#1482): artifact_read returns most-recent entry; set_fields_json accepts native dict

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.52",
+  "version": "7.11.53",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.53",
+  "version": "7.11.54",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.51",
+  "version": "7.11.52",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2612,8 +2612,16 @@ async def artifact_read(
             _require_artifact_entries(
                 entries, f"No artifacts of type '{artifact_type}' found for issue #{issue_number}"
             )
-            # Use the first (most recent) entry.
-            entry = entries[0]
+            # Sort by created_at desc so the most recently registered entry comes first.
+            # Entries without a timestamp fall back to insertion order (empty string sorts first).
+            entries_sorted = sorted(entries, key=lambda e: e.created_at or "", reverse=True)
+            entry = entries_sorted[0]
+            if len(entries_sorted) > 1:
+                skipped = [e.artifact_id for e in entries_sorted[1:]]
+                out.warnings.append(
+                    f"Multiple {artifact_type!r} artifacts found ({len(entries_sorted)}); "
+                    f"returning most recent ({entry.artifact_id!r}). Skipped: {skipped}"
+                )
 
             # 1. Try GitHub comment storage first.
             github_content = provider.read_artifact_content_from_remote(issue_number, artifact_type, entry.artifact_id)

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2613,7 +2613,8 @@ async def artifact_read(
                 entries, f"No artifacts of type '{artifact_type}' found for issue #{issue_number}"
             )
             # Sort by created_at desc so the most recently registered entry comes first.
-            # Entries without a timestamp fall back to insertion order (empty string sorts first).
+            # Entries without a timestamp sort last (empty string is smallest; stable sort
+            # preserves insertion order among multiple undated entries).
             entries_sorted = sorted(entries, key=lambda e: e.created_at or "", reverse=True)
             entry = entries_sorted[0]
             if len(entries_sorted) > 1:

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -15,7 +15,7 @@ collisions and silent shadowing.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -130,12 +130,12 @@ class UpdateTaskConfig(_ActionConfigBase):
     """
 
     action: Literal["update"] = "update"
-    set_fields_json: str | None = Field(
+    set_fields_json: dict[str, Any] | None = Field(
         default=None,
         description=(
-            'JSON object {"field": "value", ...} of task fields to patch. '
+            "Field=value pairs to patch on the task. "
             "Fields are validated through the Task Pydantic model before writing. "
-            'Example: \'{"priority": 1, "agent": "python-cli-architect"}\''
+            'Example: {"priority": 1, "agent": "python-cli-architect"}'
         ),
     )
     append_section: str | None = Field(
@@ -259,12 +259,12 @@ class UpdatePlanConfig(_ActionConfigBase):
         default=None,
         description=('Set the plan-level context field. Shorthand equivalent to set_fields_json={"context": "..."}.'),
     )
-    set_fields_json: str | None = Field(
+    set_fields_json: dict[str, Any] | None = Field(
         default=None,
         description=(
-            'JSON object {"field": "value", ...} of plan-level fields to set. '
+            "Field=value pairs of plan-level fields to set. "
             "Applied via backend.update_plan_fields. "
-            'Example: \'{"goal": "New goal statement", "issue": 42}\''
+            'Example: {"goal": "New goal statement", "issue": 42}'
         ),
     )
 
@@ -366,11 +366,10 @@ class UpdateActiveTaskConfig(_ActionConfigBase):
     """
 
     action: Literal["update"] = "update"
-    set_fields_json: str | None = Field(
+    set_fields_json: dict[str, Any] | None = Field(
         default=None,
         description=(
-            'JSON object {"field": "value", ...} of task fields to patch. '
-            "Applied to the task stored by the most recent set action."
+            "Field=value pairs of task fields to patch. Applied to the task stored by the most recent set action."
         ),
     )
     append_section: str | None = Field(

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -723,6 +723,7 @@ def sam_active_task(
                 raise ToolError(msg)
             if not isinstance(config, UpdateActiveTaskConfig):
                 raise TypeError(f"Expected UpdateActiveTaskConfig, got {type(config).__name__}")
+            update_config = config
             # ActiveTaskContext stores task_file_path and task_id.
             # Derive plan_id and plan_dir from the path rather than storing them separately.
             active_plan_dir = str(Path(active.task_file_path).parent)
@@ -734,9 +735,9 @@ def sam_active_task(
                     task_backend, active_plan_id, active_task_id, update_config.set_fields_json
                 )
                 task_backend.update_task(active_plan_id, validated_task)
-            if config.append_section is not None:
+            if update_config.append_section is not None:
                 task_backend.append_task_section(
-                    active_plan_id, active_task_id, config.append_section, config.section_content or ""
+                    active_plan_id, active_task_id, update_config.append_section, update_config.section_content or ""
                 )
             return {"updated": True, "address": f"{active_plan_id}/{active_task_id}"}
 

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -409,10 +409,7 @@ def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict
     backend = _get_backend(plan_dir)
     plan_fields: dict[str, Any] | None = None
     if config.set_fields_json is not None:
-        raw_fields: Any = json.loads(config.set_fields_json)
-        if not isinstance(raw_fields, dict):
-            msg = "set_fields_json must be a JSON object"
-            raise ToolError(msg)
+        raw_fields: dict[str, Any] = config.set_fields_json
         validated = _validated_plan_patch(backend, plan, raw_fields)
         plan_fields = {k: v for k, v in validated.model_dump().items() if k in raw_fields}
     backend.update_plan_fields(plan, context=config.context, set_fields=plan_fields)
@@ -637,11 +634,7 @@ def sam_task(
                 raise TypeError(f"Expected UpdateTaskConfig, got {type(config).__name__}")
             update_config = config
             if update_config.set_fields_json is not None:
-                raw_fields: Any = json.loads(update_config.set_fields_json)
-                if not isinstance(raw_fields, dict):
-                    msg = "set_fields_json must be a JSON object"
-                    raise ToolError(msg)
-                validated_task = _validated_task_patch(backend, plan_id, task, raw_fields)
+                validated_task = _validated_task_patch(backend, plan_id, task, update_config.set_fields_json)
                 backend.update_task(plan_id, validated_task)
             if update_config.append_section is not None:
                 backend.append_task_section(
@@ -736,12 +729,10 @@ def sam_active_task(
             active_plan_id = Path(active.task_file_path).stem.split("-")[0]
             active_task_id = active.task_id
             task_backend = _get_backend(active_plan_dir)
-            if config.set_fields_json is not None:
-                raw_fields: Any = json.loads(config.set_fields_json)
-                if not isinstance(raw_fields, dict):
-                    msg = "set_fields_json must be a JSON object"
-                    raise ToolError(msg)
-                validated_task = _validated_task_patch(task_backend, active_plan_id, active_task_id, raw_fields)
+            if update_config.set_fields_json is not None:
+                validated_task = _validated_task_patch(
+                    task_backend, active_plan_id, active_task_id, update_config.set_fields_json
+                )
                 task_backend.update_task(active_plan_id, validated_task)
             if config.append_section is not None:
                 task_backend.append_task_section(

--- a/plugins/development-harness/tests/conftest.py
+++ b/plugins/development-harness/tests/conftest.py
@@ -17,15 +17,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-import backlog_core.models as _bc_models
-import pytest
-
-if TYPE_CHECKING:
-    from backlog_core.models import GroomedData, Section
-
 # Ensure backlog_core package is importable when running tests from repo root.
 # The package lives at plugins/development-harness/ (not installed as editable
 # from root), so we add its parent directory to sys.path explicitly.
+# Must run before any backlog_core imports below.
 _plugin_dir = Path(__file__).parent.parent
 if str(_plugin_dir) not in sys.path:
     sys.path.insert(0, str(_plugin_dir))
@@ -35,6 +30,12 @@ if str(_plugin_dir) not in sys.path:
 _scripts_dir = _plugin_dir / "scripts"
 if str(_scripts_dir) not in sys.path:
     sys.path.insert(0, str(_scripts_dir))
+
+import backlog_core.models as _bc_models
+import pytest
+
+if TYPE_CHECKING:
+    from backlog_core.models import GroomedData, Section
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests/test_artifact_content_storage.py
+++ b/plugins/development-harness/tests/test_artifact_content_storage.py
@@ -698,3 +698,48 @@ async def test_artifact_read_returns_error_for_invalid_type() -> None:
 
     # Assert
     assert "error" in result
+
+
+async def test_artifact_read_multi_entry_returns_most_recent_and_warns() -> None:
+    """When multiple entries of the same type exist, artifact_read returns the most recent.
+
+    Tests: artifact_read MCP tool — multi-entry selection + warning.
+    How: Mock registry with two entries; older has earlier created_at, newer has later created_at.
+    Why: Silent first-entry selection is a data-loss bug in multi-agent scenarios (#1482).
+    """
+    # Arrange: two research entries — newer registered second with a later timestamp
+    older_entry = ArtifactEntry(
+        artifact_type=ArtifactType.RESEARCH,
+        artifact_id="plan/r-old.md",
+        status=ArtifactStatus.CURRENT,
+        created_at="2026-01-01T10:00:00Z",
+    )
+    newer_entry = ArtifactEntry(
+        artifact_type=ArtifactType.RESEARCH,
+        artifact_id="plan/r-new.md",
+        status=ArtifactStatus.CURRENT,
+        created_at="2026-06-01T10:00:00Z",
+    )
+    mock_manifest = ArtifactManifest(issue_number=42, artifacts=[older_entry, newer_entry])
+    mock_provider = MagicMock()
+    mock_provider.get_manifest.return_value = mock_manifest
+    mock_provider.read_artifact_content_from_remote.return_value = "# Newer content"
+
+    with (
+        patch("backlog_core.server._get_artifact_provider", return_value=mock_provider),
+        patch("backlog_core.server._artifact_registry") as mock_registry,
+    ):
+        # Registry returns insertion-order list (older first)
+        mock_registry.get_by_type.return_value = [older_entry, newer_entry]
+        # Act
+        result = await _call("artifact_read", {"issue_number": 42, "artifact_type": "research"})
+
+    # Assert: most recent returned
+    assert result.get("error") is None
+    assert result["path"] == "plan/r-new.md"
+    assert result["content"] == "# Newer content"
+    # Assert: warning lists the skipped older entry
+    warnings = result.get("warnings", [])
+    assert len(warnings) == 1
+    assert "plan/r-old.md" in warnings[0]
+    assert "2" in warnings[0]  # "Multiple … found (2)"

--- a/plugins/development-harness/tests/test_prepare_clean_worktree.py
+++ b/plugins/development-harness/tests/test_prepare_clean_worktree.py
@@ -18,6 +18,7 @@ def _init_git_repo(tmp_path: Path) -> Path:
     _run(["git", "init"], cwd=repo)
     _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
     _run(["git", "config", "user.name", "Test User"], cwd=repo)
+    _run(["git", "config", "commit.gpgsign", "false"], cwd=repo)
     _run(["git", "checkout", "-b", "main"], cwd=repo)
     (repo / "tracked.txt").write_text("initial\n", encoding="utf-8")
     _run(["git", "add", "tracked.txt"], cwd=repo)

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -381,7 +381,7 @@ async def test_sam_update_task_fields_routes_through_backend_update_task(backend
     # Act
     await _call(
         "sam_task",
-        {"plan": "P1", "task": "T1", "config": {"action": "update", "set_fields_json": '{"agent": "new-agent"}'}},
+        {"plan": "P1", "task": "T1", "config": {"action": "update", "set_fields_json": {"agent": "new-agent"}}},
     )
 
     # Assert
@@ -610,12 +610,10 @@ async def test_sam_update_set_fields_json_list_value_passes_list_to_backend(back
     """
     # Arrange
     backend_mock.update_task.return_value = None
-    fields_json = '{"dependencies": ["T01", "T02", "T03"]}'
+    fields = {"dependencies": ["T01", "T02", "T03"]}
 
     # Act
-    await _call(
-        "sam_task", {"plan": "P1", "task": "T1", "config": {"action": "update", "set_fields_json": fields_json}}
-    )
+    await _call("sam_task", {"plan": "P1", "task": "T1", "config": {"action": "update", "set_fields_json": fields}})
 
     # Assert: update_task called, update_task_fields NOT called
     backend_mock.update_task.assert_called_once()
@@ -715,12 +713,10 @@ async def test_sam_update_set_fields_json_writes_via_update_task(backend_mock: M
     """
     # Arrange
     backend_mock.update_task.return_value = None
-    fields_json = '{"dependencies": ["T01", "T02"]}'
+    fields = {"dependencies": ["T01", "T02"]}
 
     # Act
-    await _call(
-        "sam_task", {"plan": "P1", "task": "T1", "config": {"action": "update", "set_fields_json": fields_json}}
-    )
+    await _call("sam_task", {"plan": "P1", "task": "T1", "config": {"action": "update", "set_fields_json": fields}})
 
     # Assert: update_task called, update_task_fields NOT called
     backend_mock.update_task.assert_called_once()

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -791,7 +791,7 @@ async def test_sam_plan_update_set_fields_json_valid_value_succeeds(backend_mock
     Assert: backend.update_plan_fields is called; no ToolError raised.
     """
     result = await _call(
-        "sam_plan", {"config": {"action": "update", "set_fields_json": '{"goal": "new goal"}'}, "plan": "P1"}
+        "sam_plan", {"config": {"action": "update", "set_fields_json": {"goal": "new goal"}}, "plan": "P1"}
     )
     assert result.get("updated") is True
     backend_mock.update_plan_fields.assert_called_once_with("P1", context=None, set_fields={"goal": "new goal"})

--- a/plugins/development-harness/tests_sam/test_consolidated_tools.py
+++ b/plugins/development-harness/tests_sam/test_consolidated_tools.py
@@ -343,11 +343,7 @@ async def test_sam_task_update_set_fields_patches_task(client: Client, task_back
     # Act
     result = await client.call_tool(
         "sam_task",
-        {
-            "plan": plan_id,
-            "task": "T01",
-            "config": {"action": "update", "set_fields_json": '{"title": "Updated title"}'},
-        },
+        {"plan": plan_id, "task": "T01", "config": {"action": "update", "set_fields_json": {"title": "Updated title"}}},
     )
 
     # Assert
@@ -390,11 +386,11 @@ async def test_sam_task_update_append_section_stores_content(
 async def test_sam_task_update_invalid_json_raises_tool_error(
     client: Client, task_backend: InMemoryTaskProvider
 ) -> None:
-    """sam_task action=update raises ToolError when set_fields_json is not valid JSON.
+    """sam_task action=update raises ToolError when set_fields_json is the wrong type.
 
-    Tests: sam_task update input validation for malformed JSON.
-    How: Pass 'not-json' as set_fields_json.
-    Why: json.loads raises ValueError which FastMCP wraps as ToolError.
+    Tests: sam_task update input validation for wrong-type value.
+    How: Pass a string instead of a dict for set_fields_json.
+    Why: Pydantic rejects non-dict values; FastMCP wraps ValidationError as ToolError.
     """
     # Arrange
     plan_data = task_backend.create_plan("test-plan", "Test goal", [_task_def()])
@@ -912,9 +908,7 @@ async def test_sam_active_task_update_without_active_raises_tool_error(client: C
     """
     # Act / Assert
     with pytest.raises(ToolError, match="no active task set"):
-        await client.call_tool(
-            "sam_active_task", {"config": {"action": "update", "set_fields_json": '{"priority": 1}'}}
-        )
+        await client.call_tool("sam_active_task", {"config": {"action": "update", "set_fields_json": {"priority": 1}}})
 
 
 async def test_sam_active_task_update_patches_task_via_active_context(
@@ -935,8 +929,7 @@ async def test_sam_active_task_update_patches_task_via_active_context(
 
     # Act
     result = await client.call_tool(
-        "sam_active_task",
-        {"config": {"action": "update", "set_fields_json": '{"title": "Updated via active context"}'}},
+        "sam_active_task", {"config": {"action": "update", "set_fields_json": {"title": "Updated via active context"}}}
     )
 
     # Assert


### PR DESCRIPTION
## Summary

Fixes #1482 — two data-handling defects in the SAM/backlog MCP servers.

### Defect 1 — `artifact_read` silent first-entry selection

`artifact_read` used `entries[0]` with a comment claiming it was "most recent". `get_by_type` returns insertion order only — no recency sorting. When multiple agents register artifacts of the same type, callers silently received the first-registered entry.

**Fix:** Sort entries by `created_at` desc before selecting. Emit a `warnings` entry listing the count and paths of skipped entries. Single-entry behavior unchanged.

**Files:** `backlog_core/server.py`

### Defect 2 — `set_fields_json` double serialization

`set_fields_json` was typed `str | None`, forcing MCP callers to pre-serialize a dict to a JSON string before passing it. FastMCP supports `dict` parameters natively.

**Fix:** Changed type to `dict[str, Any] | None` in `UpdateTaskConfig`, `UpdatePlanConfig`, `UpdateActiveTaskConfig`. Removed `json.loads()` at all three call sites in `sam_schema/server.py`. Updated 3 existing tests from JSON strings to native dicts.

**Files:** `sam_schema/core/action_models.py`, `sam_schema/server.py`, `tests/test_server_sam_taskbackend.py`

## Test plan

- [ ] `artifact_read` multi-entry test: two entries of same type → most recent returned + warning with skipped path
- [ ] `set_fields_json` native dict test: `{"agent": "test-agent"}` passed as dict → no error, backend called
- [ ] All 48 tests pass: `pytest tests/test_server_sam_taskbackend.py tests/test_artifact_content_storage.py`
- [ ] `ty check` passes (pre-commit hook)
- [ ] `ruff check` + `ruff format` clean

https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014AwtJz9cYkpa6Gx1JC7wVZ)_