### PR TITLE
feat(swarm-from-markdown): markdown checkbox file to swarm task pool helper

### DIFF
--- a/.claude/skills/orchestrating-swarms/SKILL.md
+++ b/.claude/skills/orchestrating-swarms/SKILL.md
@@ -37,6 +37,12 @@ Tool signatures and message schemas -- TeamCreate, SendMessage (direct, broadcas
 
 6 orchestration patterns (parallel specialists, pipeline, swarm, research+implement, plan approval, coordinated refactoring), 3 complete workflows, best practices, quick reference.
 
+### Checklist-to-Swarm Automation
+
+`Skill(skill: "swarm-from-markdown")`
+
+Parse a markdown `- [ ]` checklist file and generate the full `TeamCreate` + `TaskCreate` + `Agent` call sequence automatically. Use when you have a `todo.md` or any checkbox file and want to dispatch items as a self-organizing swarm without writing the TaskCreate loop by hand.
+
 ---
 
 ## Quick Start
@@ -48,7 +54,8 @@ flowchart TD
     Q1 -->|Choose agent types or backends| S[swarm-spawning]
     Q1 -->|Look up tool API or message format| O[swarm-operations]
     Q1 -->|Build a workflow from a recipe| R[swarm-patterns]
-    Q1 -->|Full reference on everything| All[Load all 4 skills]
+    Q1 -->|Dispatch a markdown checklist as a swarm| M[swarm-from-markdown]
+    Q1 -->|Full reference on everything| All[Load all 5 skills]
 ```
 
 ---

--- a/.claude/skills/swarm-from-markdown/SKILL.md
+++ b/.claude/skills/swarm-from-markdown/SKILL.md
@@ -77,7 +77,7 @@ The `[x]` checked item never appears in any `TaskCreate` call.
 4. Derive team name from the filename stem: `swarm-{stem}`.
 5. Emit JSON or human-readable output showing the `TaskCreate` sequence and worker count.
 
-Worker IDs are stable: re-running on the same file with new items appended preserves existing IDs. Items in the same position keep the same `worker-{index}` across runs.
+Worker IDs are stable when items are only appended: re-running on the same file with new items added at the end preserves existing IDs. Checking (completing) an earlier item shifts all subsequent unchecked items to lower indices — do not resume a partially-executed swarm after checking items mid-list.
 
 ## marko AST Walk (GFM Checkbox Detection)
 

--- a/.claude/skills/swarm-from-markdown/SKILL.md
+++ b/.claude/skills/swarm-from-markdown/SKILL.md
@@ -85,26 +85,28 @@ The checkbox `checked` attribute lives on the `Paragraph` child of a `ListItem`,
 
 ```python
 from marko import Markdown
+from marko.block import List, ListItem, Paragraph
+from marko.inline import RawText
 
 md = Markdown(extensions=["gfm"])
 doc = md.parse(markdown_text)      # parse() returns AST — do NOT call md() which returns HTML
 
 results = []
 for node in doc.children:
-    if type(node).__name__ != "List":
+    if not isinstance(node, List):
         continue
     for item in node.children:
-        if type(item).__name__ != "ListItem":
+        if not isinstance(item, ListItem):
             continue
         for child in item.children:
-            if not hasattr(child, "checked"):
+            if not isinstance(child, Paragraph) or not hasattr(child, "checked"):
                 continue
             if child.checked is not False:   # True=checked, None=non-checkbox — both skip
                 continue
             text_parts = [
                 c.children.strip()
                 for c in child.children
-                if type(c).__name__ == "RawText"
+                if isinstance(c, RawText)
             ]
             text = " ".join(text_parts).strip()
             if text:

--- a/.claude/skills/swarm-from-markdown/SKILL.md
+++ b/.claude/skills/swarm-from-markdown/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: swarm-from-markdown
+description: Parse a markdown file's unchecked checkbox items (- [ ]) and generate a self-organizing Claude Code swarm task pool. Use when you have a todo.md, checklist.md, or any markdown file with checkbox items and want to dispatch them as parallel swarm tasks using TeamCreate + TaskCreate + worker agents. Skips checked items (- [x] / - [X]) automatically.
+---
+
+# Swarm from Markdown
+
+Converts a markdown checklist file into a self-organizing Claude Code swarm. Each unchecked `- [ ]` item becomes a `TaskCreate` call and a spawned worker agent. Checked items (`- [x]`, `- [X]`) are skipped automatically.
+
+## When to Use This Skill
+
+Use when:
+
+- You have a `todo.md`, `checklist.md`, or any markdown file with `- [ ]` checkbox items
+- You want to dispatch independent checklist items as parallel swarm tasks
+- You need to avoid hand-expanding long task lists into manual `TaskCreate` loops
+- Your task list changes over time and you want stable worker IDs for resumption
+
+## Quick Start (Worked Example)
+
+Given `tasks.md`:
+
+```markdown
+- [ ] Implement the login endpoint
+- [x] Already done — skip this
+- [ ] Write unit tests for auth
+- [ ] Update API documentation
+```
+
+Run the parser:
+
+```bash
+uv run scripts/markdown_to_task_pool.py tasks.md --json
+```
+
+Output:
+
+```json
+{
+  "team_name": "swarm-tasks",
+  "items": [
+    {"index": 0, "worker_id": "worker-0", "text": "Implement the login endpoint"},
+    {"index": 1, "worker_id": "worker-1", "text": "Write unit tests for auth"},
+    {"index": 2, "worker_id": "worker-2", "text": "Update API documentation"}
+  ],
+  "worker_count": 3
+}
+```
+
+Then orchestrate the swarm:
+
+```javascript
+// Step 1 — Create team
+TeamCreate({ team_name: "swarm-tasks" })
+
+// Step 2 — Create one task per unchecked item (checked item is excluded)
+TaskCreate({ subject: "Implement the login endpoint", description: "Implement the login endpoint", activeForm: "Working on Implement the login endpoint..." })
+TaskCreate({ subject: "Write unit tests for auth", description: "Write unit tests for auth", activeForm: "Working on Write unit tests for auth..." })
+TaskCreate({ subject: "Update API documentation", description: "Update API documentation", activeForm: "Working on Update API documentation..." })
+
+// Step 3 — Spawn one worker per task (or use --workers N to cap concurrency)
+Agent({ team_name: "swarm-tasks", name: "worker-0", subagent_type: "general-purpose", prompt: "...", run_in_background: true })
+Agent({ team_name: "swarm-tasks", name: "worker-1", subagent_type: "general-purpose", prompt: "...", run_in_background: true })
+Agent({ team_name: "swarm-tasks", name: "worker-2", subagent_type: "general-purpose", prompt: "...", run_in_background: true })
+
+// Step 4 — Observe pool state
+TaskList()
+```
+
+The `[x]` checked item never appears in any `TaskCreate` call.
+
+## How It Works
+
+1. Parse the markdown file using the marko GFM AST (not regex).
+2. Walk the AST: collect `ListItem` nodes whose child `Paragraph` has `checked is False`.
+3. Assign each item a 0-based index — `worker-{index}` — over unchecked items only.
+4. Derive team name from the filename stem: `swarm-{stem}`.
+5. Emit JSON or human-readable output showing the `TaskCreate` sequence and worker count.
+
+Worker IDs are stable: re-running on the same file with new items appended preserves existing IDs. Items in the same position keep the same `worker-{index}` across runs.
+
+## marko AST Walk (GFM Checkbox Detection)
+
+The checkbox `checked` attribute lives on the `Paragraph` child of a `ListItem`, not on the `ListItem` itself. The guard `child.checked is not False` skips both checked items (`True`) and non-checkbox list items (`None`).
+
+```python
+from marko import Markdown
+
+md = Markdown(extensions=["gfm"])
+doc = md.parse(markdown_text)      # parse() returns AST — do NOT call md() which returns HTML
+
+results = []
+for node in doc.children:
+    if type(node).__name__ != "List":
+        continue
+    for item in node.children:
+        if type(item).__name__ != "ListItem":
+            continue
+        for child in item.children:
+            if not hasattr(child, "checked"):
+                continue
+            if child.checked is not False:   # True=checked, None=non-checkbox — both skip
+                continue
+            text_parts = [
+                c.children.strip()
+                for c in child.children
+                if type(c).__name__ == "RawText"
+            ]
+            text = " ".join(text_parts).strip()
+            if text:
+                results.append(text)
+```
+
+Marko normalizes `[x]` and `[X]` to `checked=True` at parse time — no separate patterns needed.
+
+## CLI Script Reference
+
+```bash
+uv run scripts/markdown_to_task_pool.py <markdown_file> [--workers N] [--json] [-h]
+```
+
+| Argument | Description |
+|---|---|
+| `markdown_file` | Path to markdown file with checkbox items |
+| `--workers N` | Number of worker agents to spawn (default: number of unchecked items) |
+| `--json` | Emit JSON instead of human-readable output |
+| `-h` | Show help |
+
+Examples:
+
+```bash
+# Human-readable output
+uv run scripts/markdown_to_task_pool.py todo.md
+
+# JSON output (pipe to orchestration script)
+uv run scripts/markdown_to_task_pool.py tasks.md --json
+
+# Cap workers at 3 regardless of item count
+uv run scripts/markdown_to_task_pool.py tasks.md --json --workers 3
+```
+
+`--workers N` overrides the worker count while item count stays unchanged. Use it to cap concurrency when you have many items but want fewer parallel agents.
+
+## TeamCreate + TaskCreate Call Flow
+
+Full orchestration for a file with N unchecked items:
+
+```javascript
+// 1. Parse the file
+// uv run scripts/markdown_to_task_pool.py <file> --json
+// → { "team_name": "swarm-{stem}", "items": [...], "worker_count": N }
+
+// 2. Create team
+TeamCreate({ team_name: "swarm-{stem}" })
+
+// 3. Create tasks — one per unchecked item (loop over items array from script output)
+// Each unchecked item becomes one task; checked items are absent from items array
+// See the worked example above for concrete TaskCreate calls
+
+// 4. Spawn workers — one per item (or --workers N if capped)
+Agent({ team_name: "swarm-{stem}", name: "{item.worker_id}", subagent_type: "general-purpose", prompt: WORKER_PROMPT, run_in_background: true })
+// ... repeated for each worker
+
+// 5. Observe and synthesize
+TaskList()
+// Collect findings via SendMessage team-lead channel
+```
+
+## Worker Prompt Template
+
+Each worker receives this 8-step self-organizing prompt, parameterized by `{team_name}` and `{worker_id}`:
+
+```text
+You are swarm worker {worker_id} in team {team_name}.
+
+Your job loop:
+1. Call TaskList() to see all tasks in the pool.
+2. Find a task with status 'pending' and no owner field set.
+3. Claim it: call TaskUpdate with owner={worker_id} and status='in-progress'.
+4. Re-read the task description and do the actual work.
+5. Mark it done: call TaskUpdate with status='complete' and add a result summary.
+6. Send your findings to the team-lead: SendMessage({ type: "direct_message", recipient: "team-lead", content: "Completed: {task subject} — {summary}" }).
+7. Repeat from step 1 until TaskList() shows no pending tasks with no owner.
+8. Send shutdown acknowledgment: SendMessage({ type: "shutdown_acknowledgment", recipient: "team-lead", content: "No tasks remain. Shutting down." }).
+```
+
+All workers run the same prompt. They race to claim tasks and naturally load-balance — no central coordinator needed.
+
+## Output Contract
+
+JSON schema emitted by `--json`:
+
+```json
+{
+  "team_name": "swarm-{stem}",
+  "items": [
+    {"index": 0, "worker_id": "worker-0", "text": "First unchecked item text"},
+    {"index": 1, "worker_id": "worker-1", "text": "Second unchecked item text"}
+  ],
+  "worker_count": 2
+}
+```
+
+- `team_name`: `swarm-` prefix + markdown filename stem (no extension)
+- `items`: only unchecked items — checked items are absent
+- `index`: 0-based over unchecked items only
+- `worker_id`: `worker-{index}`
+- `worker_count`: defaults to `len(items)`; overridden by `--workers N`
+
+Exit codes: 0 on success (including zero-item case), 1 on file-not-found or parse failure.
+
+## Source Pattern
+
+This skill automates the manual `TaskCreate` loop at lines 109-114 of [../swarm-patterns/SKILL.md](../swarm-patterns/SKILL.md) (Pattern 3: Self-Organizing Swarm).
+
+The "Todo-Driven Delegation" pattern — parsing `todo.md` checkbox items and generating worker assignments from item indices — originates in the Octogent agent framework:
+
+SOURCE: [../../../research/agent-frameworks/octogent.md](../../../research/agent-frameworks/octogent.md) lines 51-53 (accessed 2026-05-19): "todo.md contains markdown checkbox items. The runtime parses these items and generates worker prompts from them. Incomplete items automatically become worker assignments in swarm runs, and terminal IDs like `<tentacle-id>-swarm-0` are derived from parsed item indices."

--- a/.claude/skills/swarm-patterns/SKILL.md
+++ b/.claude/skills/swarm-patterns/SKILL.md
@@ -150,6 +150,8 @@ Agent({
 // Workers race to claim tasks, naturally load-balance
 ```
 
+> **Automation tip**: The `TaskCreate` pool setup above (creating one task per file) can be generated automatically from a markdown checklist. Use `Skill(skill: "swarm-from-markdown")` to parse a `- [ ]` checklist file and emit the full `TeamCreate` + `TaskCreate` + `Agent` call sequence without writing it by hand.
+
 ---
 
 ## Pattern 4 -- Research + Implementation
@@ -576,6 +578,7 @@ TeamDelete()
 - Core concepts -- `Skill(skill: "swarm-primitives")`
 - Spawning agents -- `Skill(skill: "swarm-spawning")`
 - API reference -- `Skill(skill: "swarm-operations")`
+- Checklist-to-swarm automation -- `Skill(skill: "swarm-from-markdown")`
 
 ---
 

--- a/.claude/skills/swarm-primitives/SKILL.md
+++ b/.claude/skills/swarm-primitives/SKILL.md
@@ -258,6 +258,7 @@ TaskUpdate({ taskId: "4", addBlockedBy: ["3"] })   // #4 waits for #3
 - API reference -- `Skill(skill: "swarm-operations")`
 - Spawning agents -- `Skill(skill: "swarm-spawning")`
 - Patterns and recipes -- `Skill(skill: "swarm-patterns")`
+- Checklist-to-swarm automation -- `Skill(skill: "swarm-from-markdown")`
 
 ---
 

--- a/scripts/markdown_to_task_pool.py
+++ b/scripts/markdown_to_task_pool.py
@@ -23,9 +23,11 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import TypedDict
 
 from marko import Markdown
+from marko.block import List, ListItem, Paragraph
+from marko.inline import RawText
 
 
 class TaskItem(TypedDict):
@@ -61,23 +63,21 @@ def extract_unchecked_items(markdown_text: str) -> list[str]:
     """
     md = Markdown(extensions=["gfm"])
     doc = md.parse(markdown_text)
-    # marko's Element type lacks public attribute stubs; cast to list[Any] to walk the AST.
-    top_nodes = cast("list[Any]", doc.children)
 
     results: list[str] = []
-    for node in top_nodes:
-        if type(node).__name__ != "List":
+    for node in doc.children:
+        if not isinstance(node, List):
             continue
-        for item in cast("list[Any]", node.children):
-            if type(item).__name__ != "ListItem":
+        for item in node.children:
+            if not isinstance(item, ListItem):
                 continue
             for child in item.children:
-                if not hasattr(child, "checked"):
+                if not isinstance(child, Paragraph) or not hasattr(child, "checked"):
                     continue
                 if child.checked is not False:
                     # Skips True (checked [x]/[X]) and None (non-checkbox items)
                     continue
-                text_parts = [c.children.strip() for c in child.children if type(c).__name__ == "RawText"]
+                text_parts = [c.children.strip() for c in child.children if isinstance(c, RawText)]
                 text = " ".join(text_parts).strip()
                 if text:
                     results.append(text)

--- a/scripts/markdown_to_task_pool.py
+++ b/scripts/markdown_to_task_pool.py
@@ -159,14 +159,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument("markdown_file", type=Path, help="Path to the markdown file containing checkbox items.")
+
+    def positive_int(value: str) -> int:
+        n = int(value)
+        if n < 1:
+            raise argparse.ArgumentTypeError(f"must be >= 1, got {n}")
+        return n
+
     parser.add_argument(
         "--workers",
-        type=int,
+        type=positive_int,
         default=None,
         metavar="N",
         help=(
             "Number of worker agents to spawn (default: number of unchecked items). "
-            "Does not affect the number of tasks emitted."
+            "Must be >= 1. Does not affect the number of tasks emitted."
         ),
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output instead of human-readable text.")

--- a/scripts/markdown_to_task_pool.py
+++ b/scripts/markdown_to_task_pool.py
@@ -161,7 +161,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("markdown_file", type=Path, help="Path to the markdown file containing checkbox items.")
 
     def positive_int(value: str) -> int:
-        n = int(value)
+        try:
+            n = int(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"must be an integer, got {value!r}") from exc
         if n < 1:
             raise argparse.ArgumentTypeError(f"must be >= 1, got {n}")
         return n
@@ -195,14 +198,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     markdown_file: Path = args.markdown_file
 
-    if not markdown_file.exists():
-        print(f"error: file not found: {markdown_file}", file=sys.stderr)
-        return 1
-
     try:
         pool = build_task_pool(markdown_file, worker_count_override=args.workers)
     except OSError as exc:
-        print(f"error: cannot read file {markdown_file}: {exc}", file=sys.stderr)
+        print(f"error: {markdown_file}: {exc}", file=sys.stderr)
         return 1
     except ValueError as exc:
         print(f"error: failed to parse {markdown_file}: {exc}", file=sys.stderr)

--- a/scripts/markdown_to_task_pool.py
+++ b/scripts/markdown_to_task_pool.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env -S uv --quiet run --active --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "marko[gfm]",
+# ]
+# ///
+"""Parse unchecked checkbox items from a markdown file and emit a task pool.
+
+This script reads a markdown file containing GitHub Flavored Markdown checkbox
+items (``- [ ] ...``), extracts all unchecked items via the marko GFM AST, and
+emits either a JSON task pool or human-readable output showing the TaskCreate
+sequence and worker count for use with swarm orchestration.
+
+Usage::
+
+    uv run scripts/markdown_to_task_pool.py <markdown_file> [--workers N] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, TypedDict, cast
+
+from marko import Markdown
+
+
+class TaskItem(TypedDict):
+    """A single task item in the pool."""
+
+    index: int
+    worker_id: str
+    text: str
+
+
+class TaskPool(TypedDict):
+    """The complete task pool output structure."""
+
+    team_name: str
+    items: list[TaskItem]
+    worker_count: int
+
+
+def extract_unchecked_items(markdown_text: str) -> list[str]:
+    """Extract text from unchecked checkbox items in a markdown document.
+
+    Walks the marko GFM AST to find ``- [ ]`` list items (``checked=False``),
+    skipping checked items (``- [x]`` and ``- [X]``, both ``checked=True``).
+    Non-checkbox list items (``checked`` attribute absent or ``None``) are also
+    skipped.
+
+    Args:
+        markdown_text: Full contents of a markdown file as a string.
+
+    Returns:
+        Ordered list of text strings from unchecked checkbox items. Each string
+        is stripped of leading/trailing whitespace.
+    """
+    md = Markdown(extensions=["gfm"])
+    doc = md.parse(markdown_text)
+    # marko's Element type lacks public attribute stubs; cast to list[Any] to walk the AST.
+    top_nodes = cast("list[Any]", doc.children)
+
+    results: list[str] = []
+    for node in top_nodes:
+        if type(node).__name__ != "List":
+            continue
+        for item in cast("list[Any]", node.children):
+            if type(item).__name__ != "ListItem":
+                continue
+            for child in item.children:
+                if not hasattr(child, "checked"):
+                    continue
+                if child.checked is not False:
+                    # Skips True (checked [x]/[X]) and None (non-checkbox items)
+                    continue
+                text_parts = [c.children.strip() for c in child.children if type(c).__name__ == "RawText"]
+                text = " ".join(text_parts).strip()
+                if text:
+                    results.append(text)
+
+    return results
+
+
+def build_task_pool(markdown_file: Path, worker_count_override: int | None = None) -> TaskPool:
+    """Build a task pool dictionary from a markdown file.
+
+    Reads the markdown file, extracts unchecked checkbox items, and constructs
+    the task pool structure used for swarm orchestration.
+
+    Args:
+        markdown_file: Path to the markdown file containing checkbox items.
+        worker_count_override: If provided, overrides the default worker count
+            (which is the number of unchecked items). Does not affect the number
+            of tasks emitted.
+
+    Returns:
+        TaskPool with keys ``team_name`` (str), ``items`` (list of TaskItem with
+        ``index``, ``worker_id``, and ``text`` fields), and ``worker_count``
+        (int).
+
+    Raises:
+        OSError: If the file cannot be read.
+        ValueError: If the markdown text cannot be parsed.
+    """
+    markdown_text = markdown_file.read_text(encoding="utf-8")
+    items = extract_unchecked_items(markdown_text)
+
+    team_name = f"swarm-{markdown_file.stem}"
+    worker_count = worker_count_override if worker_count_override is not None else len(items)
+
+    return TaskPool(
+        team_name=team_name,
+        items=[TaskItem(index=i, worker_id=f"worker-{i}", text=text) for i, text in enumerate(items)],
+        worker_count=worker_count,
+    )
+
+
+def format_human_readable(pool: TaskPool) -> str:
+    """Format a task pool as human-readable text.
+
+    Args:
+        pool: Task pool as returned by :func:`build_task_pool`.
+
+    Returns:
+        Multi-line string with team name, task count, per-item details, and
+        worker count summary.
+    """
+    items = pool["items"]
+    lines: list[str] = [f"Team: {pool['team_name']}", f"Tasks: {len(items)}", ""]
+    lines.extend(f"  [{item['index']}] {item['worker_id']}: {item['text']}" for item in items)
+    lines.extend(("", f"Workers to spawn: {pool['worker_count']}"))
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument list to parse. Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        Parsed argument namespace with ``markdown_file`` (Path), ``workers``
+        (int or None), and ``json`` (bool) attributes.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Parse unchecked checkbox items from a markdown file and emit a task pool for swarm orchestration."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  %(prog)s tasks.md --json\n"
+            "  %(prog)s tasks.md --workers 3\n"
+            "  %(prog)s tasks.md --workers 3 --json"
+        ),
+    )
+    parser.add_argument("markdown_file", type=Path, help="Path to the markdown file containing checkbox items.")
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Number of worker agents to spawn (default: number of unchecked items). "
+            "Does not affect the number of tasks emitted."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output instead of human-readable text.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the markdown task pool CLI.
+
+    Parses arguments, reads the markdown file, extracts unchecked checkbox items,
+    and prints either JSON or human-readable output to stdout.
+
+    Args:
+        argv: Argument list to parse. Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        Exit code: 0 on success, 1 on error.
+    """
+    args = parse_args(argv)
+    markdown_file: Path = args.markdown_file
+
+    if not markdown_file.exists():
+        print(f"error: file not found: {markdown_file}", file=sys.stderr)
+        return 1
+
+    try:
+        pool = build_task_pool(markdown_file, worker_count_override=args.workers)
+    except OSError as exc:
+        print(f"error: cannot read file {markdown_file}: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"error: failed to parse {markdown_file}: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(pool, indent=2))
+    else:
+        print(format_human_readable(pool))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_fixture_5items.md
+++ b/scripts/test_fixture_5items.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [ ] Implement the login endpoint
+- [x] Already done — skip this
+- [ ] Write unit tests for auth
+- [X] Also already done
+- [ ] Update API documentation
+- [ ] Add rate limiting
+- [ ] Deploy to staging


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/swarm-from-markdown/SKILL.md` — skill for converting markdown checkbox lists (`- [ ]`) into self-organizing Claude Code swarm task pools via `TeamCreate` + `TaskCreate` + worker agents
- Adds `scripts/markdown_to_task_pool.py` — PEP 723 standalone script using marko GFM AST (not regex) to parse checkbox items and emit JSON or human-readable output
- Adds `scripts/test_fixture_5items.md` — 5-item/2-checked verification fixture
- Updates `swarm-patterns`, `orchestrating-swarms`, `swarm-primitives` SKILL.md files to cross-reference the new skill

## Key implementation details

- marko GFM AST walk: `Paragraph.checked is False` guard (attribute lives on Paragraph child of ListItem, not on ListItem itself)
- Both `[x]` and `[X]` normalized to `checked=True` by marko — single guard covers both
- PEP 723 shebang + inline `# /// script` block; argparse CLI (no Typer/Click to keep deps minimal)
- JSON output: `{team_name, items: [{index, worker_id, text}], worker_count}`
- `team_name` = `swarm-{stem}` from the markdown filename
- `--workers N` overrides worker count without changing item count
- Source pattern cited: `research/agent-frameworks/octogent.md` (Todo-Driven Delegation)

## Test plan

- [ ] `uv run scripts/markdown_to_task_pool.py scripts/test_fixture_5items.md --json` → 5 items, worker_count=5, team_name=swarm-test_fixture_5items
- [ ] Both checked items (`[x]` and `[X]`) absent from output
- [ ] `--workers 3` → worker_count=3, items still 5
- [ ] `uv run ruff check scripts/markdown_to_task_pool.py` exits 0
- [ ] `uv run ty check scripts/markdown_to_task_pool.py` exits 0
- [ ] Non-existent file → exit 1 with stderr

Closes #2238

https://claude.ai/code/session_01Hw7nNP5KF48E3kvnxx7SNs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw7nNP5KF48E3kvnxx7SNs)_