### PR TITLE
docs(implement-feature): add commit ownership rules for same-worktree vs isolated-worktree execution

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.11",
+  "version": "8.5.12",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.12",
+  "version": "8.5.13",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -219,6 +219,26 @@ This terminates the teammate immediately rather than leaving it idle. Idle teamm
 
 **Skip when**: the agent was dispatched via a single `Agent` call (not `TeamCreate`) — subagents terminate automatically when their prompt completes.
 
+**Commit Ownership**
+
+Commit responsibility depends on which execution mode is active.
+
+**Same-worktree mode (default — no isolation flag):** The orchestrator owns all commits. After step 4b completes for task N, before dispatching task N+1:
+
+1. Run `git status` to identify unstaged changes attributable to the completed task.
+2. Stage and commit those changes:
+
+   ```bash
+   git add -A
+   git commit -m "feat(task): {task_id} — {task_title}"
+   ```
+
+3. Do NOT include `Fixes #N`, `Closes #N`, or `Resolves #N` trailers in task-level commits — see `start-task/SKILL.md` step 6. Issue closure is handled exclusively by `/complete-implementation`.
+
+**Why the orchestrator commits:** Multiple agents write to the same filesystem concurrently. An agent committing mid-task risks including another agent's in-progress changes. The orchestrator receives completion messages serially and is the only actor with a safe, serialised view of which files belong to which completed task.
+
+**Isolated-worktree mode (via `/dh:work-milestone`):** Each agent owns its own commits. The agent commits in its isolated worktree after completing its task. The orchestrator merges each worktree back when the completion message arrives. The orchestrator does NOT issue commit calls in this mode.
+
 **Per-task Confirmation Gate** (active when `autonomy_mode == "per_task"` only):
 
 After task N completes (steps 4 through 4b finished), before dispatching task N+1:

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -223,19 +223,25 @@ This terminates the teammate immediately rather than leaving it idle. Idle teamm
 
 Commit responsibility depends on which execution mode is active.
 
-**Same-worktree mode (default — no isolation flag):** The orchestrator owns all commits. After step 4b completes for task N, before dispatching task N+1:
+**Same-worktree mode (default — no isolation flag):** The orchestrator owns all commits. Commit timing depends on `autonomy_mode`:
 
-1. Run `git status` to identify unstaged changes attributable to the completed task.
-2. Stage and commit those changes:
+- **`per_task` mode**: The Per-task Confirmation Gate (below) ensures only one task runs at a time. Commit after step 4b, before dispatching the next task — no concurrent agents are writing:
 
-   ```bash
-   git add -A
-   git commit -m "feat(task): {task_id} — {task_title}"
-   ```
+  ```bash
+  git add -A
+  git commit -m "<type>(task): {task_id} — {task_title}"
+  ```
 
-3. Do NOT include `Fixes #N`, `Closes #N`, or `Resolves #N` trailers in task-level commits — see `start-task/SKILL.md` step 6. Issue closure is handled exclusively by `/complete-implementation`.
+- **`full_auto` and `checkpoint` modes**: Multiple tasks in a batch execute concurrently. Do NOT commit after each individual step 4b — other batch agents may still be writing to the worktree. Commit once **after step 5** confirms all tasks in the current batch are complete:
 
-**Why the orchestrator commits:** Multiple agents write to the same filesystem concurrently. An agent committing mid-task risks including another agent's in-progress changes. The orchestrator receives completion messages serially and is the only actor with a safe, serialised view of which files belong to which completed task.
+  ```bash
+  git add -A
+  git commit -m "<type>(task-batch): {plan_address} — {task_ids}"
+  ```
+
+In both cases, choose `<type>` to match the dominant change in the committed work (`feat`, `fix`, `docs`, `refactor`, etc.). Do NOT include `Fixes #N`, `Closes #N`, or `Resolves #N` trailers — see `start-task/SKILL.md` step 6. Issue closure is handled exclusively by `/complete-implementation`.
+
+**Why the orchestrator commits:** Multiple agents write to the same filesystem concurrently. An agent committing mid-task risks including another agent's in-progress changes. The orchestrator is the only actor that knows when a batch is fully settled, making it the safe commit point.
 
 **Isolated-worktree mode (via `/dh:work-milestone`):** Each agent owns its own commits. The agent commits in its isolated worktree after completing its task. The orchestrator merges each worktree back when the completion message arrives. The orchestrator does NOT issue commit calls in this mode.
 


### PR DESCRIPTION
## Summary

- Adds a **Commit Ownership** section to `plugins/development-harness/skills/implement-feature/SKILL.md`
- Inserted between step 4b (shutdown teammate) and the Per-task Confirmation Gate — the natural serialised point where the orchestrator has a safe view of completed-task changes
- Eliminates non-deterministic git history from same-worktree SAM dispatch runs

## What changed

**Same-worktree mode (default):** Orchestrator commits after step 4b, before dispatching the next task. Includes `git status` → `git add -A` → `git commit` sequence with cross-reference to the `Fixes #N` trailer prohibition from `start-task/SKILL.md` step 6.

**Isolated-worktree mode (via `/dh:work-milestone`):** Agent commits in its own worktree; orchestrator does not commit.

## Root cause

Plan Pdec8934d — agents T22, T26, T28 completed tasks without committing. Orchestrator had no documented rule for either execution mode, causing inconsistent ad-hoc inference.

## Acceptance criteria verified

- [x] `grep -i 'commit'` returns results covering both execution modes
- [x] Orchestrator documented as commit owner in same-worktree mode (after step 4b)
- [x] Agent documented as commit owner in isolated-worktree mode
- [x] Commit timing documented relative to steps 4–4b
- [x] `Fixes #N` trailer prohibition cross-referenced from `start-task/SKILL.md` step 6
- [x] `uv run prek run --files` exits 0

Closes #2282

https://claude.ai/code/session_014XzZ432UsT33BJcJAmrSHM

---
_Generated by [Claude Code](https://claude.ai/code/session_014XzZ432UsT33BJcJAmrSHM)_