### PR TITLE
feat(research-curator): add frontmatter generation and --add-frontmatter mode

### DIFF
--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-curator
 description: 'Manage research entries in ./research/ — create, refresh, and validate. Use when asked to add a tool, "document this", "research this", "refresh this research", "validate research entries", or given a tool URL. Modes: default (single URL), --batch (multiple URLs in parallel), --rerun (refresh stale entries), --validate (structural check and auto-fix).'
-argument-hint: '[url] [--batch url1 url2 ...] [--rerun category/name|all] [--validate category/name|all]'
+argument-hint: '[url] [--batch url1 url2 ...] [--rerun category/name|all] [--validate category/name|all] [--add-frontmatter category/name|all]'
 ---
 
 <mode_args>$ARGUMENTS</mode_args>
@@ -35,7 +35,9 @@ flowchart TD
     Q2Layer -->|"Yes — layer filter present"| RerunLayer(["Execute Rerun Mode with layer filter applied"])
     Q2Layer -->|"No — no layer filter"| Rerun(["Execute Rerun Mode"])
     Q3 -->|"Yes — validate flag present"| Validate(["Execute Validate Mode"])
-    Q3 -->|"No — no flags matched — <mode_args/> contains a URL only"| Default(["Execute Default Mode — single URL"])
+    Q3 -->|"No — validate flag absent"| Q4{"Does <mode_args/> contain --add-frontmatter?"}
+    Q4 -->|"Yes — add-frontmatter flag present"| Frontmatter(["Execute Frontmatter Mode"])
+    Q4 -->|"No — no flags matched — <mode_args/> contains a URL only"| Default(["Execute Default Mode — single URL"])
 ```
 
 ---
@@ -117,7 +119,8 @@ Trigger: `<mode_args/>` contains a URL with no flags.
 
 3. **Wait** for structured result (status, file path, category, key findings)
 4. **Apply relay rules** -- verify pre-relay checklist before proceeding
-5. **Spawn four tasks concurrently** -- if research status is not `failed`:
+5. **Generate frontmatter** -- if research status is not `failed`, apply the Generation Procedure from [Frontmatter Generation](./references/frontmatter-generation.md) to the new entry file before any other post-creation steps
+6. **Spawn four tasks concurrently** -- if research status is not `failed`:
 
    ```text
    a. Agent tool parameters:
@@ -135,13 +138,13 @@ Trigger: `<mode_args/>` contains a URL with no flags.
    d. Update ./research/README.md -- add new entry to category table
    ```
 
-6. **Wait for all four tasks and surface results** -- collect structured return blocks from all three agents and confirm README updated:
+7. **Wait for all four tasks and surface results** -- collect structured return blocks from all three agents and confirm README updated:
 
    - **Insight**: if the result contains `IMMEDIATE_ATTENTION:`, report each item with `#{issue} {title}` and the one-sentence reason. If no `IMMEDIATE_ATTENTION` section: report "N improvements added to backlog from {resource-name}."
    - **Utilization**: relay `PROPOSALS_WRITTEN` count and `FILE` path. If `STATUS: no_utilization_surface`, report "No direct utilization surface found."
    - **Cross-references**: relay `CROSS_REFERENCES_ADDED` count.
 
-7. **Post-actions** -- lint, commit, push (see [Post-Actions](#post-actions))
+8. **Post-actions** -- lint, commit, push (see [Post-Actions](#post-actions))
 
 ### Error Handling
 
@@ -249,8 +252,9 @@ flowchart TD
 
 3. Agent reads existing entry, re-gathers fresh data, updates content and freshness tracking
 4. Apply pre-relay quality checklist to agent result
-5. Update README with refreshed date
-6. Concurrently spawn three analysis agents:
+5. Apply Generation Procedure from [Frontmatter Generation](./references/frontmatter-generation.md) to refresh `date_last_reviewed` and normalize to canonical schema
+6. Update README with refreshed date
+7. Concurrently spawn three analysis agents:
 
    ```text
    - @research-insight-extractor — "Extract improvements from ./research/{category}/{name}.md"
@@ -258,7 +262,7 @@ flowchart TD
    - @research-cross-referencer — "Add cross-references to ./research/{category}/{name}.md"
    ```
 
-7. Wait for all three; surface `IMMEDIATE_ATTENTION` items from insight result; report utilization proposal count; report cross-references added count
+8. Wait for all three; surface `IMMEDIATE_ATTENTION` items from insight result; report utilization proposal count; report cross-references added count
 
 ### All Entries Rerun
 
@@ -348,6 +352,44 @@ Validation complete:
 ```
 
 </validate_mode>
+
+---
+
+<frontmatter_mode>
+
+## Frontmatter Mode
+
+Trigger: `<mode_args/>` contains `--add-frontmatter`.
+
+Generates or upgrades YAML frontmatter on existing research entries to the canonical schema defined in [Frontmatter Generation](./references/frontmatter-generation.md). Use this to backfill entries created before frontmatter generation was part of the workflow, or to normalize entries that have partial or non-canonical frontmatter.
+
+### Target Parsing
+
+Extract the value after `--add-frontmatter`:
+
+- `category/name` — single entry at `./research/category/name.md`
+- `all` — every entry in `./research/` except `README.md` and `./research/insights/**`
+
+### Execution
+
+Follow the Standalone Backfill Procedure in [Frontmatter Generation](./references/frontmatter-generation.md).
+
+### Output
+
+```text
+Frontmatter update complete:
+  Entries processed: N
+  Updated: N (frontmatter added or upgraded to canonical)
+  Skipped: N (already canonical)
+  Failed: N
+
+Updated entries:
+  ./research/category/name.md
+```
+
+List any failures with the exact reason (field could not be extracted, file write error, etc.).
+
+</frontmatter_mode>
 
 ---
 
@@ -472,6 +514,7 @@ YYYY-MM-DD
 ## Reference Links
 
 - [Entry Template](./references/entry-template.md) -- standard format for all research entries
+- [Frontmatter Generation](./references/frontmatter-generation.md) -- canonical YAML schema, extraction rules for all entry formats, and backfill procedure for `--add-frontmatter` mode
 - [Validation Rules](./references/validation-rules.md) -- checks and severity mapping for `--validate` mode
 - [Batch Mode](./references/batch-mode.md) -- wave spawning workflow for `--batch` mode
 - Agent: `@research-curator` at `.claude/agents/research-curator.md` -- single-entry research executor

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -270,7 +270,9 @@ flowchart TD
 
 3. Agent reads existing entry, re-gathers fresh data, updates content and freshness tracking
 4. Apply pre-relay quality checklist to agent result
-5. Apply Generation Procedure from [Frontmatter Generation](./references/frontmatter-generation.md) to refresh `date_last_reviewed` and normalize to canonical schema
+5. **Update frontmatter** — two cases based on entry state after the agent completes:
+   - **Already canonical** (all of `title`, `subtitle`, `category`, `resource_url`, `date_created`, `date_last_reviewed`, `status` present): update only `date_last_reviewed` to today's date directly in the existing frontmatter; do not invoke the full Generation Procedure
+   - **Not yet canonical**: apply the full Generation Procedure from [Frontmatter Generation](./references/frontmatter-generation.md)
 6. Update README with refreshed date
 7. Concurrently spawn three analysis agents:
 

--- a/.claude/skills/research-curator/references/frontmatter-generation.md
+++ b/.claude/skills/research-curator/references/frontmatter-generation.md
@@ -11,7 +11,7 @@
 ```yaml
 ---
 title: "{Official resource name}"
-subtitle: "{Short byline contrasting with or expanding the title}"
+subtitle: "{What a reader finds inside — 5–10 words, written as a journal deck line}"
 category: "{parent directory name}"
 resource_url: "{primary URL}"
 github_url: "{GitHub URL — omit field entirely if absent}"
@@ -34,7 +34,7 @@ status: "published"
 | Field | Where to find it |
 |---|---|
 | `title` | YAML `title:` or `name:` → else first `# Heading` |
-| `subtitle` | YAML `subtitle:` → else write a short byline (5–10 words) that provides contrasting context to the title after reading the entry |
+| `subtitle` | YAML `subtitle:` → else after reading the full entry, write 5–10 words describing what a reader finds inside — the key capability, finding, or differentiator — as a journal editor would pitch the article |
 | `category` | YAML `category:` or `metadata.category:` → else parent directory name |
 | `resource_url` | YAML `resource_url:` or `metadata.source_url:` → else `**Source URL**: <url>` in body |
 | `github_url` | YAML `github_url:` or `metadata.github:` (add `https://github.com/` if no scheme) → else `**GitHub Repository**: <url>` → **omit field entirely** if absent |

--- a/.claude/skills/research-curator/references/frontmatter-generation.md
+++ b/.claude/skills/research-curator/references/frontmatter-generation.md
@@ -1,6 +1,10 @@
 # Frontmatter Generation
 
-**Read the full entry file before writing any frontmatter field.** Title, subtitle, URL, and dates all appear in the body — extracting them without reading first produces wrong values.
+**Actor**: Claude (executing the research-curator skill workflow)
+**Entry**: Path to `./research/{category}/{name}.md`
+**Outcome**: File begins with canonical YAML frontmatter block; `prek` exits 0
+
+---
 
 ## Canonical Schema
 
@@ -10,29 +14,57 @@ title: "{Official resource name}"
 subtitle: "{What it is — 5–10 words}"
 category: "{parent directory name}"
 resource_url: "{primary URL}"
-github_url: "{GitHub URL — omit field if absent}"
+github_url: "{GitHub URL — omit field entirely if absent}"
 date_created: "YYYY-MM-DD"
 date_last_reviewed: "YYYY-MM-DD"
 status: "published"
 ---
 ```
 
-## Field Extraction
+---
+
+## Procedure
+
+**1. Read** — read the complete entry file before extracting any field. Values appear in the body; reading first is required, not optional.
+
+**2. Skip check** — if the file already has all of `title`, `category`, `resource_url`, `date_created`, `date_last_reviewed`, `status` present and non-empty: stop, report SKIPPED, do not write.
+
+**3. Extract** — apply the extraction table. Required fields are `title` and `resource_url`; all others have defined fallbacks.
 
 | Field | Where to find it |
 |---|---|
 | `title` | YAML `title:` or `name:` → else first `# Heading` |
-| `subtitle` | YAML `subtitle:` → else first sentence of `## Overview` |
+| `subtitle` | YAML `subtitle:` → else first sentence of `## Overview` (up to first period, max 100 chars) |
 | `category` | YAML `category:` or `metadata.category:` → else parent directory name |
 | `resource_url` | YAML `resource_url:` or `metadata.source_url:` → else `**Source URL**: <url>` in body |
-| `github_url` | YAML `github_url:` or `metadata.github:` (prefix `https://github.com/` if no scheme) → else `**GitHub Repository**: <url>` → omit if not found |
+| `github_url` | YAML `github_url:` or `metadata.github:` (add `https://github.com/` if no scheme) → else `**GitHub Repository**: <url>` → **omit field entirely** if absent |
 | `date_created` | YAML `date_created:` or `created:` or `metadata.verified:` → else `**Research Date**: YYYY-MM-DD` in body → else `git log --follow --diff-filter=A --format='%as' -- {path} \| tail -1` |
-| `date_last_reviewed` | YAML `date_last_reviewed:` or `last_reviewed:` → else `Last Verified \| YYYY-MM-DD` row in Freshness Tracking table → fallback to `date_created` |
+| `date_last_reviewed` | YAML `date_last_reviewed:` or `last_reviewed:` → else `Last Verified \| YYYY-MM-DD` in Freshness Tracking table → else same as `date_created` |
 | `status` | Always `published` |
+
+**4. Write** — quote all date values (`"2026-05-02"`, not `2026-05-02`). Then:
+
+- **No existing frontmatter** (no `---` at line 1): prepend `---\n{fields}\n---\n` before the first line of body content
+- **Existing frontmatter present**: replace the entire block between the opening and closing `---` delimiters; leave all body content after the closing `---` unchanged
+
+**5. Verify** — read back the first 10 lines and confirm: opening `---` on line 1, closing `---` present, `title:` field visible. Then run:
+
+```bash
+uv run prek run --files ./research/{category}/{name}.md
+```
+
+---
+
+## Error Paths
+
+- `title` or `resource_url` unresolvable from all fallbacks → report UNRESOLVABLE with the file path, do not write any frontmatter, stop
+- `prek` exits non-zero → read the full error output, fix the specific violation, re-run prek; do not mark done until exit 0
+
+---
 
 ## Examples
 
-**Before** (Format A — no frontmatter):
+**Before** (no frontmatter — Format A):
 
 ```markdown
 # ESP-CLAW: Chat-Coding AI Agent Framework for IoT Devices
@@ -63,7 +95,7 @@ status: published
 
 ---
 
-**Before** (Format C — Agno nested metadata):
+**Before** (nested metadata — Format C):
 
 ```yaml
 ---
@@ -90,17 +122,4 @@ date_created: "2026-01-31"
 date_last_reviewed: "2026-01-31"
 status: published
 ---
-```
-
-## Writing Rules
-
-1. Omit `github_url` entirely when not found — do not write `github_url: ""`
-2. Quote date values — `"2026-05-02"` not `2026-05-02`
-3. Skip entries during `--add-frontmatter all` that already have all canonical fields present and non-empty
-4. After writing, read back the first 10 lines to confirm `---` delimiters are present
-
-## Validate
-
-```bash
-uv run prek run --files ./research/{category}/{name}.md
 ```

--- a/.claude/skills/research-curator/references/frontmatter-generation.md
+++ b/.claude/skills/research-curator/references/frontmatter-generation.md
@@ -1,159 +1,106 @@
 # Frontmatter Generation
 
-Canonical YAML frontmatter schema for all research entries, extraction rules from every observed existing format, and the procedure for generating or backfilling frontmatter on any entry.
-
----
+**Read the full entry file before writing any frontmatter field.** Title, subtitle, URL, and dates all appear in the body — extracting them without reading first produces wrong values.
 
 ## Canonical Schema
 
-Every research entry file must begin with this YAML frontmatter block:
-
 ```yaml
 ---
-title: "{Resource Name}"
-subtitle: "{One-phrase description of what it is}"
-category: "{directory-name}"
-resource_url: "{primary homepage or source URL}"
-github_url: "{GitHub repository URL}"
+title: "{Official resource name}"
+subtitle: "{What it is — 5–10 words}"
+category: "{parent directory name}"
+resource_url: "{primary URL}"
+github_url: "{GitHub URL — omit field if absent}"
 date_created: "YYYY-MM-DD"
 date_last_reviewed: "YYYY-MM-DD"
 status: "published"
 ---
 ```
 
-Field rules:
+## Field Extraction
 
-- `title`: Official name of the resource, no version suffix
-- `subtitle`: One short phrase — what the resource *is*, not what it *does*. 5–10 words max.
-- `category`: The parent directory name as-is (e.g., `agent-frameworks`, `mcp-ecosystem`)
-- `resource_url`: The primary URL listed in the entry — homepage preferred, GitHub if no homepage
-- `github_url`: GitHub repository URL. Omit field entirely when absent from the entry.
-- `date_created`: Date the research entry was first written
-- `date_last_reviewed`: Date of the most recent content verification
-- `status`: Always `published` for completed entries
-
----
-
-## Format Detection
-
-Before extracting fields, detect which of the four formats the entry uses:
-
-```mermaid
-flowchart TD
-    Read["Read first 30 lines of entry file"] --> Q1{"File starts with '---'?"}
-    Q1 -->|"No"| FormatA["Format A — No frontmatter<br>Pure Markdown heading body"]
-    Q1 -->|"Yes"| Q2{"Frontmatter contains 'title:' key?"}
-    Q2 -->|"Yes"| Q3{"Frontmatter contains 'resource_url:' or 'date_created:' keys?"}
-    Q3 -->|"Yes"| FormatD["Format D — Full canonical<br>esp-claw / Trellis style"]
-    Q3 -->|"No"| FormatB["Format B — Minimal<br>Trellis-minimal style (title + resource_url + created)"]
-    Q2 -->|"No"| Q4{"Frontmatter contains 'name:' key?"}
-    Q4 -->|"Yes"| FormatC["Format C — Agno-style<br>name + metadata nested block"]
-    Q4 -->|"No"| FormatB
-```
-
----
-
-## Field Extraction by Format
-
-### Format A — No frontmatter (Markdown heading body)
-
-| Target field | Extraction source |
+| Field | Where to find it |
 |---|---|
-| `title` | Content of first `# {Title}` heading — strip leading `# ` |
-| `subtitle` | First sentence of `## Overview` section body (up to first period) |
-| `category` | Parent directory name from file path |
-| `resource_url` | `**Source URL**: <url>` body pattern — extract URL from angle brackets or bare value |
-| `github_url` | `**GitHub Repository**: <url>` pattern — extract URL; omit if absent |
-| `date_created` | `**Research Date**: YYYY-MM-DD` pattern in header block; fallback: git log first-commit date |
-| `date_last_reviewed` | `Last Verified \| YYYY-MM-DD` row in Freshness Tracking table; fallback: same as `date_created` |
+| `title` | YAML `title:` or `name:` → else first `# Heading` |
+| `subtitle` | YAML `subtitle:` → else first sentence of `## Overview` |
+| `category` | YAML `category:` or `metadata.category:` → else parent directory name |
+| `resource_url` | YAML `resource_url:` or `metadata.source_url:` → else `**Source URL**: <url>` in body |
+| `github_url` | YAML `github_url:` or `metadata.github:` (prefix `https://github.com/` if no scheme) → else `**GitHub Repository**: <url>` → omit if not found |
+| `date_created` | YAML `date_created:` or `created:` or `metadata.verified:` → else `**Research Date**: YYYY-MM-DD` in body → else `git log --follow --diff-filter=A --format='%as' -- {path} \| tail -1` |
+| `date_last_reviewed` | YAML `date_last_reviewed:` or `last_reviewed:` → else `Last Verified \| YYYY-MM-DD` row in Freshness Tracking table → fallback to `date_created` |
 | `status` | Always `published` |
 
-### Format B — Minimal frontmatter (Trellis style)
+## Examples
 
-| Target field | Source key(s) |
-|---|---|
-| `title` | `title:` |
-| `subtitle` | `title:` value after em-dash if present; otherwise first sentence of `## Overview` |
-| `category` | `category:` key; fallback: parent directory name |
-| `resource_url` | `resource_url:` |
-| `github_url` | Infer from `resource_url:` if it is a `github.com` URL; otherwise look for `**Repository**: <url>` in body; omit if absent |
-| `date_created` | `created:` |
-| `date_last_reviewed` | `last_reviewed:` |
-| `status` | `status:` key if present; default `published` |
+**Before** (Format A — no frontmatter):
 
-### Format C — Agno nested metadata
+```markdown
+# ESP-CLAW: Chat-Coding AI Agent Framework for IoT Devices
 
-| Target field | Source key path |
-|---|---|
-| `title` | `name:` top-level key |
-| `subtitle` | `description:` — truncate at first period or 80 chars, whichever is shorter |
-| `category` | `metadata.category:` key; fallback: parent directory name |
-| `resource_url` | `metadata.source_url:` |
-| `github_url` | `metadata.github:` — prefix with `https://github.com/` if value has no scheme |
-| `date_created` | `metadata.verified:` (earliest available proxy) |
-| `date_last_reviewed` | `metadata.verified:` |
-| `status` | Always `published` |
+**Research Date**: 2026-05-02
+**Source URL**: <https://esp-claw.com/>
+**GitHub Repository**: <https://github.com/espressif/esp-claw>
 
-### Format D — Full canonical (already has matching fields)
+## Overview
 
-Reuse existing values. Normalize field names if needed (e.g., `created:` → `date_created:`). Do not regenerate fields that are already correct.
-
----
-
-## Generation Procedure
-
-Apply to a single entry file — use this whether creating frontmatter for a new entry or updating an existing one.
-
-```mermaid
-flowchart TD
-    Start(["Entry file path known"]) --> Detect["Detect format — follow Format Detection diagram"]
-    Detect --> Extract["Extract all target fields using format-specific rules"]
-    Extract --> Validate{"Any required field empty<br>after extraction?"}
-    Validate -->|"Yes — field could not be extracted"| Fill["Fill missing field:<br>title/subtitle: read ## Overview and derive<br>resource_url: search body for any URL near resource name<br>dates: use git log --follow --diff-filter=A --format='%as' -- {path} | tail -1<br>category: use parent directory name"]
-    Validate -->|"No — all fields resolved"| HasFrontmatter{"Does file already<br>have YAML frontmatter?"}
-    Fill --> HasFrontmatter
-    HasFrontmatter -->|"No — Format A"| Prepend["Prepend frontmatter block to file<br>Write '---\\n{fields}\\n---\\n' before existing content"]
-    HasFrontmatter -->|"Yes — Formats B/C/D"| Replace["Replace existing frontmatter block<br>Write canonical fields in place of old block<br>Preserve all body content unchanged"]
-    Prepend --> Verify["Read first 10 lines of modified file<br>Confirm '---' delimiters present and field count matches"]
-    Replace --> Verify
-    Verify --> Done(["Frontmatter written"])
+ESP-CLAW is Espressif's event-driven AI agent framework...
 ```
 
-### Writing the frontmatter block
+**After**:
 
-Write only fields that have non-empty values. Always include `title`, `category`, `resource_url`, `date_created`, `date_last_reviewed`, `status`. Include `subtitle` when extractable. Omit `github_url` when absent — do not write `github_url: ""`.
-
+```yaml
 ---
-
-## Standalone Backfill Procedure (`--add-frontmatter`)
-
-Use when the SKILL.md `--add-frontmatter` mode is invoked. Targets one entry or all entries in the vault.
-
-```mermaid
-flowchart TD
-    Start(["--add-frontmatter argument parsed"]) --> Q{"Argument value?"}
-    Q -->|"category/name — single entry"| VerifyFile{"Does ./research/category/name.md exist?"}
-    Q -->|"all — every entry"| GlobAll["Glob ./research/**/*.md<br>Exclude README.md and ./research/insights/**"]
-    VerifyFile -->|"No"| Error(["Report: entry not found. Stop."])
-    VerifyFile -->|"Yes"| Single["Apply Generation Procedure to single file"]
-    Single --> CommitSingle(["Commit: 'docs(research): add frontmatter to category/name'"])
-    GlobAll --> Filter["Filter out entries that already have Format D canonical frontmatter<br>(all 8 target fields present and non-empty)"]
-    Filter --> Count["Report: N entries need frontmatter, M already complete"]
-    Count --> Wave["Process in waves of 10:<br>Apply Generation Procedure to each file<br>Collect paths of modified files"]
-    Wave --> WaveDone{"All entries processed?"}
-    WaveDone -->|"No — more entries"| Wave
-    WaveDone -->|"Yes"| CommitAll["Commit all modified files:<br>'docs(research): backfill frontmatter on N entries'"]
-    CommitAll --> Report(["Report: N updated, M skipped (already canonical), K failed (list paths)"])
+title: ESP-CLAW
+subtitle: Chat-Coding AI Agent Framework for ESP32 IoT Devices
+category: agent-frameworks
+resource_url: https://esp-claw.com/
+github_url: https://github.com/espressif/esp-claw
+date_created: "2026-05-02"
+date_last_reviewed: "2026-05-02"
+status: published
+---
 ```
 
-### Skipping logic
-
-Skip an entry during `--all` backfill if its frontmatter already contains all of these fields with non-empty values: `title`, `category`, `resource_url`, `date_created`, `date_last_reviewed`, `status`. Partial frontmatter (missing any field) is not skipped — it is upgraded to canonical.
-
 ---
 
-## Integration Points
+**Before** (Format C — Agno nested metadata):
 
-- **Default mode**: After `@research-curator` agent returns the new entry path, apply the Generation Procedure to that file before spawning the four concurrent post-creation tasks.
-- **Rerun mode**: After `@research-curator` agent updates an existing entry, apply the Generation Procedure to refresh `date_last_reviewed` and ensure canonical format.
-- **Standalone**: `--add-frontmatter category/name` or `--add-frontmatter all` follows the Standalone Backfill Procedure above.
+```yaml
+---
+name: Agno
+description: Agno is a Python framework for building multi-agent systems...
+metadata:
+  category: agent-frameworks
+  source_url: https://docs.agno.com
+  github: agno-agi/agno
+  verified: "2026-01-31"
+---
+```
+
+**After**:
+
+```yaml
+---
+title: Agno
+subtitle: Python framework for building multi-agent systems
+category: agent-frameworks
+resource_url: https://docs.agno.com
+github_url: https://github.com/agno-agi/agno
+date_created: "2026-01-31"
+date_last_reviewed: "2026-01-31"
+status: published
+---
+```
+
+## Writing Rules
+
+1. Omit `github_url` entirely when not found — do not write `github_url: ""`
+2. Quote date values — `"2026-05-02"` not `2026-05-02`
+3. Skip entries during `--add-frontmatter all` that already have all canonical fields present and non-empty
+4. After writing, read back the first 10 lines to confirm `---` delimiters are present
+
+## Validate
+
+```bash
+uv run prek run --files ./research/{category}/{name}.md
+```

--- a/.claude/skills/research-curator/references/frontmatter-generation.md
+++ b/.claude/skills/research-curator/references/frontmatter-generation.md
@@ -11,7 +11,7 @@
 ```yaml
 ---
 title: "{Official resource name}"
-subtitle: "{What it is — 5–10 words}"
+subtitle: "{Short byline contrasting with or expanding the title}"
 category: "{parent directory name}"
 resource_url: "{primary URL}"
 github_url: "{GitHub URL — omit field entirely if absent}"
@@ -34,7 +34,7 @@ status: "published"
 | Field | Where to find it |
 |---|---|
 | `title` | YAML `title:` or `name:` → else first `# Heading` |
-| `subtitle` | YAML `subtitle:` → else first sentence of `## Overview` (up to first period, max 100 chars) |
+| `subtitle` | YAML `subtitle:` → else write a short byline (5–10 words) that provides contrasting context to the title after reading the entry |
 | `category` | YAML `category:` or `metadata.category:` → else parent directory name |
 | `resource_url` | YAML `resource_url:` or `metadata.source_url:` → else `**Source URL**: <url>` in body |
 | `github_url` | YAML `github_url:` or `metadata.github:` (add `https://github.com/` if no scheme) → else `**GitHub Repository**: <url>` → **omit field entirely** if absent |

--- a/.claude/skills/research-curator/references/frontmatter-generation.md
+++ b/.claude/skills/research-curator/references/frontmatter-generation.md
@@ -1,0 +1,159 @@
+# Frontmatter Generation
+
+Canonical YAML frontmatter schema for all research entries, extraction rules from every observed existing format, and the procedure for generating or backfilling frontmatter on any entry.
+
+---
+
+## Canonical Schema
+
+Every research entry file must begin with this YAML frontmatter block:
+
+```yaml
+---
+title: "{Resource Name}"
+subtitle: "{One-phrase description of what it is}"
+category: "{directory-name}"
+resource_url: "{primary homepage or source URL}"
+github_url: "{GitHub repository URL}"
+date_created: "YYYY-MM-DD"
+date_last_reviewed: "YYYY-MM-DD"
+status: "published"
+---
+```
+
+Field rules:
+
+- `title`: Official name of the resource, no version suffix
+- `subtitle`: One short phrase — what the resource *is*, not what it *does*. 5–10 words max.
+- `category`: The parent directory name as-is (e.g., `agent-frameworks`, `mcp-ecosystem`)
+- `resource_url`: The primary URL listed in the entry — homepage preferred, GitHub if no homepage
+- `github_url`: GitHub repository URL. Omit field entirely when absent from the entry.
+- `date_created`: Date the research entry was first written
+- `date_last_reviewed`: Date of the most recent content verification
+- `status`: Always `published` for completed entries
+
+---
+
+## Format Detection
+
+Before extracting fields, detect which of the four formats the entry uses:
+
+```mermaid
+flowchart TD
+    Read["Read first 30 lines of entry file"] --> Q1{"File starts with '---'?"}
+    Q1 -->|"No"| FormatA["Format A — No frontmatter<br>Pure Markdown heading body"]
+    Q1 -->|"Yes"| Q2{"Frontmatter contains 'title:' key?"}
+    Q2 -->|"Yes"| Q3{"Frontmatter contains 'resource_url:' or 'date_created:' keys?"}
+    Q3 -->|"Yes"| FormatD["Format D — Full canonical<br>esp-claw / Trellis style"]
+    Q3 -->|"No"| FormatB["Format B — Minimal<br>Trellis-minimal style (title + resource_url + created)"]
+    Q2 -->|"No"| Q4{"Frontmatter contains 'name:' key?"}
+    Q4 -->|"Yes"| FormatC["Format C — Agno-style<br>name + metadata nested block"]
+    Q4 -->|"No"| FormatB
+```
+
+---
+
+## Field Extraction by Format
+
+### Format A — No frontmatter (Markdown heading body)
+
+| Target field | Extraction source |
+|---|---|
+| `title` | Content of first `# {Title}` heading — strip leading `# ` |
+| `subtitle` | First sentence of `## Overview` section body (up to first period) |
+| `category` | Parent directory name from file path |
+| `resource_url` | `**Source URL**: <url>` body pattern — extract URL from angle brackets or bare value |
+| `github_url` | `**GitHub Repository**: <url>` pattern — extract URL; omit if absent |
+| `date_created` | `**Research Date**: YYYY-MM-DD` pattern in header block; fallback: git log first-commit date |
+| `date_last_reviewed` | `Last Verified \| YYYY-MM-DD` row in Freshness Tracking table; fallback: same as `date_created` |
+| `status` | Always `published` |
+
+### Format B — Minimal frontmatter (Trellis style)
+
+| Target field | Source key(s) |
+|---|---|
+| `title` | `title:` |
+| `subtitle` | `title:` value after em-dash if present; otherwise first sentence of `## Overview` |
+| `category` | `category:` key; fallback: parent directory name |
+| `resource_url` | `resource_url:` |
+| `github_url` | Infer from `resource_url:` if it is a `github.com` URL; otherwise look for `**Repository**: <url>` in body; omit if absent |
+| `date_created` | `created:` |
+| `date_last_reviewed` | `last_reviewed:` |
+| `status` | `status:` key if present; default `published` |
+
+### Format C — Agno nested metadata
+
+| Target field | Source key path |
+|---|---|
+| `title` | `name:` top-level key |
+| `subtitle` | `description:` — truncate at first period or 80 chars, whichever is shorter |
+| `category` | `metadata.category:` key; fallback: parent directory name |
+| `resource_url` | `metadata.source_url:` |
+| `github_url` | `metadata.github:` — prefix with `https://github.com/` if value has no scheme |
+| `date_created` | `metadata.verified:` (earliest available proxy) |
+| `date_last_reviewed` | `metadata.verified:` |
+| `status` | Always `published` |
+
+### Format D — Full canonical (already has matching fields)
+
+Reuse existing values. Normalize field names if needed (e.g., `created:` → `date_created:`). Do not regenerate fields that are already correct.
+
+---
+
+## Generation Procedure
+
+Apply to a single entry file — use this whether creating frontmatter for a new entry or updating an existing one.
+
+```mermaid
+flowchart TD
+    Start(["Entry file path known"]) --> Detect["Detect format — follow Format Detection diagram"]
+    Detect --> Extract["Extract all target fields using format-specific rules"]
+    Extract --> Validate{"Any required field empty<br>after extraction?"}
+    Validate -->|"Yes — field could not be extracted"| Fill["Fill missing field:<br>title/subtitle: read ## Overview and derive<br>resource_url: search body for any URL near resource name<br>dates: use git log --follow --diff-filter=A --format='%as' -- {path} | tail -1<br>category: use parent directory name"]
+    Validate -->|"No — all fields resolved"| HasFrontmatter{"Does file already<br>have YAML frontmatter?"}
+    Fill --> HasFrontmatter
+    HasFrontmatter -->|"No — Format A"| Prepend["Prepend frontmatter block to file<br>Write '---\\n{fields}\\n---\\n' before existing content"]
+    HasFrontmatter -->|"Yes — Formats B/C/D"| Replace["Replace existing frontmatter block<br>Write canonical fields in place of old block<br>Preserve all body content unchanged"]
+    Prepend --> Verify["Read first 10 lines of modified file<br>Confirm '---' delimiters present and field count matches"]
+    Replace --> Verify
+    Verify --> Done(["Frontmatter written"])
+```
+
+### Writing the frontmatter block
+
+Write only fields that have non-empty values. Always include `title`, `category`, `resource_url`, `date_created`, `date_last_reviewed`, `status`. Include `subtitle` when extractable. Omit `github_url` when absent — do not write `github_url: ""`.
+
+---
+
+## Standalone Backfill Procedure (`--add-frontmatter`)
+
+Use when the SKILL.md `--add-frontmatter` mode is invoked. Targets one entry or all entries in the vault.
+
+```mermaid
+flowchart TD
+    Start(["--add-frontmatter argument parsed"]) --> Q{"Argument value?"}
+    Q -->|"category/name — single entry"| VerifyFile{"Does ./research/category/name.md exist?"}
+    Q -->|"all — every entry"| GlobAll["Glob ./research/**/*.md<br>Exclude README.md and ./research/insights/**"]
+    VerifyFile -->|"No"| Error(["Report: entry not found. Stop."])
+    VerifyFile -->|"Yes"| Single["Apply Generation Procedure to single file"]
+    Single --> CommitSingle(["Commit: 'docs(research): add frontmatter to category/name'"])
+    GlobAll --> Filter["Filter out entries that already have Format D canonical frontmatter<br>(all 8 target fields present and non-empty)"]
+    Filter --> Count["Report: N entries need frontmatter, M already complete"]
+    Count --> Wave["Process in waves of 10:<br>Apply Generation Procedure to each file<br>Collect paths of modified files"]
+    Wave --> WaveDone{"All entries processed?"}
+    WaveDone -->|"No — more entries"| Wave
+    WaveDone -->|"Yes"| CommitAll["Commit all modified files:<br>'docs(research): backfill frontmatter on N entries'"]
+    CommitAll --> Report(["Report: N updated, M skipped (already canonical), K failed (list paths)"])
+```
+
+### Skipping logic
+
+Skip an entry during `--all` backfill if its frontmatter already contains all of these fields with non-empty values: `title`, `category`, `resource_url`, `date_created`, `date_last_reviewed`, `status`. Partial frontmatter (missing any field) is not skipped — it is upgraded to canonical.
+
+---
+
+## Integration Points
+
+- **Default mode**: After `@research-curator` agent returns the new entry path, apply the Generation Procedure to that file before spawning the four concurrent post-creation tasks.
+- **Rerun mode**: After `@research-curator` agent updates an existing entry, apply the Generation Procedure to refresh `date_last_reviewed` and ensure canonical format.
+- **Standalone**: `--add-frontmatter category/name` or `--add-frontmatter all` follows the Standalone Backfill Procedure above.

--- a/.claude/skills/research-curator/references/frontmatter-generation.md
+++ b/.claude/skills/research-curator/references/frontmatter-generation.md
@@ -27,7 +27,7 @@ status: "published"
 
 **1. Read** — read the complete entry file before extracting any field. Values appear in the body; reading first is required, not optional.
 
-**2. Skip check** — if the file already has all of `title`, `category`, `resource_url`, `date_created`, `date_last_reviewed`, `status` present and non-empty: stop, report SKIPPED, do not write.
+**2. Skip check** — if the file already has all of `title`, `subtitle`, `category`, `resource_url`, `date_created`, `date_last_reviewed`, `status` present and non-empty: stop, report SKIPPED, do not write.
 
 **3. Extract** — apply the extraction table. Required fields are `title` and `resource_url`; all others have defined fallbacks.
 

--- a/research/knowledge-explorer.py
+++ b/research/knowledge-explorer.py
@@ -885,6 +885,54 @@ def _parse_date_field(raw: Any) -> date:
     return _parse_research_date(str(raw))
 
 
+def _from_research_curator_meta(top: Any, path: Path) -> KBEntry:
+    """Parse a KBEntry from canonical research-curator frontmatter schema.
+
+    Handles entries written by the research-curator skill's frontmatter
+    generation procedure: title/subtitle/category/resource_url/github_url/
+    date_created/date_last_reviewed/status at the top level.
+
+    Field mapping to KBEntry:
+        title           -> name  (topic defaults to file stem)
+        subtitle        -> description
+        resource_url    -> source_url
+        date_created    -> verified
+        date_last_reviewed -> next_review
+        github_url      -> github
+
+    Args:
+        top: Full parsed frontmatter metadata dict.
+        path: File path for error reporting.
+
+    Returns:
+        KBEntry populated from research-curator format.
+
+    Raises:
+        FrontmatterValidationError: If required fields are missing.
+        ParseError: If date fields cannot be parsed.
+    """
+    required = [f for f in ("title", "resource_url", "date_created", "date_last_reviewed") if f not in top]
+    if required:
+        raise FrontmatterValidationError(path=path, missing_fields=required, invalid_fields=[])
+
+    category = str(top.get("category") or path.parent.name)
+    github_raw = top.get("github_url")
+
+    return KBEntry(
+        topic=path.stem,
+        name=str(top["title"]),
+        description=str(top.get("subtitle") or ""),
+        category=category,
+        source_url=str(top["resource_url"]),
+        verified=_parse_date_field(top["date_created"]),
+        next_review=_parse_date_field(top["date_last_reviewed"]),
+        github=str(github_raw) if github_raw is not None else None,
+        file_path=path,
+        body="",
+        has_frontmatter=True,
+    )
+
+
 def _from_skill_spec_meta(top: Any, path: Path) -> KBEntry:
     """Parse a KBEntry from new skill-spec frontmatter (metadata sub-mapping).
 
@@ -985,10 +1033,13 @@ def _from_flat_meta(meta: Any, path: Path) -> KBEntry:
 def parse_frontmatter_entry(text: str, path: Path) -> KBEntry:
     """Parse an entry in YAML frontmatter format.
 
-    Handles both formats:
-    - New skill-spec format: top-level ``name``, ``description``, ``license``; KB
+    Handles three formats:
+    - Skill-spec format: top-level ``name``, ``description``, ``license``; KB
       fields inside a ``metadata`` mapping.
-    - Old flat format: all KB fields at top level (topic, name, category, …).
+    - Research-curator format: top-level ``title``, ``resource_url``,
+      ``date_created``, ``date_last_reviewed`` (produced by the research-curator
+      skill's frontmatter generation procedure).
+    - Flat format: all KB fields at top level (topic, name, category, …).
 
     Args:
         text: Raw file content.
@@ -1007,7 +1058,12 @@ def parse_frontmatter_entry(text: str, path: Path) -> KBEntry:
         raise ParseError(path=path, detail=f"YAML parse error: {exc}") from exc
 
     top = post.metadata
-    entry = _from_skill_spec_meta(top, path) if isinstance(top.get("metadata"), dict) else _from_flat_meta(top, path)
+    if isinstance(top.get("metadata"), dict):
+        entry = _from_skill_spec_meta(top, path)
+    elif "title" in top and "resource_url" in top:
+        entry = _from_research_curator_meta(top, path)
+    else:
+        entry = _from_flat_meta(top, path)
     entry.body = post.content
     return entry
 


### PR DESCRIPTION
## Summary

- Adds `references/frontmatter-generation.md` to the research-curator skill: canonical YAML frontmatter schema, extraction rules for all four observed entry formats, and the backfill procedure
- Updates `SKILL.md` with `--add-frontmatter` mode routing, frontmatter generation as a final step in Default and Rerun modes, and a new Frontmatter Mode section

## What this unblocks

Backlog item #2097 (semantic deduplication) was RT-ICA BLOCKED on two MISSING conditions:

- **Condition 2**: Only 8.9% of vault entries had YAML `title:` frontmatter — the dedup helper had no consistent field to compare against
- **Condition 10**: No fallback defined for the ~280 entries using Markdown H1 headings instead of YAML frontmatter

This PR defines the extraction rules for all formats and the path to backfill them, resolving both conditions.

## How to backfill existing entries

Once merged, run:

```
/research-curator --add-frontmatter all
```

This processes all entries in `./research/` (excluding `README.md` and `insights/`), skips entries already in canonical format, and commits in one batch.

## Test plan

- [ ] Run `/research-curator https://example.com` — new entry should have YAML frontmatter after agent completes
- [ ] Run `/research-curator --add-frontmatter agent-frameworks/esp-claw` — should report "Skipped (already canonical)"
- [ ] Run `/research-curator --add-frontmatter agent-frameworks/agno` — should upgrade Agno-style frontmatter to canonical schema
- [ ] Run `/research-curator --add-frontmatter all` — should report counts of updated vs skipped entries

https://claude.ai/code/session_01SS8Le85Knmb9aKmM8ariaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS8Le85Knmb9aKmM8ariaL)_