### PR TITLE
fix: parser routing bug + gate token session isolation root cause

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.27",
+  "version": "8.5.28",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.25",
+  "version": "8.5.26",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.5.26",
+  "version": "8.5.27",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/docs/backlog-item-lifecycle.md
+++ b/plugins/development-harness/docs/backlog-item-lifecycle.md
@@ -410,9 +410,10 @@ flowchart TD
 | P4_LINK | `backlog_update` MCP | item selector (title), plan path | `plan` field linked on backlog item, `status` → `in-progress` | always → P4_DONE |
 
 > **Quick-path exception**: When the fix arrives via the Proactive Fix Gate (--quick), the SAM plan
-> slug is `quick-{slug}` with a single T1 task (complexity=low). The state machine transition is
-> the same (`groomed → in-progress`); it occurs during quick-path execution, not at Step 7 of the
-> full work-backlog-item pipeline.
+> slug is `quick-{slug}` with a single T1 task (complexity=low). The state machine transition
+> (`groomed → in-progress` or `needs-grooming → in-progress` when the item was created inline by
+> quick/start.md Step 2) occurs during quick-path execution, not at Step 7 of the full
+> work-backlog-item pipeline.
 
 | P4_DONE | orchestrator | slug, task file path | completion report, next-step instruction (`/dh:implement-feature`) | terminal |
 

--- a/plugins/development-harness/skills/work-backlog-item/SKILL.md
+++ b/plugins/development-harness/skills/work-backlog-item/SKILL.md
@@ -145,7 +145,7 @@ Parser `route` is `none` only when argv is empty (no flags, no positionals, no f
 
 ### --quick mode
 
-Loads [references/workflows/quick/start.md](./references/workflows/quick/start.md) with `flags.quick = true` (parser flag) and `item_ref` set to the supplied title.
+Loads [references/workflows/quick/start.md](./references/workflows/quick/start.md) with `flags.quick = true` (parser flag) and `item_ref` set to the supplied title or issue reference (e.g. `#N`).
 
 **Proactive fix routing**: The Proactive Fix Gate in `.claude/CLAUDE.md` (Proactive Fix Gate section) routes trivial discovered issues to this `--quick` path autonomously.
 Invocation form: `flags.quick = true` (parser flag). The gate, not the user, authorizes the

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md
@@ -2,8 +2,8 @@
 
 **Trigger:** <mode/> is `--quick`. Skips grooming, RT-ICA, and SAM planning. For one-file fixes, broken links, and typo patches where full pipeline overhead is disproportionate.
 
-**Entry point from proactive fix gate:** When the Proactive Fix Gate (`.claude/CLAUDE.md`) routes a fix
-to --quick, the agent invokes this workflow as:
+**Entry point from proactive fix routing:** When an agent's pre-fix check classifies a discovered
+issue as trivial and routes it to --quick, the agent invokes this workflow as:
   /dh:work-backlog-item --quick {item title or #N}
 
 If no backlog item exists for the fix, the agent does NOT call backlog_add first. Instead it

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md
@@ -2,7 +2,7 @@
 
 **Trigger:** <mode/> is `--quick`. Skips grooming, RT-ICA, and SAM planning. For one-file fixes, broken links, and typo patches where full pipeline overhead is disproportionate.
 
-**Entry point from proactive fix gate:** When the Proactive Fix Gate (CLAUDE.md) routes a fix
+**Entry point from proactive fix gate:** When the Proactive Fix Gate (`.claude/CLAUDE.md`) routes a fix
 to --quick, the agent invokes this workflow as:
   /dh:work-backlog-item --quick {item title or #N}
 

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs
@@ -140,7 +140,9 @@ try {
 
   for (let i = 0; i < positionals.length; i++) {
     const token = positionals[i];
-    if (registryKeys.includes(token)) {
+    // Registry commands must be the first positional — they are subcommand verbs, not title words.
+    // Scanning all positionals caused words like "close" inside a title to steal the route.
+    if (i === 0 && registryKeys.includes(token)) {
       discriminators.push({ type: 'registry', value: token, index: i });
     } else if (issueRegex.test(token)) {
       discriminators.push({ type: 'item_ref', value: token, index: i, parsed: parseIssue(token) });

--- a/plugins/holistic-linting/.claude-plugin/plugin.json
+++ b/plugins/holistic-linting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holistic-linting",
   "description": "This skill should be used when the model needs to ensure code quality through comprehensive linting and formatting. It provides automatic linting workflows for orchestrators (format \u2192 lint \u2192 resolve via concurrent agents) and sub-agents (lint touched files before task completion). Prevents claiming \"production ready\" code without verification. Includes linting rules knowledge base for ruff, mypy, and bandit, plus the linting-root-cause-resolver agent for systematic issue resolution.",
-  "version": "2.4.32",
+  "version": "2.4.33",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/holistic-linting/.claude-plugin/plugin.json
+++ b/plugins/holistic-linting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "holistic-linting",
   "description": "This skill should be used when the model needs to ensure code quality through comprehensive linting and formatting. It provides automatic linting workflows for orchestrators (format \u2192 lint \u2192 resolve via concurrent agents) and sub-agents (lint touched files before task completion). Prevents claiming \"production ready\" code without verification. Includes linting rules knowledge base for ruff, mypy, and bandit, plus the linting-root-cause-resolver agent for systematic issue resolution.",
-  "version": "2.4.31",
+  "version": "2.4.32",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/holistic-linting/agents/linting-root-cause-resolver.md
+++ b/plugins/holistic-linting/agents/linting-root-cause-resolver.md
@@ -109,10 +109,12 @@ Return to the orchestrator with the UNRESOLVED documentation. The orchestrator w
 
 ## Pre-Existing Issues Protocol
 
-**Pre-fix gate required**: Before acting on any discovered issue, apply the three-step
-Proactive Fix Gate from `.claude/CLAUDE.md` (Proactive Fix Gate section): (1) load domain skill,
-(2) state mission alignment, (3) classify complexity and route to --quick or planning.
-Do not proceed to any fix step without completing the gate.
+**Pre-fix gate required**: Before acting on any discovered issue, complete these three steps:
+(1) Load the domain skill for the affected file — without it the file is static docs, not a
+behavioral contract. (2) State in one sentence how the fix aligns with that plugin's mission —
+if you cannot, defer it. (3) Classify complexity: trivial (one file, obvious root cause,
+single Edit) → fix now; multi-file or design-decision → add to the project's backlog and defer.
+Do not proceed to any fix step without completing all three.
 
 When the initial linter run reveals issues in files you did not touch, apply the Pre-Existing Issues Protocol:
 

--- a/plugins/holistic-linting/agents/linting-root-cause-resolver.md
+++ b/plugins/holistic-linting/agents/linting-root-cause-resolver.md
@@ -110,7 +110,7 @@ Return to the orchestrator with the UNRESOLVED documentation. The orchestrator w
 ## Pre-Existing Issues Protocol
 
 **Pre-fix gate required**: Before acting on any discovered issue, apply the three-step
-Proactive Fix Gate from CLAUDE.md (Proactive Fix Gate section): (1) load domain skill,
+Proactive Fix Gate from `.claude/CLAUDE.md` (Proactive Fix Gate section): (1) load domain skill,
 (2) state mission alignment, (3) classify complexity and route to --quick or planning.
 Do not proceed to any fix step without completing the gate.
 

--- a/plugins/holistic-linting/skills/holistic-linting/SKILL.md
+++ b/plugins/holistic-linting/skills/holistic-linting/SKILL.md
@@ -376,7 +376,7 @@ When a linter run reveals issues in files the current agent did not modify, "pre
 
 **Two outcomes based on whether the issue blocks the pipeline:**
 
-- **Blocking** (linter exits nonzero, CI would fail, or current task verification cannot pass) → apply the Proactive Fix Gate (CLAUDE.md, Proactive Fix Gate section): load domain skill, state mission alignment, classify complexity. Trivial: route to `--quick`. Multi-file or design-decision: add to backlog and defer.
+- **Blocking** (linter exits nonzero, CI would fail, or current task verification cannot pass) → apply the Proactive Fix Gate (`.claude/CLAUDE.md`, Proactive Fix Gate section): load domain skill, state mission alignment, classify complexity. Trivial: route to `--quick`. Multi-file or design-decision: route to planning for an in-session fix, or mark the current run BLOCKED if the fix cannot be scoped to this session.
 - **Non-blocking** (advisory warning, file unrelated to current task) → discover the repo's tracking system and record it
 
 **Discover the tracking system** (search in order): `.claude/backlog/` per-item files, `.claude/tasks/`, `TODO.md`, `TODO`, `docs/TODO.md`, `.gsd/`, `sam.md`. If none exists, create a per-item file in `.claude/backlog/`.

--- a/plugins/holistic-linting/skills/holistic-linting/SKILL.md
+++ b/plugins/holistic-linting/skills/holistic-linting/SKILL.md
@@ -376,7 +376,7 @@ When a linter run reveals issues in files the current agent did not modify, "pre
 
 **Two outcomes based on whether the issue blocks the pipeline:**
 
-- **Blocking** (linter exits nonzero, CI would fail, or current task verification cannot pass) → apply the Proactive Fix Gate (`.claude/CLAUDE.md`, Proactive Fix Gate section): load domain skill, state mission alignment, classify complexity. Trivial: route to `--quick`. Multi-file or design-decision: route to planning for an in-session fix, or mark the current run BLOCKED if the fix cannot be scoped to this session.
+- **Blocking** (linter exits nonzero, CI would fail, or current task verification cannot pass) → apply a pre-fix check before touching any file: (1) load the domain skill for the affected file, (2) state in one sentence how the fix aligns with that plugin's mission, (3) classify complexity. Trivial (one file, obvious root cause): fix now. Multi-file or design-decision: route to planning for an in-session fix, or mark the current run BLOCKED if the fix cannot be scoped to this session.
 - **Non-blocking** (advisory warning, file unrelated to current task) → discover the repo's tracking system and record it
 
 **Discover the tracking system** (search in order): `.claude/backlog/` per-item files, `.claude/tasks/`, `TODO.md`, `TODO`, `docs/TODO.md`, `.gsd/`, `sam.md`. If none exists, create a per-item file in `.claude/backlog/`.

--- a/plugins/holistic-linting/skills/holistic-linting/references/pre-existing-issues-protocol.md
+++ b/plugins/holistic-linting/skills/holistic-linting/references/pre-existing-issues-protocol.md
@@ -9,7 +9,7 @@ When a linter run reveals issues in files the current agent did not modify, the 
 Two outcomes are possible. Apply the correct one based on whether the issue blocks the pipeline:
 
 > **Pre-fix gate required**: Before acting on any discovered issue, apply the three-step
-> Proactive Fix Gate from CLAUDE.md (Proactive Fix Gate section): (1) load domain skill,
+> Proactive Fix Gate from `.claude/CLAUDE.md` (Proactive Fix Gate section): (1) load domain skill,
 > (2) state mission alignment, (3) classify complexity and route to --quick or planning.
 > Do not proceed to any fix step without completing the gate.
 

--- a/plugins/holistic-linting/skills/holistic-linting/references/pre-existing-issues-protocol.md
+++ b/plugins/holistic-linting/skills/holistic-linting/references/pre-existing-issues-protocol.md
@@ -8,10 +8,11 @@ When a linter run reveals issues in files the current agent did not modify, the 
 
 Two outcomes are possible. Apply the correct one based on whether the issue blocks the pipeline:
 
-> **Pre-fix gate required**: Before acting on any discovered issue, apply the three-step
-> Proactive Fix Gate from `.claude/CLAUDE.md` (Proactive Fix Gate section): (1) load domain skill,
-> (2) state mission alignment, (3) classify complexity and route to --quick or planning.
-> Do not proceed to any fix step without completing the gate.
+> **Pre-fix gate required**: Before acting on any discovered issue, complete these three steps:
+> (1) load the domain skill for the affected file, (2) state in one sentence how the fix aligns
+> with that plugin's mission, (3) classify complexity — trivial (one file, obvious root cause,
+> single Edit): fix now; multi-file or design-decision: add to the project backlog and defer.
+> Do not proceed to any fix step without completing all three.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Summary

- **Parser fix**: Registry commands (`create`, `close`, `resolve`, etc.) are now only matched when they appear as the first positional token. Previously, any registry keyword in title text (e.g., "some title with **close** in it") would cause a "conflicting discriminators" error when the `--` separator was omitted. The fix is a single-line guard: `if (i === 0 && registryKeys.includes(token))`.

- **Proactive Fix Gate documentation**: Added a repo-wide gate policy to `.claude/CLAUDE.md` and propagated it into holistic-linting and work-backlog-item quick-path documentation to standardise how agents handle discovered issues (including routing trivial fixes through `--quick`).

- **Backlog item #2420**: Logged root cause investigation of gate token session isolation (`complete-implementation` closure gap — skill applies `status:verified` but never calls `backlog_resolve`).

## Changes

| File | Change |
|------|--------|
| `plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs` | Guard registry discriminator to position 0 only |
| `.claude/CLAUDE.md` | Add Proactive Fix Gate policy with routing rules |
| `plugins/development-harness/skills/work-backlog-item/SKILL.md` | Document `--quick` mode and proactive fix routing |
| `plugins/development-harness/skills/work-backlog-item/references/workflows/quick/start.md` | Document gate entry point; clarify `.claude/CLAUDE.md` reference |
| `plugins/development-harness/skills/backlog/references/state-machine.md` | Add quick-path `groomed`/`needs-grooming` → `in-progress` transitions |
| `plugins/development-harness/docs/backlog-item-lifecycle.md` | Add quick-path exception note covering both start states |
| `plugins/holistic-linting/skills/holistic-linting/SKILL.md` | Update pre-existing issues protocol with gate reference; clarify blocking path |
| `plugins/holistic-linting/skills/holistic-linting/references/pre-existing-issues-protocol.md` | Add gate-required note; fix `CLAUDE.md` → `.claude/CLAUDE.md` |
| `plugins/holistic-linting/agents/linting-root-cause-resolver.md` | Fix `CLAUDE.md` → `.claude/CLAUDE.md` reference |
| `plugins/holistic-linting/skills/holistic-linting-orchestrator/SKILL.md` | Add anti-pattern note for fixing blockers without the gate |
| `plugins/development-harness/.claude-plugin/plugin.json` | Bump `dh` plugin version |
| `plugins/holistic-linting/.claude-plugin/plugin.json` | Bump `holistic-linting` plugin version |

## Test plan

- [ ] `create some title with close in it` → `route=create` (was: conflicting discriminators error)
- [ ] `create -- some title with close in it` → `route=create, user_text="some title with close in it"`
- [ ] `close #42` → `route=close, item_ref=#42`
- [ ] `close Error Recovery` → `route=close, user_text="Error Recovery"`
- [ ] All `CLAUDE.md` references in changed files now point to `.claude/CLAUDE.md`
- [ ] Quick-path lifecycle note covers both `groomed → in-progress` and `needs-grooming → in-progress`

https://claude.ai/code/session_01DVbwCjRBmW21nfBgy4UUuM