### PR TITLE
refactor(backlog): deduplicate SECTION_HEADING — use rendering as single source

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.8",
+  "version": "8.5.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/github_sync.py
+++ b/plugins/development-harness/backlog_core/github_sync.py
@@ -40,12 +40,8 @@ _METADATA_LINE_RE = re.compile(r"^(\w+):\s*(.*)$")
 _GROOMED_HEADING_RE = re.compile(r"^##\s+Groomed\s*\(([^)]*)\)")
 _SUBSECTION_RE = re.compile(r"### ([^\n]+)\n([\s\S]*?)(?=\n### |\Z)")
 
-# Section key (used in BacklogItem.sections) -> GitHub markdown heading text
-SECTION_HEADING: dict[str, str] = {
-    "fact_check": "Fact-Check",
-    "rt_ica": "RT-ICA",
-    "issue_classification": "Issue Classification",
-}
+# Re-exported from rendering — canonical definition lives in rendering.SECTION_HEADING
+SECTION_HEADING = _rendering.SECTION_HEADING
 
 # Reverse lookup: heading text (lowercased) -> section key
 _HEADING_TO_KEY: dict[str, str] = {v.lower(): k for k, v in SECTION_HEADING.items()}


### PR DESCRIPTION
## Summary

- Removes the independent `SECTION_HEADING` dict definition from `github_sync.py` (lines 44–48)
- Replaces it with `SECTION_HEADING = _rendering.SECTION_HEADING` — a direct reference to the canonical definition already in `rendering.py`
- `_HEADING_TO_KEY` and `_KNOWN_SECTION_KEYS` continue to derive from `SECTION_HEADING` unchanged
- `SECTION_HEADING` remains in `__all__` for backward-compatible re-export

## Test plan

- [x] 60 existing tests pass (`test_github_sync.py`, `test_rendering.py`, `test_sections_index_consistency.py`)
- [x] `ruff`, `ty`, and all pre-commit hooks pass
- [x] No consumers import `SECTION_HEADING` directly from `github_sync` (verified via grep)

Closes #2370

https://claude.ai/code/session_01CHtrjSTcKYtPru4d6aNsd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHtrjSTcKYtPru4d6aNsd3)_