### PR TITLE
feat(python-standards): add expand-acronyms identifier naming rule (section 1.5)

### DIFF
--- a/plugins/python-engineering/.claude-plugin/plugin.json
+++ b/plugins/python-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python-engineering",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
-  "version": "9.22.9",
+  "version": "9.22.10",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python-engineering/.claude-plugin/plugin.json
+++ b/plugins/python-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python-engineering",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
-  "version": "9.22.6",
+  "version": "9.22.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python-engineering/.claude-plugin/plugin.json
+++ b/plugins/python-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python-engineering",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
-  "version": "9.22.8",
+  "version": "9.22.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python-engineering/.claude-plugin/plugin.json
+++ b/plugins/python-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python-engineering",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
-  "version": "9.22.7",
+  "version": "9.22.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python-engineering/agents/code-reviewer.md
+++ b/plugins/python-engineering/agents/code-reviewer.md
@@ -111,6 +111,8 @@ Look for:
 - Missing docstrings
 - Undocumented CLI options
 - Missing type hints
+- Identifier naming violations: acronym-named public functions or methods (`gcd`, `lcm`,
+  `bfs`, `dfs`) that should be expanded (see python3-standards.md §1.5)
 
 ### Step 6: Execute Automated Analysis
 

--- a/plugins/python-engineering/skills/python3-core/SKILL.md
+++ b/plugins/python-engineering/skills/python3-core/SKILL.md
@@ -20,7 +20,7 @@ Consult `references/python3-standards.md` for the full standards document.
 - No `Any`, broad `object`, or unchecked `cast()` in internal code
 - Code smells are design signals to investigate, not noise to suppress
 - Expand acronyms in public names: `greatest_common_divisor()` not `gcd()`; domain
-  acronyms (URL, API, SQL, HTTP, JSON, XML) are exempt; see python3-standards.md §1.5
+  acronyms (URL, API, SQL, HTTP, JSON, XML) are exempt; see `references/python3-standards.md` §1.5
 
 ### Type Coverage
 

--- a/plugins/python-engineering/skills/python3-core/SKILL.md
+++ b/plugins/python-engineering/skills/python3-core/SKILL.md
@@ -19,6 +19,8 @@ Consult `references/python3-standards.md` for the full standards document.
 - `__all__` in public modules
 - No `Any`, broad `object`, or unchecked `cast()` in internal code
 - Code smells are design signals to investigate, not noise to suppress
+- Expand acronyms in public names: `greatest_common_divisor()` not `gcd()`; domain
+  acronyms (URL, API, SQL, HTTP, JSON, XML) are exempt; see python3-standards.md §1.5
 
 ### Type Coverage
 

--- a/plugins/python-engineering/skills/python3-core/references/python3-standards.md
+++ b/plugins/python-engineering/skills/python3-core/references/python3-standards.md
@@ -45,13 +45,15 @@ This document centralizes the shared Python 3.11+ development standards, quality
 
 - **Expand Acronyms**: Expand acronyms in public function names, method names, and class
   names. `gcd()` is opaque; `greatest_common_divisor()` is self-documenting.
-  SOURCE: TheAlgorithms-Python CONTRIBUTING.md — "Expand acronyms because `gcd()` is hard
+  SOURCE: `research/learning-resources/TheAlgorithms-Python.md` line 150 (accessed 2026-04-27,
+  citing TheAlgorithms/Python CONTRIBUTING.md) — "Expand acronyms because `gcd()` is hard
   to understand but `greatest_common_divisor()` is not."
 - **Contrast Example**: Prefer `greatest_common_divisor(a, b)` over `gcd(a, b)` for any
   public API.
 - **Domain Acronym Exceptions**: Established domain acronyms that are the standard term
-  in their field may remain abbreviated: `URL`, `API`, `SQL`, `HTTP`, `JSON`, `XML`.
-  Example: `parse_url()` and `fetch_api_response()` are acceptable.
+  in their field may remain abbreviated. Per PEP 8, they appear lowercase in `snake_case`
+  identifiers: `url`, `api`, `sql`, `http`, `json`, `xml`.
+  Example: `parse_url()`, `fetch_api_response()`, `run_sql_query()`.
 - **Local Variable Scope**: Short names are acceptable for local variables with a lifetime
   under 5 lines (loop indices, comprehension variables, short closures). Expand acronyms
   when the variable is referenced beyond 5 lines of its definition.

--- a/plugins/python-engineering/skills/python3-core/references/python3-standards.md
+++ b/plugins/python-engineering/skills/python3-core/references/python3-standards.md
@@ -41,6 +41,21 @@ This document centralizes the shared Python 3.11+ development standards, quality
 - **Caching**: Cache repeated expensive function calls.
 - **String Building**: Avoid string concatenation in loops; use `.join()` or list comprehensions.
 
+### 1.5 Identifier Naming
+
+- **Expand Acronyms**: Expand acronyms in public function names, method names, and class
+  names. `gcd()` is opaque; `greatest_common_divisor()` is self-documenting.
+  SOURCE: TheAlgorithms-Python CONTRIBUTING.md — "Expand acronyms because `gcd()` is hard
+  to understand but `greatest_common_divisor()` is not."
+- **Contrast Example**: Prefer `greatest_common_divisor(a, b)` over `gcd(a, b)` for any
+  public API.
+- **Domain Acronym Exceptions**: Established domain acronyms that are the standard term
+  in their field may remain abbreviated: `URL`, `API`, `SQL`, `HTTP`, `JSON`, `XML`.
+  Example: `parse_url()` and `fetch_api_response()` are acceptable.
+- **Local Variable Scope**: Short names are acceptable for local variables with a lifetime
+  under 5 lines (loop indices, comprehension variables, short closures). Expand acronyms
+  when the variable is referenced beyond 5 lines of its definition.
+
 ### 1.6 Script Dependency Trade-offs
 Understand the complexity vs portability trade-off when creating Python CLI scripts:
 

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "8.4.20",
+  "version": "8.4.21",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "8.4.21",
+  "version": "8.4.22",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "8.4.22",
+  "version": "8.4.23",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "8.4.19",
+  "version": "8.4.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/agents/code-reviewer.md
+++ b/plugins/python3-development/agents/code-reviewer.md
@@ -45,6 +45,7 @@ Verify code follows shared Python patterns documented in this plugin. Consult `.
 - CLI Standards (Typer/Rich)
 - Service Integration Standards (Protocol classes)
 - Testing Standards (pytest-mock, 80% coverage)
+- Identifier Naming Standards (expand acronyms in public APIs; see §1.5)
 
 ## SOP (Code Review)
 

--- a/plugins/python3-development/skills/python3-development/SKILL.md
+++ b/plugins/python3-development/skills/python3-development/SKILL.md
@@ -99,6 +99,7 @@ Consult `references/python3-standards.md` when applying shared rules for:
 - CLI Standards (Typer/Rich)
 - Service Integration Standards (Protocol classes)
 - Testing Standards (pytest-mock, 80% coverage)
+- Identifier Naming Standards (expand acronyms in public names; see §1.5)
 
 ### Python Development Process Graph
 

--- a/plugins/python3-development/skills/python3-development/references/python3-standards.md
+++ b/plugins/python3-development/skills/python3-development/references/python3-standards.md
@@ -45,13 +45,15 @@ This document centralizes the shared Python 3.11+ development standards, quality
 
 - **Expand Acronyms**: Expand acronyms in public function names, method names, and class
   names. `gcd()` is opaque; `greatest_common_divisor()` is self-documenting.
-  SOURCE: TheAlgorithms-Python CONTRIBUTING.md — "Expand acronyms because `gcd()` is hard
+  SOURCE: `research/learning-resources/TheAlgorithms-Python.md` line 150 (accessed 2026-04-27,
+  citing TheAlgorithms/Python CONTRIBUTING.md) — "Expand acronyms because `gcd()` is hard
   to understand but `greatest_common_divisor()` is not."
 - **Contrast Example**: Prefer `greatest_common_divisor(a, b)` over `gcd(a, b)` for any
   public API.
 - **Domain Acronym Exceptions**: Established domain acronyms that are the standard term
-  in their field may remain abbreviated: `URL`, `API`, `SQL`, `HTTP`, `JSON`, `XML`.
-  Example: `parse_url()` and `fetch_api_response()` are acceptable.
+  in their field may remain abbreviated. Per PEP 8, they appear lowercase in `snake_case`
+  identifiers: `url`, `api`, `sql`, `http`, `json`, `xml`.
+  Example: `parse_url()`, `fetch_api_response()`, `run_sql_query()`.
 - **Local Variable Scope**: Short names are acceptable for local variables with a lifetime
   under 5 lines (loop indices, comprehension variables, short closures). Expand acronyms
   when the variable is referenced beyond 5 lines of its definition.

--- a/plugins/python3-development/skills/python3-development/references/python3-standards.md
+++ b/plugins/python3-development/skills/python3-development/references/python3-standards.md
@@ -41,6 +41,21 @@ This document centralizes the shared Python 3.11+ development standards, quality
 - **Caching**: Cache repeated expensive function calls.
 - **String Building**: Avoid string concatenation in loops; use `.join()` or list comprehensions.
 
+### 1.5 Identifier Naming
+
+- **Expand Acronyms**: Expand acronyms in public function names, method names, and class
+  names. `gcd()` is opaque; `greatest_common_divisor()` is self-documenting.
+  SOURCE: TheAlgorithms-Python CONTRIBUTING.md — "Expand acronyms because `gcd()` is hard
+  to understand but `greatest_common_divisor()` is not."
+- **Contrast Example**: Prefer `greatest_common_divisor(a, b)` over `gcd(a, b)` for any
+  public API.
+- **Domain Acronym Exceptions**: Established domain acronyms that are the standard term
+  in their field may remain abbreviated: `URL`, `API`, `SQL`, `HTTP`, `JSON`, `XML`.
+  Example: `parse_url()` and `fetch_api_response()` are acceptable.
+- **Local Variable Scope**: Short names are acceptable for local variables with a lifetime
+  under 5 lines (loop indices, comprehension variables, short closures). Expand acronyms
+  when the variable is referenced beyond 5 lines of its definition.
+
 ### 1.6 Script Dependency Trade-offs
 Understand the complexity vs portability trade-off when creating Python CLI scripts:
 


### PR DESCRIPTION
## Summary

- Inserts §1.5 "Identifier Naming" subsection into both `python3-standards.md` copies (python3-development and python-engineering plugins), with expand-acronyms rule, contrast example (`gcd()` → `greatest_common_divisor()`), domain-acronym exception list (`url`, `api`, `sql`, `http`, `json`, `xml`), and local-variable scope relaxation
- Adds expand-acronyms bullet to `python-engineering/skills/python3-core/SKILL.md` Code Quality section
- Adds "Identifier Naming Standards" to `python3-development/skills/python3-development/SKILL.md` standards enumeration
- Adds "Identifier Naming Standards" check to `python3-development/agents/code-reviewer.md`
- Adds "Identifier naming violations" check to `python-engineering/agents/code-reviewer.md`

## Verification

- TN verification: PASS — all 7 acceptance criteria met (AC1–AC6 transitioned from exit-1 to exit-0; AC7 stable)
- Quality gates (Pb8c0b1d2): all 6 phases complete — code review (PASS, 0 blocking findings), feature verification, integration check, drift audit, doc update, context refinement
- `uv run prek run` exits 0 on all modified files

Closes #1958

https://claude.ai/code/session_01RWLvnFujnmh6mxE7XAXXnM