### PR TITLE
fix(ecosystem-registry): union agent_frontmatter_keys into guard set (#515)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional development workflow extensions for Python engineers, DevOps practitioners, and AI agent developers. Covers modern Python toolchains, GitLab CI/CD automation, code quality enforcement, MCP server creation, and plugin/agent development patterns.",
-    "version": "6.3.311"
+    "version": "6.3.312"
   },
   "plugins": [
     {

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/scripts/ecosystem_registry.py
+++ b/plugins/plugin-creator/scripts/ecosystem_registry.py
@@ -72,17 +72,21 @@ _REGISTRY: dict[str, EcosystemSpec] = {
 }
 
 _ECOSYSTEM_OWNED_SKILL_KEYS: frozenset[str] = frozenset().union(
-    *(spec.skill_frontmatter_keys for spec in _REGISTRY.values())
+    *(spec.skill_frontmatter_keys | spec.agent_frontmatter_keys for spec in _REGISTRY.values())
 )
 
 
 def get_ecosystem_owned_skill_keys() -> frozenset[str]:
-    """Return the union of all skill_frontmatter_keys across every registered ecosystem.
+    """Return the union of all ecosystem-owned frontmatter keys across every registered ecosystem.
+
+    Unions both ``skill_frontmatter_keys`` and ``agent_frontmatter_keys`` from each
+    registered ecosystem, producing a complete guard set covering all file types.
 
     Returns:
         Immutable frozenset of top-level YAML key names owned by any registered
-        ecosystem in their ``skill_frontmatter_keys``.  Callers can safely check
-        ``key in get_ecosystem_owned_skill_keys()`` without risk of accidental mutation.
+        ecosystem in either ``skill_frontmatter_keys`` or ``agent_frontmatter_keys``.
+        Callers can safely check ``key in get_ecosystem_owned_skill_keys()`` without
+        risk of accidental mutation.
     """
     return _ECOSYSTEM_OWNED_SKILL_KEYS
 

--- a/plugins/plugin-creator/tests/test_ecosystem_registry.py
+++ b/plugins/plugin-creator/tests/test_ecosystem_registry.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import pytest
 
-from ecosystem_registry import get_ecosystem_for_key, get_ecosystem_owned_skill_keys
+import ecosystem_registry
+from ecosystem_registry import EcosystemSpec, get_ecosystem_for_key, get_ecosystem_owned_skill_keys
 
 
 class TestGetEcosystemOwnedKeys:
@@ -158,3 +159,82 @@ class TestGetEcosystemForKey:
 
         # Assert
         assert result is None, f"Expected None for key {unknown_key!r}, got {result!r}"
+
+    def test_finds_key_in_agent_frontmatter_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_ecosystem_for_key() returns ecosystem name for agent_frontmatter_keys.
+
+        Tests: agent_frontmatter_keys branch of get_ecosystem_for_key()
+        How: Monkeypatch _REGISTRY with a test ecosystem whose agent_frontmatter_keys
+             contains 'agent_test_key'; call function; assert ecosystem name returned
+        Why: This branch (checking spec.agent_frontmatter_keys) had no test coverage.
+             Future ecosystems with agent-specific keys must be discoverable via this
+             function, and the branch must not regress silently.
+        """
+        # Arrange — register a test ecosystem with an agent-only key
+        test_spec = EcosystemSpec(
+            display_name="TestEco",
+            source_url="https://test.example.com",
+            verified_date="2026-01-01",
+            skill_frontmatter_keys=frozenset(),
+            agent_frontmatter_keys=frozenset({"agent_test_key"}),
+            notes="Test-only ecosystem for branch coverage",
+        )
+        monkeypatch.setitem(ecosystem_registry._REGISTRY, "testeco", test_spec)
+
+        # Act
+        result = get_ecosystem_for_key("agent_test_key")
+
+        # Assert
+        assert result == "testeco"
+
+
+class TestOwnedKeysUnionBothFieldTypes:
+    """Regression tests verifying _ECOSYSTEM_OWNED_SKILL_KEYS unions both key types.
+
+    Before fix: frozenset().union(*(spec.skill_frontmatter_keys ...)) omitted agent keys.
+    After fix: frozenset().union(*(skill_keys | agent_keys ...)) includes both.
+    """
+
+    def test_owned_keys_includes_agent_frontmatter_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_ecosystem_owned_skill_keys() returns keys from agent_frontmatter_keys.
+
+        Tests: _ECOSYSTEM_OWNED_SKILL_KEYS unions both skill and agent key types
+        How: Patch _REGISTRY with a test ecosystem that has agent_frontmatter_keys;
+             assert the old (buggy) pattern omits the agent key; assert the new
+             (fixed) pattern includes it; patch the module constant and verify
+             the public function returns it.
+        Why: Before fix, the generator expression referenced only skill_frontmatter_keys,
+             silently excluding agent_frontmatter_keys from the guard set.
+        """
+        # Arrange — register a test ecosystem with both skill and agent keys
+        test_spec = EcosystemSpec(
+            display_name="TestEco",
+            source_url="https://test.example.com",
+            verified_date="2026-01-01",
+            skill_frontmatter_keys=frozenset({"skill_test_key"}),
+            agent_frontmatter_keys=frozenset({"agent_test_key"}),
+            notes="Test-only ecosystem for regression coverage",
+        )
+        monkeypatch.setitem(ecosystem_registry._REGISTRY, "testeco", test_spec)
+
+        # Verify the OLD (buggy) pattern omits agent keys
+        old_pattern = frozenset().union(
+            *(spec.skill_frontmatter_keys for spec in ecosystem_registry._REGISTRY.values())
+        )
+        assert "agent_test_key" not in old_pattern, "Old pattern should omit agent keys (documents the bug)"
+
+        # Verify the NEW (fixed) pattern includes agent keys
+        new_pattern = frozenset().union(
+            *(
+                spec.skill_frontmatter_keys | spec.agent_frontmatter_keys
+                for spec in ecosystem_registry._REGISTRY.values()
+            )
+        )
+        assert "agent_test_key" in new_pattern, "New pattern must include agent_frontmatter_keys"
+        assert "skill_test_key" in new_pattern, "New pattern must still include skill_frontmatter_keys"
+
+        # Verify the public function returns the fixed pattern
+        monkeypatch.setattr(ecosystem_registry, "_ECOSYSTEM_OWNED_SKILL_KEYS", new_pattern)
+        owned = get_ecosystem_owned_skill_keys()
+        assert "agent_test_key" in owned
+        assert "skill_test_key" in owned


### PR DESCRIPTION
## Summary

- `_ECOSYSTEM_OWNED_SKILL_KEYS` was built from `skill_frontmatter_keys` only, silently excluding `agent_frontmatter_keys` despite `EcosystemSpec` declaring both fields
- The sibling function `get_ecosystem_for_key()` already checked both fields correctly — establishing the design intent that both key types belong in the guard set
- Fix: change the union generator to `skill_frontmatter_keys | agent_frontmatter_keys` per spec

**Design root cause**: The materialization of the guard set (`_ECOSYSTEM_OWNED_SKILL_KEYS`) was written to match only one of two documented key categories on `EcosystemSpec`. The data model was always correct; the construction was incomplete.

**Current impact**: zero — `agent_frontmatter_keys` is `frozenset()` for all registered ecosystems. The bug is latent: any future ecosystem registering agent-specific keys would have those keys silently excluded from the guard set.

## Changes

- `plugins/plugin-creator/scripts/ecosystem_registry.py`
  - Line 74-76: union generator now uses `skill_frontmatter_keys | agent_frontmatter_keys`
  - Docstring updated to name both field types
- `plugins/plugin-creator/tests/test_ecosystem_registry.py`
  - `test_finds_key_in_agent_frontmatter_keys` — covers the previously untested `agent_frontmatter_keys` branch in `get_ecosystem_for_key()` via monkeypatch
  - `test_owned_keys_includes_agent_frontmatter_keys` — regression test documenting old (buggy) pattern and verifying the fix

## Test plan

- [x] `uv run pytest plugins/plugin-creator/tests/test_ecosystem_registry.py` — 17 passed, `ecosystem_registry.py` 100% coverage
- [x] All pre-commit hooks pass (ruff lint, ruff format, ty check)
- [x] Two new tests explicitly cover the `agent_frontmatter_keys` branch

Closes #515

https://claude.ai/code/session_01VSjd3KE5gLTXZx6mH3Kj45