### PR TITLE
feat(pipeline): add primary-source fetch to planning pipeline agents (#2405)

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.18",
+  "version": "8.5.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.17",
+  "version": "8.5.18",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -85,6 +85,9 @@ Your training data is 6-18 months stale. Treat pre-existing knowledge as hypothe
 1. **Verify before asserting** - Read files before claiming what's in them
 2. **Cite sources** - Reference file:line for all claims about the codebase
 3. **Flag uncertainty** - "Based on patterns I found" not "The codebase does X"
+4. **Follow upstream URLs** - When research artifacts contain `resource_url` or
+   `github_url`, fetch the primary source before adapting. Local research summaries
+   are discovery artifacts, not authoritative documents.
 
 ## Discovery is Understanding, Not Design
 
@@ -168,6 +171,42 @@ For either input type, identify:
 | **WHY**  | What problem does this solve? |
 
 Do NOT answer HOW - that's implementation.
+
+## Step 2.5: Fetch Primary Sources from Research Artifact Frontmatter
+
+If the orchestrator provided `prior_artifacts` that include a research artifact, read
+that artifact via `artifact_read` and inspect its YAML frontmatter for `resource_url`
+and `github_url` fields.
+
+```python
+# Pseudocode — detect and follow upstream URLs
+if prior_artifacts contains artifact_type="research":
+    content = artifact_read(issue_number, "research")
+    frontmatter = parse_yaml_frontmatter(content)
+    resource_url = frontmatter.get("resource_url")
+    github_url   = frontmatter.get("github_url")
+```
+
+For each URL found:
+
+1. Fetch the URL using `mcp__Ref__ref_read_url` (preferred) or `WebFetch` as fallback.
+2. Treat the fetched content as the **authoritative primary source**.
+3. Use the local research summary only as an index — a map to the primary source, not a
+   substitute for it.
+
+**Fallback rule**: If a URL is absent, returns 4xx/5xx, or times out:
+
+- Log a warning in the feature-context document under a `## Research Source Notes` section:
+  `"resource_url {url} unreachable ({reason}) — proceeding from local research summary."`
+- Continue with the local research summary as the source.
+- NEVER hard-fail the pipeline because a URL is unreachable.
+
+**Conditional trigger**: This step runs ONLY when:
+- A research artifact is present in `prior_artifacts`, AND
+- The research artifact frontmatter contains at least one of `resource_url` or `github_url`
+
+When no research artifact is present, or when no URL fields appear in its frontmatter,
+skip this step entirely and proceed to Step 3.
 
 ## Step 3: Explore Codebase
 

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -187,11 +187,13 @@ if prior_artifacts contains artifact_type="research":
     github_url   = frontmatter.get("github_url")
 ```
 
-For each URL found:
+For each URL found, use ordered fallback:
 
-1. Fetch the URL using `mcp__Ref__ref_read_url` (preferred) or `WebFetch` as fallback.
-2. Treat the fetched content as the **authoritative primary source**.
-3. Use the local research summary only as an index — a map to the primary source, not a
+1. If `resource_url` is present, fetch it first using `mcp__Ref__ref_read_url` (preferred) or
+   `WebFetch` as fallback.
+2. Use `github_url` only if `resource_url` is absent or returns 4xx/5xx/timeout.
+3. Treat the fetched content as the **authoritative primary source**.
+4. Use the local research summary only as an index — a map to the primary source, not a
    substitute for it.
 
 **Fallback rule**: If a URL is absent, returns 4xx/5xx, or times out:

--- a/plugins/development-harness/docs/plan-artifact-lifecycle.md
+++ b/plugins/development-harness/docs/plan-artifact-lifecycle.md
@@ -56,6 +56,13 @@ These artifacts are produced by agents during planning phases. They may be updat
 | Task plan | `sam_read(plan="P{id}")` | `swarm-task-planner` agent | Status fields by hooks; Context Manifest by `context-refinement` |
 | Context Manifest | Embedded in task file (via `sam_read`) | `context-gathering` agent | `context-refinement` agent (existing behavior) |
 
+> **Research artifacts as discovery pointers**: Research artifacts (`artifact_type="research"`)
+> may contain `resource_url` and `github_url` YAML frontmatter fields pointing to upstream
+> primary sources. Consuming agents (feature-researcher, architect) MUST follow these URLs
+> when present — the local research summary is a discovery index, not an authoritative
+> document. See `add-new-feature/SKILL.md` Phase 1 and Phase 3 delegation prompts for the
+> authoritative fetch directive.
+
 ---
 
 ## Rules for Human-Decision Artifacts

--- a/plugins/development-harness/docs/plan-artifact-lifecycle.md
+++ b/plugins/development-harness/docs/plan-artifact-lifecycle.md
@@ -60,7 +60,7 @@ These artifacts are produced by agents during planning phases. They may be updat
 > may contain `resource_url` and `github_url` YAML frontmatter fields pointing to upstream
 > primary sources. Consuming agents (feature-researcher, architect) MUST follow these URLs
 > when present — the local research summary is a discovery index, not an authoritative
-> document. See `add-new-feature/SKILL.md` Phase 1 and Phase 3 delegation prompts for the
+> document. See [add-new-feature/SKILL.md](../skills/add-new-feature/SKILL.md) Phase 1 and Phase 3 delegation prompts for the
 > authoritative fetch directive.
 
 ---

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -132,6 +132,13 @@ Research #{issue}: "{title}".
 If research artifacts exist for this issue, read them via
 artifact_read(issue_number={issue}, artifact_type="research") before starting
 discovery — they contain prior investigation findings that should be incorporated.
+IMPORTANT: Research artifacts are discovery pointers, not authoritative documents.
+After reading the research artifact, inspect its YAML frontmatter for `resource_url`
+and `github_url` fields. If either is present, fetch the upstream source using
+mcp__Ref__ref_read_url (or WebFetch as fallback) and treat it as the authoritative
+primary source. Use the local research summary as an index to the primary source only.
+If the URL is absent or unreachable (4xx/5xx/timeout), log a warning in the
+feature-context document and proceed from the local summary — never hard-fail.
 Produce feature-context-{slug}.md content with WHAT/WHY analysis — problem space, desired
 outcome, stakeholders, risks, open questions.
 Do NOT prescribe HOW to build it.
@@ -370,6 +377,15 @@ Read the feature context via artifact_read(issue_number={issue}, artifact_type="
 If research artifacts exist for this issue, read them via
 artifact_read(issue_number={issue}, artifact_type="research") for prior research
 findings that should inform the architecture.
+IMPORTANT: Research artifacts are discovery pointers, not authoritative documents.
+After reading any research artifact, inspect its YAML frontmatter for `resource_url`
+and `github_url` fields. If either is present, fetch the upstream source using
+mcp__Ref__ref_read_url (or WebFetch as fallback) and verify currency and completeness
+of the research summary against the primary source before designing. If the URL is
+absent or unreachable (4xx/5xx/timeout), log a warning in the architect document
+and proceed from the research summary — never hard-fail.
+Additionally, run a WebSearch for current best practices relevant to this feature before
+finalizing the architecture. Training data is stale; current community practice may differ.
 Produce architect-{slug}.md content with interfaces, contracts, data models, module boundaries.
 Do NOT implement — define WHAT to build, not the code.
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -138,7 +138,8 @@ and `github_url` fields. If either is present, fetch the upstream source using
 mcp__Ref__ref_read_url (or WebFetch as fallback) and treat it as the authoritative
 primary source. Use the local research summary as an index to the primary source only.
 If the URL is absent or unreachable (4xx/5xx/timeout), log a warning in the
-feature-context document and proceed from the local summary — never hard-fail.
+`## Research Source Notes` section of the feature-context document and proceed from the
+local summary — never hard-fail.
 Produce feature-context-{slug}.md content with WHAT/WHY analysis — problem space, desired
 outcome, stakeholders, risks, open questions.
 Do NOT prescribe HOW to build it.
@@ -382,8 +383,8 @@ After reading any research artifact, inspect its YAML frontmatter for `resource_
 and `github_url` fields. If either is present, fetch the upstream source using
 mcp__Ref__ref_read_url (or WebFetch as fallback) and verify currency and completeness
 of the research summary against the primary source before designing. If the URL is
-absent or unreachable (4xx/5xx/timeout), log a warning in the architect document
-and proceed from the research summary — never hard-fail.
+absent or unreachable (4xx/5xx/timeout), log a warning in the `## Research Source Notes`
+section of the architect document and proceed from the research summary — never hard-fail.
 Additionally, run a WebSearch for current best practices relevant to this feature before
 finalizing the architecture. Training data is stale; current community practice may differ.
 Produce architect-{slug}.md content with interfaces, contracts, data models, module boundaries.

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -77,6 +77,8 @@ You are an orchestrator. You coordinate work across specialized agents. Prefer d
 
 Every phase delegation prompt starts with this block. Fill `{work_type}`, `{feature_name}`, and `{issue}` from the values in the **Template Variables** section at the bottom of this skill.
 
+The `{quality_vigilance}` template variable used in every phase delegation template below expands to the `<quality_vigilance>` block defined here — this is the single canonical definition.
+
 ```text
 You are part of a team that is currently working on the {work_type} {feature_name}.
 Read the details about the milestone and plan you are a part of at backlog_view(selector="#{issue}").
@@ -114,19 +116,7 @@ Delegation prompt template:
 You are part of a team that is currently working on the {work_type} {feature_name}.
 Read the details about the milestone and plan you are a part of at backlog_view(selector="#{issue}").
 
-<quality_vigilance>
-Your task among all other things you are doing is to be consistently striving for
-product quality improvements and aligning with the design intent. If you see something
-that seems misaligned, verify it, and then note your concerns and findings concisely
-in your response in a <concerns></concerns> block. Point out duplication, contradictions,
-statements of fact without citation, code smells, missing documentation.
-
-For claims derived from research artifacts: verify the claim against the upstream
-primary source, not just the local research summary. If the research artifact frontmatter
-contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
-Cite the fetched primary URL, not the research summary file path, when the claim originates
-from external upstream content.
-</quality_vigilance>
+{quality_vigilance}
 
 Research #{issue}: "{title}".
 If research artifacts exist for this issue, read them via
@@ -188,19 +178,7 @@ Delegation prompt template (one per focus area):
 You are part of a team that is currently working on the {work_type} {feature_name}.
 Read the details about the milestone and plan you are a part of at backlog_view(selector="#{issue}").
 
-<quality_vigilance>
-Your task among all other things you are doing is to be consistently striving for
-product quality improvements and aligning with the design intent. If you see something
-that seems misaligned, verify it, and then note your concerns and findings concisely
-in your response in a <concerns></concerns> block. Point out duplication, contradictions,
-statements of fact without citation, code smells, missing documentation.
-
-For claims derived from research artifacts: verify the claim against the upstream
-primary source, not just the local research summary. If the research artifact frontmatter
-contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
-Cite the fetched primary URL, not the research summary file path, when the claim originates
-from external upstream content.
-</quality_vigilance>
+{quality_vigilance}
 
 Analyze {focus_area} for #{issue}: "{title}".
 Produce {focus_area}.md content documenting what exists today — patterns,
@@ -358,19 +336,7 @@ Delegation prompt template:
 You are part of a team that is currently working on the {work_type} {feature_name}.
 Read the details about the milestone and plan you are a part of at backlog_view(selector="#{issue}").
 
-<quality_vigilance>
-Your task among all other things you are doing is to be consistently striving for
-product quality improvements and aligning with the design intent. If you see something
-that seems misaligned, verify it, and then note your concerns and findings concisely
-in your response in a <concerns></concerns> block. Point out duplication, contradictions,
-statements of fact without citation, code smells, missing documentation.
-
-For claims derived from research artifacts: verify the claim against the upstream
-primary source, not just the local research summary. If the research artifact frontmatter
-contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
-Cite the fetched primary URL, not the research summary file path, when the claim originates
-from external upstream content.
-</quality_vigilance>
+{quality_vigilance}
 
 Design the implementation for #{issue}: "{title}".
 Read the feature context via artifact_read(issue_number={issue}, artifact_type="feature-context").
@@ -426,19 +392,7 @@ Delegation prompt template:
 You are part of a team that is currently working on the {work_type} {feature_name}.
 Read the details about the milestone and plan you are a part of at backlog_view(selector="#{issue}").
 
-<quality_vigilance>
-Your task among all other things you are doing is to be consistently striving for
-product quality improvements and aligning with the design intent. If you see something
-that seems misaligned, verify it, and then note your concerns and findings concisely
-in your response in a <concerns></concerns> block. Point out duplication, contradictions,
-statements of fact without citation, code smells, missing documentation.
-
-For claims derived from research artifacts: verify the claim against the upstream
-primary source, not just the local research summary. If the research artifact frontmatter
-contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
-Cite the fetched primary URL, not the research summary file path, when the claim originates
-from external upstream content.
-</quality_vigilance>
+{quality_vigilance}
 
 Decompose #{issue}: "{title}" into executable tasks.
 Read the architecture spec via artifact_read(issue_number={issue}, artifact_type="architect").
@@ -493,19 +447,7 @@ Delegation prompt template:
 You are part of a team that is currently working on the {work_type} {feature_name}.
 Read the details about the milestone and plan you are a part of at backlog_view(selector="#{issue}").
 
-<quality_vigilance>
-Your task among all other things you are doing is to be consistently striving for
-product quality improvements and aligning with the design intent. If you see something
-that seems misaligned, verify it, and then note your concerns and findings concisely
-in your response in a <concerns></concerns> block. Point out duplication, contradictions,
-statements of fact without citation, code smells, missing documentation.
-
-For claims derived from research artifacts: verify the claim against the upstream
-primary source, not just the local research summary. If the research artifact frontmatter
-contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
-Cite the fetched primary URL, not the research summary file path, when the claim originates
-from external upstream content.
-</quality_vigilance>
+{quality_vigilance}
 
 Validate plan P{N} for #{issue}: "{title}".
 Check: AC coverage, dependency DAG, agent assignments, verification steps,
@@ -525,19 +467,7 @@ Delegation prompt template:
 You are part of a team that is currently working on the {work_type} {feature_name}.
 Read the details about the milestone and plan you are a part of at backlog_view(selector="#{issue}").
 
-<quality_vigilance>
-Your task among all other things you are doing is to be consistently striving for
-product quality improvements and aligning with the design intent. If you see something
-that seems misaligned, verify it, and then note your concerns and findings concisely
-in your response in a <concerns></concerns> block. Point out duplication, contradictions,
-statements of fact without citation, code smells, missing documentation.
-
-For claims derived from research artifacts: verify the claim against the upstream
-primary source, not just the local research summary. If the research artifact frontmatter
-contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
-Cite the fetched primary URL, not the research summary file path, when the claim originates
-from external upstream content.
-</quality_vigilance>
+{quality_vigilance}
 
 Add context manifest to plan P{N} for #{issue}: "{title}".
 Read the plan via sam_plan. Write the context manifest via sam_plan.
@@ -560,6 +490,7 @@ Fill these values before constructing each delegation prompt. All values come fr
 | `{goal_from_feature_request}` | The one-sentence goal extracted from the feature context doc (Phase 4 only) |
 | `{domain_skills}` | Pre-formatted YAML list lines (e.g., `- plugin-creator:hook-creator`) collected by the Phase 3 domain signal scan; empty string if no signals matched; passed verbatim into Phase 4 delegation prompt |
 | `{N}` | SAM plan number returned by `sam_plan` after Phase 4 completes |
+| `{quality_vigilance}` | Full `<quality_vigilance>...</quality_vigilance>` block — canonical text defined in §Shared Delegation Preamble above; substitute verbatim when constructing delegation prompts |
 
 ---
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -57,6 +57,7 @@ Research-type artifacts (`artifact_type="research"`) are especially valuable —
 
 **Research artifacts as discovery pointers (not authoritative sources):** Research entries
 record summary findings and upstream source references — they are NOT the primary source.
+Research artifacts are discovery pointers, not authoritative documents.
 The YAML frontmatter of a research artifact may contain `resource_url` and/or `github_url`
 fields pointing to the upstream content. Phase agents receiving a research artifact MUST
 check these fields and fetch the upstream source before adapting content from the summary.
@@ -86,6 +87,12 @@ product quality improvements and aligning with the design intent. If you see som
 that seems misaligned, verify it, and then note your concerns and findings concisely
 in your response in a <concerns></concerns> block. Point out duplication, contradictions,
 statements of fact without citation, code smells, missing documentation.
+
+For claims derived from research artifacts: verify the claim against the upstream
+primary source, not just the local research summary. If the research artifact frontmatter
+contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
+Cite the fetched primary URL, not the research summary file path, when the claim originates
+from external upstream content.
 </quality_vigilance>
 ```
 
@@ -113,6 +120,12 @@ product quality improvements and aligning with the design intent. If you see som
 that seems misaligned, verify it, and then note your concerns and findings concisely
 in your response in a <concerns></concerns> block. Point out duplication, contradictions,
 statements of fact without citation, code smells, missing documentation.
+
+For claims derived from research artifacts: verify the claim against the upstream
+primary source, not just the local research summary. If the research artifact frontmatter
+contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
+Cite the fetched primary URL, not the research summary file path, when the claim originates
+from external upstream content.
 </quality_vigilance>
 
 Research #{issue}: "{title}".
@@ -173,6 +186,12 @@ product quality improvements and aligning with the design intent. If you see som
 that seems misaligned, verify it, and then note your concerns and findings concisely
 in your response in a <concerns></concerns> block. Point out duplication, contradictions,
 statements of fact without citation, code smells, missing documentation.
+
+For claims derived from research artifacts: verify the claim against the upstream
+primary source, not just the local research summary. If the research artifact frontmatter
+contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
+Cite the fetched primary URL, not the research summary file path, when the claim originates
+from external upstream content.
 </quality_vigilance>
 
 Analyze {focus_area} for #{issue}: "{title}".
@@ -337,6 +356,12 @@ product quality improvements and aligning with the design intent. If you see som
 that seems misaligned, verify it, and then note your concerns and findings concisely
 in your response in a <concerns></concerns> block. Point out duplication, contradictions,
 statements of fact without citation, code smells, missing documentation.
+
+For claims derived from research artifacts: verify the claim against the upstream
+primary source, not just the local research summary. If the research artifact frontmatter
+contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
+Cite the fetched primary URL, not the research summary file path, when the claim originates
+from external upstream content.
 </quality_vigilance>
 
 Design the implementation for #{issue}: "{title}".
@@ -390,6 +415,12 @@ product quality improvements and aligning with the design intent. If you see som
 that seems misaligned, verify it, and then note your concerns and findings concisely
 in your response in a <concerns></concerns> block. Point out duplication, contradictions,
 statements of fact without citation, code smells, missing documentation.
+
+For claims derived from research artifacts: verify the claim against the upstream
+primary source, not just the local research summary. If the research artifact frontmatter
+contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
+Cite the fetched primary URL, not the research summary file path, when the claim originates
+from external upstream content.
 </quality_vigilance>
 
 Decompose #{issue}: "{title}" into executable tasks.
@@ -451,6 +482,12 @@ product quality improvements and aligning with the design intent. If you see som
 that seems misaligned, verify it, and then note your concerns and findings concisely
 in your response in a <concerns></concerns> block. Point out duplication, contradictions,
 statements of fact without citation, code smells, missing documentation.
+
+For claims derived from research artifacts: verify the claim against the upstream
+primary source, not just the local research summary. If the research artifact frontmatter
+contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
+Cite the fetched primary URL, not the research summary file path, when the claim originates
+from external upstream content.
 </quality_vigilance>
 
 Validate plan P{N} for #{issue}: "{title}".
@@ -477,6 +514,12 @@ product quality improvements and aligning with the design intent. If you see som
 that seems misaligned, verify it, and then note your concerns and findings concisely
 in your response in a <concerns></concerns> block. Point out duplication, contradictions,
 statements of fact without citation, code smells, missing documentation.
+
+For claims derived from research artifacts: verify the claim against the upstream
+primary source, not just the local research summary. If the research artifact frontmatter
+contains `resource_url` or `github_url`, fetch that URL and check the claim against it.
+Cite the fetched primary URL, not the research summary file path, when the claim originates
+from external upstream content.
 </quality_vigilance>
 
 Add context manifest to plan P{N} for #{issue}: "{title}".

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -55,6 +55,15 @@ inform your output.
 
 Research-type artifacts (`artifact_type="research"`) are especially valuable — they contain investigation findings gathered before planning began. Phase agents should read these first when present.
 
+**Research artifacts as discovery pointers (not authoritative sources):** Research entries
+record summary findings and upstream source references — they are NOT the primary source.
+The YAML frontmatter of a research artifact may contain `resource_url` and/or `github_url`
+fields pointing to the upstream content. Phase agents receiving a research artifact MUST
+check these fields and fetch the upstream source before adapting content from the summary.
+This is especially important for Phase 1 (feature-researcher) and Phase 3 (architect).
+Failure to fetch the primary source causes information loss from the summary layer to
+propagate into feature context and architecture decisions.
+
 ---
 
 ## Orchestrator Discipline

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "14.0.6",
+  "version": "14.0.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "14.0.7",
+  "version": "14.0.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/skills/feature-discovery/SKILL.md
+++ b/plugins/plugin-creator/skills/feature-discovery/SKILL.md
@@ -158,11 +158,12 @@ EXPLORE:
 passed a `prior_artifacts` block containing a research artifact, inspect its YAML frontmatter
 for `resource_url` and `github_url` fields. If either is present:
 
-1. Fetch the upstream URL using `WebFetch` or `mcp__Ref__ref_read_url`.
+1. Fetch the upstream URL using `mcp__Ref__ref_read_url` (preferred; `WebFetch` as fallback).
 2. Treat the fetched content as the authoritative source; use the local research summary
    as an index only.
 3. If the URL is absent or unreachable (4xx/5xx/timeout), log a note in the output
-   document: `"Upstream URL unreachable — discovery based on local research summary."`
+   document under a `## Research Source Notes` section:
+   `"Upstream URL unreachable — discovery based on local research summary."`
    Then continue normally. Never hard-fail because a URL is unreachable.
 
 For each similar pattern found, record:

--- a/plugins/plugin-creator/skills/feature-discovery/SKILL.md
+++ b/plugins/plugin-creator/skills/feature-discovery/SKILL.md
@@ -154,6 +154,17 @@ EXPLORE:
   - Record: upstream source URL, update frequency
   - Examples: API specs, CLI references, framework guides
 
+**Primary source verification (when research artifacts are present):** If the orchestrator
+passed a `prior_artifacts` block containing a research artifact, inspect its YAML frontmatter
+for `resource_url` and `github_url` fields. If either is present:
+
+1. Fetch the upstream URL using `WebFetch` or `mcp__Ref__ref_read_url`.
+2. Treat the fetched content as the authoritative source; use the local research summary
+   as an index only.
+3. If the URL is absent or unreachable (4xx/5xx/timeout), log a note in the output
+   document: `"Upstream URL unreachable — discovery based on local research summary."`
+   Then continue normally. Never hard-fail because a URL is unreachable.
+
 For each similar pattern found, record:
 
 - File path and line numbers


### PR DESCRIPTION
## Summary

Fixes the missing-guardrail in the `add-new-feature` planning pipeline where agents treat local research summaries as authoritative sources rather than fetching the upstream primary source referenced in research artifact frontmatter (`resource_url`, `github_url`).

- **`feature-researcher.md`**: New Step 2.5 inserts a conditional upstream-fetch step between Step 2 and Step 3. When research artifact frontmatter contains `resource_url` or `github_url`, the agent fetches the primary source via `mcp__Ref__ref_read_url` (WebFetch fallback) and treats it as authoritative. Fallback: URL absent/unreachable → log warning, proceed from summary, never hard-fail. Philosophy section extended with item 4: "Follow upstream URLs."
- **`add-new-feature/SKILL.md`**: Extended `prior_artifacts` commentary to signal that research entries are discovery pointers, not authoritative documents. Phase 1 and Phase 3 delegation prompts gain explicit `resource_url` fetch directives. All 7 `quality_vigilance` preamble blocks extended to require primary-URL citation for external content.
- **`feature-discovery/SKILL.md`**: Parallel gap closed — same primary-source verification directive added to Step 3 for the plugin-creator pipeline.
- **`plan-artifact-lifecycle.md`**: Research artifacts callout added after Category 2 table explaining discovery-pointer semantics.

Closes #2405

## Test plan

- [ ] `grep -c 'Step 2.5: Fetch Primary Sources' plugins/development-harness/agents/feature-researcher.md` → 1
- [ ] `grep -c 'resource_url' plugins/development-harness/skills/add-new-feature/SKILL.md` → ≥ 1 in Phase 1 delegation
- [ ] `grep -c 'fetch that URL and check the claim against it' plugins/development-harness/skills/add-new-feature/SKILL.md` → 7 (all quality_vigilance blocks updated)
- [ ] `grep -c 'resource_url' plugins/plugin-creator/skills/feature-discovery/SKILL.md` → ≥ 1 in Step 3
- [ ] `grep -c 'Research artifacts as discovery pointers' plugins/development-harness/docs/plan-artifact-lifecycle.md` → 1
- [ ] `uv run prek run --files <each changed file>` → exit 0

https://claude.ai/code/session_014gn8ju6cyi7Kwe5Ru3gfVR

---
_Generated by [Claude Code](https://claude.ai/code/session_014gn8ju6cyi7Kwe5Ru3gfVR)_