### PR TITLE
fix(bd-runner): add env_overrides parameter required by architect spec §4.1

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.4",
+  "version": "8.5.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/bd_runner.py
+++ b/plugins/development-harness/backlog_core/backends/bd_runner.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Final
 from backlog_core.models import BackendUnavailableError
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
 __all__ = ["_DEFAULT_BD_TIMEOUT_SECONDS", "BdInvocationError", "BdJsonDecodeError", "BdNotInstalledError", "BdRunner"]
 
@@ -131,6 +131,12 @@ class BdRunner:
 
     Parameters
     ----------
+    env_overrides:
+        Extra environment variables merged into the environment passed to each
+        ``bd`` subprocess call.  Applied on top of the base environment produced
+        by :func:`_bd_env`.  Blocked variables (e.g. ``GITHUB_TOKEN``) are
+        silently dropped even if listed here.  ``None`` (default) means no extra
+        variables.
     timeout_seconds:
         Maximum number of seconds to wait for any single ``bd`` invocation.
         Defaults to :data:`_DEFAULT_BD_TIMEOUT_SECONDS`.
@@ -143,9 +149,20 @@ class BdRunner:
     inside the MCP server does not add latency at startup.
     """
 
-    def __init__(self, timeout_seconds: int = _DEFAULT_BD_TIMEOUT_SECONDS) -> None:
-        """Store configuration only.  Does not touch the filesystem."""
+    def __init__(
+        self, *, env_overrides: Mapping[str, str] | None = None, timeout_seconds: int = _DEFAULT_BD_TIMEOUT_SECONDS
+    ) -> None:
+        """Store configuration only.  Does not touch the filesystem.
+
+        Args:
+            env_overrides: Extra environment variables merged into every
+                subprocess call.  Blocked variables are silently dropped.
+            timeout_seconds: Subprocess timeout in seconds.
+        """
         self._timeout_seconds = timeout_seconds
+        self._env_overrides: dict[str, str] = (
+            {k: v for k, v in env_overrides.items() if k not in _BLOCKED_ENV_VARS} if env_overrides else {}
+        )
         self._bd_path: str | None = None
         self._available: bool | None = None
 
@@ -233,7 +250,7 @@ class BdRunner:
                 encoding="utf-8",
                 errors="replace",
                 check=False,
-                env=_bd_env(),
+                env=self._effective_env(),
             )
             self._available = True
         except (OSError, subprocess.SubprocessError):
@@ -243,6 +260,19 @@ class BdRunner:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _effective_env(self) -> dict[str, str]:
+        """Return the filtered base environment merged with instance-level overrides.
+
+        Returns:
+        -------
+        dict[str, str]
+            Environment mapping safe to pass to ``bd`` subprocesses.
+        """
+        env = _bd_env()
+        if self._env_overrides:
+            env.update(self._env_overrides)
+        return env
 
     def _resolve_bd_path(self) -> str:
         """Lazily locate ``bd`` on ``PATH`` and cache the result.
@@ -298,7 +328,7 @@ class BdRunner:
                 encoding="utf-8",
                 errors="replace",
                 check=False,
-                env=_bd_env(),
+                env=self._effective_env(),
             )
         except subprocess.TimeoutExpired as exc:
             elapsed_ms = int((time.monotonic() - t0) * 1000)

--- a/plugins/development-harness/tests_backlog/test_bd_runner.py
+++ b/plugins/development-harness/tests_backlog/test_bd_runner.py
@@ -2,13 +2,6 @@
 
 Verifies BdRunner subprocess wrapper behavior using pytest-mock.
 No live bd binary is invoked — all subprocess interactions are mocked.
-
-Divergence Note DN-1
---------------------
-Task requirement #10 specified testing an ``env_overrides`` parameter on
-BdRunner.  The actual implementation has no such parameter; GITHUB_TOKEN
-filtering is handled unconditionally by the module-level ``_bd_env()``
-function.  These tests cover the implemented behavior.
 """
 
 from __future__ import annotations
@@ -284,19 +277,12 @@ def test_resolve_bd_path_caches_after_first_call(mocker: MockerFixture) -> None:
 
 # ---------------------------------------------------------------------------
 # _bd_env — GITHUB_TOKEN filtering
-# (DN-1: task req #10 specified an 'env_overrides' parameter that does not
-#  exist; BdRunner filters GITHUB_TOKEN unconditionally via _bd_env())
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 def test_bd_env_removes_github_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_bd_env strips GITHUB_TOKEN to prevent credential leakage into bd subprocesses.
-
-    Note (DN-1): Original requirement specified an ``env_overrides`` parameter
-    that does not exist.  Implemented behavior is unconditional GITHUB_TOKEN
-    removal via the module-level ``_bd_env()`` helper.
-    """
+    """_bd_env strips GITHUB_TOKEN to prevent credential leakage into bd subprocesses."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_supersecret")
     monkeypatch.setenv("HOME", "/home/testuser")
 
@@ -314,3 +300,55 @@ def test_bd_env_passes_non_blocked_vars_through(monkeypatch: pytest.MonkeyPatch)
     env = _bd_env()
 
     assert env["MY_CUSTOM_VAR"] == "custom_value"
+
+
+# ---------------------------------------------------------------------------
+# env_overrides — per-instance environment injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_env_overrides_merged_into_subprocess_env(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """env_overrides are merged into the subprocess environment on each invocation."""
+    monkeypatch.setenv("HOME", "/home/testuser")
+    mocker.patch("backlog_core.backends.bd_runner.shutil.which", return_value=_FAKE_BD)
+    mock_run = mocker.patch("backlog_core.backends.bd_runner.subprocess.run", return_value=_proc())
+
+    runner = BdRunner(env_overrides={"BD_WORKSPACE": "/my/workspace"})
+    runner.run_json(["list"])
+
+    _args, call_kwargs = mock_run.call_args
+    assert call_kwargs["env"]["BD_WORKSPACE"] == "/my/workspace"
+    assert "HOME" in call_kwargs["env"]
+
+
+@pytest.mark.unit
+def test_env_overrides_blocked_vars_are_silently_dropped(mocker: MockerFixture) -> None:
+    """Blocked variables in env_overrides are silently dropped — security filter cannot be bypassed."""
+    mocker.patch("backlog_core.backends.bd_runner.shutil.which", return_value=_FAKE_BD)
+    mock_run = mocker.patch("backlog_core.backends.bd_runner.subprocess.run", return_value=_proc())
+
+    runner = BdRunner(env_overrides={"GITHUB_TOKEN": "evil_token", "BD_WORKSPACE": "/my/workspace"})
+    runner.run_json(["list"])
+
+    _args, call_kwargs = mock_run.call_args
+    assert "GITHUB_TOKEN" not in call_kwargs["env"]
+    assert call_kwargs["env"]["BD_WORKSPACE"] == "/my/workspace"
+
+
+@pytest.mark.unit
+def test_env_overrides_default_none_does_not_inject_extra_vars(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With default env_overrides=None, _bd_env() is used unmodified — no extra vars injected."""
+    monkeypatch.setenv("HOME", "/home/testuser")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    mocker.patch("backlog_core.backends.bd_runner.shutil.which", return_value=_FAKE_BD)
+    mock_run = mocker.patch("backlog_core.backends.bd_runner.subprocess.run", return_value=_proc())
+
+    runner = BdRunner()
+    runner.run_json(["list"])
+
+    _args, call_kwargs = mock_run.call_args
+    assert "GITHUB_TOKEN" not in call_kwargs["env"]
+    assert "HOME" in call_kwargs["env"]


### PR DESCRIPTION
## Summary

Closes #2288

`BdRunner.__init__` was missing the `env_overrides: Mapping[str, str] | None = None` parameter specified in the architect spec §4.1 line 214. Every subprocess call hardcoded `_bd_env()` with no caller-controlled override path — violating the contract between `BdRunner` and its callers (`BeadsBackend`, `dispatch_state`, etc.).

**Design bug (not just a missing parameter):** The absence of `env_overrides` means callers cannot configure bd's subprocess environment without subclassing — preventing workspace scoping, credential injection for non-GITHUB_TOKEN auth flows, and testability with controlled environments.

## Changes

- `BdRunner.__init__` now accepts `env_overrides: Mapping[str, str] | None = None` as a keyword-only parameter (matching spec's `*` signature)
- Blocked vars (`GITHUB_TOKEN`) are silently dropped from `env_overrides` at construction time — security filter cannot be bypassed
- New `_effective_env()` instance method merges `_bd_env()` + instance overrides
- `_run()` and `is_available()` call `self._effective_env()` instead of `_bd_env()`
- DN-1 divergence note removed from test file (gap is now closed)
- 3 new tests: merge coverage, security-drop (blocked var cannot be injected), None-default (no extra vars)

## Test plan

- [ ] `uv run pytest plugins/development-harness/tests_backlog/test_bd_runner.py` — 23 passed
- [ ] `uv run prek run --files ...bd_runner.py ...test_bd_runner.py` — all hooks pass
- [ ] `ty check` passes — `Mapping` kept in `TYPE_CHECKING` block, `from __future__ import annotations` handles runtime annotation evaluation

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyzDsNHVXCQ6tKQB7GpcyB)_