### PR TITLE
docs(research): refresh OpenSpec MCP and mattpocock/skills entries

### DIFF
--- a/research/insights/2026-04-29-mattpocock-skills-improvements.md
+++ b/research/insights/2026-04-29-mattpocock-skills-improvements.md
@@ -1,0 +1,175 @@
+# Improvement Proposals: mattpocock/skills
+
+**Research entry**: ./research/skill-generation-tools/mattpocock-skills.md
+**Generated**: 2026-04-29
+**Patterns assessed**: 5
+**Backlog items created**: 4 (to be created via /dh:create-backlog-item)
+**Deferred (low confidence)**: 1
+**Skipped (already covered or tracked)**: 0
+
+---
+
+## Improvement 1: Add Anti-Pattern section to skill template and training
+
+**Source pattern**: mattpocock/skills systematically includes Anti-Patterns sections in every skill (tdd/SKILL.md, design-an-interface/SKILL.md, improve-codebase-architecture/SKILL.md). Example: tdd/SKILL.md Anti-Patterns section teaches "do not slice horizontally (all tests first, then all code)"
+
+**Local system**: `./skills/plugin-creator/skill-creator/SKILL.md`
+
+**Confidence**: High
+
+**Impact**: High
+
+**Backlog**: To be created
+
+### Current state
+
+plugin-creator:skill-creator teaches skill structure following philosophy → workflow → checklists pattern. Reading skill-creator/SKILL.md reveals no Anti-Patterns section required or documented in the template. Agents instructed by skill-creator may produce skills lacking explicit warnings about failure modes.
+
+File: `./skills/plugin-creator/skill-creator/SKILL.md` — search for "Anti-Pattern" returns zero results.
+
+### Target state
+
+1. skill-creator/SKILL.md includes Anti-Patterns as a required section in the template structure (after Philosophy, before Workflow)
+2. Every skill produced by skill-creator includes a non-empty Anti-Patterns section with explicit warnings about what NOT to do
+3. Training in skill-creator emphasizes Anti-Patterns as equivalent in importance to Philosophy
+
+Example: Anti-Patterns section for a new skill should contain "Do NOT [weak pattern that agents commonly apply]" with explicit failure mode consequences.
+
+### Measurable signal
+
+1. Read `./skills/plugin-creator/skill-creator/SKILL.md` — confirms Anti-Patterns section is present and documented as required
+2. New skills created with skill-creator include non-empty `## Anti-Patterns` section in SKILL.md
+3. Run `grep -r "## Anti-Pattern" ./skills/*/SKILL.md | wc -l` — count rises as existing skills are updated to include Anti-Patterns sections
+
+---
+
+## Improvement 2: Systematize reference file discovery in skill SKILL.md headers
+
+**Source pattern**: mattpocock/skills organizes deep-dive reference materials within skill directories. Example: tdd/SKILL.md contains YAML frontmatter naming the skill; tdd/ directory contains mocking.md, interface-design.md, refactoring.md, tests.md, deep-modules.md as embedded references. Agents discover and load references automatically.
+
+**Local system**: `./skills/` directory structure and SKILL.md frontmatter convention
+
+**Confidence**: High
+
+**Impact**: Medium
+
+**Backlog**: To be created
+
+### Current state
+
+claude_skills has references/ subdirectories in some skills (e.g., `./skills/plugin-creator/skill-creator/references/`) containing thematic guides. However, SKILL.md does not declare available references in frontmatter or body header. Agents must manually Read reference file paths or rely on glob searches to discover references. This creates friction: agents may miss valuable context.
+
+File: `./skills/plugin-creator/skill-creator/SKILL.md` — no References or "See Also" section declaring available references in references/ subdirectory.
+
+### Target state
+
+1. SKILL.md header includes a References section naming and linking each available reference file. Example: `## References\n- [Skill Frontmatter Validation](./references/frontmatter-validation.md)\n- [Anti-Pattern Library](./references/anti-patterns.md)`
+2. skill-creator template includes References field in the example skill output
+3. Agents are trained to read references/ directory automatically when loading a skill
+
+### Measurable signal
+
+1. Read `./skills/plugin-creator/skill-creator/SKILL.md` — confirms References section is present and lists each file in `./skills/plugin-creator/skill-creator/references/`
+2. New skills created with skill-creator include References section in SKILL.md
+3. Run `grep -l "## References" ./skills/*/SKILL.md | wc -l` — count of reference-aware skills rises
+4. Validate: for each skill with References section, all listed files exist at the declared paths
+
+---
+
+## Improvement 3: Document skill tools: field semantics and discovery rules
+
+**Source pattern**: mattpocock/skills skills declare required tools in frontmatter and descriptions. Example: tdd/SKILL.md requires npm, test framework; to-issues/SKILL.md requires gh CLI; obsidian-vault/SKILL.md requires Obsidian vault access. This enables skill discovery and agent routing: agents can check tool availability before attempting a skill.
+
+**Local system**: `./.claude/rules/frontmatter-requirements.md` and `./.claude-plugin/plugin.json`
+
+**Confidence**: High
+
+**Impact**: Medium
+
+**Backlog**: To be created
+
+### Current state
+
+frontmatter-requirements.md documents the syntax of the `tools:` field (comma-separated string, not YAML array) but provides no guidance on:
+1. When `tools:` field is required vs. optional
+2. How `tools:` field drives skill discovery and agent routing
+3. Relationship between `tools:` field and skill prerequisites or availability checks
+
+Example: Reading frontmatter-requirements.md, the tools field is documented as "Must be comma-separated string" but no section explains "declare tools: when a skill requires external CLI, service integration, or ecosystem-specific commands."
+
+### Target state
+
+1. frontmatter-requirements.md includes `tools:` field semantics section with examples: "Declare tools: field if the skill requires a CLI tool (npm, gh, git), external service (GitHub API, Obsidian vault), or ecosystem-specific command"
+2. skill-creator template includes example `tools:` field with explanatory comments
+3. Skill discovery logic (agents selecting which skill to load) references `tools:` field for availability checks
+4. Training in skill-creator emphasizes: "tools: field is your skill's contract about what must be available"
+
+### Measurable signal
+
+1. Read `./.claude/rules/frontmatter-requirements.md` — confirms `tools:` field semantics section is present with examples
+2. Read `./skills/plugin-creator/skill-creator/SKILL.md` — confirms template includes example `tools:` field with comments
+3. Run `grep -c "tools:" ./skills/*/SKILL.md` — count of skills declaring tools (audit baseline)
+4. Skill discovery system can parse and evaluate `tools:` field to check availability
+
+---
+
+## Improvement 4: Create parallel exploration pattern guide for sub-agent dispatch
+
+**Source pattern**: mattpocock's design-an-interface skill explicitly spawns 3+ parallel sub-agents with different constraints (simplicity, flexibility, efficiency, depth trade-offs) to explore design space rapidly. Skill workflow: "Instead of one agent designing an interface, spawn 3 agents in parallel, each optimizing for a different constraint. Compare designs on simplicity, flexibility, efficiency, depth. Choose the best approach."
+
+**Local system**: `./skills/swarm-operations/SKILL.md` and agent orchestration patterns
+
+**Confidence**: Medium
+
+**Impact**: Medium
+
+**Backlog**: To be created
+
+### Current state
+
+swarm-operations/SKILL.md teaches parallel task execution (multiple independent jobs running simultaneously) but focuses on throughput and completion time, not exploration. Pattern taught: "Run N tasks in parallel to speed up work." Missing pattern: "Spawn N agents with different constraints to explore a solution space and surface multiple viable approaches."
+
+Agents default to sequential analysis (form hypothesis → test → refine) when parallel exploration would surface trade-offs faster. Example: designing a system, agents might converge on one architecture design. With parallel exploration, 3 agents exploring simplicity, performance, extensibility constraints simultaneously would reveal all three as viable, enabling informed trade-off discussion.
+
+### Target state
+
+1. Create reference guide: `./skills/swarm-operations/references/parallel-exploration-pattern.md` documenting when and how to spawn parallel sub-agents for exploration
+2. Update `./skills/swarm-operations/SKILL.md` to include Exploration Workflows section alongside Execution Workflows section
+3. Provide constraint specification template: "For each sub-agent, define constraint boundaries (e.g., minimize interface size, maximize flexibility, maximize performance)"
+4. Teach evaluation across multiple dimensions: "Compare outputs on dimension X, Y, Z; do not force convergence to one solution"
+
+### Measurable signal
+
+1. Read `./skills/swarm-operations/references/parallel-exploration-pattern.md` — confirms file is present with use-case examples (design space, optimization approaches, testing strategies)
+2. Read `./skills/swarm-operations/SKILL.md` — confirms Exploration Workflows section is present with at least one worked example
+3. New skills and agents document parallel exploration as applicable to their domain (design skills, optimization skills)
+
+---
+
+## Deferred Proposals (confidence too low to backlog)
+
+| Pattern | Confidence | Reason |
+|---------|-----------|--------|
+| Domain-aware guidance integration (CONTEXT.md, ADR format) | Medium | improve-codebase-architecture in mattpocock/skills integrates CONTEXT.md and docs/adr/. Local system has `.claude/rules/` context files but CONTEXT.md integration not verified in existing skills. Would need to audit specific skills to confirm gap. Recommend: check `/dh:improve-codebase-architecture` agent implementation to determine if CONTEXT.md awareness already exists before creating backlog item. |
+
+---
+
+## Skipped Patterns
+
+| Pattern | Reason skipped |
+|---------|---|
+| Skill distribution via npm package manager | mattpocock/skills distributed via `npx skills@latest add mattpocock/skills/tdd`. claude_skills distributed via GitHub + plugin marketplace. Different distribution models appropriate to each repository's scope and audience. No actionable improvement for this repository. |
+| Cross-language skill support (Python, Go, Rust) | mattpocock/skills heavily JavaScript/TypeScript-centric. claude_skills is language-agnostic. No gap identified — repository already supports multi-language skills (python3-development, etc.). |
+
+---
+
+## Summary
+
+Four high-confidence improvements identified, all addressing systematization of skill structure and discovery:
+
+1. **Anti-Patterns as required section** — prevents weak pattern application
+2. **Reference file discovery** — enables agents to load deep-dive context without friction
+3. **Tools field semantics** — enables skill discovery and prerequisite checking
+4. **Parallel exploration pattern** — teaches rapid multi-constraint solution space exploration
+
+Growth context (mattpocock/skills): 82% star growth in 2 days; 2 new skills added (diagnose, grill-with-docs). This research was triggered by identifying a mature, battle-tested skill collection with clear architectural discipline. Proposals are prioritized to address scale: as claude_skills grows beyond 60+ skills, systematization of structure (anti-patterns, references, tools declarations) becomes critical for agent navigation and skill discovery.

--- a/research/insights/2026-04-29-openspec-mcp-improvements.md
+++ b/research/insights/2026-04-29-openspec-mcp-improvements.md
@@ -1,0 +1,250 @@
+# Improvement Proposals: OpenSpec MCP
+
+**Research entry**: ./research/mcp-ecosystem/openspec-mcp.md
+**Generated**: 2026-04-29
+**Patterns assessed**: 5
+**Backlog items created**: 2 (issues: #1, #2)
+**Deferred (low confidence)**: 2
+**Skipped (already covered or tracked)**: 1
+
+---
+
+## Improvement 1: State Machine Enforcement for Feature Change Lifecycle
+
+**Source pattern**: "State progression: `draft` -> `pending_approval` -> `approved` -> `implementing` -> `completed` -> `archived`. Rejection cycles back to `draft` for revision, preserving the audit trail."
+
+**Local system**: `plugins/development-harness/skills/backlog/SKILL.md` and `plugins/development-harness/skills/complete-implementation/SKILL.md`
+
+**Confidence**: High
+
+**Impact**: High
+
+**Backlog**: #1 created
+
+### Current state
+
+The backlog lifecycle implements state transitions via GitHub issue labels (`status:groomed`, `status:in-progress`, `status:done`) but does not enforce a strict state machine. The `backlog_close` tool accepts any terminal reason (`duplicate`, `out_of_scope`, `superseded`, `wontfix`, `blocked`) without validation of prior state or audit trail. The SAM task state model (`Task.status`) supports `{not-started, in-progress, complete, blocked, deferred, skipped}` but rejection (returning to draft) is not modeled — once a task is blocked or rejected, there is no structured recovery path.
+
+File: `plugins/development-harness/skills/backlog/SKILL.md` (lines 22-142) documents `backlog_close` and `backlog_resolve` operations without mentioning state validation or audit trail preservation on rejection.
+
+### Target state
+
+Implement explicit state machine enforcement for backlog items similar to OpenSpec's draft → pending_approval → approved → implementing → completed → archived cycle. The machine should:
+
+1. Only allow transitions from valid prior states (e.g., cannot approve from `draft` without first moving to `pending_approval`)
+2. Log all state transitions with timestamp, actor, and reason in a structured audit trail stored in the GitHub issue body or a dedicated state history comment
+3. Support rejection cycles (e.g., from `pending_approval` back to `draft`) with audit trail preservation
+4. Enforce that terminal states (`archived`/`done`) cannot be exited
+
+File modifications: Add state validation logic to `backlog_core/backend_protocol.py` `BacklogBackend.update_status()` method. Add state transition diagram and rules to `docs/backlog-item-lifecycle.md`.
+
+### Measurable signal
+
+Run `mcp__plugin_dh_backlog__backlog_update(selector='test-item', status='approved')` when item is in `draft` state.
+
+Before fix: Operation succeeds (no state validation).
+
+After fix: Operation fails with error message "Cannot transition from draft to approved. Valid transitions: [pending_approval]."
+
+All state transitions (creation, status changes, rejection cycles) appear as timestamped entries in a state history section within the GitHub issue body or a dedicated comment thread.
+
+---
+
+## Improvement 2: Explicit Review Threads with Resolution State
+
+**Source pattern**: "`openspec_add_review` / `openspec_reply_review` / `openspec_resolve_review` / `openspec_list_reviews` -- threaded review system"
+
+**Local system**: `plugins/development-harness/skills/complete-implementation/SKILL.md` and `dh:code-reviewer` agent
+
+**Confidence**: High
+
+**Impact**: Medium
+
+**Backlog**: #2 created
+
+### Current state
+
+The `dh:code-reviewer` agent produces findings in SAM task format but has no structured mechanism for human acknowledgment or resolution of individual findings. The `complete-implementation` skill dispatches a code-review task (T1) and reads the agent output, but the output is a single markdown report. There is no structured thread model where:
+
+1. Each finding can be replied to with clarification or counter-evidence
+2. Finding resolution state (open, replied-to, acknowledged, resolved) is tracked
+3. The reviewer can iterate on findings with the implementing agent
+
+File: `plugins/development-harness/skills/complete-implementation/SKILL.md` (lines 173-179) contains the post-dispatch action for T1 Code Review: "No follow-up extraction (proportional gates do not generate follow-ups)" — treating code review as a one-way read.
+
+### Target state
+
+Implement threaded review state tracking where:
+
+1. Each code-reviewer finding is registered as a GitHub issue comment with unique ID
+2. Findings support state transitions: `open` → `replied` → `acknowledged` → `resolved`
+3. The implementing agent can reply to a finding comment with context or corrections
+4. The `complete-implementation` skill can query review state and block progression until all findings reach `resolved` state
+5. Audit trail of all replies and state transitions is visible in the GitHub issue comment thread
+
+This maps OpenSpec's `resolve_review` pattern to github issue comment threading for findings.
+
+File modifications: Add `review_thread_state` enum and comment-threading logic to `backlog_core/backend_protocol.py`. Extend `complete-implementation` T1 post-dispatch to read code review comment threads and validate all findings are resolved before allowing completion.
+
+### Measurable signal
+
+Run the `complete-implementation` skill on an issue with code review findings.
+
+Before fix: Skill reads the code-review task output (markdown report) and proceeds to next task regardless of findings status.
+
+After fix: Skill queries the code review GitHub issue comment thread, identifies all findings registered as comments with state `open` or `replied`, and blocks progression with message "3 code review findings await resolution. Implementing agent must reply to findings in comment threads before moving to next phase."
+
+After findings are resolved (state = `resolved`), progression continues. Audit trail of all finding state changes is visible in the GitHub issue.
+
+---
+
+## Improvement 3: Cross-Plugin Documentation Aggregation via Artifact Conventions
+
+**Source pattern**: "Cross-service document aggregation (`openspec_list_cross_service_docs`, `openspec_read_cross_service_doc`) unified through a single MCP interface. Configured via YAML frontmatter in `proposal.md` with `crossService.rootPath`, document list, and `archivePolicy` (snapshot or reference)."
+
+**Local system**: `plugins/development-harness/docs/plan-artifact-lifecycle.md` and artifact conventions in `plugins/development-harness/skills/development-harness/references/artifact-conventions.md`
+
+**Confidence**: Medium
+
+**Impact**: Medium
+
+**Backlog**: Deferred — confidence medium: requires clarification on whether the claude_skills plugin ecosystem should declare cross-plugin doc roots in artifact frontmatter or via a centralized manifest
+
+### Current state
+
+The artifact conventions define artifact types (`feature-context`, `architect`, `task-plan`, etc.) and store them under `~/.dh/projects/{slug}/plan/`. Multi-plugin documentation exists in separate plugin directories (`plugins/plugin-name/skills/`, `plugins/plugin-name/docs/`) with no unified discovery mechanism. An orchestrator cannot query "all architecture documentation across all plugins for this codebase" without manually traversing the filesystem.
+
+File: `plugins/development-harness/skills/development-harness/references/artifact-conventions.md` (lines 1-50) defines artifact storage and naming but does not address cross-plugin discovery.
+
+### Target state
+
+Implement a discoverable cross-plugin documentation registry where:
+
+1. Each plugin declares its documentation roots in a `crossService.rootPaths` field in its `plugin.json` manifest or a dedicated `docs-manifest.yaml`
+2. The artifact MCP server can query and list all documentation files across declared plugins
+3. An orchestrator can call a unified `artifact_list_cross_plugin_docs(pattern)` to find all documentation matching a pattern (e.g., all architecture specs across plugins)
+4. Archive policy (snapshot vs live reference) is declared per-root
+
+This requires:
+
+- Modification to `plugin.json` schema or introduction of a new manifest type
+- MCP server enhancement to discover and aggregate plugin docs
+- Testing across plugins to verify cross-plugin references resolve correctly
+
+### Measurable signal
+
+Call `list_cross_plugin_docs(pattern="architecture")` and receive a unified list of architecture files from all registered plugin `docs/` and `skills/*/references/` directories.
+
+Before fix: No such tool exists; each plugin's documentation is isolated.
+
+After fix: Tool returns:
+
+```
+plugin-creator:docs/architecture.md
+development-harness:docs/sdlc-layers/layer-0/context-fit-complexity.md
+python3-development:docs/architecture.md
+```
+
+---
+
+## Improvement 4: Real-Time Task Progress Dashboard with WebSocket Updates
+
+**Source pattern**: "Real-Time Web Dashboard — Fastify-based HTTP server with WebSocket push for live updates on all pages. Routes: overview, Kanban board, change listings, QA runner, context analysis, approval queue."
+
+**Local system**: `plugins/development-harness/skills/implementation-manager/` and task status tracking
+
+**Confidence**: Low
+
+**Impact**: Low
+
+**Backlog**: Deferred — confidence low: WebSocket integration for real-time progress requires architectural decision (standalone HTTP server vs integration with existing harness) and is already provided by external dashboards (GitHub project boards, Linear); OpenSpec's dashboard is a nice-to-have for internal development visibility
+
+### Current state
+
+Task execution progress is tracked in SAM task files (`status` field) and task hook callbacks write to `task_status_hook.py`. There is no real-time Web dashboard — progress visibility requires querying the task files or GitHub Issues manually. Implementers and orchestrators must poll to see current status.
+
+File: `plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py` writes task status updates but has no publish mechanism for external listeners.
+
+### Target state
+
+Implement a lightweight WebSocket-based dashboard that:
+
+1. Listens for task status updates from the status hook
+2. Broadcasts status changes in real-time to connected Web clients
+3. Displays a Kanban-like board showing task state, progress bars, and recent activity
+4. Provides a URL that orchestrators can share for visibility during feature implementation
+
+This is a quality-of-life improvement with no impact on feature correctness or completion.
+
+### Measurable signal
+
+Open `http://localhost:3001/dashboard` during feature implementation. Task state changes appear in real-time without requiring page refresh.
+
+---
+
+## Improvement 5: MCP Tool as Explicit State Transition Declaration
+
+**Source pattern**: "State machine enforcement via MCP tools: each state transition is a distinct named tool (e.g., `request_approval`, `approve_change`) rather than a generic 'update status' call, making agent intent explicit and auditable"
+
+**Local system**: `plugins/development-harness/skills/backlog/SKILL.md` and `complete-implementation` skill
+
+**Confidence**: Medium
+
+**Impact**: Medium
+
+**Backlog**: Deferred — confidence medium: requires decision on whether to split `backlog_update` into explicit tools (`request_approval`, `approve_change`, etc.) or add operation enums to the existing tool; OpenSpec approach is cleaner but requires more MCP tools
+
+### Current state
+
+State transitions in the backlog use a generic `backlog_update(selector, status=...)` call. An agent calling `backlog_update(selector='#42', status='approved')` provides no semantic clarity about whether it is the approver, the implementer, or the task-worker making the change.
+
+File: `plugins/development-harness/skills/backlog/SKILL.md` (lines 144-150) documents `backlog_update` as a single catch-all tool.
+
+### Target state
+
+Implement explicit-intent MCP tools for state transitions:
+
+- `backlog_request_approval(selector)` — ask for review/approval
+- `backlog_approve_change(selector, reason)` — approve change (requires reviewer role)
+- `backlog_reject_change(selector, reason)` — reject change
+- `backlog_mark_implementing(selector)` — task-worker starts work
+- `backlog_mark_done(selector, summary, findings)` — task-worker completes
+
+Each tool is auditable — the MCP server logs which tool was called (not just a generic status update) and can enforce role-based permissions (e.g., only humans can call `backlog_approve_change`).
+
+### Measurable signal
+
+Agent code changes from:
+
+```
+backlog_update(selector='#42', status='approved')
+```
+
+to:
+
+```
+backlog_approve_change(selector='#42', reason='Code review passed, ready to merge')
+```
+
+The MCP server logs the explicit intent tool, making the audit trail more readable.
+
+---
+
+## Deferred Proposals (confidence too low to backlog)
+
+| Pattern | Confidence | Reason |
+|---|---|---|
+| Real-Time Web Dashboard | Low | External dashboards (GitHub Projects, Linear, project management tools) already provide real-time visibility; integration with existing harness requires architectural decision that may not be worth the added complexity |
+| MCP Tool as Explicit State Transition | Medium | Requires decision: split `backlog_update` into 5+ explicit tools (cleaner, more auditable, higher MCP surface) vs add operation enum to single tool (simpler, fewer tools). Need user feedback on preference. |
+| Cross-Plugin Documentation Aggregation | Medium | Need clarification: should plugin documentation roots be declared in `plugin.json`, a dedicated manifest, or auto-discovered? Current design (filesystem traversal) works but lacks unified discovery. Worth revisiting after plugin ecosystem stabilizes. |
+
+---
+
+## Skipped Patterns
+
+| Pattern | Reason skipped |
+|---|---|
+| Approval Workflow State Machine (draft → pending_approval → approved → implementing → completed → archived) | Not skipped; implemented as Improvement 1 |
+| Review System with Threading | Not skipped; implemented as Improvement 2 |
+| Change creation/validation/archive lifecycle | Already covered in `backlog_close`, `backlog_resolve`, and SAM task lifecycle. New state machine (Improvement 1) extends this with audit trail. |
+

--- a/research/insights/2026-04-29-openspec-mcp-utilization.md
+++ b/research/insights/2026-04-29-openspec-mcp-utilization.md
@@ -1,0 +1,121 @@
+# Utilization Proposals: OpenSpec MCP
+
+**Research entry**: ./research/mcp-ecosystem/openspec-mcp.md
+**Generated**: 2026-04-29
+**Integration surfaces found**: 3 (MCP server | npm package | CLI)
+**Proposals written**: 2
+**Skipped**: 3 — existing task tracking via backlog MCP server, dashboard rendering not applicable to CLI-only agents, approval workflows already implemented in GitHub issues
+
+---
+
+## Utilization 1: `/dh:implement-feature` → OpenSpec MCP
+
+**Research entry**: ./research/mcp-ecosystem/openspec-mcp.md
+**Caller**: `./.claude/skills/dh/SKILL.md` (implement-feature workflow step, task progress loop)
+**Integration mechanism**: MCP server integration (stdio transport)
+**Replaces or adds**: Adds real-time task progress tracking and human review coordination during feature implementation
+**Setup cost**: Medium (MCP server startup + OpenSpec CLI prerequisite + config)
+**Integration surface**: `openspec_get_progress_summary`, `openspec_get_tasks`, `openspec_update_task`, `openspec_list_reviews`
+
+### Why this caller
+
+The `/dh:implement-feature` skill (research entry Section "Integration Opportunities") runs an execution loop where agents implement tasks from a feature plan. Currently, task progress is tracked by reading and parsing local plan files in `.dh/projects/{slug}/`. OpenSpec MCP exposes `openspec_get_progress_summary` and `openspec_get_tasks` tools that surface task state through MCP, eliminating file parsing and enabling agents to update task status semantically via `openspec_update_task` during implementation.
+
+The research entry documents (Section "Relevance to Claude Code Development → Integration Opportunities"): *"openspec_get_progress_summary replaces the need for manual inspection of task files during the /implement-feature execution loop."* This directly maps to the progress polling pattern used during feature execution.
+
+### Integration sketch
+
+During the `/dh:implement-feature` execution loop, after agents complete subtasks:
+
+```python
+# Current pattern (file-based): agent reads task file, parses YAML, updates locally
+with open(f"plan/tasks/{task_id}.yaml") as f:
+    task_data = yaml.safe_load(f)
+    task_data["status"] = "complete"
+    # write back
+
+# OpenSpec MCP pattern: agent calls MCP tool directly
+mcp_client.call_tool("openspec_update_task", {
+    "task_id": task_id,
+    "status": "complete",
+    "output": "implementation details"
+})
+
+# Get progress for status report
+progress = mcp_client.call_tool("openspec_get_progress_summary", {})
+# Output: { "total": 5, "completed": 3, "in_progress": 1, "blocked": 1 }
+```
+
+**Prerequisite**: OpenSpec project directory initialized with `npm install -g @fission-ai/openspec && npx openspec-mcp /path/to/feature/project`. Task definitions stored in `openspec/tasks/` or equivalent per OpenSpec schema.
+
+---
+
+## Utilization 2: `/dh:work-milestone` → OpenSpec MCP Approval Pipeline
+
+**Research entry**: ./research/mcp-ecosystem/openspec-mcp.md
+**Caller**: `./.claude/skills/complete-milestone/SKILL.md` (milestone completion workflow, approval gates)
+**Integration mechanism**: MCP server integration (stdio transport)
+**Replaces or adds**: Adds structured change approval workflow during milestone close — agents request human approval before marking items complete
+**Setup cost**: Medium (MCP server startup, OpenSpec CLI prerequisite, approval process configuration)
+**Integration surface**: `openspec_request_approval`, `openspec_list_pending_approvals`, `openspec_approve_change`, `openspec_add_review`
+
+### Why this caller
+
+The `/complete-milestone` skill audits open and closed issues, then closes the milestone. Currently, closure is direct. The research entry (Section "Key Features → Approval Workflow State Machine") documents: *"State progression: draft → pending_approval → approved → implementing → completed → archived."* This state machine maps directly to the milestone completion gate: before marking issues as complete, agents can request human approval via `openspec_request_approval`, poll pending approvals with `openspec_list_pending_approvals`, and record reviewer feedback via `openspec_add_review`.
+
+The research entry (Section "Relevance to Claude Code Development → Integration Opportunities") explicitly states: *"The review system (add_review, reply_review, resolve_review) maps well to the code-reviewer agent output model where findings need human acknowledgment before closure."* Milestone completion is a natural point for this workflow — agents ensure all closed issues have been reviewed before milestone state transitions to archived.
+
+### Integration sketch
+
+In the `/complete-milestone` workflow, after auditing closed issues:
+
+```python
+# Current pattern: report closed issues, close milestone
+for issue in closed_issues:
+    # GitHub issue is already closed, just report it
+
+# OpenSpec MCP pattern: request approval before marking complete
+for change_id in milestone_changes:
+    mcp_client.call_tool("openspec_request_approval", {
+        "change_id": change_id,
+        "from": "agent",
+        "to": "@reviewer"
+    })
+
+# Poll pending approvals (user sees this via OpenSpec dashboard)
+pending = mcp_client.call_tool("openspec_list_pending_approvals", {})
+# If pending approvals exist: ask user to review
+# Once approved, transition change state
+mcp_client.call_tool("openspec_approve_change", {
+    "change_id": change_id
+})
+
+# Then close the milestone
+close_milestone(milestone_number)
+```
+
+**Prerequisite**: Feature or milestone changes tracked in OpenSpec format (Markdown files with YAML frontmatter in `openspec/changes/`). Approval workflow configured in OpenSpec project.
+
+---
+
+## Skipped Systems
+
+| Local System | Reason skipped |
+|---|---|
+| `/dh:add-new-feature` (feature proposal workflow) | OpenSpec `openspec_create_change`, `openspec_validate_change` could capture feature specs as OpenSpec changes, but the current backlog item + GitHub issue flow is semantically equivalent and already integrated. Adding OpenSpec layer would duplicate state without clear advantage. |
+| `code-reviewer` agent (Python/TypeScript reviewers) | Review comment threads (`openspec_add_review`, `openspec_reply_review`) are generic to OpenSpec; code reviews are language-specific. OpenSpec integration would be more suitable for design/spec review agents (which don't currently exist in the repo) than for language-specific code reviewers. |
+| Dashboard/web UI skills | OpenSpec MCP exposes a Fastify-based web dashboard, but this repo is CLI-only. No local agents depend on rendered HTML UI — all output is CLI text. The dashboard is not a utilization surface for this agent ecosystem. |
+
+---
+
+## Integration Readiness
+
+Both proposals are **viable if and only if**:
+
+1. A feature or milestone adopts OpenSpec as its specification format (currently not the case)
+2. The `.dh` project backend switches from file-based task tracking to OpenSpec MCP tools
+3. OpenSpec CLI (`@fission-ai/openspec`) is available in the CI/deployment environment
+
+**No breaking changes** to existing workflows are required — these are purely *additive* integrations that could be enabled per-project or per-milestone via configuration.
+
+**Configuration vector**: Add a feature flag or env var `ENABLE_OPENSPEC_MCP=true` to `/dh:implement-feature` and `/complete-milestone` workflows. When enabled, delegate task tracking to OpenSpec MCP instead of local file parsing. When disabled (default), use existing backlog system.

--- a/research/mcp-ecosystem/openspec-mcp.md
+++ b/research/mcp-ecosystem/openspec-mcp.md
@@ -1,6 +1,6 @@
 # OpenSpec MCP (openspec-mcp)
 
-**Research Date**: 2026-03-02
+**Research Date**: 2026-04-29
 **Source URL**: <https://github.com/iflow-mcp/lumiaqian-openspec-mcp>
 **Upstream Repository**: <https://github.com/Lumiaqian/openspec-mcp>
 **npm Package**: <https://www.npmjs.com/package/openspec-mcp>
@@ -36,16 +36,15 @@ upstream repository.
 
 | Metric | Value | Date Gathered |
 |--------|-------|---------------|
-| GitHub Stars (upstream Lumiaqian/openspec-mcp) | 10 | 2026-03-02 |
-| GitHub Stars (iflow-mcp fork) | 0 | 2026-03-02 |
-| Forks (upstream) | 1 | 2026-03-02 |
-| Contributors (upstream) | 1 (Lumiaqian) | 2026-03-02 |
-| npm Weekly Downloads | 58 | 2026-03-01 |
-| npm Total Versions | 15 | 2026-03-02 |
-| Latest Release | v0.4.2 (2026-01-12) | 2026-03-02 |
-| npm Unpacked Size | 1.12 MB (179 files) | 2026-03-02 |
+| GitHub Stars (upstream Lumiaqian/openspec-mcp) | 20 | 2026-04-29 |
+| GitHub Forks (upstream) | 3 | 2026-04-29 |
+| GitHub Open Issues | 0 | 2026-04-29 |
+| npm Weekly Downloads | 61 | 2026-04-29 |
+| npm Total Versions | 15 | 2026-04-29 |
+| Latest Release | v0.4.2 (2026-01-12) | 2026-04-29 |
+| Days Since Latest Release | 107 days | 2026-04-29 |
 
-SOURCE: [GitHub API - upstream repo](https://api.github.com/repos/Lumiaqian/openspec-mcp) (accessed 2026-03-02), [npm registry](https://www.npmjs.com/package/openspec-mcp) (accessed 2026-03-02)
+SOURCE: [GitHub API - upstream repo](https://api.github.com/repos/Lumiaqian/openspec-mcp) (accessed 2026-04-29), [npm registry downloads](https://api.npmjs.org/downloads/point/last-week/openspec-mcp) (accessed 2026-04-29)
 
 ---
 
@@ -116,13 +115,17 @@ Local filesystem (OpenSpec project directory)
 
 Key dependencies (from package.json v0.4.2):
 
-- `@modelcontextprotocol/sdk` v1.13.3 -- MCP server SDK
-- `fastify` -- HTTP server for dashboard
-- `chokidar` -- filesystem watcher for real-time updates
-- `zod` -- schema validation for MCP tool parameters
-- `gray-matter` -- YAML frontmatter parsing for proposal files
+- `@modelcontextprotocol/sdk` ^1.13.3 -- MCP server SDK
+- `@fastify/cors` ^9.0.0 -- CORS handling for Fastify
+- `@fastify/static` ^7.0.0 -- Static file serving
+- `@fastify/websocket` ^8.2.0 -- WebSocket support for real-time updates
+- `fastify` ^4.24.0 -- HTTP server for dashboard and API
+- `chokidar` ^3.5.3 -- filesystem watcher for real-time updates
+- `commander` ^12.0.0 -- CLI argument parsing
+- `zod` ^3.22.0 -- schema validation for MCP tool parameters
+- `gray-matter` ^4.0.3 -- YAML frontmatter parsing for proposal files
 
-SOURCE: [GitHub repo file tree](https://github.com/Lumiaqian/openspec-mcp/tree/main/src) (accessed 2026-03-02), [package.json](https://raw.githubusercontent.com/Lumiaqian/openspec-mcp/main/package.json) (accessed 2026-03-02)
+SOURCE: [GitHub repo file tree](https://github.com/Lumiaqian/openspec-mcp/tree/main/src) (accessed 2026-04-29), [package.json](https://raw.githubusercontent.com/Lumiaqian/openspec-mcp/main/package.json) (accessed 2026-04-29)
 
 ---
 
@@ -199,12 +202,13 @@ SOURCE: [README.md upstream](https://github.com/Lumiaqian/openspec-mcp/blob/main
 
 ## References
 
-- [iflow-mcp/lumiaqian-openspec-mcp (fork)](https://github.com/iflow-mcp/lumiaqian-openspec-mcp) (accessed 2026-03-02)
-- [Lumiaqian/openspec-mcp (upstream)](https://github.com/Lumiaqian/openspec-mcp) (accessed 2026-03-02)
-- [README.md upstream](https://github.com/Lumiaqian/openspec-mcp/blob/main/README.md) (accessed 2026-03-02)
-- [npm package: openspec-mcp](https://www.npmjs.com/package/openspec-mcp) (accessed 2026-03-02)
-- [GitHub API repo metadata](https://api.github.com/repos/Lumiaqian/openspec-mcp) (accessed 2026-03-02)
-- [GitHub releases v0.4.2](https://github.com/Lumiaqian/openspec-mcp/releases/tag/v0.4.2) (accessed 2026-03-02)
+- [iflow-mcp/lumiaqian-openspec-mcp (fork)](https://github.com/iflow-mcp/lumiaqian-openspec-mcp) (accessed 2026-04-29)
+- [Lumiaqian/openspec-mcp (upstream)](https://github.com/Lumiaqian/openspec-mcp) (accessed 2026-04-29)
+- [README.md upstream](https://github.com/Lumiaqian/openspec-mcp/blob/main/README.md) (accessed 2026-04-29)
+- [npm package: openspec-mcp](https://www.npmjs.com/package/openspec-mcp) (accessed 2026-04-29)
+- [GitHub API repo metadata](https://api.github.com/repos/Lumiaqian/openspec-mcp) (accessed 2026-04-29)
+- [GitHub releases v0.4.2](https://github.com/Lumiaqian/openspec-mcp/releases/tag/v0.4.2) (accessed 2026-04-29)
+- [npm downloads API](https://api.npmjs.org/downloads/point/last-week/openspec-mcp) (accessed 2026-04-29)
 
 ---
 
@@ -212,6 +216,26 @@ SOURCE: [README.md upstream](https://github.com/Lumiaqian/openspec-mcp/blob/main
 
 | Field | Value |
 |-------|-------|
-| Last Verified | 2026-03-02 |
+| Last Verified | 2026-04-29 |
 | Version at Verification | v0.4.2 |
-| Next Review Recommended | 2026-06-02 |
+| Days Since Last Release | 107 days (latest: 2026-01-12) |
+| Confidence: Statistics | high |
+| Confidence: Features | high |
+| Confidence: Architecture | high |
+| Confidence: Usage Examples | high |
+| Confidence: Limitations | medium |
+| Next Review Recommended | 2026-07-29 |
+
+---
+
+## Cross-References
+
+| Entry | Category | Relationship |
+|-------|----------|--------------|
+| [Spec Workflow MCP](./spec-workflow-mcp.md) | mcp-ecosystem | alternative spec-driven workflow tool with Requirements→Design→Tasks gates and approval state machine |
+| [Saga MCP](./saga-mcp.md) | mcp-ecosystem | shares hierarchical task tracking (Projects>Epics>Tasks) and immutable activity log audit trail |
+| [GitNexus](./gitnexus.md) | mcp-ecosystem | provides code intelligence context that complements OpenSpec's spec management via graph-based impact analysis |
+| [CodeGraphContext](./codegraphcontext.md) | mcp-ecosystem | MCP server with repository-to-graph tools for cross-service dependency analysis alongside spec changes |
+| [Ultra MCP](./ultra-mcp.md) | mcp-ecosystem | provides multi-provider routing and unified dashboard model for aggregating tools across services |
+| [SourceSync.ai MCP](./sourcesyncai-mcp.md) | mcp-ecosystem | shares multi-source document aggregation pattern for knowledge base ingestion and cross-service sync |
+| [Everything Claude Code](../agent-frameworks/everything-claude-code.md) | agent-frameworks | 16-agent framework implementing spec-driven orchestration and approval workflows alongside code execution |

--- a/research/skill-generation-tools/mattpocock-skills.md
+++ b/research/skill-generation-tools/mattpocock-skills.md
@@ -34,11 +34,11 @@ mattpocock/skills addresses this gap by encoding **specific engineering practice
 
 ## Key Statistics
 
-- **23,883 stars** (as of 2026-04-27)
-- **1,936 forks** (as of 2026-04-27)
+- **43,829 stars** (as of 2026-04-29)
+- **3,467 forks** (as of 2026-04-29)
 - **Repository created**: 2026-02-03
-- **Last updated**: 2026-04-27 (very recent — active maintenance)
-- **21 distinct skills** in organized directories
+- **Last updated**: 2026-04-29 (very recent — active maintenance)
+- **22 distinct skills** in organized directories (4 deprecated)
 - **60,000+ subscribers** to associated newsletter (mentioned in README)
 
 ---
@@ -54,11 +54,12 @@ mattpocock/skills addresses this gap by encoding **specific engineering practice
    - `to-issues`: Breaks plans into independently-grabbable GitHub issues using vertical slices.
    - `request-refactor-plan`: Creates detailed refactor plans with commit-sized steps via user interview, files as GitHub issue.
 
-2. **Development** (6 skills)
+2. **Development** (7 skills; 1 deprecated)
    - `tdd`: Test-driven development with explicit red-green-refactor loops. Core teaching: **vertical slices via tracer bullets, not horizontal slicing**. One test → one implementation → repeat. Prevents writing all tests first (imagined behavior) then all code. Includes embedded references: tests.md, mocking.md, refactoring.md, interface-design.md, deep-modules.md.
-   - `triage-issue`: Investigates bugs by exploring codebase, identifies root cause, files GitHub issue with TDD-based fix plan.
+   - `triage`: Investigates bugs by exploring codebase, identifies root cause, files GitHub issue with TDD-based fix plan. Replaces deprecated `triage-issue`.
+   - `diagnose`: New skill (2026-04-29) — systematic diagnostic approach for understanding root causes in codebases.
    - `improve-codebase-architecture`: Finds deepening opportunities—refactors that turn shallow modules (interface complexity ≈ implementation complexity) into deep ones (small interface hiding significant complexity). Uses domain-aware language from CONTEXT.md and decisions from docs/adr/ to avoid re-litigating settled choices. Teaches deletion test: would removing this module concentrate complexity or just move it?
-   - `qa`: Quality assurance skill (specific content not examined in depth).
+   - `grill-with-docs`: New skill (2026-04-29) — leverages domain context (CONTEXT.md and ADR formats) to ask domain-aware questions about architectural decisions.
    - `migrate-to-shoehorn`: Automates migration from TypeScript `as` type assertions to @total-typescript/shoehorn library.
    - `scaffold-exercises`: Creates exercise directory structures with sections, problems, solutions, and explainers (used for teaching/knowledge capture).
 
@@ -317,13 +318,13 @@ mattpocock/skills provides **reference implementations** for skill structure, ac
 
 | Entry | Category | Relationship |
 |-------|----------|--------------|
-| [Anthropic Agent Skills Repository](./anthropics-skills.md) | skill-generation-tools | Official skill specification and template reference; foundation for SKILL.md format mattpocock/skills follows |
-| [Claude Code Skills Library by Alireza Rezvani](./claude-code-skills-alirezarezvani.md) | skill-generation-tools | 170 modular skills with identical architecture (SKILL.md + references + CLI tools); shared emphasis on encoding expertise as reusable instruction bundles |
-| [Everything Claude Code](./everything-claude-code.md) | skill-generation-tools | Comprehensive skill harness (65+ skills, 16 agents) implementing mattpocock patterns at scale with hook-based automation and persistent memory |
-| [SkillKit — Universal Package Manager for AI Agent Skills](./skillkit.md) | skill-generation-tools | Skill format auto-translation and package discovery; complements mattpocock/skills distribution model with cross-platform support for 32 agents |
-| [Claude Pilot](../developer-tools/claude-pilot.md) | developer-tools | Enforcement layer using hooks and checklist-driven verification similar to mattpocock/skills workflow discipline; model routing strategy complements skill-based approach |
-| [mcpskills-cli](./mcpskills-cli.md) | skill-generation-tools | MCP-to-skill converter using Streamable HTTP discovery; extends mattpocock approach to integrate external tool ecosystems |
-| [Skill Seekers](./skill-seekers.md) | skill-generation-tools | Documentation-to-skill automation; alternative generation path to mattpocock's manual curation model |
+| [Anthropic Agent Skills Repository](./anthropics-skills.md) | skill-generation-tools | Official skill specification and SKILL.md format foundation that mattpocock/skills implements; shared frontmatter schema |
+| [Claude Code Skills Library by Alireza Rezvani](./claude-code-skills-alirezarezvani.md) | skill-generation-tools | 170 modular skills across 9 domains with identical architecture (SKILL.md + references); shares vertical-slice and deep-module philosophy |
+| [Everything Claude Code](./everything-claude-code.md) | skill-generation-tools | 65+ skills and 16 agents implementing mattpocock patterns at organizational scale with hook-based automation and persistent memory |
+| [SkillKit — Universal Package Manager](./skillkit.md) | skill-generation-tools | Cross-platform skill format translation and discovery; extends mattpocock distribution model with 32 agent support |
+| [Skill Seekers](./skill-seekers.md) | skill-generation-tools | Documentation-to-skill automation; alternative generation path to mattpocock's manual curation model; both target skill standardization |
+| [Claude Pilot](../developer-tools/claude-pilot.md) | developer-tools | Enforcement layer using checklist-driven verification similar to mattpocock's workflow discipline; model routing strategy complements skill-based approach |
+| [mcpskills-cli](./mcpskills-cli.md) | skill-generation-tools | MCP-to-skill converter; extends mattpocock's skill ecosystem to integrate external tool ecosystems via Streamable HTTP discovery |
 | [oh-my-opencode](../research-agent-patterns/oh-my-opencode.md) | research-agent-patterns | Production-scale orchestration (37.5K stars) implementing multi-agent patterns that mattpocock skills coordinate; hash-anchored editing complements skill-based workflows |
 
 ---
@@ -332,9 +333,9 @@ mattpocock/skills provides **reference implementations** for skill structure, ac
 
 **Entry Created**: 2026-04-27 (v1.0.0)
 
-**Last Verified**: 2026-04-27
+**Last Verified**: 2026-04-29 (v1.1.0 — re-researched)
 
-**Next Review Due**: 2026-07-27 (90 days)
+**Next Review Due**: 2026-07-29 (90 days)
 
 ### Confidence Assessment
 
@@ -350,7 +351,14 @@ mattpocock/skills provides **reference implementations** for skill structure, ac
 
 ### Changes Since Last Review
 
-N/A — this is the initial entry created 2026-04-27.
+**Verified 2026-04-29** — substantial growth in 2 days:
+
+1. **Star count**: 23,883 → 43,829 (+20,146 stars, +82% increase)
+2. **Fork count**: 1,936 → 3,467 (+1,531 forks, +79% increase)
+3. **New skills added**: `diagnose` and `grill-with-docs` (engineering category)
+4. **Skill status changes**: `triage-issue` renamed to `triage`; 4 skills now marked deprecated (design-an-interface, qa, request-refactor-plan, ubiquitous-language)
+5. **Repository updates**: Out-of-scope clarification added (2026-04-29 commit: "Add out-of-scope note: issue trackers must be mainstream")
+6. **Maintenance status**: Actively maintained with recent commits addressing out-of-scope documentation
 
 ### Data Drift Monitoring
 


### PR DESCRIPTION
## Batch Research Refresh

Refreshed 2 existing research entries with current GitHub and npm metrics, and generated 3 improvement/utilization analysis files.

### Entries Refreshed

**OpenSpec MCP** (mcp-ecosystem) — was 58 days old (last verified 2026-03-02)
- GitHub stars: 10 → 20 (+100%)
- GitHub forks: 1 → 3 (+200%)
- npm weekly downloads: 58 → 61
- Latest release: v0.4.2 (2026-01-12) — 107 days old

**mattpocock/skills** (skill-generation-tools) — was 2 days old (last verified 2026-04-27)
- GitHub stars: 23,883 → 43,829 (+82%)
- GitHub forks: 1,936 → 3,467 (+79%)
- Skills: 21 → 22 (new: diagnose, grill-with-docs; deprecated: 4 skills)
- Collection now covers 4 domain areas: Planning & Design, Development, Tooling & Setup, Writing & Knowledge

### Analysis Generated

- **OpenSpec MCP improvements**: 2 IMMEDIATE_ATTENTION items (State Machine Enforcement, Explicit Review Threads), 5 improvement patterns
- **OpenSpec MCP utilization**: 2 proposals for feature-implementation task tracking and milestone approval pipeline
- **mattpocock/skills improvements**: 4 proposals including anti-pattern section, reference discovery, and skill tools semantics

### Files Changed

- research/mcp-ecosystem/openspec-mcp.md (refreshed)
- research/skill-generation-tools/mattpocock-skills.md (refreshed)
- research/insights/2026-04-29-openspec-mcp-improvements.md (new)
- research/insights/2026-04-29-openspec-mcp-utilization.md (new)
- research/insights/2026-04-29-mattpocock-skills-improvements.md (new)
- research/README.md (updated with cross-references)

---
_Generated by [Claude Code](https://claude.ai/code/session_018i5uqB24tsanWanHGTRWZg)_