### PR TITLE
fix(gate): add in-progress relevance check + fix backlog_add signature in quick mode

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.19",
+  "version": "8.5.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md
@@ -4,17 +4,82 @@
 
 1. Extract title from <item_ref/>+ joined. Build slug: title lowercased, spaces → hyphens.
 
-2. Find the item via `backlog_view(selector="{title or #N}", summary=false)`. If not found (response contains `error` key), create a minimal item using the two-step pattern:
+2. **In-Progress Relevance Check** — Before creating a new backlog item, determine whether this fix belongs to work already in progress. If it does, add it to the active plan instead of opening a new item.
+
+   **a. Discover active work:**
+
+   - Call `mcp__plugin_dh_sam__sam_active_task(config={"action": "get"})` — returns the currently claimed SAM task for this agent session (look for `plan` and `task_id` fields). Record as `active_task`.
+   - Call `mcp__plugin_dh_backlog__backlog_list(status="in-progress")` — lists items currently being worked. Record as `in_progress_items`.
+
+   **b. Relevance checklist** (evaluate all three):
+
+   - [ ] Is there active work? (`active_task` is non-empty OR `in_progress_items` is non-empty)
+   - [ ] Does the fix title or description overlap in scope, subject, or affected files with the active issue's goal, acceptance criteria, or description?
+   - [ ] Would addressing this fix be required — or directly unblock — the active work to be considered complete?
+
+   **c. Decision:**
+
+   If ALL three checklist items pass → Route to **step 2a** (Plan Integration Path). Skip steps 3–7.
+
+   Otherwise → Continue to step 3 (create a new backlog item as usual).
+
+2a. **Plan Integration Path** (all relevance checks passed):
+
+   Resolve the active plan ID:
+   - If `active_task` is non-empty: use its `plan` field as `active_plan_id`.
+   - Else: call `mcp__plugin_dh_backlog__backlog_view(selector="{first in_progress_items title}", summary=false)` and read the item's `plan` field as `active_plan_id`.
+   - If neither yields a plan ID: fall through to step 3 (cannot integrate without a plan reference).
+
+   Append the fix as a new task on the active plan:
 
    ```text
-   backlog_add(title="{title}", gate_token="<gate_token>")
+   mcp__plugin_dh_sam__sam_plan(
+     config={
+       "action": "append_task",
+       "plan": "{active_plan_id}",
+       "task": {
+         "id": "T{next_available_id}",
+         "title": "{title}",
+         "status": "not-started",
+         "agent": "task-worker",
+         "dependencies": [],
+         "priority": 1,
+         "complexity": "low"
+       }
+     }
+   )
    ```
+
+   Report to the user:
+
+   ```text
+   Fix added to active plan: {active_plan_id}
+   Task: {title}
+
+   The fix is included in the current implementation cycle.
+   To execute immediately: /dh:start-task {active_plan_id} {task_id}
+   ```
+
+   Stop — do not continue to step 3 or create a new backlog item.
+
+3. Find the item via `mcp__plugin_dh_backlog__backlog_view(selector="{title or #N}", summary=false)`. If not found (response contains `error` key), create a minimal item:
+
+   ```text
+   mcp__plugin_dh_backlog__backlog_add(
+     title="{title}",
+     priority="P2",
+     description="{title}",
+     gate_token="<gate_token>"
+   )
+   ```
+
+   `<gate_token>` is the session token injected by the skill at load time from the `<gate_token>` block in SKILL.md. It is not a literal placeholder — the skill resolves it to the actual token value before these instructions are read.
 
    If found, extract description and acceptance criteria from `response["sections"]`.
 
-3. Extract the item's description and acceptance criteria if available.
+4. Extract the item's description and acceptance criteria if available.
 
-4. Create the quick plan using the SAM MCP tool:
+5. Create the quick plan using the SAM MCP tool:
 
    ```text
    mcp__plugin_dh_sam__sam_plan(
@@ -29,9 +94,9 @@
 
    `sam_plan(action='create')` handles path resolution internally — do not resolve or pass a file path.
 
-5. Call the `mcp__plugin_dh_backlog__backlog_update` tool with `selector="{title}"` and `plan="quick-{slug}"` to record the plan slug.
+6. Call the `mcp__plugin_dh_backlog__backlog_update` tool with `selector="{title}"` and `plan="quick-{slug}"` to record the plan slug.
 
-6. Report the path returned by `sam_plan(action='create')`:
+7. Report the path returned by `sam_plan(action='create')`:
 
    ```text
    Quick plan created: {path returned by sam_plan(action='create')}


### PR DESCRIPTION
## Summary

- **Fixes incomplete `backlog_add` call** in `quick/start.md` — the call was missing the now-required `priority` and `description` parameters. Updated to use the full `mcp__plugin_dh_backlog__backlog_add` tool name and pass `priority="P2"` and `description="{title}"` (title as fallback description for quick fixes). Added a clarifying note that `<gate_token>` is the session token injected by the skill at load time, not a literal placeholder.
- **Adds In-Progress Relevance Check (step 2)** — before the quick mode opens a new backlog item, it now checks whether the proactive fix is in-scope for the currently active in-progress issue. If all three relevance conditions pass (active work exists, scope overlaps, fix unblocks or is required by active work), it routes to the new **Plan Integration Path (step 2a)** and appends a task to the existing SAM plan instead of creating a new backlog item.
- Renumbered legacy steps 2–6 → 3–7 to accommodate the new steps.

## Test plan

- [ ] Run `/dh:work-backlog-item --quick fix-some-thing` with no in-progress items — should follow steps 3–7 (create backlog item + plan) as before
- [ ] Run with an in-progress item whose scope matches the fix — should append a task to the active plan and stop at step 2a
- [ ] Verify `backlog_add` call no longer returns "Gate token required" or missing-param errors

https://claude.ai/code/session_01ESfjYUuRcpXEQ3zwkFunBg

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESfjYUuRcpXEQ3zwkFunBg)_