### PR TITLE
feat(pre-commit): add actionlint structural validation for GitHub Actions workflows

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -47,8 +47,8 @@ Before executing, review plan:
 Implement plan:
 
 1. Make changes to workflow YAML files
-2. Validate YAML syntax: `python3 -m yaml <file>` or equivalent
-3. Run `uv run prek run --files <file>` if applicable
+2. Validate workflow structure: `uv run prek run --files .github/workflows/<file>` (runs `actionlint` for schema validation and `check-yaml` for parsability)
+3. Run `uv run prek run --files <file>` for non-workflow files if applicable
 4. Commit with descriptive message explaining what changed and why
 
 **Gate**: Changes committed and pass local validation.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Run file hygiene hooks
         env:
-          SKIP: sync-pre-commit-deps,conventional-pre-commit,repair-symlinks,biome-check,ruff,ruff-format,pypfmt,markdownlint-cli2,shell-fmt-go,shellcheck,auto-sync-manifests,skilllint,ty,enable-rerere
+          SKIP: sync-pre-commit-deps,conventional-pre-commit,repair-symlinks,biome-check,ruff,ruff-format,pypfmt,markdownlint-cli2,actionlint,shell-fmt-go,shellcheck,auto-sync-manifests,skilllint,ty,enable-rerere
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE=$(git merge-base "origin/${GITHUB_HEAD_REF}" "origin/${GITHUB_BASE_REF}")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,12 @@ repos:
       - id: markdownlint-cli2
         exclude: ^(plan/|\.claude/backlog/|\.claude/BACKLOG\.md)
 
+  # GitHub Actions structural validation (beyond YAML parsability)
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   # Shell formatting
   - repo: https://github.com/pecigonzalo/pre-commit-shfmt
     rev: v2.2.0


### PR DESCRIPTION
## Summary

Closes #1933

Adds `rhysd/actionlint` (v1.7.12) as a pre-commit hook to catch GitHub Actions structural errors locally before push, replacing the push-and-observe feedback loop.

**Before**: `check-yaml` validated YAML parsability only. Malformed `needs:` references, invalid job DAGs, broken expressions, and missing required keys passed pre-commit silently and only failed after git push triggered GitHub Actions.

**After**: `actionlint` validates schema structure on every pre-commit run against `.github/workflows/*.ya?ml` files. Invalid workflow structure is caught in milliseconds locally.

## Changes

- **`.pre-commit-config.yaml`**: New remote-repo hook `rhysd/actionlint` v1.7.12, scoped to `^\\.github/workflows/.*\\.ya?ml$`. Managed via `sync-pre-commit-deps` for auto rev-pin updates.
- **`.github/workflows/code-quality.yml`**: Added `actionlint` to `file-hygiene` job `SKIP` list (line 185). Binary is not pre-installed on `ubuntu-latest`; hook runs locally only. CI surface unchanged.
- **`.claude/rules/ci-workflows.md`**: Phase 4 step 2 updated from `python3 -m yaml <file>` (parsability only) to `uv run prek run --files .github/workflows/<file>` (structural validation via actionlint + parsability via check-yaml).

## Acceptance Criteria Verification

- [x] `grep -E 'actionlint|wrkflw' .pre-commit-config.yaml` returns match on `id: actionlint` line
- [x] `uv run prek run --files .github/workflows/code-quality.yml` exits 0, shows "Lint GitHub Actions workflow files...Passed"
- [x] Injecting `needs: [does-not-exist]` caused hook to exit 1 and report: `job "lint-python" needs job "does-not-exist" which does not exist [job-needs]` at the correct line
- [x] `uv run prek run --files README.md` shows "no files to check" for actionlint — correctly scoped to workflows only
- [x] `.claude/rules/ci-workflows.md` Phase 4 no longer references `python3 -m yaml` as sole validation
- [x] `actionlint` added to `file-hygiene` SKIP list — CI job does not fail on clean PRs

## Test plan

- [ ] Review the three changed files for correctness
- [ ] Confirm `file-hygiene` CI job passes on this PR (actionlint is in SKIP list)
- [ ] Optionally: install actionlint locally (`go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`) and run `prek run --files .github/workflows/` to validate all 7 workflow files

https://claude.ai/code/session_01QwoJWqEc2z4GWmkKsTkd8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwoJWqEc2z4GWmkKsTkd8J)_