### PR TITLE
docs(research): add tw93/Waza research entry

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -393,6 +393,7 @@ Tools and services that automate the creation of AI skills from documentation, c
 | [vercel-labs-skills.md](./skill-generation-tools/vercel-labs-skills.md) | Vercel Labs Skills - universal CLI for installing skills to 40+ AI coding agents with symlink-first design (6.3K stars) | 2026-02-20   |
 | [claude-scientific-skills.md](./skill-generation-tools/claude-scientific-skills.md) | Claude Scientific Skills - 170+ skills across 15 scientific domains (bioinformatics, cheminformatics, ML, physics, materials science); 250+ accessible databases; agentskills.io compliance for Cursor, Claude Code, Codex, Gemini CLI | 2026-03-16   |
 | [graphify.md](./skill-generation-tools/graphify.md)           | graphify v3 — dual AST+LLM extraction pipeline, 19-language tree-sitter support, confidence-tagged edges (EXTRACTED/INFERRED/AMBIGUOUS), 71.5x token reduction on mixed corpora, multi-format export (HTML/JSON/Markdown/SVG/GraphML/Cypher/Obsidian), PreToolUse hook integration | 2026-04-08   |
+| [waza.md](./skill-generation-tools/waza.md)                   | Waza (技) — 8 engineering-habit skills (think, check, hunt, design, read, write, learn, health) for Claude Code; multi-mode architecture, runtime project context extraction, smoke-tested packaging (4,369 stars, MIT) | 2026-05-04   |
 
 **Key Topics**:
 

--- a/research/insights/2026-05-04-waza-improvements.md
+++ b/research/insights/2026-05-04-waza-improvements.md
@@ -83,7 +83,7 @@ Add a script + pre-commit hook. Adding a fake skill reference like `/dh:nonexist
 **Local system**: This repo's CLAUDE.md (`/home/user/claude_skills/.claude/CLAUDE.md`) defines "Response style: Concise, precise, direct answer only" but no per-skill output marker convention exists.
 **Confidence**: High
 **Impact**: Low
-**Backlog**: Deferred — impact too narrow to justify a backlog item: per-skill output markers are a Waza branding choice; this repo's convention is "concise direct answer only" which is functionally equivalent for the AI consumer. Adopting an emoji marker would conflict with `/home/user/claude_skills/.claude/CLAUDE.md` rule "For clear communication with the user the assistant MUST avoid using emojis."
+**Backlog**: Deferred — impact too narrow to justify a backlog item: per-skill output markers are a Waza branding choice; this repo's convention is "concise direct answer only" which is functionally equivalent for the AI consumer. Adopting an emoji marker would conflict with `.claude/CLAUDE.md` rule "Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked." (Tone and style section).
 
 ### Current state
 

--- a/research/insights/2026-05-04-waza-improvements.md
+++ b/research/insights/2026-05-04-waza-improvements.md
@@ -1,0 +1,190 @@
+# Improvement Proposals: Waza — Engineering Habits as Claude Skills
+
+**Research entry**: ./research/skill-generation-tools/waza.md
+**Generated**: 2026-05-04
+**Patterns assessed**: 6
+**Backlog items created**: 3 (issues recorded in each proposal)
+**Deferred (low confidence)**: 1
+**Skipped (already covered or tracked)**: 2
+
+---
+
+## Improvement 1: Marketplace ↔ skill directory cross-reference validation
+
+**Source pattern**: From research entry, "Verification and Validation" — `./scripts/verify-skills.sh` "enforces ... Every marketplace entry has a matching `skills/*/SKILL.md` directory" and "`skills/RESOLVER.md` routing table references only existing skills". Verified directly against `.worktrees/waza/AGENTS.md` Verification section: "Marketplace, resolver, or root dispatcher changes: run `./scripts/verify-skills.sh` and confirm every marketplace source points at an existing skill directory."
+**Local system**: `/home/user/claude_skills/.claude-plugin/marketplace.json` (30 plugin entries) and `plugins/*/` directories; current validator is `uvx skilllint@latest` which checks individual skill structure but does not cross-reference marketplace entries against actual plugin directories.
+**Confidence**: High
+**Impact**: High
+**Backlog**: #1965 created
+
+### Current state
+
+`/home/user/claude_skills/.claude-plugin/marketplace.json` lists 30 plugins as `{ "name": "...", "source": "./plugins/..." }` entries. Plugin auto-sync is handled by `plugins/plugin-creator/scripts/auto_sync_manifests.py`, which updates plugin component arrays and version fields on commit. There is no validator that walks `marketplace.json` plugin entries, resolves each `source` path, and verifies the referenced directory exists with a valid `.claude-plugin/plugin.json`. A renamed/deleted plugin directory results in a stale marketplace entry that passes lint but breaks installation. Evidence: no script in `/home/user/claude_skills/scripts/` or `plugins/plugin-creator/scripts/` references `marketplace.json` cross-validation; `grep -r "marketplace.*skills\|skills.*marketplace"` over `plugin-creator/scripts/` returns zero hits.
+
+### Target state
+
+A validator script `scripts/verify_marketplace_consistency.py` runs in pre-commit and CI. For every entry in `.claude-plugin/marketplace.json`'s `plugins[]` array: (1) resolves `source` relative to repo root; (2) confirms the directory exists; (3) confirms `<source>/.claude-plugin/plugin.json` exists and is valid JSON; (4) confirms the `name` field in `marketplace.json` matches the `name` in the plugin's own `plugin.json`. Exits non-zero on any mismatch with a list of broken entries.
+
+### Measurable signal
+
+Run: `uv run scripts/verify_marketplace_consistency.py` — exit code 0 with no output when consistent. Manually delete a plugin directory and re-run — exit code is non-zero with an error like `marketplace entry 'agent-orchestration' references missing directory ./plugins/agent-orchestration`. Pre-commit hook entry added to `.pre-commit-config.yaml` invoking the script. CI workflow `quality-gate-audit.yml` includes a step that runs the script.
+
+---
+
+## Improvement 2: "Not for" exclusion section in skill frontmatter description
+
+**Source pattern**: From research entry "Skill Design Principles" (item 4): "Explicit 'Not for' sections — Each skill states what it doesn't do, reducing ambiguity about when to use which skill." Verified directly in `.worktrees/waza/skills/check/SKILL.md` line 3: `description: "... Not for exploring ideas or debugging."` and `.worktrees/waza/AGENTS.md`: "Create or update `skills/<name>/SKILL.md`; keep the description concrete, triggerable, and include a `Not for ...` exclusion."
+**Local system**: `/home/user/claude_skills/plugins/plugin-creator/skills/skill-creator/SKILL.md` (Step 5 frontmatter guidance) and `/home/user/claude_skills/plugins/plugin-creator/skills/write-frontmatter-description/`.
+**Confidence**: High
+**Impact**: Medium
+**Backlog**: #1966 created
+
+### Current state
+
+`plugins/plugin-creator/skills/skill-creator/SKILL.md` Step 5 §"Frontmatter" instructs authors on how to write `description` (lines ~471-477): "Include both what the Skill does and specific triggers/contexts for when to use it. Include all 'when to use' information here." There is no guidance to include an explicit exclusion clause naming what the skill is NOT for. Spot-check of local skills (e.g., `plugins/development-harness/skills/discovery/SKILL.md` line 3) shows descriptions list positive triggers only, no negative scope. With ~280 skills and overlapping triggers (e.g., `discovery` vs `find-cause` vs `rt-ica`), Claude has no explicit signal to disambiguate when multiple descriptions could match.
+
+### Target state
+
+`plugin-creator/skills/skill-creator/SKILL.md` Step 5 §"Frontmatter" gains a required clause: "End the description with a `Not for: <comma-separated list>` clause naming workflows this skill explicitly excludes." `plugin-creator/skills/write-frontmatter-description/SKILL.md` is updated with the same rule and an example. `skilllint` adds a new informational rule (e.g., `SK0XX-not-for-clause-missing`) that warns when a skill description does not contain a `Not for` clause — INFO-level only, not blocking.
+
+### Measurable signal
+
+Read `plugins/plugin-creator/skills/skill-creator/SKILL.md` — the Step 5 §"Frontmatter" section contains the literal string `Not for:` requirement and an example description ending with a `Not for ...` clause. Read `plugins/plugin-creator/skills/write-frontmatter-description/SKILL.md` — same rule present. Run `uvx skilllint@latest check plugins/development-harness/skills/discovery/` — output includes informational notice naming the missing `Not for` clause.
+
+---
+
+## Improvement 3: Routing table validation for skill name → trigger consistency
+
+**Source pattern**: From research entry "Verification and Validation": "`skills/RESOLVER.md` routing table references only existing skills". Verified in `.worktrees/waza/skills/RESOLVER.md` (60 lines of trigger → SKILL.md path tables) and `.worktrees/waza/AGENTS.md`: "Keep `skills/RESOLVER.md` in sync when a skill description, trigger, or scope changes."
+**Local system**: `/home/user/claude_skills/plugins/development-harness/skills/development-harness/SKILL.md` and per-plugin `CLAUDE.md` files document skill routing (e.g., the dh CLAUDE.md "Skills Overview" section lists 30+ `/dh:*` skills with one-line descriptions).
+**Confidence**: Medium
+**Impact**: Medium
+**Backlog**: Deferred — confidence medium: the routing-table-as-validation-target pattern depends on whether this repo wants to formalize per-plugin SKILL routing tables (Waza has one resolver for 8 skills; this repo has 30 plugins with 200+ skills, so the equivalent design choice is non-obvious).
+
+### Current state
+
+Each plugin's `CLAUDE.md` lists its skills in a "Skills Overview" section as bullet points with short descriptions (e.g., `plugins/development-harness/CLAUDE.md` lines listing `/dh:add-new-feature`, `/dh:implement-feature`, etc.). These lists are maintained by hand. There is no validator that confirms every skill listed in `CLAUDE.md` exists as a directory under `plugins/<name>/skills/`, and no validator that confirms every skill directory under `skills/` is referenced in `CLAUDE.md`. Drift is possible in either direction.
+
+### Target state
+
+A validator that, for each plugin with a `CLAUDE.md`, parses the "Skills Overview" / Skills inventory section and (1) resolves each `/<plugin>:<skill>` reference to a directory path; (2) reports references with no matching skill directory; (3) reports skill directories not referenced in `CLAUDE.md`.
+
+### Measurable signal
+
+Add a script + pre-commit hook. Adding a fake skill reference like `/dh:nonexistent-skill` to `plugins/development-harness/CLAUDE.md` causes the validator to fail with the stale reference name. Removing a referenced skill's directory causes the validator to fail with the orphaned reference.
+
+**Deferral reason**: This repo's per-plugin CLAUDE.md design differs from Waza's single RESOLVER.md, and the marginal value over `skilllint`'s existing component-presence checks needs evaluation. Recommend revisiting after Improvement 1 (marketplace cross-reference) lands to evaluate whether the same machinery can be extended to the per-plugin CLAUDE.md case.
+
+---
+
+## Improvement 4: Mandatory shared output marker enforced by linter
+
+**Source pattern**: From research entry "Verification and Validation": "Shared output marker `🥷` present in every skill". Verified in `.worktrees/waza/skills/check/SKILL.md` line 11: "Prefix your first line with 🥷 inline, not as its own paragraph" and `.worktrees/waza/skills/RESOLVER.md` line 5: "所有技能都沿用同一个输出约定：首行内联带上 `🥷` ... `verify-skills.sh` 也会校验它."
+**Local system**: This repo's CLAUDE.md (`/home/user/claude_skills/.claude/CLAUDE.md`) defines "Response style: Concise, precise, direct answer only" but no per-skill output marker convention exists.
+**Confidence**: High
+**Impact**: Low
+**Backlog**: Deferred — impact too narrow to justify a backlog item: per-skill output markers are a Waza branding choice; this repo's convention is "concise direct answer only" which is functionally equivalent for the AI consumer. Adopting an emoji marker would conflict with `/home/user/claude_skills/.claude/CLAUDE.md` rule "For clear communication with the user the assistant MUST avoid using emojis."
+
+### Current state
+
+Per the cited CLAUDE.md rule, this repo explicitly avoids emoji in assistant output. Waza's marker pattern is a cosmetic identification for users who want to see "this came from a Waza skill" — incompatible with this repo's no-emoji rule.
+
+### Target state
+
+No change. The Waza pattern is rejected as architecturally incompatible.
+
+### Measurable signal
+
+N/A.
+
+---
+
+## Improvement 5: Multi-mode skill architecture — explicit mode branching with disambiguation rules
+
+**Source pattern**: From research entry "Skill Modes and Branching": `/think` skill has three independent modes (Standard/Lightweight/Evaluation); `/check` skill has three parallel modes (Code review/Ship-Release/Triage). Verified in `.worktrees/waza/skills/check/SKILL.md` Triage Mode section (line 34) and Ship/Release Follow-through section (line 51). Disambiguation rules in `.worktrees/waza/skills/RESOLVER.md` lines 46-55 (numbered rules 1-9 explaining when each mode wins).
+**Local system**: `/home/user/claude_skills/plugins/plugin-creator/skills/skill-creator/SKILL.md` (Step 5 body guidance) and `plugins/plugin-creator/skills/refactor-skill/SKILL.md`.
+**Confidence**: Medium
+**Impact**: Medium
+**Backlog**: Deferred — confidence medium: this repo's existing pattern is "split when domains diverge" (refactor-skill pattern) — Waza's "branch within one skill via labelled modes" is the opposite design choice. Whether multi-mode-within-one-skill is a net improvement depends on the trade-off between description length budget (1024 chars) and the overhead of cross-skill orchestration. Needs experiment to validate.
+
+### Current state
+
+`plugins/plugin-creator/skills/refactor-skill/SKILL.md` is the canonical guidance for splitting oversized skills: when a skill covers multiple domains, split into separate skills (`SKILL_SPLIT` task type). There is no documented pattern for the alternative — keeping one skill that branches into named modes via clear disambiguation rules. The `skill-creator` Step 5 body template encourages flowcharts but does not give a "multi-mode within one skill" template.
+
+### Target state
+
+`skill-creator/references/workflows.md` gains a section "Multi-mode skill pattern" with: (1) when to use it (mutually exclusive workflows that share project-context extraction or other expensive setup steps); (2) required components (numbered disambiguation rules between modes, explicit "Activate when..." clause per mode); (3) example template based on Waza's `/check` (Code review / Ship / Triage).
+
+### Measurable signal
+
+Read `plugins/plugin-creator/skills/skill-creator/references/workflows.md` — section "Multi-mode skill pattern" present, contains a numbered disambiguation rule list and an example template. At least one local skill (candidates: `dh:work-backlog-item`, `dh:dispatch`) has been audited against the new template and either restructured or annotated with rationale.
+
+**Deferral reason**: This is a pattern recommendation, not a bug fix. Add to backlog only after one experimental application to a candidate skill to measure whether description-length and routing accuracy actually improve.
+
+---
+
+## Improvement 6: Scoped smoke tests with mock-environment validation for installer scripts
+
+**Source pattern**: From research entry "Verification and Validation": Makefile smoke targets — `smoke-statusline-installer: Tests installer with mock environment (HOME, PATH override)`, `smoke-english-coaching-installer: Tests coaching rule install idempotence`, `smoke-package: Validates generated ZIP has exactly one root SKILL.md`, `smoke-verify-skills: Tests 6 validation edge cases`. Verified in `.worktrees/waza/AGENTS.md` Commands section: `make test`, `make package`, `./scripts/verify-skills.sh`.
+**Local system**: `/home/user/claude_skills/scripts/` (9 maintenance scripts including `check_symlinks.py`, `repair_symlinks.py`, `process-research-integration.py`) and `plugins/plugin-creator/scripts/` (init_skill, package_skill, etc.). Pre-commit hooks via `.pre-commit-config.yaml` and `prek` runner. CI workflows at `.github/workflows/`.
+**Confidence**: High
+**Impact**: Medium
+**Backlog**: #1967 created
+
+### Current state
+
+Pre-commit hooks run linters (`ruff`, `ty`, `markdownlint`, `auto_sync_manifests.py`). CI workflow `code-quality.yml` runs the same. No script in `/home/user/claude_skills/scripts/` or under any plugin runs an end-to-end smoke test of installer or scaffolder scripts (e.g., `init_skill.py`, `package_skill.py`) against a mock `HOME`/`PATH` environment to verify idempotence and edge cases. `init_skill.py` validates inputs but is never executed in CI with a tmpdir target. `package_skill.py` is never executed against a known-good skill directory in CI to validate ZIP structure. Failure mode: a regression that breaks `init_skill.py` (e.g., wrong path resolution, missing example file) is only caught when a developer runs it manually.
+
+### Target state
+
+A `Makefile` (or equivalent `scripts/smoke_tests.py`) at repo root with targets:
+
+- `smoke-init-skill`: runs `init_skill.py demo-skill --path $(mktemp -d)` and asserts the generated tree matches expected layout (SKILL.md exists, frontmatter parses, `scripts/`, `references/`, `assets/` present, example files exist).
+- `smoke-package-skill`: runs `package_skill.py` against a known-good fixture skill in `tests/fixtures/` and asserts the resulting `.skill` ZIP contains exactly the expected entries.
+- `smoke-validate-skills`: runs `uvx skilllint@latest check` against a corpus of intentionally-broken skill fixtures and asserts each emits its expected error code.
+
+CI workflow `code-quality.yml` invokes these targets after lint passes.
+
+### Measurable signal
+
+Run `make smoke-init-skill` — exit code 0, output ends with `OK: skill scaffolded with N expected files`. Run `make smoke-package-skill` — exit code 0, output names the produced ZIP and lists its expected entries. Intentionally break `init_skill.py` (e.g., remove a line writing `references/`) — `make smoke-init-skill` exits non-zero with a specific assertion message naming the missing path. CI workflow `.github/workflows/code-quality.yml` contains an explicit `make smoke-*` step.
+
+---
+
+## Improvement 7: Source-root SKILL.md / dispatcher anti-pattern check
+
+**Source pattern**: From research entry "Distribution and Installation": "Release: v3.12.2 (May 4, 2026) restores default `npx skills add tw93/Waza` behavior for direct skill discovery and removes source-root `SKILL.md` that caused discovery to halt at `/waza`." And "Distribution Packaging" — source has no root `SKILL.md`; Claude Desktop ZIP contains a single generated root `SKILL.md` for distribution only. Verified in `.worktrees/waza/AGENTS.md` Distribution Rules: "Do not add a source-root `SKILL.md`; it prevents nested skill discovery."
+**Local system**: This repo's structure — no `SKILL.md` exists at repo root, but `plugins/<name>/` directories use the documented Claude Code plugin structure. Existing rule in `/home/user/claude_skills/.claude/CLAUDE.md`: "All skill directories must sit directly under `skills/` — one level deep only. Do not create grouping subdirectories" — already addresses the analogous "subdirectory namespacing" anti-pattern.
+**Confidence**: High
+**Impact**: Low
+**Backlog**: Skipped — already covered by the existing CLAUDE.md rule "Subdirectory Namespaces — Skills Do NOT Support This" which addresses the same class of discovery-halting structural error. The Waza-specific "source-root SKILL.md" variant does not occur in this repo because plugins are the unit of distribution, not a top-level SKILL.md. No action required.
+
+### Current state
+
+CLAUDE.md rule "Subdirectory Namespaces — Skills Do NOT Support This" already prohibits the analogous pattern. No `SKILL.md` exists at any plugin root or repo root. `.claude/skills/` correctly contains skills directly (no nesting).
+
+### Target state
+
+No change. Existing rule is sufficient.
+
+### Measurable signal
+
+N/A — already enforced.
+
+---
+
+## Deferred Proposals (confidence too low to backlog)
+
+| Pattern | Confidence | Reason |
+|---|---|---|
+| Routing table validation (Improvement 3) | Medium | Per-plugin CLAUDE.md design diverges from Waza's single RESOLVER.md; needs scoping decision before backlogging |
+| Multi-mode skill architecture (Improvement 5) | Medium | Pattern recommendation only — needs one experimental application to validate net benefit before backlogging |
+
+---
+
+## Skipped Patterns
+
+| Pattern | Reason skipped |
+|---|---|
+| Shared output marker `🥷` (Improvement 4) | Architecturally incompatible — repo CLAUDE.md prohibits emoji in assistant output |
+| Source-root SKILL.md anti-pattern (Improvement 7) | Already covered by existing CLAUDE.md rule "Subdirectory Namespaces — Skills Do NOT Support This" |

--- a/research/insights/2026-05-04-waza-improvements.md
+++ b/research/insights/2026-05-04-waza-improvements.md
@@ -3,7 +3,7 @@
 **Research entry**: ./research/skill-generation-tools/waza.md
 **Generated**: 2026-05-04
 **Patterns assessed**: 6
-**Backlog items created**: 3 (issues recorded in each proposal)
+**Backlog items created**: 3 (issues: #2124, #2125, #2126)
 **Deferred (low confidence)**: 1
 **Skipped (already covered or tracked)**: 2
 
@@ -15,7 +15,7 @@
 **Local system**: `/home/user/claude_skills/.claude-plugin/marketplace.json` (30 plugin entries) and `plugins/*/` directories; current validator is `uvx skilllint@latest` which checks individual skill structure but does not cross-reference marketplace entries against actual plugin directories.
 **Confidence**: High
 **Impact**: High
-**Backlog**: #1965 created
+**Backlog**: #2124 created
 
 ### Current state
 
@@ -37,7 +37,7 @@ Run: `uv run scripts/verify_marketplace_consistency.py` — exit code 0 with no 
 **Local system**: `/home/user/claude_skills/plugins/plugin-creator/skills/skill-creator/SKILL.md` (Step 5 frontmatter guidance) and `/home/user/claude_skills/plugins/plugin-creator/skills/write-frontmatter-description/`.
 **Confidence**: High
 **Impact**: Medium
-**Backlog**: #1966 created
+**Backlog**: #2125 created
 
 ### Current state
 
@@ -129,7 +129,7 @@ Read `plugins/plugin-creator/skills/skill-creator/references/workflows.md` — s
 **Local system**: `/home/user/claude_skills/scripts/` (9 maintenance scripts including `check_symlinks.py`, `repair_symlinks.py`, `process-research-integration.py`) and `plugins/plugin-creator/scripts/` (init_skill, package_skill, etc.). Pre-commit hooks via `.pre-commit-config.yaml` and `prek` runner. CI workflows at `.github/workflows/`.
 **Confidence**: High
 **Impact**: Medium
-**Backlog**: #1967 created
+**Backlog**: #2126 created
 
 ### Current state
 

--- a/research/insights/2026-05-04-waza-utilization.md
+++ b/research/insights/2026-05-04-waza-utilization.md
@@ -1,0 +1,148 @@
+# Utilization Proposals: Waza
+
+**Research entry**: ./research/skill-generation-tools/waza.md
+**Generated**: 2026-05-04
+**Integration surfaces found**: 4 (CLI skills + installation mechanism)
+**Proposals written**: 3
+**Skipped**: 2 — pattern-only (no direct callable surface documented)
+
+---
+
+## Utilization 1: `dh:analyze-test-failures` → Waza `/hunt` skill
+
+**Research entry**: ./research/skill-generation-tools/waza.md
+**Caller**: ./plugins/development-harness/skills/analyze-test-failures/SKILL.md
+**Integration mechanism**: CLI skill invocation (`/hunt`)
+**Replaces or adds**: Extends root-cause-first debugging discipline with multi-platform reproducibility verification
+**Setup cost**: Low (install via `npx skills add tw93/Waza -a claude-code -g -y`)
+**Integration surface**: `/hunt` skill (GitHub: tw93/Waza)
+
+### Why this caller
+
+The `analyze-test-failures` skill in development-harness guides agents through debugging test failures, but it is context-limited to test execution output within a single codebase. Waza's `/hunt` skill ("bugs, crashes, regressions, test failures, unexpected behavior") is a generalized debugging entrypoint that enforces the same discipline (`find root cause before applying fix`) across all failure types — not just tests. The skill's documented design rule ("Focuses on reproducible failures and confirmed root causes") matches our error-handling philosophy in [code-review-python](./plugins/development-harness/skills/code-review-python/SKILL.md) (lines 56-60: "Exception messages must include context to diagnose without reading the source").
+
+Reading `./plugins/development-harness/skills/analyze-test-failures/SKILL.md`, the current flow is: gather output → propose hypothesis → instrument/isolate → validate. Waza's `/hunt` enforces structured reproduction before hypothesis, making it more rigorous. Integration would allow callers to route general-purpose debugging to `/hunt` when the failure is not test-specific (server crashes, integration bugs, unexpected behavior).
+
+### Integration sketch
+
+```markdown
+## When to use `/hunt` (Waza)
+
+Route to `/hunt` when:
+- Failure occurs in production or integration environment (not test sandbox)
+- Reproduction steps are unclear or non-deterministic
+- Multiple systems interact (not isolated test failure)
+- The error is not a test assertion but unexpected behavior
+
+Route to `/dh:analyze-test-failures` when:
+- Failure is in `pytest` or test runner output
+- Test is isolated and reproducible in CI/local environment
+- Root cause is suspected to be within the code under test
+```
+
+**Before integration**: Verify that Waza `/hunt` skill is installable and operational in this repo's Claude Code session via `npx skills add tw93/Waza -a claude-code -g -y` and that it can be invoked as `/hunt <problem description>`.
+
+---
+
+## Utilization 2: `dh:code-review-python` (and siblings) → Waza `/check` skill
+
+**Research entry**: ./research/skill-generation-tools/waza.md
+**Caller**: ./plugins/development-harness/skills/code-review-python/SKILL.md (and code-review-{cli,nodejs,typescript,web})
+**Integration mechanism**: CLI skill invocation (`/check`)
+**Replaces or adds**: Adds project-context-aware review mode to language-specific reviewers
+**Setup cost**: Low (install via `npx skills add tw93/Waza -a claude-code -g -y`)
+**Integration surface**: `/check` skill with ship/release/triage modes (GitHub: tw93/Waza)
+
+### Why this caller
+
+The `code-review-python` skill (and its sibling language-specific skills) focuses on enforcing language and stack-specific rules (ruff, ty, pytest conventions, error handling patterns). Waza's `/check` skill is positioned earlier in the release workflow: it extracts project context (README, CI, manifests, version sync requirements) and performs project-aware review (safe auto-fixes, release asset verification, artifact protection). Reading lines 85-91 of the research entry, Waza's `/check` "extracts constraints from the target repository: Project commands from README, package manifests, Makefiles; CI workflow files; Release docs and scripts."
+
+Our language-specific reviewers assume a shared harness context. Waza's `/check` is agnostic to language and runs *before* language-specific review — it answers "is this safe to release?" independent of how the code was written. Integration would allow callers to invoke `/check` before routing to `dh:code-review-python`, ensuring release-safety checks happen before style/idiom enforcement.
+
+Reading `./plugins/development-harness/skills/code-review-python/SKILL.md`, the current scope is: Python-specific rules (type hints, ruff, pytest, uv). It does not handle project-context concerns (release assets, version sync, artifact protection, safe auto-fixes based on CI configuration). Waza fills that gap.
+
+### Integration sketch
+
+```markdown
+## Release / Ship workflow integration
+
+When reviewing a change for release/publication/push:
+
+1. Route to `/check` with context: target repository, intended action (release/publish/push)
+2. Waza extracts project constraints and produces artifact checklist
+3. Only after Waza's `/check` passes, route to language-specific reviewer:
+   - `/code-review-python` for Python stacks
+   - `/code-review-nodejs` for Node.js stacks
+   - etc.
+```
+
+**Before integration**: Verify that Waza `/check` skill can be invoked with a repository context (diff, PR, or path), and that its output includes artifact verification and version sync requirements. Test against a sample PR in this repo.
+
+---
+
+## Utilization 3: `refresh-research` → Waza `/learn` skill
+
+**Research entry**: ./research/skill-generation-tools/waza.md
+**Caller**: ./claude_skills/.claude/skills/refresh-research/SKILL.md (and research-curator agent)
+**Integration mechanism**: CLI skill invocation (`/learn`)
+**Replaces or adds**: Extends research workflow with structured six-phase methodology and self-review gate
+**Setup cost**: Low (install via `npx skills add tw93/Waza -a claude-code -g -y`)
+**Integration surface**: `/learn` skill (six-phase workflow: collect, digest, outline, fill, refine, review) (GitHub: tw93/Waza)
+
+### Why this caller
+
+The `refresh-research` skill (and the `research-curator` agent at `.claude/agents/research-curator.md`) guide research workflows. Reading the research entry (lines 50, end of "Eight Skills" table), Waza's `/learn` skill "runs a six-phase research workflow: collect, digest, outline, fill in, refine, then self-review and publish." The `research-curator` agent (lines 1-50 of `.claude/agents/research-curator.md`) orchestrates research waves and produces `./research/{category}/{name}.md` outputs; it does not itself execute the research phases — it delegates to agents.
+
+Waza's `/learn` provides structured phases for *conducting* research (phases: collect sources, digest findings, outline structure, fill in sections, refine prose, then self-review before publication). Our current research workflow (via `research-curator`) manages the *orchestration* (waves, freshness tracking, backlink detection) but does not prescribe internal research phases. Integration would allow callers to use `/learn` for individual research topics, then feed the output into our backlog/insight pipeline.
+
+Reading `./claude_skills/.claude/skills/refresh-research/SKILL.md` and `./claude_skills/.claude/agents/research-curator.md`, the current research lifecycle is: identify topic → spawn agent to research → write entry → auto-extract insights. Waza's `/learn` adds rigor to the middle phase (the actual research conduct) with explicit phases and self-review gate.
+
+### Integration sketch
+
+```markdown
+## Research workflow with `/learn`
+
+When conducting deep research on a topic:
+
+1. Identify topic and required research depth
+2. Invoke `/learn` with the topic:
+   - It will guide you through collect → digest → outline → fill → refine → review
+3. Output from `/learn` becomes source for `research-curator` pipeline:
+   - Entry is normalized into `.md` format and registered with `artifact_register`
+   - Insights are extracted via `research-insight-extractor`
+   - Backlog items are created for actionable proposals
+```
+
+**Before integration**: Verify that Waza `/learn` skill can be invoked with a research topic and that its output is in a format compatible with our research entry format (markdown with frontmatter). Test a sample research topic.
+
+---
+
+## Skipped Systems
+
+| Local System | Reason skipped |
+|---|---|
+| `.claude/skills/fact-check/SKILL.md` | Waza's `/read` skill (fetches URLs/PDFs) does not overlap with fact-check scope (verify claims against sources). The `/read` skill is a content fetcher, not a verifier. No direct utilization opportunity; pattern adoption only. |
+| `plugins/orchestrator-discipline/` | Waza's skill design principles (explicit "Not for" sections, manual chaining) are patterns. The research entry documents them but does not provide a callable surface for orchestration discipline enforcement. No utilization surface. |
+
+---
+
+## Next Steps
+
+1. **Install and test Waza skills** — Run `npx skills add tw93/Waza -a claude-code -g -y` in a test session and verify `/hunt`, `/check`, `/learn` are available.
+
+2. **For Utilization 1** (`/hunt`): Create a backlog item to add routing logic to `dh:analyze-test-failures` that delegates non-test failures to `/hunt`. Test with a production crash scenario.
+
+3. **For Utilization 2** (`/check`): Integrate `/check` as a pre-release gate in the harness code-review pipeline. Modify `code-review-python` (and siblings) to accept an optional `check-first` mode that invokes Waza `/check` before language-specific rules.
+
+4. **For Utilization 3** (`/learn`): Test `/learn` on a sample research topic, verify output format, then link from `research-curator` as an optional structured research mode for deep-dive topics.
+
+---
+
+## Confidence Assessment
+
+| Proposal | Confidence | Why |
+|---|---|---|
+| Utilization 1 (`/hunt`) | High | Clear overlap with debugging discipline; Waza's design is documented and the skill is production-tested. Requires routing logic only. |
+| Utilization 2 (`/check`) | High | Waza's project-context extraction is novel and fills a gap our language-specific reviewers don't address. Integration is additive, not replacing. |
+| Utilization 3 (`/learn`) | Medium | Waza's `/learn` phases are documented but we have not tested the skill's output format against our research entry schema. Format compatibility must be verified before committing integration. |
+

--- a/research/insights/2026-05-04-waza-utilization.md
+++ b/research/insights/2026-05-04-waza-utilization.md
@@ -19,7 +19,7 @@
 
 ### Why this caller
 
-The `analyze-test-failures` skill in development-harness guides agents through debugging test failures, but it is context-limited to test execution output within a single codebase. Waza's `/hunt` skill ("bugs, crashes, regressions, test failures, unexpected behavior") is a generalized debugging entrypoint that enforces the same discipline (`find root cause before applying fix`) across all failure types — not just tests. The skill's documented design rule ("Focuses on reproducible failures and confirmed root causes") matches our error-handling philosophy in [code-review-python](./plugins/development-harness/skills/code-review-python/SKILL.md) (lines 56-60: "Exception messages must include context to diagnose without reading the source").
+The `analyze-test-failures` skill in development-harness guides agents through debugging test failures, but it is context-limited to test execution output within a single codebase. Waza's `/hunt` skill ("bugs, crashes, regressions, test failures, unexpected behavior") is a generalized debugging entrypoint that enforces the same discipline (`find root cause before applying fix`) across all failure types — not just tests. The skill's documented design rule ("Focuses on reproducible failures and confirmed root causes") matches our error-handling philosophy in `plugins/development-harness/skills/code-review-python/SKILL.md` (lines 56-60: "Exception messages must include context to diagnose without reading the source").
 
 Reading `./plugins/development-harness/skills/analyze-test-failures/SKILL.md`, the current flow is: gather output → propose hypothesis → instrument/isolate → validate. Waza's `/hunt` enforces structured reproduction before hypothesis, making it more rigorous. Integration would allow callers to route general-purpose debugging to `/hunt` when the failure is not test-specific (server crashes, integration bugs, unexpected behavior).
 
@@ -83,7 +83,7 @@ When reviewing a change for release/publication/push:
 ## Utilization 3: `refresh-research` → Waza `/learn` skill
 
 **Research entry**: ./research/skill-generation-tools/waza.md
-**Caller**: ./claude_skills/.claude/skills/refresh-research/SKILL.md (and research-curator agent)
+**Caller**: `.claude/skills/refresh-research/SKILL.md` (and research-curator agent)
 **Integration mechanism**: CLI skill invocation (`/learn`)
 **Replaces or adds**: Extends research workflow with structured six-phase methodology and self-review gate
 **Setup cost**: Low (install via `npx skills add tw93/Waza -a claude-code -g -y`)
@@ -95,7 +95,7 @@ The `refresh-research` skill (and the `research-curator` agent at `.claude/agent
 
 Waza's `/learn` provides structured phases for *conducting* research (phases: collect sources, digest findings, outline structure, fill in sections, refine prose, then self-review before publication). Our current research workflow (via `research-curator`) manages the *orchestration* (waves, freshness tracking, backlink detection) but does not prescribe internal research phases. Integration would allow callers to use `/learn` for individual research topics, then feed the output into our backlog/insight pipeline.
 
-Reading `./claude_skills/.claude/skills/refresh-research/SKILL.md` and `./claude_skills/.claude/agents/research-curator.md`, the current research lifecycle is: identify topic → spawn agent to research → write entry → auto-extract insights. Waza's `/learn` adds rigor to the middle phase (the actual research conduct) with explicit phases and self-review gate.
+Reading `.claude/skills/refresh-research/SKILL.md` and `.claude/agents/research-curator.md`, the current research lifecycle is: identify topic → spawn agent to research → write entry → auto-extract insights. Waza's `/learn` adds rigor to the middle phase (the actual research conduct) with explicit phases and self-review gate.
 
 ### Integration sketch
 

--- a/research/skill-generation-tools/waza.md
+++ b/research/skill-generation-tools/waza.md
@@ -1,0 +1,236 @@
+# Waza
+
+**Research Date**: 2026-05-04
+**Source URL**: <https://github.com/tw93/Waza>
+**GitHub Repository**: <https://github.com/tw93/Waza>
+**Version at Research**: v3.20.0 (check: 3.20.0, think: 3.17.0, design: 3.19.0, hunt: 3.19.0, read: 3.14.0, write: 3.18.0, learn: 3.15.0, health: 3.17.0)
+**License**: MIT License
+
+---
+
+## Overview
+
+Waza is a skill collection for Claude Code and Codex that packages eight specialized engineering workflows based on actual professional practices refined across 300+ sessions and 500 hours of real-world use. The name derives from the Japanese martial arts term for technique (技, わざ)—a move practiced until it becomes instinct. Each skill channels AI capability into precision by setting clear goals and constraints, then allowing the model to execute without generic defaults.
+
+The project is part of an intentional trilogy: Kaku (書く) writes code, Waza (技) drills habits, Kami (紙) ships documents.
+
+---
+
+## Problem Addressed
+
+| Problem | Solution |
+|---------|----------|
+| AI output lacks structure and drifts into generic, imprecise work | Eight narrowly-scoped skills set clear trigger, goal, and constraints for each engineering habit |
+| Debugging requires multiple blind passes without systematic root-cause analysis | `/hunt` implements systematic debugging: root cause confirmed before any fix is applied |
+| Code review is either skipped or surface-level, missing project-specific constraints | `/check` reviews diffs, extracts project constraints from public repository context, auto-fixes safe issues, and drives release follow-through |
+| Planning ideas produces documents but no decision-ready implementation plans | `/think` challenges requirements, pressure-tests design, and produces decision-complete plans with validated structure |
+| UI design defaults to generic instead of distinctive | `/design` produces production-grade interfaces with screenshot-driven aesthetic iteration |
+| Prose writing carries AI patterns and stiff formulation | `/write` rewrites to sound natural in Chinese and English |
+| Research requires manual synthesis across unstructured sources | `/learn` implements six-phase research workflow: collect, digest, outline, fill, refine, self-review, publish |
+| Fetching web content for reading or citation is platform-dependent | `/read` fetches any URL or PDF as clean Markdown with platform-specific routing (GitHub, PDFs, WeChat, Feishu, paywalls, JS-heavy pages) |
+| Auditing Claude Code setup is manual and incomplete | `/health` performs budget-aware audit of CLAUDE.md, rules, skills, hooks, MCP, and behavior with severity flagging |
+
+---
+
+## Key Statistics
+
+| Metric | Value | Date Gathered |
+|--------|-------|---------------|
+| GitHub Stars | 4,369 | 2026-05-04 |
+| Forks | 265 | 2026-05-04 |
+| Contributors | 6 | 2026-05-04 |
+| Latest Release | v3.12.2 | 2026-05-04 |
+| Created | 2026-03-12 | 2026-05-04 |
+| Last Pushed | 2026-05-04 | 2026-05-04 |
+
+---
+
+## Key Features
+
+### Eight Specialized Skills
+
+Each skill has a clear trigger, single responsibility, and explicit scope boundaries.
+
+- **`/think`** (v3.17.0) — Turns rough ideas into approved, decision-complete plans with validated structure before code writing. Covers new features, architecture decisions, value judgments. Not for bug fixes or small edits. Activates on triggers: `出方案, 给方案, 深入分析, 怎么设计, 用什么方案, 判断一下, 有没有必要, 值不值得, what's the best approach, plan this, how should I, should we keep this`
+
+- **`/check`** (v3.20.0) — Reviews code diffs and release-ready changes, extracts project-specific constraints from repository context (README, CI workflows, package manifests, Makefiles), auto-fixes safe issues, drives approved release/publish/push/reaction follow-through, triages issues and PRs. Not for exploring ideas or debugging.
+
+- **`/hunt`** (v3.19.0) — Systematic debugging: finds root cause of errors, crashes, regressions, screenshot-reported defects, unexpected behavior, failing tests. Root cause confirmed before any fix applied. Not for code review or new features.
+
+- **`/design`** (v3.19.0) — Produces distinctive, production-grade UI for any component, page, or visual interface. Handles screenshot-driven iteration when user sends image with visual complaint. Not for backend logic or data pipelines.
+
+- **`/read`** (v3.14.0) — Fetches any URL or PDF as clean Markdown for reading, quoting, citation, downstream work. Handles paywalls, JS-heavy pages, X/Twitter, Chinese platforms via proxy cascade. Not for local text files already in repo.
+
+- **`/write`** (v3.18.0) — Strips AI writing patterns and rewrites prose to sound natural in Chinese or English. Only activates on explicit writing/editing requests. Not for code comments, commit messages, or inline docs.
+
+- **`/learn`** (v3.15.0) — Six-phase research workflow: collect, digest, outline, fill in, refine, self-review, publish. Turns unfamiliar domains or collected sources into publish-ready output. Not for quick lookups or single-file reads.
+
+- **`/health`** (v3.17.0) — Budget-aware audit of Claude Code setup: checks CLAUDE.md, rules, skills, hooks, MCP servers, behavior. Flags issues by severity. Default summary audit avoids burning quota; deep/full audit available on request. Claude Code only.
+
+### Technical Architecture
+
+**Skill Organization** (Source: `.claude-plugin/marketplace.json`, `AGENTS.md`):
+
+- Individual skills stored at `skills/{name}/SKILL.md` with YAML frontmatter metadata (name, description, when_to_use triggers, version)
+- Specialized reviewer/inspector agents under `skills/*/agents/`
+- Supporting references, scripts, and helper utilities under `skills/*/references/` and `skills/*/scripts/`
+- Shared routing and skill resolution via `skills/RESOLVER.md`
+- Distribution via marketplace manifest (`.claude-plugin/marketplace.json`), plugin installer, or Claude Desktop ZIP
+
+**Project-Aware Code Review** (`skills/check/references/project-context.md`):
+
+- `/check` extracts project constraints at runtime from public repository context: README, CI workflows, package manifests, lockfiles, build configs, test configs, release notes
+- Identifies changed languages, frameworks, generated outputs, protected files
+- Compresses findings into review context: verification commands, release artifacts, domain risks, public reply rules
+- Applies stricter project rules when they override generic Waza rules
+
+**Skill Composition and Chaining**:
+
+- Skills are designed to chain but transitions are manual
+- Common workflows: Design: `/think` → approve → say "implement X" → `/check` → merge; Fix: `/hunt` → fix → `/check` → release/publish/push; Research and write: `/read` → `/learn` → `/write`; Debug and verify: `/hunt` → fix → `/check`
+
+**Distribution Mechanisms**:
+
+1. Claude Code direct slash commands: `npx skills add tw93/Waza -a claude-code -g -y`
+2. Codex: `npx skills add tw93/Waza -a codex -g -y`
+3. Claude Code plugin marketplace: `/plugin marketplace add tw93/Waza`
+4. Claude Desktop: ZIP file from releases (`waza.zip`)
+
+**Script Helpers** (Source: `scripts/`, `Makefile`):
+
+- Statusline setup: `scripts/setup-statusline.sh` — minimal statusline for Claude Code showing context window and quota thresholds (color-coded: green <70%, yellow 70-85%, red >85%)
+- English coaching: `scripts/setup-english-coaching.sh` — optional rule appending short corrections to English errors in prompts
+- Packaging: `scripts/package-skill.sh` — builds Claude Desktop dispatcher ZIP with inlined skill bodies
+- Verification: `scripts/verify-skills.sh` — validates skill descriptions, routing, versions match across marketplace.json, RESOLVER.md, SKILL.md files
+
+---
+
+## Installation & Usage
+
+### Claude Code (Global Installation)
+
+```bash
+# Install all eight skills globally
+npx skills add tw93/Waza -a claude-code -g -y
+
+# Update to latest version
+npx skills update -g -y
+```
+
+Once installed, invoke skills using slash commands:
+
+```text
+🥷 /think about building a new authentication system
+🥷 /check the changes before merge
+🥷 /hunt down the race condition in this test
+🥷 /design a distinctive login flow
+🥷 /read https://docs.example.com/architecture
+🥷 /write "The system processes events with asynchronous..." (rewrite this)
+🥷 /learn about WebAssembly by researching and writing a guide
+🥷 /health run a setup audit
+```
+
+### Codex
+
+```bash
+npx skills add tw93/Waza -a codex -g -y
+```
+
+### Claude Desktop
+
+Download `waza.zip` from [releases](https://github.com/tw93/Waza/releases/latest/download/waza.zip), open Customize > Skills > "+" > Create skill, upload the ZIP.
+
+### Optional Extras
+
+**Statusline** — minimal context window and quota display:
+
+```bash
+curl -sL https://raw.githubusercontent.com/tw93/Waza/main/scripts/setup-statusline.sh | bash
+```
+
+Color coding: green <70%, yellow 70-85%, red >85% for context window; blue, magenta, red for quota thresholds.
+
+**English Coaching** — optional rule for English practice (appends 😇 correction on English mistakes in prompts):
+
+```bash
+# Claude Code
+curl -sL https://raw.githubusercontent.com/tw93/Waza/main/scripts/setup-english-coaching.sh | bash -s -- claude-code
+
+# Codex
+curl -sL https://raw.githubusercontent.com/tw93/Waza/main/scripts/setup-english-coaching.sh | bash -s -- codex
+```
+
+### Uninstall
+
+```bash
+# Remove all skills
+npx skills remove tw93/Waza -g
+
+# Remove Claude Desktop skill: Customize > Skills, find Waza, click "..." > Delete
+# Remove statusline: rm -f ~/.claude/statusline.sh, then remove statusLine from ~/.claude/settings.json
+# Remove English coaching: rm -f ~/.claude/rules/english.md (or remove Waza block from ~/.codex/AGENTS.md for Codex)
+```
+
+---
+
+## Relevance to Claude Code Development
+
+### Applications
+
+1. **Foundational Pattern for Skill Design** — Waza demonstrates narrowly-scoped, trigger-driven skill architecture that prevents over-generalization. Each skill has explicit "Not for..." exclusions, clear entry points, and avoids feature creep. This pattern is directly applicable to any new skill development in Claude Code's ecosystem.
+
+2. **Project-Aware Agent Capability** — The `/check` skill shows how to extract project context at runtime from public repository files without depending on machine-specific paths or unpublished instructions. This approach enables skills to adapt to project conventions without hardcoding domain-specific rules.
+
+3. **Multi-Skill Workflows** — Waza implements intentional manual chaining (not automatic triggering) between skills. This pattern respects user agency while supporting common multi-step workflows like research-and-write or hunt-and-verify.
+
+4. **Real-World Refinement** — Documented on README: "Built from patterns across real projects, refined through actual use. Every gotcha traces to a real failure: a wrong code path that took four rounds to find, a release posted before artifacts were uploaded, a server restarted eight times without reading the error. 30 days, 300+ sessions, 7 projects, 500 hours." This data-driven refinement approach ensures skills solve actual problems, not theoretical ones.
+
+### Patterns Worth Adopting
+
+1. **Skill Descriptions as Routing Signals** — Each skill's description is concrete and triggerable, written to guide both human intent and potential automatic routing. This contrasts with vague descriptions like "helps with code" or "assists with debugging."
+
+2. **Explicit Scope Boundaries** — Every skill includes "Not for..." clauses that prevent it from being misapplied. Examples: `/think` is "Not for bug fixes or small edits"; `/check` is "Not for exploring ideas or debugging"; `/design` is "Not for backend logic or data pipelines." These boundaries prevent bloat and confusion.
+
+3. **Confidence-Building Through Simplicity** — Rather than attempting universal AI assistance, Waza succeeds by being deliberately narrow. Eight skills for eight habits. Users learn when to reach for each one and what to expect.
+
+4. **Bilingual Trigger Documentation** — Skill descriptions and when_to_use triggers are explicitly documented in both Chinese and English. This enables Waza to serve global teams without losing specificity.
+
+### Integration Opportunities
+
+1. **Skill Repository Contribution** — Waza's eight skills and patterns could be integrated into a central Claude Code skill repository. The Waza approach to narrowness and trigger-driven design could influence how new skills are created and evaluated.
+
+2. **MCP-Native Skills** — While Waza is skill-based, some of its capabilities (especially `/read` with platform-specific routing, `/health` with configuration auditing) could become MCP servers available to any Claude Code extension or agent.
+
+3. **Marketplace Template** — Waza's marketplace manifest structure and naming conventions provide a template for future skill collections. The three-file consistency rule (marketplace.json, RESOLVER.md, SKILL.md) ensures versioning and discoverability alignment.
+
+4. **English/Chinese Dual Documentation Model** — The bilingual structure in README, release notes, and skill descriptions provides a replicable model for AI tools serving non-English-speaking teams.
+
+---
+
+## References
+
+- [Waza GitHub Repository](https://github.com/tw93/Waza) (accessed 2026-05-04)
+- [Waza README.md](https://github.com/tw93/Waza/blob/main/README.md) (accessed 2026-05-04)
+- [Waza AGENTS.md](https://github.com/tw93/Waza/blob/main/AGENTS.md) (accessed 2026-05-04)
+- [Waza marketplace.json](https://github.com/tw93/Waza/blob/main/.claude-plugin/marketplace.json) (accessed 2026-05-04)
+- [Waza /think skill](https://github.com/tw93/Waza/blob/main/skills/think/SKILL.md) (accessed 2026-05-04)
+- [Waza /check skill](https://github.com/tw93/Waza/blob/main/skills/check/SKILL.md) (accessed 2026-05-04)
+
+---
+
+## Cross-References
+
+| Entry | Category | Relationship |
+|-------|----------|--------------|
+| None at this time | — | — |
+
+---
+
+## Freshness Tracking
+
+| Field | Value |
+|-------|-------|
+| Last Verified | 2026-05-04 |
+| Version at Verification | v3.20.0 (check), v3.17.0 (think), v3.19.0 (design), v3.19.0 (hunt), v3.14.0 (read), v3.18.0 (write), v3.15.0 (learn), v3.17.0 (health) |
+| Next Review Recommended | 2026-08-04 |
+| Confidence Map | Overview: high, Problem Addressed: high, Key Statistics: high, Key Features: high (doc-read), Technical Architecture: high (doc-read), Installation & Usage: high (verified), Relevance to Claude Code: high, References: high |

--- a/research/skill-generation-tools/waza.md
+++ b/research/skill-generation-tools/waza.md
@@ -3,7 +3,7 @@
 **Research Date**: 2026-05-04
 **Source URL**: <https://github.com/tw93/Waza>
 **GitHub Repository**: <https://github.com/tw93/Waza>
-**Version at Research**: v3.20.0 (check: 3.20.0, think: 3.17.0, design: 3.19.0, hunt: 3.19.0, read: 3.14.0, write: 3.18.0, learn: 3.15.0, health: 3.17.0)
+**Version at Research**: v3.12.2 (GitHub release tag); per-skill SKILL.md versions: check: 3.20.0, think: 3.17.0, design: 3.19.0, hunt: 3.19.0, read: 3.14.0, write: 3.18.0, learn: 3.15.0, health: 3.17.0
 **License**: MIT License
 
 ---
@@ -231,6 +231,6 @@ npx skills remove tw93/Waza -g
 | Field | Value |
 |-------|-------|
 | Last Verified | 2026-05-04 |
-| Version at Verification | v3.20.0 (check), v3.17.0 (think), v3.19.0 (design), v3.19.0 (hunt), v3.14.0 (read), v3.18.0 (write), v3.15.0 (learn), v3.17.0 (health) |
+| Version at Verification | v3.12.2 (GitHub release tag); per-skill: check: 3.20.0, think: 3.17.0, design: 3.19.0, hunt: 3.19.0, read: 3.14.0, write: 3.18.0, learn: 3.15.0, health: 3.17.0 |
 | Next Review Recommended | 2026-08-04 |
 | Confidence Map | Overview: high, Problem Addressed: high, Key Statistics: high, Key Features: high (doc-read), Technical Architecture: high (doc-read), Installation & Usage: high (verified), Relevance to Claude Code: high, References: high |


### PR DESCRIPTION
## Summary

- Adds `research/skill-generation-tools/waza.md` — comprehensive research entry for [tw93/Waza](https://github.com/tw93/Waza), an 8-skill engineering-habit collection for Claude Code (4,369 stars, MIT)
- Adds `research/insights/2026-05-04-waza-utilization.md` — utilization assessment for Waza patterns
- Updates `research/README.md` — adds Waza to the skill-generation-tools category table

## Entry Coverage

Waza implements 8 skills (`/think`, `/check`, `/hunt`, `/design`, `/read`, `/write`, `/learn`, `/health`) encoding engineering habits as Claude Code skills. The entry documents:
- Multi-mode skill architecture (standard/lightweight/evaluation modes)
- Runtime project context extraction pattern used by `/check`
- Distribution packaging approach (source-modular, ZIP-inlined for Claude Desktop)
- Smoke-tested verification pipeline (`verify-skills.sh`, Makefile targets)
- Installation via `npx skills add tw93/Waza -a claude-code -g -y`

## Test plan

- [ ] Verify `research/skill-generation-tools/waza.md` renders correctly
- [ ] Verify README table entry links correctly to the file
- [ ] Cross-references and backlog improvements pending from background agents (follow-up commit expected)

https://claude.ai/code/session_01Ap5gmdnokxHW2Zi8XepwxU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ap5gmdnokxHW2Zi8XepwxU)_