### PR TITLE
feat: Add proactive Fact Verification First pre-flight rule (#2102)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,7 +61,7 @@ For debugging, investigation, problem solving, unknowns, or repeated errors: use
 
 - No planning in "Weeks" or "Sprints" — work scales with parallelism
 - Output contains "likely", "probably", or "I think" — STOP and verify before continuing
-- Prompt names a specific product, version, or release event — run `WebSearch` FIRST before planning. See [Fact Verification First](./.claude/rules/fact-verification-first.md)
+- Prompt names a specific product, version, or release event — run `WebSearch` FIRST before planning. See [Fact Verification First](./rules/fact-verification-first.md)
 - **Pass file paths, let agents read** — agents perform their own Chain of Verification against actual source. Provide the path; the agent reads, verifies, and acts on it with a fresh context window. Never transcribe file contents into prompts — it bypasses agent verification.
 - Do NOT discover file paths on behalf of agents — the agent has full tool access and an empty context window; it finds what it needs itself. Pre-discovering paths wastes orchestrator context and duplicates agent work.
 - **Structured thinking before action** — form a hypothesis and plan internally before acting. Then:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,6 +61,7 @@ For debugging, investigation, problem solving, unknowns, or repeated errors: use
 
 - No planning in "Weeks" or "Sprints" — work scales with parallelism
 - Output contains "likely", "probably", or "I think" — STOP and verify before continuing
+- Prompt names a specific product, version, or release event — run `WebSearch` FIRST before planning. See [Fact Verification First](./.claude/rules/fact-verification-first.md)
 - **Pass file paths, let agents read** — agents perform their own Chain of Verification against actual source. Provide the path; the agent reads, verifies, and acts on it with a fresh context window. Never transcribe file contents into prompts — it bypasses agent verification.
 - Do NOT discover file paths on behalf of agents — the agent has full tool access and an empty context window; it finds what it needs itself. Pre-discovering paths wastes orchestrator context and duplicates agent work.
 - **Structured thinking before action** — form a hypothesis and plan internally before acting. Then:

--- a/.claude/rules/fact-verification-first.md
+++ b/.claude/rules/fact-verification-first.md
@@ -1,0 +1,35 @@
+# Fact Verification First
+
+When a prompt names a specific product, technology, version, or release event, the FIRST action MUST be a `WebSearch` (or `mcp__Ref__ref_search_documentation`) call to confirm existence, release status, current version, and specs. No planning, design, or code generation may occur before this verification step completes.
+
+## Trigger Patterns
+
+| Trigger Type | Pattern Examples | Required Action |
+|---|---|---|
+| Named product (hardware/device) | "DJI Pocket 4", "iPhone 17", "Nano Banana Pro" | WebSearch BEFORE planning |
+| Named software product or AI model | "Gemini 3 Pro", "Claude 4 Sonnet", "GPT-5" | WebSearch BEFORE planning |
+| Versioned library or framework | "React 20", "fastmcp v2.3", "Python 3.14" | WebSearch BEFORE planning |
+| Semantic version string | "v1.2.3", "2.0.0-beta", "v3.0.0-rc1" | WebSearch BEFORE planning |
+| Named release event or launch | "Gemini 3 Pro launch", "OpenAI DevDay 2026" | WebSearch BEFORE planning |
+| Named API or service (possibly changed since training) | "Anthropic Files API", "OpenAI Assistants API v2" | WebSearch BEFORE planning |
+
+Both `WebSearch` and `mcp__Ref__ref_search_documentation` are acceptable verification tools. Use whichever returns current, authoritative information for the named entity.
+
+## What Does NOT Trigger Verification
+
+- Generic categories without a version or product name — "Python", "React", "a language model"
+- Hedging language in the prompt — those trigger the "likely/probably/I think" STOP gate in Critical Constraints, not this rule
+- Hypothetical or conditional framing — "if DJI releases a Pocket 4", "suppose React adds X"
+- Historical or canonical references with well-established, stable facts — "HTTP/1.1", "the Unix epoch"
+
+## Relationship to the Reactive fact-check Skill
+
+This rule is **proactive**: it fires on the incoming prompt BEFORE any planning, file writes, or design decisions occur.
+
+The `/fact-check` skill is **reactive**: it fires AFTER content is written, triggered by `UNVERIFIED` tags or backlog items flagged for fact verification. It spawns parallel verification agents and produces VERIFIED/REFUTED/INCONCLUSIVE verdicts with citations.
+
+These two mechanisms address different lifecycle phases and do not overlap. Satisfying this rule does not substitute for the reactive `/fact-check` pass when that skill is triggered.
+
+## Source
+
+SOURCE: `research/ai-design-tools/huashu-design.md` lines 110–112 — Principle #0 "Fact Verification First" from Huashu Design v2.0 (verified 2026-05-03). Quote: "when the task mentions a specific product / technology / event (e.g., 'DJI Pocket 4', 'Nano Banana Pro', 'Gemini 3 Pro'), the first action **must** be a `WebSearch` to confirm existence, release status, current version, and specs. No claims from training-corpus memory. Cost of a search: ~10 seconds. Cost of a wrong assumption: 1–2 hours of rework."


### PR DESCRIPTION
## Summary

- **New file** `.claude/rules/fact-verification-first.md` — 35-line behavioral-process rule declaring that when a user prompt names a specific product, technology, library version, or release event, the agent's first action MUST be a `WebSearch` (or `mcp__Ref__ref_search_documentation`) call before any planning, design, or code generation
- **Modified** `.claude/CLAUDE.md` — inserted one bullet in the Critical Constraints section referencing the new rule, positioned immediately after the existing hedging-language verification trigger

## Acceptance criteria verified

All 5 acceptance criteria from #2102 confirmed PASS by TN verification gate and code review:

1. `grep -l "Fact Verification First\|named product\|Principle #0" .claude/CLAUDE.md .claude/rules/*.md` returns both files (exit 0)
2. Trigger table with 6 named-entity pattern rows and mandatory WebSearch action present
3. Rule positioned in Critical Constraints section — before Task Classification and all planning/code-gen sections
4. Explicit lifecycle boundary section separating proactive (this rule) from reactive (`/fact-check` skill)
5. `uv run prek run --files .claude/CLAUDE.md .claude/rules/fact-verification-first.md` exits 0

## Quality gates

- Code review: PASS (5/5 AC met, 0 blocking findings)
- Feature verification: PASS (all 4 goals met)
- Integration check: PASS (link valid, file exists at referenced path)
- Documentation drift: No drift detected
- TN verification: PASS (all criteria improved, none regressed)

Closes #2102

https://claude.ai/code/session_01NfgNtAWsJ5pU73KS8KoKDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfgNtAWsJ5pU73KS8KoKDx)_