### PR TITLE
docs(claude-md): add Investigation Escalation Hard-Stop (restored from stale #683)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,6 +100,12 @@ When ANY tool use is denied by the user:
 
 Reason: Permission denial is a user boundary signal. Some commands are blocked because safer alternatives exist (e.g., `git checkout` is destructive — `git switch` is the safe equivalent). When no permitted alternative exists, state the block and wait for direction.
 
+**Investigation Escalation Hard-Stop:**
+
+Three or more Read/Grep/Bash calls on source files without an intervening Edit/Write or Task delegation are the trigger signal for investigation escalation.
+
+When triggered: STOP. Write the file paths and observations gathered so far into a delegation prompt. Do not read one more file. Delegate to a specialist agent.
+
 **Parallel execution rule**: When 2+ independent tasks need doing, use TeamCreate to dispatch parallel agents. Create the team, create tasks for tracking, spawn one agent per independent problem domain as a teammate. Teams are the standard mechanism for parallel work — not a special case. Do not serialize independent work.
 
 ---

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,9 +100,9 @@ When ANY tool use is denied by the user:
 
 Reason: Permission denial is a user boundary signal. Some commands are blocked because safer alternatives exist (e.g., `git checkout` is destructive — `git switch` is the safe equivalent). When no permitted alternative exists, state the block and wait for direction.
 
-**Investigation Escalation Hard-Stop:**
+### Investigation Escalation Hard-Stop
 
-Three or more Read/Grep/Bash calls on source files without an intervening Edit/Write or Task delegation are the trigger signal for investigation escalation.
+Three or more Read/Grep/Bash calls on source files without an intervening Edit/Write or delegating to a specialist agent are the trigger signal for investigation escalation.
 
 When triggered: STOP. Write the file paths and observations gathered so far into a delegation prompt. Do not read one more file. Delegate to a specialist agent.
 


### PR DESCRIPTION
Replaces #683 (closed as stale — 50 commits behind main, no merge-base, 37k+ disjoint additions).

## Background

PR #683 attempted to apply remaining orchestrator anti-pattern fixes from `plans/delegation_improvements.md`. Per its own description, "Most changes were merged to main via prior sessions". The branch also added a parallel `packages/sam_schema/` directory that has since been superseded by `plugins/development-harness/sam_schema/`. The CLAUDE.md edits in #683 also removed sections that have since been added to main (Standard of Excellence, Plugin runtime files, MCP server validation), making a direct rebase regression-prone.

This PR cherry-picks the **only** unique, still-applicable contribution from #683: the Investigation Escalation Hard-Stop rule.

## Change

Adds a new section to `.claude/CLAUDE.md` immediately after the `Tool Use Denial Protocol`:

> **Investigation Escalation Hard-Stop:**
>
> Three or more Read/Grep/Bash calls on source files without an intervening Edit/Write or Task delegation are the trigger signal for investigation escalation.
>
> When triggered: STOP. Write the file paths and observations gathered so far into a delegation prompt. Do not read one more file. Delegate to a specialist agent.

This formalises a behavioural constraint that complements the existing `Pass file paths, let agents read` rule (line 64) and the `agent-orchestration` skill — without it, an orchestrator can drift into open-ended investigation instead of delegating.

## Test plan

- [ ] `uv run prek run --files .claude/CLAUDE.md` (markdownlint passes)
- [ ] Section renders with correct anchor on GitHub

Replaces #683.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaBiBeBhn24ReXJtJAPztJ)_