### PR TITLE
fix(ci): use git diff HEAD to detect marketplace.json changes

### DIFF
--- a/.github/workflows/bump-marketplace.yml
+++ b/.github/workflows/bump-marketplace.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Commit if changed
         run: |
-          if git diff --quiet .claude-plugin/marketplace.json; then
+          if git diff HEAD --quiet .claude-plugin/marketplace.json; then
             echo "No marketplace changes to commit"
           else
             git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

- `_sync_marketplace_mode()` in `auto_sync_manifests.py` calls `_git_stage_file()` (i.e. `git add`) on `marketplace.json` before returning
- The workflow's "Commit if changed" step then ran `git diff --quiet .claude-plugin/marketplace.json`, which compares **working tree to index (staging area)**
- After `git add`, working tree == index → `git diff` always exits 0 → "No marketplace changes to commit" → no commit ever made
- Fix: `git diff HEAD --quiet` compares working tree to HEAD, correctly detecting the modification regardless of staging state

## Test plan

- [ ] Merge a change to `plugins/**` into main
- [ ] Confirm the bump-marketplace workflow run produces a commit with a bumped version in `marketplace.json`
- [ ] Confirm `[skip ci]` in the bot commit prevents an infinite loop

https://claude.ai/code/session_01XbMMABfEbXh9Sfc2wZfQDn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbMMABfEbXh9Sfc2wZfQDn)_