### PR TITLE
refactor(backlog): abstract rendering utilities from github_sync into BacklogBackend protocol

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.6",
+  "version": "8.5.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.7",
+  "version": "8.5.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.5",
+  "version": "8.5.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/ARCHITECTURE.md
+++ b/plugins/development-harness/backlog_core/ARCHITECTURE.md
@@ -213,7 +213,7 @@ transition.
 **Responsibility**: Bidirectional conversion between `BacklogItem` and GitHub issue body markdown.
 Operations layer never writes raw markdown body strings directly — they go through this adapter.
 
-**Public API** (`__all__`): `render_issue_body`, `parse_issue_body`, `merge_item`
+**Public API** (`__all__`): `render_issue_body`, `parse_issue_body`, `merge_item`, `SECTION_HEADING`, `heading_to_section_key`, `heading_to_unknown_key`, `unknown_key_to_heading`
 
 - `render_issue_body(item)` — serialises `BacklogItem` to GitHub markdown; embeds metadata in an
   invisible `<!-- backlog-metadata: -->` HTML comment; renders description, entry-bearing sections,
@@ -224,6 +224,10 @@ Operations layer never writes raw markdown body strings directly — they go thr
 - `merge_item(local, remote)` — merges remote into local; local metadata is authoritative; sections
   are merged per-entry (struck state wins over active; longer content wins on tie; unique entries
   from either side are preserved)
+- `SECTION_HEADING` — dict mapping section storage keys to GitHub markdown heading text (e.g. `"fact_check"` → `"Fact-Check"`)
+- `heading_to_section_key(heading_text)` — maps a `## Heading` text to its section storage key; returns `None` for unknown headings
+- `heading_to_unknown_key(heading_text)` — converts an unknown heading to an `"unknown__"` prefixed storage key
+- `unknown_key_to_heading(key)` — reverses `heading_to_unknown_key`; strips prefix, title-cases result
 
 **Known section keys** (BacklogItem.sections):
 - `"fact_check"` → `## Fact-Check`
@@ -237,6 +241,24 @@ do not import from `gh_client.py`, `operations.py`, or `server.py`)
 **Imports from other modules**: `from .entry_blocks import parse_entries`,
 `from .models import BacklogItem, Entry, GroomedData, Section`,
 `from .parsing import extract_sections`
+
+---
+
+## Module: rendering.py
+
+**Responsibility**: Backend-neutral shared rendering utilities for backlog sections. Extracts rendering logic from `github_sync` into a location all three `BacklogBackend` implementations (GitHub, SQLite, memory) can import, ensuring identical section rendering across backends.
+
+**Dependency direction**: `models ← rendering` (must remain acyclic; do not import from `github_sync`, `operations`, `gh_client`, or `server`)
+
+**Public API** (`__all__`): `GROOMED_SUBSECTION_ORDER`, `SECTION_HEADING`, `render_groomed_section`, `section_display_title`, `unknown_key_to_heading`
+
+- `SECTION_HEADING` — dict mapping known section storage keys to display heading text (e.g. `"fact_check"` → `"Fact-Check"`); shared constant used by all backends
+- `GROOMED_SUBSECTION_ORDER` — canonical render order for `GroomedData` subsections (heading text as stored)
+- `render_groomed_section(groomed)` — renders a `GroomedData` as `## Groomed ({date})` with `### subsection` children in canonical order; extras appended alphabetically
+- `section_display_title(key, groomed_date)` — returns the human-readable title for a section storage key; handles known keys via `SECTION_HEADING`, `"unknown__"` prefix via `unknown_key_to_heading`, and the special `"groomed"` key with optional date
+- `unknown_key_to_heading(key)` — strips `"unknown__"` prefix, replaces underscores with spaces, and title-cases the result
+
+**Imports from other modules**: `from .models import GroomedData` (type annotation only, under `TYPE_CHECKING`)
 
 ---
 

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1212,11 +1212,11 @@ async def backlog_add(
     if expected_token is None:
         await ctx.warning("Gate token file unreadable for session %s", session_id)
         return {
-            "error": "Gate token file could not be read for this session. Load /dh:create-backlog-item — the skill writes the required token at load time."
+            "error": "Gate token file could not be read for this session. Load /dh:work-backlog-item create — the skill writes the required token at load time."
         }
     if gate_token != expected_token:
         return {
-            "error": "Direct backlog_add calls are not permitted. Load and follow /dh:create-backlog-item — it will provide the required gate_token."
+            "error": 'Direct backlog_add calls are not permitted. Load and follow /dh:work-backlog-item create -- "<description>" — it will provide the required gate_token.'
         }
     out = Output()
     try:

--- a/plugins/development-harness/tests/test_backlog_core_server.py
+++ b/plugins/development-harness/tests/test_backlog_core_server.py
@@ -168,7 +168,7 @@ async def test_backlog_add_gate_rejects_missing_token():
         )
 
     mock_add.assert_not_called()
-    expected_error = "Direct backlog_add calls are not permitted. Load and follow /dh:create-backlog-item — it will provide the required gate_token."
+    expected_error = 'Direct backlog_add calls are not permitted. Load and follow /dh:work-backlog-item create -- "<description>" — it will provide the required gate_token.'
     assert response_missing["error"] == expected_error
     assert response_wrong["error"] == expected_error
 


### PR DESCRIPTION
## Summary

- Adds `render_groomed_section`, `section_heading`, and `section_display_title` to the `BacklogBackend` protocol (`backend_protocol.py`)
- Extracts backend-neutral rendering logic from `github_sync` into new `backlog_core/rendering.py` module; all three backends (GitHub, SQLite, InMemory) delegate to it
- Removes `operations.py` coupling to `github_sync.SECTION_HEADING` and `github_sync._render_groomed`; rendering now dispatches via `get_config().backend.*`
- Adds AST regression test `TestOperationsDoesNotImportFromGithubSync` to permanently lock in the decoupling
- Fixes `backlog_add` gate token error message routing (referenced deprecated `/dh:create-backlog-item`; corrected to `/dh:work-backlog-item create`)
- Documents `rendering.py` module and `github_sync` re-exports in `ARCHITECTURE.md`

## Quality gates (all passed)

- T1 Code Review: PASS (8 MET / 2 PARTIAL pre-existing baseline drift, 0 UNMET, 0 blocking)
- T2 Feature Verification: VERIFIED (all 5 acceptance criteria met)
- T3 Integration Check: VERIFIED (clean architecture, no circular deps, end-to-end data flow confirmed)
- T4 Doc Drift Audit: 2 gaps found in ARCHITECTURE.md (fixed in T5)
- T5 Docs Update: github_sync public API list and rendering.py module section added
- T6 Context Refinement: plan context updated with 6 implementation discoveries

## Test plan

- [ ] `uv run pytest plugins/development-harness/backlog_core/tests/test_rendering.py` — 7/7 pass
- [ ] `uv run pytest plugins/development-harness/backlog_core/tests/` — 46/46 pass
- [ ] Grep confirms zero `github_sync` rendering imports in `operations.py`

https://claude.ai/code/session_01KscayMzY7AHY3ZJvncbUnu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KscayMzY7AHY3ZJvncbUnu)_