### PR TITLE
fix(summarizer): add agent_type matcher to SubagentStop hook

### DIFF
--- a/plugins/summarizer/.claude-plugin/plugin.json
+++ b/plugins/summarizer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "summarizer",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Faithful information summarization with fidelity preservation, structured output, and anti-hallucination methodology. Provides skills for file, URL, and image summarization; agents for autonomous summarization tasks; and hooks for validating agent output structure.",
   "author": {
     "name": "jamie-bitflight-skills",

--- a/plugins/summarizer/hooks/hooks.json
+++ b/plugins/summarizer/hooks/hooks.json
@@ -2,6 +2,7 @@
   "hooks": {
     "SubagentStop": [
       {
+        "matcher": "^(file-summarizer|url-summarizer|image-summarizer)$",
         "hooks": [
           {
             "type": "prompt",


### PR DESCRIPTION
## Summary

- Add `agent_type` matcher to SubagentStop hook to eliminate noise on non-summarizer agents

## Context

This branch was created while working on backlog item #2103 (vague-brief fallback for research-curator and skill-research-process). The RT-ICA gate returned BLOCKED — 4 MISSING inputs require human decisions before implementation can proceed. See issue #2103 for the blocking questions.

## Test plan

- [ ] Verify SubagentStop hook only fires for summarizer agents
- [ ] Confirm no noise from non-summarizer agent stops

---
_Generated by [Claude Code](https://claude.ai/code/session_01M22h77yU5ttxZ9J8FATcF4)_