### PR TITLE
fix(review): resolve silent failures from 24h code-review findings

### DIFF
--- a/.claude/skills/gh/scripts/setup_gh.py
+++ b/.claude/skills/gh/scripts/setup_gh.py
@@ -961,6 +961,11 @@ def write_gh_config(config_path: Path, owner_repo: str) -> bool:
         error_console.print(f":warning: [yellow]Warning: could not read {config_path}: {exc}[/yellow]")
         return False
 
+    existing_gh = data.get("gh")
+    if existing_gh is not None and not isinstance(existing_gh, dict):
+        error_console.print(
+            f":warning: [yellow]Warning: replacing non-dict 'gh' value ({type(existing_gh).__name__}) in {config_path}[/yellow]"
+        )
     if not isinstance(data.get("gh"), dict):
         data["gh"] = _CommentedMap()
     data["gh"]["repo"] = owner_repo
@@ -1001,23 +1006,30 @@ def _apply_repo_detection() -> str | None:
         The detected owner/repo slug, or None if detection failed.
     """
     owner_repo = detect_owner_repo()
-    if owner_repo is not None:
-        _ = write_gh_config(Path.cwd() / ".dh" / "config.yaml", owner_repo)
+    if owner_repo is not None and not write_gh_config(Path.cwd() / ".dh" / "config.yaml", owner_repo):
+        error_console.print(
+            ":warning: [yellow]Warning: write_gh_config returned False — config may not have been persisted[/yellow]"
+        )
     return owner_repo
 
 
-def _run_detect_only() -> None:
-    """Execute --detect-only mode: refresh config and print rendered examples to stdout."""
+def _run_detect_only() -> bool:
+    """Execute --detect-only mode: refresh config and print rendered examples to stdout.
+
+    Returns:
+        True if detection and rendering succeeded, False if owner/repo could not be determined.
+    """
     owner_repo = _apply_repo_detection()
     if owner_repo is None:
         error_console.print(
             ":warning: [yellow]Warning: could not detect owner/repo from git remote. "
             "Set GITHUB_REPO=owner/repo to override.[/yellow]"
         )
-        return
+        return False
     rendered = _render_template(owner_repo)
     if rendered is not None:
         sys.stdout.write(rendered)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1068,8 +1080,8 @@ def main(
     """
     # --detect-only: no network calls, no install — refresh config and emit examples to stdout.
     if detect_only:
-        _run_detect_only()
-        raise typer.Exit(code=0)
+        success = _run_detect_only()
+        raise typer.Exit(code=0 if success else 1)
 
     # 1. Check if gh is already installed
     gh_which = shutil.which(BINARY_NAME)

--- a/.claude/skills/gh/scripts/setup_gh.py
+++ b/.claude/skills/gh/scripts/setup_gh.py
@@ -1027,8 +1027,9 @@ def _run_detect_only() -> bool:
         )
         return False
     rendered = _render_template(owner_repo)
-    if rendered is not None:
-        sys.stdout.write(rendered)
+    if rendered is None:
+        return False
+    sys.stdout.write(rendered)
     return True
 
 

--- a/.claude/skills/gh/scripts/test_setup_gh.py
+++ b/.claude/skills/gh/scripts/test_setup_gh.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env -S uv --quiet run --active --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "typer>=0.21.0",
+#   "httpx>=0.28.1",
+#   "ruamel.yaml>=0.18.0",
+# ]
+# ///
+"""Tests for setup_gh.py — verifies --detect-only exit codes."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+import setup_gh
+from setup_gh import app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Provide a Typer CliRunner for invoke calls."""
+    return CliRunner()
+
+
+class TestDetectOnlyExitCodes:
+    """--detect-only exits 0 on full success and 1 on any partial failure."""
+
+    def test_detect_only_success(self, runner: CliRunner) -> None:
+        """Exit 0 when detection returns a valid slug and template renders successfully.
+
+        Both _apply_repo_detection and _render_template succeed — the full
+        happy path through _run_detect_only returns True, so the CLI raises
+        typer.Exit(code=0).
+        """
+        with (
+            patch.object(setup_gh, "_apply_repo_detection", return_value="owner/repo"),
+            patch.object(setup_gh, "_render_template", return_value="gh -R owner/repo issue list"),
+        ):
+            result = runner.invoke(app, ["--detect-only"])
+
+        assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}. Output:\n{result.output}"
+
+    def test_detect_only_failure_no_detection(self, runner: CliRunner) -> None:
+        """Exit 1 when _apply_repo_detection returns None (no git remote detected).
+
+        _run_detect_only returns False when owner/repo cannot be determined,
+        so the CLI raises typer.Exit(code=1).
+        """
+        with patch.object(setup_gh, "_apply_repo_detection", return_value=None):
+            result = runner.invoke(app, ["--detect-only"])
+
+        assert result.exit_code == 1, f"Expected exit code 1, got {result.exit_code}. Output:\n{result.output}"
+
+    def test_detect_only_failure_no_template(self, runner: CliRunner) -> None:
+        """Exit 1 when detection succeeds but the template file is missing.
+
+        _apply_repo_detection returns a valid slug, but _render_template
+        returns None (template not found) — _run_detect_only returns False,
+        so the CLI raises typer.Exit(code=1).
+        """
+        with (
+            patch.object(setup_gh, "_apply_repo_detection", return_value="owner/repo"),
+            patch.object(setup_gh, "_render_template", return_value=None),
+        ):
+            result = runner.invoke(app, ["--detect-only"])
+
+        assert result.exit_code == 1, f"Expected exit code 1, got {result.exit_code}. Output:\n{result.output}"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.16",
+  "version": "8.5.17",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.15",
+  "version": "8.5.16",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.14",
+  "version": "8.5.15",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/bd_runner.py
+++ b/plugins/development-harness/backlog_core/backends/bd_runner.py
@@ -166,9 +166,14 @@ class BdRunner:
     ) -> None:
         """Store configuration only.  Does not touch the filesystem."""
         self._timeout_seconds = timeout_seconds
-        self._env_overrides: dict[str, str] = (
-            {k: v for k, v in env_overrides.items() if k not in _BLOCKED_ENV_VARS} if env_overrides else {}
-        )
+        if env_overrides:
+            blocked = [k for k in env_overrides if k in _BLOCKED_ENV_VARS]
+            if blocked:
+                for key in blocked:
+                    _log.warning("env_overrides key %r is blocked and will be ignored", key)
+            self._env_overrides = {k: v for k, v in env_overrides.items() if k not in _BLOCKED_ENV_VARS}
+        else:
+            self._env_overrides = {}
         self._bd_path: str | None = None
         self._available: bool | None = None
 

--- a/plugins/development-harness/backlog_core/backends/bd_runner.py
+++ b/plugins/development-harness/backlog_core/backends/bd_runner.py
@@ -171,9 +171,9 @@ class BdRunner:
             if blocked:
                 for key in blocked:
                     _log.warning("env_overrides key %r is blocked and will be ignored", key)
-            self._env_overrides = {k: v for k, v in env_overrides.items() if k not in _BLOCKED_ENV_VARS}
+            self._env_overrides: dict[str, str] = {k: v for k, v in env_overrides.items() if k not in _BLOCKED_ENV_VARS}
         else:
-            self._env_overrides = {}
+            self._env_overrides: dict[str, str] = {}
         self._bd_path: str | None = None
         self._available: bool | None = None
 

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -452,10 +452,13 @@ class GitHubBackend:
     def unknown_key_to_heading(self, key: str) -> str:
         """Convert an unknown section key to a markdown heading string.
 
+        Delegates to :func:`backlog_core.rendering.unknown_key_to_heading` so
+        that all backends share a single canonical implementation.
+
         Returns:
             Heading text string (e.g. ``"My Section"``).
         """
-        return github_sync.unknown_key_to_heading(key)
+        return _rendering.unknown_key_to_heading(key)
 
     @property
     def section_heading(self) -> dict[str, str]:

--- a/plugins/development-harness/backlog_core/backends/memory_backend.py
+++ b/plugins/development-harness/backlog_core/backends/memory_backend.py
@@ -514,8 +514,15 @@ class InMemoryBackend:
         return remote
 
     def unknown_key_to_heading(self, key: str) -> str:
-        """Convert a snake_case key to a Title Case heading."""
-        return key.replace("_", " ").title()
+        """Convert an unknown section key to a markdown heading string.
+
+        Delegates to :func:`backlog_core.rendering.unknown_key_to_heading` to
+        strip the ``"unknown__"`` prefix before title-casing.
+
+        Returns:
+            Heading text string (e.g. ``"Rt Ica"`` for ``"unknown__rt_ica"``).
+        """
+        return _rendering.unknown_key_to_heading(key)
 
     @property
     def section_heading(self) -> dict[str, str]:

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -1002,15 +1002,15 @@ class SQLiteBackend:
         return remote
 
     def unknown_key_to_heading(self, key: str) -> str:
-        """Convert a snake_case key to a Title Case heading.
+        """Convert an unknown section key to a markdown heading string.
 
-        Args:
-            key: Section key string.
+        Delegates to :func:`backlog_core.rendering.unknown_key_to_heading` to
+        strip the ``"unknown__"`` prefix before title-casing.
 
         Returns:
-            Title Case heading string.
+            Heading text string (e.g. ``"Rt Ica"`` for ``"unknown__rt_ica"``).
         """
-        return key.replace("_", " ").title()
+        return _rendering.unknown_key_to_heading(key)
 
     @property
     def section_heading(self) -> dict[str, str]:

--- a/plugins/development-harness/backlog_core/tests/test_rendering.py
+++ b/plugins/development-harness/backlog_core/tests/test_rendering.py
@@ -173,3 +173,33 @@ class TestBackendProtocolSectionHeadingProperty:
         required_keys = {"fact_check", "rt_ica", "issue_classification"}
         missing = required_keys - heading_map.keys()
         assert not missing, f"{type(backend_instance).__name__}.section_heading is missing required keys: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — unknown_key_to_heading strips prefix and title-cases
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownKeyToHeading:
+    """unknown_key_to_heading strips the ``unknown__`` prefix and title-cases the result."""
+
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("unknown__rt_ica", "Rt Ica"),
+            ("unknown__custom_analysis", "Custom Analysis"),
+            ("unknown__story", "Story"),
+            ("unknown__my_custom_section", "My Custom Section"),
+            ("unknown__single", "Single"),
+        ],
+        ids=["rt_ica", "custom_analysis", "story", "my_custom_section", "single_word"],
+    )
+    def test_unknown_key_to_heading_strips_prefix_and_title_cases(self, key: str, expected: str) -> None:
+        """Strips the ``unknown__`` prefix, replaces underscores with spaces, title-cases.
+
+        Verifies that the canonical rendering module correctly reverses the
+        ``unknown__`` prefixing applied during section storage, producing a
+        human-readable heading for display.
+        """
+        result = _rendering.unknown_key_to_heading(key)
+        assert result == expected, f"unknown_key_to_heading({key!r}) returned {result!r}, expected {expected!r}"


### PR DESCRIPTION
## Summary

- **`setup_gh.py`**: `--detect-only` now exits with code 1 when detection fails (was silently exiting 0); `_apply_repo_detection` logs a warning when `write_gh_config` returns False instead of discarding the signal; `write_gh_config` warns before clobbering a non-dict `gh:` value in config
- **`bd_runner.py`**: `BdRunner.__init__` now logs a warning for each key in `env_overrides` that is blocked and dropped, so callers are not silently surprised
- **`memory_backend.py`**: `unknown_key_to_heading` now delegates to `rendering.unknown_key_to_heading`, fixing a double-space bug (`'unknown__rt_ica'` → `'Rt Ica'` not `'Unknown  Rt Ica'`)
- **`github_backend.py`**: `unknown_key_to_heading` routes to `rendering` instead of `github_sync` so all backends share a single canonical implementation

## Test plan

- [ ] Run `uv run python -c "from backlog_core.backends.memory_backend import MemoryBackend; b = MemoryBackend(); print(b.unknown_key_to_heading('unknown__rt_ica'))"` — expect `Rt Ica`
- [ ] Run `setup_gh.py --detect-only` in a repo with no origin remote — expect exit code 1
- [ ] Run `setup_gh.py --detect-only` in a normal repo — expect exit code 0 with rendered examples on stdout
- [ ] Construct `BdRunner(env_overrides={"GITHUB_TOKEN": "x"})` and check logs for warning

https://claude.ai/code/session_01D713ryWDyqHCafa6oH4v6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01D713ryWDyqHCafa6oH4v6T)_