### PR TITLE
fix(sam_schema): restore #1926 (Plan.model_validate guardrail for set_fields_json)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.315"
+    "version": "6.3.316"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.314"
+    "version": "6.3.315"
   },
   "plugins": [
     {

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.49",
+  "version": "7.11.50",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.11.48",
+  "version": "7.11.49",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -258,6 +258,32 @@ def _validated_task_patch(backend: TaskBackend, plan_id: str, task_id: str, raw_
     return Task.model_validate({**current.model_dump(), **raw_fields})
 
 
+def _validated_plan_patch(backend: TaskBackend, plan_id: str, raw_fields: dict[str, Any]) -> Plan:
+    """Validate raw JSON patch fields through the Pydantic Plan model.
+
+    Reads the current plan, merges *raw_fields* into its data, then passes the
+    merged dict through ``Plan.model_validate`` so field validators run (e.g.
+    ``coerce_issue_to_str`` normalises the ``issue`` field).  Returns the
+    fully-validated Plan model so callers use normalized field values, not the
+    raw input.
+
+    Args:
+        backend: Active TaskBackend instance.
+        plan_id: Backend-assigned plan identifier.
+        raw_fields: JSON-decoded patch dict from ``set_fields_json``.
+
+    Returns:
+        Fully-validated Plan model with the patched fields applied.
+
+    Raises:
+        PlanNotFoundError: When plan_id cannot be resolved by the backend.
+        pydantic.ValidationError: When a field value fails Plan model validation.
+    """
+    plan_data = backend.read_plan(plan_id)
+    current = Plan.model_validate(plan_data)
+    return Plan.model_validate({**current.model_dump(), **raw_fields})
+
+
 # Actions that require the ``plan`` parameter to be supplied.
 _SAM_PLAN_REQUIRED_ACTIONS: frozenset[str] = frozenset({"read", "status", "ready", "update", "append_task", "finalize"})
 
@@ -383,12 +409,13 @@ def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict
         Dict with ``updated`` (bool) and ``address`` (plan identifier) keys.
     """
     backend = _get_backend(plan_dir)
-    plan_fields: dict[str, str | int | list[str]] | None = None
+    plan_fields: dict[str, Any] | None = None
     if config.set_fields_json is not None:
         raw_fields: Any = json.loads(config.set_fields_json)
         if not isinstance(raw_fields, dict):
-            raise ValueError("set_fields_json must be a JSON object")
-        plan_fields = cast("dict[str, str | int | list[str]]", raw_fields)
+            raise ToolError("set_fields_json must be a JSON object")
+        validated = _validated_plan_patch(backend, plan, raw_fields)
+        plan_fields = {k: v for k, v in validated.model_dump().items() if k in raw_fields}
     backend.update_plan_fields(plan, context=config.context, set_fields=plan_fields)
     return {"updated": True, "address": plan}
 

--- a/plugins/development-harness/sam_schema/server.py
+++ b/plugins/development-harness/sam_schema/server.py
@@ -413,7 +413,8 @@ def _sam_plan_update(plan: str, config: UpdatePlanConfig, plan_dir: str) -> dict
     if config.set_fields_json is not None:
         raw_fields: Any = json.loads(config.set_fields_json)
         if not isinstance(raw_fields, dict):
-            raise ToolError("set_fields_json must be a JSON object")
+            msg = "set_fields_json must be a JSON object"
+            raise ToolError(msg)
         validated = _validated_plan_patch(backend, plan, raw_fields)
         plan_fields = {k: v for k, v in validated.model_dump().items() if k in raw_fields}
     backend.update_plan_fields(plan, context=config.context, set_fields=plan_fields)
@@ -512,10 +513,11 @@ def sam_plan(
         ToolError: When ``plan`` is None for an action that requires it.
     """
     if config.action in _SAM_PLAN_REQUIRED_ACTIONS and plan is None:
-        raise ToolError(
+        msg = (
             f"sam_plan: action='{config.action}' requires the 'plan' parameter "
             f"(e.g., plan='P1'). Actions that do not need 'plan': list, create."
         )
+        raise ToolError(msg)
 
     match config.action:
         case "read":
@@ -535,7 +537,8 @@ def sam_plan(
         case "finalize":
             return _sam_plan_finalize(cast("str", plan), plan_dir)
         case _:  # pragma: no cover
-            raise ValueError(f"sam_plan: unhandled action '{config.action}'")
+            msg = f"sam_plan: unhandled action '{config.action}'"
+            raise ValueError(msg)
 
 
 @mcp.tool(
@@ -620,7 +623,8 @@ def sam_task(
             if update_config.set_fields_json is not None:
                 raw_fields: Any = json.loads(update_config.set_fields_json)
                 if not isinstance(raw_fields, dict):
-                    raise ToolError("set_fields_json must be a JSON object")
+                    msg = "set_fields_json must be a JSON object"
+                    raise ToolError(msg)
                 validated_task = _validated_task_patch(backend, plan_id, task, raw_fields)
                 backend.update_task(plan_id, validated_task)
             if update_config.append_section is not None:
@@ -630,7 +634,8 @@ def sam_task(
             return {"updated": True, "address": f"{plan}/{task}"}
 
         case _:  # pragma: no cover
-            raise ValueError(f"sam_task: unhandled action '{config.action}'")
+            msg = f"sam_task: unhandled action '{config.action}'"
+            raise ValueError(msg)
 
 
 @mcp.tool(
@@ -701,10 +706,11 @@ def sam_active_task(
         case "update":
             active = ctx_backend.get_active_task(resolved_session)
             if active is None:
-                raise ToolError(
+                msg = (
                     "sam_active_task: no active task set for this session. "
                     "Call sam_active_task(action='set', plan=..., task=...) first."
                 )
+                raise ToolError(msg)
             update_config = cast("UpdateActiveTaskConfig", config)
             # ActiveTaskContext stores task_file_path and task_id.
             # Derive plan_id and plan_dir from the path rather than storing them separately.
@@ -715,7 +721,8 @@ def sam_active_task(
             if update_config.set_fields_json is not None:
                 raw_fields: Any = json.loads(update_config.set_fields_json)
                 if not isinstance(raw_fields, dict):
-                    raise ToolError("set_fields_json must be a JSON object")
+                    msg = "set_fields_json must be a JSON object"
+                    raise ToolError(msg)
                 validated_task = _validated_task_patch(task_backend, active_plan_id, active_task_id, raw_fields)
                 task_backend.update_task(active_plan_id, validated_task)
             if update_config.append_section is not None:
@@ -729,4 +736,5 @@ def sam_active_task(
             return {"cleared": removed}
 
         case _:  # pragma: no cover
-            raise ValueError(f"sam_active_task: unhandled action '{config.action}'")
+            msg = f"sam_active_task: unhandled action '{config.action}'"
+            raise ValueError(msg)

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -799,4 +799,3 @@ async def test_sam_plan_update_set_fields_json_valid_value_succeeds(backend_mock
     )
     assert result.get("updated") is True
     backend_mock.update_plan_fields.assert_called_once_with("P1", context=None, set_fields={"goal": "new goal"})
-

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -761,3 +761,42 @@ async def test_sam_active_task_set_get_round_trip_persists_parent_issue_number(b
         assert active_task.get("parent_issue_number") == 42
     finally:
         reset_context_config()
+
+
+# ---------------------------------------------------------------------------
+# Plan-level set_fields_json validation (fix #1512)
+# ---------------------------------------------------------------------------
+
+
+async def test_sam_plan_update_set_fields_json_invalid_enum_raises_tool_error(backend_mock: MagicMock) -> None:
+    """sam_plan action=update with set_fields_json validates fields through Plan model.
+
+    Plan-level set_fields_json must route through Plan.model_validate, not cast().
+    Passing an invalid enum value for `state` must raise ToolError, not silently
+    accept the invalid value.
+
+    Arrange: inject mock backend.
+    Act: call sam_plan with action=update, plan='P1', set_fields_json containing
+         an invalid PlanState enum value.
+    Assert: ToolError is raised (pydantic.ValidationError propagates as ToolError).
+    """
+    with pytest.raises(ToolError):
+        await _call(
+            "sam_plan", {"config": {"action": "update", "set_fields_json": '{"state": "invalid-value"}'}, "plan": "P1"}
+        )
+    backend_mock.update_plan_fields.assert_not_called()
+
+
+async def test_sam_plan_update_set_fields_json_valid_value_succeeds(backend_mock: MagicMock) -> None:
+    """sam_plan action=update with valid set_fields_json passes validation and calls backend.
+
+    Arrange: inject mock backend.
+    Act: call sam_plan with action=update, plan='P1', set_fields_json with a valid goal string.
+    Assert: backend.update_plan_fields is called; no ToolError raised.
+    """
+    result = await _call(
+        "sam_plan", {"config": {"action": "update", "set_fields_json": '{"goal": "new goal"}'}, "plan": "P1"}
+    )
+    assert result.get("updated") is True
+    backend_mock.update_plan_fields.assert_called_once_with("P1", context=None, set_fields={"goal": "new goal"})
+


### PR DESCRIPTION
Replaces #1926 (closed — merge-base too far back, file 3-way merge had unresolvable phantom conflict via API).

This PR adds the `_validated_plan_patch` helper to mirror the existing `_validated_task_patch` pattern, and re-points `_sam_plan_update` to use it.

## Changes

### `plugins/development-harness/sam_schema/server.py`

- **New helper** `_validated_plan_patch` (mirrors `_validated_task_patch`): reads the current plan, merges raw fields into `plan.model_dump()`, and runs `Plan.model_validate` so field validators execute.
- **`_sam_plan_update`** routes through the new helper and uses `ToolError` for non-dict JSON (consistent with task-level path).

### `plugins/development-harness/tests/test_server_sam_taskbackend.py`

Two new tests:
- `test_sam_plan_update_set_fields_json_invalid_enum_raises_tool_error` — passing `{"state": "invalid-value"}` raises `ToolError`; backend never called.
- `test_sam_plan_update_set_fields_json_valid_value_succeeds` — passing `{"goal": "new goal"}` succeeds and is forwarded to the backend.

## Test plan

- [ ] `uv run pytest plugins/development-harness/tests/test_server_sam_taskbackend.py -v` → all tests pass

Closes #1512. Replaces #1926.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaBiBeBhn24ReXJtJAPztJ)_