### PR TITLE
fix(agents): contract-verification must output explicit result and send teammate message

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -528,6 +528,10 @@ uv run prek run --files <file>
 
 ---
 
+- Agent Output Contracts (explicit terminal output required — no silent exits): `.claude/rules/agent-output-contracts.md`
+
+---
+
 - Exception Handling (narrow catches, BLE001, the "must not crash" anti-pattern): `.claude/rules/exception-handling.md`
 
 ---

--- a/.claude/rules/agent-output-contracts.md
+++ b/.claude/rules/agent-output-contracts.md
@@ -1,0 +1,83 @@
+# Agent Output Contracts — Explicit Terminal Output Required
+
+Every agent MUST emit an explicit terminal message as its final response. Silent completion is
+indistinguishable from a crash, context-limit truncation, or mid-task abandonment — the
+orchestrator cannot tell the difference.
+
+## The Rule
+
+**An agent that produces no output is broken from the orchestrator's perspective.**
+
+This applies in ALL cases including:
+- No findings (analysis agent found nothing)
+- No changes (refactoring agent found nothing to change)
+- Verification passed (no violations, no drift, no mismatches)
+- No improvements generated (kaizen agent found nothing to improve)
+
+## Required Pattern
+
+Every agent must end with a STATUS block:
+
+```
+STATUS: DONE
+{artifact path or key result}
+{one-line summary}
+```
+
+Or for blocked/failed:
+
+```
+STATUS: BLOCKED
+Reason: {specific reason}
+```
+
+When operating as a **teammate** (spawned via `TeamCreate`), also send:
+
+```
+SendMessage(to="team-lead", summary="[brief]", message="[full STATUS block]")
+```
+
+## The "Write to File" Anti-Pattern
+
+"Write all output to files — never return large analysis as message text" means write a file
+AND return STATUS. It does NOT mean return nothing. Writing to a file is not visible to the
+orchestrator until the STATUS block confirms the file path.
+
+## The "No Findings" Case
+
+This is the most dangerous silent-exit case. When an analysis agent finds nothing, it must
+say so explicitly:
+
+```
+STATUS: DONE
+Findings: None — {reason why nothing was found, e.g. "all contracts satisfied", "no violations detected"}
+```
+
+NOT:
+- Returning nothing
+- Returning only the STATUS with no findings summary
+- Omitting the section / block / response entirely
+
+## Prohibited Instructions in Agent Files
+
+Never write these as agent output instructions:
+
+| Prohibited | Replace with |
+|---|---|
+| "Return nothing" | "Output: `[explicit success message]`" |
+| "Return an empty response" | "Output: `STATUS: DONE — [what was verified]`" |
+| "Omit this section if no X found" | "If no X found, include: `[explicit no-findings line]`" |
+| "Silent success" | Explicit STATUS: DONE |
+| "No output needed" | "Output: `STATUS: DONE — [why no action was needed]`" |
+
+## Enforcement
+
+When writing or reviewing agent files:
+1. Check that a STATUS: DONE format exists in the agent's output section
+2. Check that the "no findings" case produces explicit output — not silence
+3. Check that "write to file" instructions are paired with STATUS output, not replacing it
+4. Check `SendMessage` is present when the agent is used as a teammate
+
+SOURCE: Persistent orchestrator confusion from silent agent exits (observed 2026-05-18).
+Pattern: agent completes analysis with no findings → returns nothing → orchestrator cannot
+distinguish from crash → orchestrator hunts for the agent → wasted compute and context.

--- a/plugins/agentskill-kaizen/.claude-plugin/plugin.json
+++ b/plugins/agentskill-kaizen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentskill-kaizen",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Analyze Claude Code agent session transcripts to identify inefficiencies, anti-patterns, repeated mistakes, missing tooling opportunities, and user frustration signals for continuous improvement",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/agentskill-kaizen/agents/improvement-generator.md
+++ b/plugins/agentskill-kaizen/agents/improvement-generator.md
@@ -56,6 +56,27 @@ You are an improvement generation specialist. Your job is to transform kaizen an
 
 Each improvement file follows the templates from the kaizen-improvement skill. Reference the improvement templates via the loaded kaizen-improvement skill for exact formats.
 
+## Terminal Output (Required)
+
+After writing all improvement files (or determining there is nothing to generate), return:
+
+```
+STATUS: DONE
+Improvements generated: {N}
+Files written: {list of paths}
+Summary: {one-line description, e.g. "3 hook proposals, 1 CLAUDE.md update, 2 agent patches"}
+```
+
+If the analysis produced no actionable improvements:
+
+```
+STATUS: DONE
+Improvements generated: 0
+Reason: {why — e.g. "all findings were informational only, no actionable pattern changes identified"}
+```
+
+Never end without this STATUS block. Writing files to `.planning/kaizen/improvements/` is not a completion signal to the orchestrator — the STATUS block is.
+
 ## Constraints
 
 - Generate outcome-focused delegation prompts — describe the problem and desired outcome, never prescribe specific code changes

--- a/plugins/agentskill-kaizen/agents/transcript-analyst.md
+++ b/plugins/agentskill-kaizen/agents/transcript-analyst.md
@@ -58,6 +58,28 @@ You are a transcript analysis specialist. Your job is to query Claude Code sessi
 ## Dimension 2: ...
 ```
 
+## Terminal Output (Required)
+
+After writing all output files, return this as your final message:
+
+```
+STATUS: DONE
+Analysis file: {path to written .md file}
+Dimensions covered: {list}
+Sessions analyzed: {N}
+Findings: {brief one-line summary, e.g. "47 tool-misuse violations, 12 error patterns"}
+```
+
+If no sessions matched the filters or no findings were produced:
+
+```
+STATUS: DONE
+Analysis file: {path}
+Findings: None — no sessions matched the configured filters or no violations detected.
+```
+
+Never end without this STATUS block. "Write all output to files" means write a file AND emit this status — the file and the status are both required outputs.
+
 ## Constraints
 
 - Write all output to files — never return large analysis as message text

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.2.25",
+  "version": "8.2.26",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.2.24",
+  "version": "8.2.25",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/agents/contract-verification.md
+++ b/plugins/development-harness/agents/contract-verification.md
@@ -154,8 +154,9 @@ When operating as a **teammate** (spawned via `TeamCreate`), also send:
 
 - Extract contracts from the spec text exactly as written — do not interpret or infer
 - Report only what is observable from the spec and the code — no guesses
-- If the architect spec has no Component Design or Type System Design section, return
-  nothing (no contracts to verify)
+- If the architect spec has no Component Design or Type System Design section, output
+  `No contract concerns — no contracts defined in spec` and, if operating as a teammate,
+  send `SendMessage(to="team-lead", summary="No contract concerns found", message="No Component Design or Type System Design section in spec — no contracts to verify.")`
 - If a modified file does not exist or cannot be read, note it in the concerns block
   as a CONTRACT GAP with reason "file not found"
 - Do not modify any files — this is a read-only verification step

--- a/plugins/development-harness/agents/contract-verification.md
+++ b/plugins/development-harness/agents/contract-verification.md
@@ -1,6 +1,6 @@
 ---
 name: contract-verification
-description: Post-task verifier that compares method signatures and type contracts from the architect spec against files modified by the just-completed task. Reads the architect spec Component Design and Type System Design sections, extracts expected signatures and contracts, then greps the modified files to find actual signatures. Reports mismatches as a concerns block with CONTRACT VIOLATION (signature mismatch) and CONTRACT GAP (spec defines contract but implementation is silent) severity levels. Returns an empty response when no mismatches are found.
+description: Post-task verifier that compares method signatures and type contracts from the architect spec against files modified by the just-completed task. Reads the architect spec Component Design and Type System Design sections, extracts expected signatures and contracts, then greps the modified files to find actual signatures. Reports mismatches as a concerns block with CONTRACT VIOLATION (signature mismatch) and CONTRACT GAP (spec defines contract but implementation is silent) severity levels. Outputs "No contract concerns" when all contracts in scope are satisfied.
 model: haiku
 tools: Read, Grep, Glob, Bash, Skill, SendMessage, mcp__plugin_dh_sam__sam_plan, mcp__plugin_dh_sam__sam_task, mcp__plugin_dh_sam__sam_active_task, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_migrate, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
 skills:
@@ -145,9 +145,10 @@ Each concern entry must include:
 
 ### When No Mismatches Are Found
 
-Return nothing. An empty response signals that all contracts in scope are satisfied.
-Do not return a status message, do not return "no issues found", do not return the
-concerns block with empty content.
+Output: `No contract concerns — all contracts in scope are satisfied.`
+
+When operating as a **teammate** (spawned via `TeamCreate`), also send:
+`SendMessage(to="team-lead", summary="No contract concerns found", message="All contracts in scope verified — no violations or gaps.")`
 
 ## Operating Rules
 

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -189,7 +189,7 @@ For each modified file, grep for function/class definitions and extract actual s
 Compare against the contracts defined in the spec.
 Report mismatches in a <concerns> block with severity CONTRACT VIOLATION (signature mismatch)
 or CONTRACT GAP (spec defines contract but implementation is silent).
-If no mismatches are found, return an empty response with no <concerns> block.
+If no mismatches are found, output `No contract concerns — all contracts in scope are satisfied.` with no <concerns> block.
 """
 )
 ```


### PR DESCRIPTION
When no contract mismatches are found, the agent previously returned nothing (silent empty response). This caused the swarm orchestrator to treat silence as an unknown state rather than a confirmed pass.

## Changes

- **Explicit output**: agent now outputs `No contract concerns — all contracts in scope are satisfied.` instead of returning nothing
- **Teammate signal**: when spawned via `TeamCreate`, also sends `SendMessage(to="team-lead", ...)` so the orchestrator receives a positive confirmation
- **Frontmatter description**: updated to reflect the explicit output behavior

## Why

Silent success is indistinguishable from a hung or incomplete agent. Explicit output lets the orchestrator and user confirm the agent ran to completion.