### PR TITLE
fix(bd_runner): add env_overrides parameter to BdRunner.__init__

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.10",
+  "version": "8.5.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.9",
+  "version": "8.5.10",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/bd_runner.py
+++ b/plugins/development-harness/backlog_core/backends/bd_runner.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Final
 from backlog_core.models import BackendUnavailableError
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
 __all__ = ["_DEFAULT_BD_TIMEOUT_SECONDS", "BdInvocationError", "BdJsonDecodeError", "BdNotInstalledError", "BdRunner"]
 
@@ -131,6 +131,13 @@ class BdRunner:
 
     Parameters
     ----------
+    env_overrides:
+        Optional mapping of environment variable names to values that are
+        merged into every ``bd`` subprocess environment.  Keys in this
+        mapping take precedence over the inherited process environment.
+        Variables listed in :data:`_BLOCKED_ENV_VARS` are removed first,
+        then overrides are applied.  Pass ``None`` (default) to use the
+        inherited environment unchanged.
     timeout_seconds:
         Maximum number of seconds to wait for any single ``bd`` invocation.
         Defaults to :data:`_DEFAULT_BD_TIMEOUT_SECONDS`.
@@ -143,8 +150,11 @@ class BdRunner:
     inside the MCP server does not add latency at startup.
     """
 
-    def __init__(self, timeout_seconds: int = _DEFAULT_BD_TIMEOUT_SECONDS) -> None:
+    def __init__(
+        self, *, env_overrides: Mapping[str, str] | None = None, timeout_seconds: int = _DEFAULT_BD_TIMEOUT_SECONDS
+    ) -> None:
         """Store configuration only.  Does not touch the filesystem."""
+        self._env_overrides = env_overrides
         self._timeout_seconds = timeout_seconds
         self._bd_path: str | None = None
         self._available: bool | None = None
@@ -233,7 +243,7 @@ class BdRunner:
                 encoding="utf-8",
                 errors="replace",
                 check=False,
-                env=_bd_env(),
+                env=self._build_env(),
             )
             self._available = True
         except (OSError, subprocess.SubprocessError):
@@ -243,6 +253,13 @@ class BdRunner:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _build_env(self) -> dict[str, str]:
+        """Return subprocess environment with blocked vars removed and overrides applied."""
+        env = _bd_env()
+        if self._env_overrides:
+            env.update(self._env_overrides)
+        return env
 
     def _resolve_bd_path(self) -> str:
         """Lazily locate ``bd`` on ``PATH`` and cache the result.
@@ -298,7 +315,7 @@ class BdRunner:
                 encoding="utf-8",
                 errors="replace",
                 check=False,
-                env=_bd_env(),
+                env=self._build_env(),
             )
         except subprocess.TimeoutExpired as exc:
             elapsed_ms = int((time.monotonic() - t0) * 1000)

--- a/plugins/development-harness/backlog_core/backends/bd_runner.py
+++ b/plugins/development-harness/backlog_core/backends/bd_runner.py
@@ -255,10 +255,15 @@ class BdRunner:
     # ------------------------------------------------------------------
 
     def _build_env(self) -> dict[str, str]:
-        """Return subprocess environment with blocked vars removed and overrides applied."""
+        """Return subprocess environment with blocked vars removed and overrides applied.
+
+        Blocked variables (see :data:`_BLOCKED_ENV_VARS`) are stripped from
+        both the inherited process environment and from *env_overrides*, so
+        callers cannot inadvertently re-inject a blocked credential.
+        """
         env = _bd_env()
         if self._env_overrides:
-            env.update(self._env_overrides)
+            env.update({k: v for k, v in self._env_overrides.items() if k not in _BLOCKED_ENV_VARS})
         return env
 
     def _resolve_bd_path(self) -> str:

--- a/plugins/development-harness/backlog_core/backends/bd_runner.py
+++ b/plugins/development-harness/backlog_core/backends/bd_runner.py
@@ -137,7 +137,7 @@ class BdRunner:
         mapping take precedence over the inherited process environment.
         Variables listed in :data:`_BLOCKED_ENV_VARS` are removed first,
         then overrides are applied.  Pass ``None`` (default) to use the
-        inherited environment unchanged.
+        inherited environment with blocked variables removed.
     timeout_seconds:
         Maximum number of seconds to wait for any single ``bd`` invocation.
         Defaults to :data:`_DEFAULT_BD_TIMEOUT_SECONDS`.

--- a/plugins/development-harness/tests_backlog/test_bd_runner.py
+++ b/plugins/development-harness/tests_backlog/test_bd_runner.py
@@ -361,3 +361,17 @@ def test_env_overrides_none_preserves_inherited_env_without_blocked_vars(
     env = mock_run.call_args.kwargs["env"]
     assert "HOME" in env
     assert "GITHUB_TOKEN" not in env
+
+
+@pytest.mark.unit
+def test_env_overrides_cannot_inject_blocked_vars(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Blocked vars (e.g. GITHUB_TOKEN) in env_overrides are silently stripped."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    mocker.patch("backlog_core.backends.bd_runner.shutil.which", return_value=_FAKE_BD)
+    mock_run = mocker.patch("backlog_core.backends.bd_runner.subprocess.run", return_value=_proc(stdout='{"ok": true}'))
+
+    BdRunner(env_overrides={"GITHUB_TOKEN": "injected", "SAFE_VAR": "ok"}).run_json(["show", "bd-a3f8"])
+
+    env = mock_run.call_args.kwargs["env"]
+    assert "GITHUB_TOKEN" not in env
+    assert env["SAFE_VAR"] == "ok"

--- a/plugins/development-harness/tests_backlog/test_bd_runner.py
+++ b/plugins/development-harness/tests_backlog/test_bd_runner.py
@@ -375,3 +375,19 @@ def test_env_overrides_cannot_inject_blocked_vars(mocker: MockerFixture, monkeyp
     env = mock_run.call_args.kwargs["env"]
     assert "GITHUB_TOKEN" not in env
     assert env["SAFE_VAR"] == "ok"
+
+
+@pytest.mark.unit
+def test_is_available_passes_env_overrides_to_subprocess(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """is_available passes env_overrides into its subprocess call, stripping blocked vars."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    mocker.patch("backlog_core.backends.bd_runner.shutil.which", return_value=_FAKE_BD)
+    mock_run = mocker.patch("backlog_core.backends.bd_runner.subprocess.run", return_value=_proc())
+
+    BdRunner(env_overrides={"BD_AVAIL_VAR": "check_value"}).is_available()
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["BD_AVAIL_VAR"] == "check_value"
+    assert "GITHUB_TOKEN" not in env

--- a/plugins/development-harness/tests_backlog/test_bd_runner.py
+++ b/plugins/development-harness/tests_backlog/test_bd_runner.py
@@ -2,13 +2,6 @@
 
 Verifies BdRunner subprocess wrapper behavior using pytest-mock.
 No live bd binary is invoked — all subprocess interactions are mocked.
-
-Divergence Note DN-1
---------------------
-Task requirement #10 specified testing an ``env_overrides`` parameter on
-BdRunner.  The actual implementation has no such parameter; GITHUB_TOKEN
-filtering is handled unconditionally by the module-level ``_bd_env()``
-function.  These tests cover the implemented behavior.
 """
 
 from __future__ import annotations
@@ -284,19 +277,12 @@ def test_resolve_bd_path_caches_after_first_call(mocker: MockerFixture) -> None:
 
 # ---------------------------------------------------------------------------
 # _bd_env — GITHUB_TOKEN filtering
-# (DN-1: task req #10 specified an 'env_overrides' parameter that does not
-#  exist; BdRunner filters GITHUB_TOKEN unconditionally via _bd_env())
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 def test_bd_env_removes_github_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_bd_env strips GITHUB_TOKEN to prevent credential leakage into bd subprocesses.
-
-    Note (DN-1): Original requirement specified an ``env_overrides`` parameter
-    that does not exist.  Implemented behavior is unconditional GITHUB_TOKEN
-    removal via the module-level ``_bd_env()`` helper.
-    """
+    """_bd_env strips GITHUB_TOKEN to prevent credential leakage into bd subprocesses."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_supersecret")
     monkeypatch.setenv("HOME", "/home/testuser")
 
@@ -314,3 +300,64 @@ def test_bd_env_passes_non_blocked_vars_through(monkeypatch: pytest.MonkeyPatch)
     env = _bd_env()
 
     assert env["MY_CUSTOM_VAR"] == "custom_value"
+
+
+# ---------------------------------------------------------------------------
+# env_overrides — constructor parameter (architect spec §4.1 line 214)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_init_stores_env_overrides() -> None:
+    """BdRunner stores env_overrides for use in subprocess invocations."""
+    runner = BdRunner(env_overrides={"MY_VAR": "my_value"})
+    assert runner._env_overrides == {"MY_VAR": "my_value"}
+
+
+@pytest.mark.unit
+def test_init_env_overrides_defaults_to_none() -> None:
+    """BdRunner defaults env_overrides to None."""
+    runner = BdRunner()
+    assert runner._env_overrides is None
+
+
+@pytest.mark.unit
+def test_run_json_passes_env_overrides_to_subprocess(mocker: MockerFixture) -> None:
+    """run_json merges env_overrides into the subprocess environment."""
+    mocker.patch("backlog_core.backends.bd_runner.shutil.which", return_value=_FAKE_BD)
+    mock_run = mocker.patch("backlog_core.backends.bd_runner.subprocess.run", return_value=_proc(stdout='{"ok": true}'))
+
+    BdRunner(env_overrides={"BD_TEST_VAR": "test_value"}).run_json(["show", "bd-a3f8"])
+
+    assert mock_run.call_args.kwargs["env"]["BD_TEST_VAR"] == "test_value"
+
+
+@pytest.mark.unit
+def test_env_overrides_take_precedence_over_inherited_env(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """env_overrides values override inherited process environment variables."""
+    monkeypatch.setenv("BD_EXISTING_VAR", "original_value")
+    mocker.patch("backlog_core.backends.bd_runner.shutil.which", return_value=_FAKE_BD)
+    mock_run = mocker.patch("backlog_core.backends.bd_runner.subprocess.run", return_value=_proc(stdout='{"ok": true}'))
+
+    BdRunner(env_overrides={"BD_EXISTING_VAR": "overridden_value"}).run_json(["show", "bd-a3f8"])
+
+    assert mock_run.call_args.kwargs["env"]["BD_EXISTING_VAR"] == "overridden_value"
+
+
+@pytest.mark.unit
+def test_env_overrides_none_preserves_inherited_env_without_blocked_vars(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """env_overrides=None passes inherited env minus blocked vars, same as no overrides."""
+    monkeypatch.setenv("HOME", "/home/testuser")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
+    mocker.patch("backlog_core.backends.bd_runner.shutil.which", return_value=_FAKE_BD)
+    mock_run = mocker.patch("backlog_core.backends.bd_runner.subprocess.run", return_value=_proc(stdout='{"ok": true}'))
+
+    BdRunner(env_overrides=None).run_json(["show", "bd-a3f8"])
+
+    env = mock_run.call_args.kwargs["env"]
+    assert "HOME" in env
+    assert "GITHUB_TOKEN" not in env


### PR DESCRIPTION
## Summary

- Add `env_overrides: Mapping[str, str] | None = None` keyword-only parameter to `BdRunner.__init__` per architect spec §4.1 line 214
- Add `_build_env()` helper that merges `_bd_env()` output with `env_overrides` (overrides take precedence)
- Update `_run()` and `is_available()` to call `self._build_env()` instead of the module-level `_bd_env()`
- Both constructor params are now keyword-only (`*`); all existing callers already use kwargs — no breaking change
- Remove resolved Divergence Note DN-1 from `test_bd_runner.py` module docstring
- Add 5 new tests covering: storage, default None, subprocess merge, precedence over inherited env, None passthrough behavior

## Test plan

- [ ] `uv run pytest plugins/development-harness/tests_backlog/test_bd_runner.py -x -q` → 25 passed
- [ ] All pre-commit hooks pass (ruff lint + format, ty check, conventional commit)

Closes #2288

https://claude.ai/code/session_01NVyX8CgEvej9MNr5iyPxpB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVyX8CgEvej9MNr5iyPxpB)_