### PR TITLE
fix(test): correct test_mcp_null_scalar_preserved assertion (false-fail from #1930)

### DIFF
--- a/plugins/plugin-creator/tests/test_frontmatter_fixes.py
+++ b/plugins/plugin-creator/tests/test_frontmatter_fixes.py
@@ -92,11 +92,15 @@ class TestMcpBlockPreservation:
 
         # Serialized output preserves the mcp key.
         assert "mcp:" in result
+        # Both parsed metadata objects MUST contain the mcp key explicitly
+        # (.get() would return None for a missing key, which would silently pass).
+        assert "mcp" in post.metadata
+        assert "mcp" in reloaded.metadata
         # Round-trip preserves None on the original parsed metadata.
-        assert post.metadata.get("mcp") is None
+        assert post.metadata["mcp"] is None
         # Re-loading the dumped output also returns None (not a dict — the
         # emitter must not have produced a block-mapping).
-        assert reloaded.metadata.get("mcp") is None
+        assert reloaded.metadata["mcp"] is None
 
     def test_description_with_colon_still_detected_after_mcp_null(self) -> None:
         """Non-mcp fields after mcp: null are loaded correctly (no state bleed).

--- a/plugins/plugin-creator/tests/test_frontmatter_fixes.py
+++ b/plugins/plugin-creator/tests/test_frontmatter_fixes.py
@@ -74,12 +74,14 @@ class TestMcpBlockPreservation:
         assert "URL: https://example.com/docs" in result
 
     def test_mcp_null_scalar_preserved(self) -> None:
-        """mcp: null scalar survives a round-trip without becoming a block.
+        """mcp: null scalar survives a round-trip; reload returns None.
 
-        Asserts both that the serialized output retains the scalar form
-        ``mcp: null`` (not a block ``mcp:\n`` followed by indented children)
-        and that re-loading the dumped output round-trips ``None`` back into
-        metadata.
+        Verifies both the original parsed metadata and the re-loaded dumped
+        output preserve ``None`` on the ``mcp`` key. The exact serialized form
+        (``mcp:`` vs ``mcp: null`` vs ``mcp: ~``) is the YAML emitter's choice;
+        what matters is that re-loading the dump yields ``None`` and that the
+        emitter does not produce a block-mapping (``mcp:`` followed by indented
+        child keys), which would change the value from None to a dict.
         """
         from frontmatter_utils import dump_frontmatter, loads_frontmatter
 
@@ -88,12 +90,12 @@ class TestMcpBlockPreservation:
         result = dump_frontmatter(post)
         reloaded = loads_frontmatter(result)
 
-        # Serialized output preserves the scalar form, not the block form.
-        assert "mcp: null" in result
-        assert "mcp:\n" not in result
+        # Serialized output preserves the mcp key.
+        assert "mcp:" in result
         # Round-trip preserves None on the original parsed metadata.
         assert post.metadata.get("mcp") is None
-        # Re-loading the dumped output also returns None.
+        # Re-loading the dumped output also returns None (not a dict — the
+        # emitter must not have produced a block-mapping).
         assert reloaded.metadata.get("mcp") is None
 
     def test_description_with_colon_still_detected_after_mcp_null(self) -> None:


### PR DESCRIPTION
Quick fix for a test assertion I introduced in #1930 that doesn't match ruamel.yaml's actual emitter behavior.

## Problem

`test_mcp_null_scalar_preserved` asserts `"mcp: null" in result`, but ruamel.yaml emits null values as `mcp:` (key with empty value), not `mcp: null`. Both forms are valid YAML representations of null. The assertion was therefore always false on dumped output, breaking CI on any PR running tests after #1930 merged.

## Fix

Soften the assertions to verify what actually matters:
- `mcp:` key is present in the serialized output
- Re-loading the dumped output returns `None` for `mcp` (which would be `False` if the emitter had produced a block mapping — the regression we actually want to catch)

This preserves the regression-protection intent without false-positive failures.

## Test plan

- [ ] `uv run pytest plugins/plugin-creator/tests/test_frontmatter_fixes.py -v` exits 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaBiBeBhn24ReXJtJAPztJ)_