### PR TITLE
fix(scientific-method): replace prompt SubagentStop hook with command script

### DIFF
--- a/plugins/scientific-method/.claude-plugin/plugin.json
+++ b/plugins/scientific-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scientific-method",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/scientific-method/.claude-plugin/plugin.json
+++ b/plugins/scientific-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scientific-method",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/scientific-method/hooks/hooks.json
+++ b/plugins/scientific-method/hooks/hooks.json
@@ -4,9 +4,9 @@
       {
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "You are validating the output of a scientific investigation sub-agent that uses the scientific-method plugin.\n\nInspect the agent's output for the investigation status.\n\nStep 1: Find the status line.\n- Look for 'status: resolved-verified' in section 14 of the Unified Investigation Template output.\n- Also check for a line matching 'status:' followed by one of: resolved-verified, mitigated, unresolved, unknown.\n\nStep 2: If status is 'resolved-verified':\n- Notify the user with this exact message: 'Investigation complete (resolved-verified). The retrospective-analyst agent can produce a mermaid timeline and structured retrospective from this investigation. Invoke it with the full investigation output as input.'\n- Then return {\"ok\": true}.\n\nStep 3: If status is anything other than 'resolved-verified' (mitigated, unresolved, unknown):\n- Do not notify. Return {\"ok\": true}.\n\nStep 4: If no status line is found in the output:\n- The agent did not complete a full investigation cycle. Return {\"ok\": true} silently.\n\nDo not block or fail any agent output. This hook is informational only.",
-            "timeout": 15
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/notify-investigation-complete.cjs\"",
+            "timeout": 10
           }
         ]
       }

--- a/plugins/scientific-method/hooks/notify-investigation-complete.cjs
+++ b/plugins/scientific-method/hooks/notify-investigation-complete.cjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * SubagentStop hook — detects completed scientific investigations and notifies
+ * the user that the retrospective-analyst agent is available.
+ *
+ * Fires on: SubagentStop (no matcher — fires on all agents, fast grep only)
+ * Action: non-blocking — emits systemMessage when status: resolved-verified
+ *         is found in section 14 of the Unified Investigation Template output.
+ *
+ * Replaces the former "prompt" type hook, which made an LLM call on every
+ * SubagentStop. This script does a text search on the transcript instead.
+ *
+ * Test:
+ *   echo '{"hook_event_name":"SubagentStop","agent_type":"general-purpose","agent_transcript_path":"/tmp/test.jsonl"}' \
+ *     | node ./plugins/scientific-method/hooks/notify-investigation-complete.cjs
+ */
+
+const fs = require('node:fs');
+
+const NOTIFICATION =
+  'Investigation complete (resolved-verified). The retrospective-analyst agent can produce a mermaid timeline and structured retrospective from this investigation. Invoke it with the full investigation output as input.';
+
+/**
+ * Extract the text content from the last assistant message in a JSONL transcript.
+ * @param {string} transcriptPath
+ * @returns {string} Combined text content, or empty string on any error.
+ */
+function extractLastAssistantText(transcriptPath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(transcriptPath, 'utf8');
+  } catch {
+    return '';
+  }
+
+  const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+  let lastAssistantText = '';
+
+  for (const line of lines) {
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (record.type !== 'assistant') continue;
+    const message = record.message;
+    if (!message || message.role !== 'assistant') continue;
+    const content = Array.isArray(message.content) ? message.content : [];
+    const textParts = content
+      .filter((c) => c && c.type === 'text' && typeof c.text === 'string')
+      .map((c) => c.text);
+    if (textParts.length > 0) {
+      lastAssistantText = textParts.join('\n');
+    }
+  }
+
+  return lastAssistantText;
+}
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  let data = {};
+  try {
+    data = JSON.parse(input || '{}');
+  } catch {
+    process.stdout.write(JSON.stringify({}));
+    process.exit(0);
+  }
+
+  const transcriptPath = data.agent_transcript_path || '';
+  if (!transcriptPath) {
+    process.stdout.write(JSON.stringify({}));
+    process.exit(0);
+  }
+
+  const text = extractLastAssistantText(transcriptPath);
+  if (!text) {
+    process.stdout.write(JSON.stringify({}));
+    process.exit(0);
+  }
+
+  // Look for status: resolved-verified anywhere in the output
+  if (/status:\s*resolved-verified/i.test(text)) {
+    process.stdout.write(JSON.stringify({ systemMessage: NOTIFICATION }));
+    process.exit(0);
+  }
+
+  process.stdout.write(JSON.stringify({}));
+  process.exit(0);
+});

--- a/plugins/scientific-method/hooks/notify-investigation-complete.cjs
+++ b/plugins/scientific-method/hooks/notify-investigation-complete.cjs
@@ -5,15 +5,18 @@
  * SubagentStop hook — detects completed scientific investigations and notifies
  * the user that the retrospective-analyst agent is available.
  *
- * Fires on: SubagentStop (no matcher — fires on all agents, fast grep only)
- * Action: non-blocking — emits systemMessage when status: resolved-verified
- *         is found in section 14 of the Unified Investigation Template output.
+ * Fires on: SubagentStop (no matcher — fires on all agents)
+ * Action: non-blocking — emits systemMessage when "status: resolved-verified"
+ *         is found anywhere in the subagent's final response text.
+ *
+ * Detection uses data.last_assistant_message (direct payload field) to avoid
+ * disk I/O. Falls back to JSONL transcript parsing only if that field is absent.
  *
  * Replaces the former "prompt" type hook, which made an LLM call on every
- * SubagentStop. This script does a text search on the transcript instead.
+ * SubagentStop. This script does a plain text search instead.
  *
  * Test:
- *   echo '{"hook_event_name":"SubagentStop","agent_type":"general-purpose","agent_transcript_path":"/tmp/test.jsonl"}' \
+ *   echo '{"hook_event_name":"SubagentStop","agent_type":"general-purpose","last_assistant_message":"status: resolved-verified"}' \
  *     | node ./plugins/scientific-method/hooks/notify-investigation-complete.cjs
  */
 
@@ -24,6 +27,7 @@ const NOTIFICATION =
 
 /**
  * Extract the text content from the last assistant message in a JSONL transcript.
+ * Used as a fallback when last_assistant_message is absent from the payload.
  * @param {string} transcriptPath
  * @returns {string} Combined text content, or empty string on any error.
  */
@@ -71,28 +75,28 @@ process.stdin.on('end', () => {
   try {
     data = JSON.parse(input || '{}');
   } catch {
-    process.stdout.write(JSON.stringify({}));
     process.exit(0);
   }
 
-  const transcriptPath = data.agent_transcript_path || '';
-  if (!transcriptPath) {
-    process.stdout.write(JSON.stringify({}));
-    process.exit(0);
-  }
+  // Primary: use last_assistant_message from the payload (no disk I/O)
+  let text = typeof data.last_assistant_message === 'string' ? data.last_assistant_message : '';
 
-  const text = extractLastAssistantText(transcriptPath);
+  // Fallback: parse JSONL transcript if payload field is absent
   if (!text) {
-    process.stdout.write(JSON.stringify({}));
-    process.exit(0);
+    const transcriptPath = data.agent_transcript_path || '';
+    if (!transcriptPath) {
+      process.exit(0);
+    }
+    text = extractLastAssistantText(transcriptPath);
+    if (!text) {
+      process.exit(0);
+    }
   }
 
   // Look for status: resolved-verified anywhere in the output
   if (/status:\s*resolved-verified/i.test(text)) {
     process.stdout.write(JSON.stringify({ systemMessage: NOTIFICATION }));
-    process.exit(0);
   }
 
-  process.stdout.write(JSON.stringify({}));
   process.exit(0);
 });


### PR DESCRIPTION
## Summary

- Replaces the `scientific-method` SubagentStop `prompt` hook (LLM call on every subagent stop) with a fast Node.js `command` hook that greps the transcript for `status: resolved-verified`
- Behaviour is identical: emits a `systemMessage` suggesting the `retrospective-analyst` agent when a completed investigation is detected; exits silently in all other cases
- This is the last unfenced/expensive SubagentStop hook in the repo — all others (`development-harness`, `the-rewrite-room`, `summarizer`) already used `command` type or had `matcher` fields

## Context

Audit of all `hooks.json` files found one SubagentStop hook without an agent-type fence and using a `prompt` type (LLM round-trip per subagent stop). The `summarizer` plugin had the same class of problem (#2235, fixed in de35747). This PR applies the same fix pattern.

## Test plan

- [ ] `echo '{"hook_event_name":"SubagentStop","agent_type":"general-purpose","agent_transcript_path":"/dev/null"}' | node plugins/scientific-method/hooks/notify-investigation-complete.cjs` exits 0 with `{}`
- [ ] Transcript containing `status: resolved-verified` produces `{"systemMessage":"Investigation complete..."}` on stdout
- [ ] Transcript without the status line exits 0 silently

https://claude.ai/code/session_01WvGdxyh2axxoGxDX7JYegy

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvGdxyh2axxoGxDX7JYegy)_