### PR TITLE
feat(research-curator): wire research-backlink-detector as post-cross-referencer pass

### DIFF
--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -141,7 +141,7 @@ Trigger: `<mode_args/>` contains a URL with no flags.
    - **Utilization**: relay `PROPOSALS_WRITTEN` count and `FILE` path. If `STATUS: no_utilization_surface`, report "No direct utilization surface found."
    - **Cross-references**: relay `CROSS_REFERENCES_ADDED` count.
 
-7. **Spawn backlink-detector** -- after cross-referencer completes, spawn a sequential backlink pass:
+7. **Spawn backlink-detector** -- if cross-referencer returned `STATUS: complete`, spawn a sequential backlink pass (skip this step if cross-referencer returned `STATUS: failed`; failures of insight-extractor or utilization-assessor do not block this step):
 
    ```text
    Agent tool parameters:
@@ -152,6 +152,7 @@ Trigger: `<mode_args/>` contains a URL with no flags.
 8. **Wait for backlink-detector and relay result**:
 
    - **Backlinks**: relay `BACKLINKS_ADDED` count and `ENTRIES_MODIFIED` paths. If `BACKLINKS_ADDED: 0`, report "No backlink rows added."
+   - **Skipped**: if `SKIPPED` is non-empty, relay each `(path, reason)` pair verbatim so dangling links and conflicting descriptions are visible to the user.
 
 9. **Post-actions** -- lint, commit, push (see [Post-Actions](#post-actions))
 
@@ -246,11 +247,12 @@ flowchart TD
     SpawnAnalysis1 --> WaitAnalysis1["Wait for all 3 agents<br>Surface IMMEDIATE_ATTENTION items from insight result<br>Report utilization proposal count<br>Report cross-references added count"]
     WaitAnalysis1 --> SpawnBacklinks1["Spawn @research-backlink-detector<br>'Add backlinks for ./research/category/name.md'"]
     SpawnBacklinks1 --> WaitBacklinks1["Wait for backlink-detector<br>Relay BACKLINKS_ADDED count and ENTRIES_MODIFIED paths"]
-    WaitBacklinks1 --> PostActions(["Execute Post-Actions — lint, commit, push"])
+    WaitBacklinks1 --> RelayBacklinks1["Relay BACKLINKS_ADDED count<br>Relay non-empty SKIPPED list verbatim"]
+    RelayBacklinks1 --> PostActions(["Execute Post-Actions — lint, commit, push"])
     UpdateDates --> SpawnAnalysisN["For each updated entry (concurrent, up to 5 entries)<br>spawn 3 agents per entry:<br>@research-insight-extractor<br>@research-utilization-assessor<br>@research-cross-referencer"]
     SpawnAnalysisN --> WaitAnalysisN["Wait for all analysis agents<br>Collect IMMEDIATE_ATTENTION items<br>Report total utilization proposals and cross-references added"]
-    WaitAnalysisN --> SpawnBacklinksN["For each updated entry: spawn @research-backlink-detector<br>'Add backlinks for ./research/category/name.md'"]
-    SpawnBacklinksN --> WaitBacklinksN["Wait for all backlink-detector agents<br>Report total BACKLINKS_ADDED count"]
+    WaitAnalysisN --> SpawnBacklinksN["For each updated entry in sequence (one at a time):<br>spawn @research-backlink-detector<br>'Add backlinks for ./research/category/name.md'<br>wait for completion before spawning next<br>(sequential to prevent write races on shared cited entries)"]
+    SpawnBacklinksN --> WaitBacklinksN["After all backlink passes complete:<br>Report total BACKLINKS_ADDED count<br>Relay non-empty SKIPPED lists verbatim"]
     WaitBacklinksN --> PostActions
 ```
 
@@ -282,7 +284,7 @@ flowchart TD
    @research-backlink-detector — "Add backlinks for ./research/{category}/{name}.md"
    ```
 
-9. Wait for backlink-detector; relay `BACKLINKS_ADDED` count and `ENTRIES_MODIFIED` paths. If `BACKLINKS_ADDED: 0`, report "No backlink rows added."
+9. Wait for backlink-detector; relay `BACKLINKS_ADDED` count and `ENTRIES_MODIFIED` paths. If `BACKLINKS_ADDED: 0`, report "No backlink rows added." If `SKIPPED` is non-empty, relay each `(path, reason)` pair verbatim.
 
 ### All Entries Rerun
 

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -141,7 +141,19 @@ Trigger: `<mode_args/>` contains a URL with no flags.
    - **Utilization**: relay `PROPOSALS_WRITTEN` count and `FILE` path. If `STATUS: no_utilization_surface`, report "No direct utilization surface found."
    - **Cross-references**: relay `CROSS_REFERENCES_ADDED` count.
 
-7. **Post-actions** -- lint, commit, push (see [Post-Actions](#post-actions))
+7. **Spawn backlink-detector** -- after cross-referencer completes, spawn a sequential backlink pass:
+
+   ```text
+   Agent tool parameters:
+     agent: .claude/agents/research-backlink-detector.md
+     prompt: "Add backlinks for {file-path-from-agent-result}"
+   ```
+
+8. **Wait for backlink-detector and relay result**:
+
+   - **Backlinks**: relay `BACKLINKS_ADDED` count and `ENTRIES_MODIFIED` paths. If `BACKLINKS_ADDED: 0`, report "No backlink rows added."
+
+9. **Post-actions** -- lint, commit, push (see [Post-Actions](#post-actions))
 
 ### Error Handling
 
@@ -166,7 +178,7 @@ Extract all tokens after `--batch` matching `https?://` as target URLs. Non-URL 
 
 ### Wave Spawning
 
-Spawn up to 5 `@research-curator` agents per wave via Agent tool. Wait for all agents in the current wave before spawning the next. After all waves complete, for each successful entry spawn three concurrent agents: `@research-insight-extractor`, `@research-utilization-assessor`, and `@research-cross-referencer` (up to 5 entries processed concurrently — 3 agents each). See [Batch Mode reference](./references/batch-mode.md) for the complete wave spawning diagram.
+Spawn up to 5 `@research-curator` agents per wave via Agent tool. Wait for all agents in the current wave before spawning the next. After all waves complete, for each successful entry spawn three concurrent agents: `@research-insight-extractor`, `@research-utilization-assessor`, and `@research-cross-referencer` (up to 5 entries processed concurrently — 3 agents each), followed by a sequential `@research-backlink-detector` pass for each entry after cross-referencer completes. See [Batch Mode reference](./references/batch-mode.md) for the complete wave spawning diagram.
 
 ### Duplicate Detection
 
@@ -232,10 +244,14 @@ flowchart TD
     RelayCheck2 --> UpdateDates["Update ./research/README.md<br>refresh freshness dates for all re-researched entries"]
     UpdateDate --> SpawnAnalysis1["Concurrently spawn 3 agents:<br>@research-insight-extractor 'Extract improvements from ./research/category/name.md'<br>@research-utilization-assessor 'Assess utilization opportunities from ./research/category/name.md'<br>@research-cross-referencer 'Add cross-references to ./research/category/name.md'"]
     SpawnAnalysis1 --> WaitAnalysis1["Wait for all 3 agents<br>Surface IMMEDIATE_ATTENTION items from insight result<br>Report utilization proposal count<br>Report cross-references added count"]
-    WaitAnalysis1 --> PostActions(["Execute Post-Actions — lint, commit, push"])
+    WaitAnalysis1 --> SpawnBacklinks1["Spawn @research-backlink-detector<br>'Add backlinks for ./research/category/name.md'"]
+    SpawnBacklinks1 --> WaitBacklinks1["Wait for backlink-detector<br>Relay BACKLINKS_ADDED count and ENTRIES_MODIFIED paths"]
+    WaitBacklinks1 --> PostActions(["Execute Post-Actions — lint, commit, push"])
     UpdateDates --> SpawnAnalysisN["For each updated entry (concurrent, up to 5 entries)<br>spawn 3 agents per entry:<br>@research-insight-extractor<br>@research-utilization-assessor<br>@research-cross-referencer"]
     SpawnAnalysisN --> WaitAnalysisN["Wait for all analysis agents<br>Collect IMMEDIATE_ATTENTION items<br>Report total utilization proposals and cross-references added"]
-    WaitAnalysisN --> PostActions
+    WaitAnalysisN --> SpawnBacklinksN["For each updated entry: spawn @research-backlink-detector<br>'Add backlinks for ./research/category/name.md'"]
+    SpawnBacklinksN --> WaitBacklinksN["Wait for all backlink-detector agents<br>Report total BACKLINKS_ADDED count"]
+    WaitBacklinksN --> PostActions
 ```
 
 ### Single Entry Rerun
@@ -259,6 +275,14 @@ flowchart TD
    ```
 
 7. Wait for all three; surface `IMMEDIATE_ATTENTION` items from insight result; report utilization proposal count; report cross-references added count
+
+8. Spawn backlink-detector after cross-referencer completes:
+
+   ```text
+   @research-backlink-detector — "Add backlinks for ./research/{category}/{name}.md"
+   ```
+
+9. Wait for backlink-detector; relay `BACKLINKS_ADDED` count and `ENTRIES_MODIFIED` paths. If `BACKLINKS_ADDED: 0`, report "No backlink rows added."
 
 ### All Entries Rerun
 
@@ -478,5 +502,6 @@ YYYY-MM-DD
 - Agent: `@research-insight-extractor` at `.claude/agents/research-insight-extractor.md` -- extracts backlog improvements from research entries
 - Agent: `@research-utilization-assessor` at `.claude/agents/research-utilization-assessor.md` -- assesses direct API/service utilization opportunities
 - Agent: `@research-cross-referencer` at `.claude/agents/research-cross-referencer.md` -- appends Cross-References section to research entries
+- Agent: `@research-backlink-detector` at `.claude/agents/research-backlink-detector.md` -- appends reciprocal backlink rows to all entries cited by the target entry; runs as a sequential post-pass after `@research-cross-referencer`
 
 SOURCE: Agent result relay rules and pre-relay checklist adapted from `plugins/summarizer/skills/agent-result-relay/SKILL.md` (accessed 2026-03-06).

--- a/.claude/skills/research-curator/references/batch-mode.md
+++ b/.claude/skills/research-curator/references/batch-mode.md
@@ -48,7 +48,8 @@ flowchart TD
     SpawnAnalysisPartial --> Partial["Update ./research/README.md<br>with successful entries only<br>(concurrent with analysis agents)"]
     UpdateAll --> WaitAnalysis["Wait for all analysis agents to complete<br>Collect IMMEDIATE_ATTENTION items from insight results<br>Collect PROPOSALS_WRITTEN counts from utilization results<br>Collect CROSS_REFERENCES_ADDED counts from cross-referencer results"]
     Partial --> WaitAnalysis
-    WaitAnalysis --> NotifyUser["If any IMMEDIATE_ATTENTION items exist:<br>report each to user with issue number and reason<br>Otherwise: report total backlog items created count<br>Report total utilization proposals written<br>Report total cross-references added"]
+    WaitAnalysis --> BacklinkPass["For each successful entry in sequence (one at a time):<br>spawn @research-backlink-detector<br>'Add backlinks for {file-path}'<br>wait for completion before spawning next<br>(sequential to prevent write races on shared cited entries)"]
+    BacklinkPass --> NotifyUser["If any IMMEDIATE_ATTENTION items exist:<br>report each to user with issue number and reason<br>Otherwise: report total backlog items created count<br>Report total utilization proposals written<br>Report total cross-references added<br>Report total BACKLINKS_ADDED count<br>Relay non-empty SKIPPED lists verbatim"]
     NotifyUser --> PostActions(["Execute Post-Actions — lint, commit, push"])
 ```
 
@@ -57,6 +58,8 @@ flowchart TD
 **Sequential waves**: Wait for all agents in current wave to complete before spawning next wave. This prevents overwhelming MCP tool rate limits.
 
 **Analysis phase concurrency**: After all curator waves complete, analysis agents spawn concurrently per entry: up to 5 entries × 3 agents (insight-extractor + utilization-assessor + cross-referencer) = maximum 15 concurrent agents. This is distinct from the 5-agent curator wave limit.
+
+**Backlink phase serialization**: After all analysis agents complete, backlink-detector agents run **sequentially** — one entry at a time. Concurrent backlink passes on multiple entries that cite a shared target file would produce a write race (each agent reads a stale snapshot and the last writer drops the other's row). Sequential execution prevents this.
 
 ---
 
@@ -87,6 +90,8 @@ Files created: [list]
 README updated: Yes
 Utilization proposals written: N files
 Cross-references added: N entries updated
+Backlinks added: N rows across M entries
+Backlink skipped: [(path, reason), ...] (omitted when empty)
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Wires `@research-backlink-detector` into the research-curator orchestration as a sequential post-pass after `@research-cross-referencer` in all three modes (default, rerun, batch)
- The agent file, `backlink_lib.py` library, and `validate_research.py check-backlinks` subcommand were already implemented; only the SKILL.md orchestration wiring was missing
- Adds `@research-backlink-detector` to the Reference Links section

## What changed

`research-curator/SKILL.md`:
- **Default mode**: added steps 7–8 to spawn `@research-backlink-detector` and relay `BACKLINKS_ADDED` count; post-actions renumbered to step 9
- **Rerun mode**: added steps 8–9 for the same sequential backlink pass after the three concurrent agents
- **Batch mode**: updated summary text and Mermaid diagram with backlink-detector nodes for single-entry and multi-entry paths
- **Reference Links**: added `@research-backlink-detector` agent entry

## Test plan

- [x] `uv run prek run --files .claude/skills/research-curator/SKILL.md` — all hooks pass
- [x] `uv run .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research/` — runs and reports 655 asymmetric cross-references (expected; vault has no backlinks yet)
- [ ] End-to-end: run research-curator on a new entry, verify backlink-detector fires and cited entries receive reciprocal rows

Closes #1953

https://claude.ai/code/session_01YEbbuM55vGGTqNYgg5XXix

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEbbuM55vGGTqNYgg5XXix)_