### PR TITLE
fix(artifact_provider): translate GithubException to BacklogError in get_manifest and set_manifest

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/artifact_provider.py
+++ b/plugins/development-harness/backlog_core/artifact_provider.py
@@ -455,29 +455,33 @@ class GitHubGistArtifactProvider:
                 failures.
         """
         issue_number = _reject_beads_issue_number("GitHubGistArtifactProvider", issue_number)
-        repo = get_github(self._repo)
-        owner, repo_name = self._repo.split("/", 1)
-        issue = _fetch_issue_graphql(repo, owner, repo_name, issue_number)
-        body = issue.get("body") or ""
+        try:
+            repo = get_github(self._repo)
+            owner, repo_name = self._repo.split("/", 1)
+            issue = _fetch_issue_graphql(repo, owner, repo_name, issue_number)
+            body = issue.get("body") or ""
 
-        # Current format: Gist-backed manifest.
-        gist = self._get_gist(issue_number, body)
-        if gist is not None:
-            gist_file = gist.files.get("manifest.json")
-            if gist_file is not None:
-                return ArtifactManifest.model_validate_json(gist_file.content)
+            # Current format: Gist-backed manifest.
+            gist = self._get_gist(issue_number, body)
+            if gist is not None:
+                gist_file = gist.files.get("manifest.json")
+                if gist_file is not None:
+                    return ArtifactManifest.model_validate_json(gist_file.content)
+                return ArtifactManifest(issue_number=issue_number)
+
+            # Legacy inline manifest — lazy migration to Gist storage.
+            if "<!-- artifact-manifest:begin -->" in body:
+                manifest = parse_manifest_section(body, issue_number)
+                manifest_json = manifest.model_dump_json(by_alias=True)
+                self._create_and_link_gist(
+                    issue_number, issue["id"], body, {"manifest.json": InputFileContent(manifest_json)}
+                )
+                return manifest
+
             return ArtifactManifest(issue_number=issue_number)
-
-        # Legacy inline manifest — lazy migration to Gist storage.
-        if "<!-- artifact-manifest:begin -->" in body:
-            manifest = parse_manifest_section(body, issue_number)
-            manifest_json = manifest.model_dump_json(by_alias=True)
-            self._create_and_link_gist(
-                issue_number, issue["id"], body, {"manifest.json": InputFileContent(manifest_json)}
-            )
-            return manifest
-
-        return ArtifactManifest(issue_number=issue_number)
+        except GithubException as exc:
+            msg = f"GitHub API error retrieving artifact manifest for issue #{issue_number}: {exc}"
+            raise BacklogError(msg) from exc
 
     def set_manifest(self, issue_number: str | int, manifest: ArtifactManifest) -> None:
         """Persist *manifest* by writing it to the linked Gist.
@@ -496,21 +500,27 @@ class GitHubGistArtifactProvider:
                 failures.
         """
         issue_number = _reject_beads_issue_number("GitHubGistArtifactProvider", issue_number)
-        repo = get_github(self._repo)
-        owner, repo_name = self._repo.split("/", 1)
-        issue = _fetch_issue_graphql(repo, owner, repo_name, issue_number)
-        body = issue.get("body") or ""
+        try:
+            repo = get_github(self._repo)
+            owner, repo_name = self._repo.split("/", 1)
+            issue = _fetch_issue_graphql(repo, owner, repo_name, issue_number)
+            body = issue.get("body") or ""
 
-        # Stamp last_updated before serialising.
-        manifest = manifest.model_copy(update={"last_updated": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")})
-        manifest_json = manifest.model_dump_json(by_alias=True)
+            # Stamp last_updated before serialising.
+            manifest = manifest.model_copy(update={"last_updated": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")})
+            manifest_json = manifest.model_dump_json(by_alias=True)
 
-        gist = self._get_gist(issue_number, body)
-        if gist is not None:
-            gist.edit(files={"manifest.json": InputFileContent(manifest_json)})
-            return
+            gist = self._get_gist(issue_number, body)
+            if gist is not None:
+                gist.edit(files={"manifest.json": InputFileContent(manifest_json)})
+                return
 
-        self._create_and_link_gist(issue_number, issue["id"], body, {"manifest.json": InputFileContent(manifest_json)})
+            self._create_and_link_gist(
+                issue_number, issue["id"], body, {"manifest.json": InputFileContent(manifest_json)}
+            )
+        except GithubException as exc:
+            msg = f"GitHub API error persisting artifact manifest for issue #{issue_number}: {exc}"
+            raise BacklogError(msg) from exc
 
     def read_artifact_content(self, path: str) -> str:
         """Read artifact file content from the root worktree filesystem.


### PR DESCRIPTION
## Summary

- `GitHubGistArtifactProvider.get_manifest` and `set_manifest` both document `BacklogError` on GitHub API failures, but `GithubException` from `get_github()` and `_fetch_issue_graphql()` escaped uncaught
- `_try_register_task_plan_artifact` in `server.py` catches `(BacklogError, ValueError, OSError)` — missing `GithubException` — so it propagated and caused `test_sam_create_returns_plan_ref_with_issue` to fail in the full test suite

## Root cause

`init_paths()` tests set `DEFAULT_REPO` as global state. On the same pytest-xdist worker, `test_sam_create_returns_plan_ref_with_issue` found `DEFAULT_REPO` set, triggered the GitHub artifact registration path, and hit the uncaught `GithubException`. In isolation `DEFAULT_REPO` is unset, so `_try_register_task_plan_artifact` returns early.

## Fix

Wrapped the GitHub-dependent operations in both `get_manifest` and `set_manifest` with `try/except GithubException → BacklogError`, honouring the docstring contract and enabling the best-effort handler in `server.py` to catch it.

## Test plan

- [x] `uv run pytest tests_sam/test_server.py::test_sam_create_returns_plan_ref_with_issue` — passes in isolation
- [x] `uv run pytest --tb=no -q` full suite — `3611 passed, 0 failed` (was `1 failed` before)
- [x] `uv run prek run --files plugins/development-harness/backlog_core/artifact_provider.py` — all hooks pass including ruff, ty

Closes #1882

https://claude.ai/code/session_012WrLpJuyvJYFSyGZKis6Fg

---
_Generated by [Claude Code](https://claude.ai/code/session_012WrLpJuyvJYFSyGZKis6Fg)_