### PR TITLE
docs(live-validation): document DEFERRED_SKILL intent for claude-skill sentinel

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.6",
+  "version": "8.6.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.5",
+  "version": "8.6.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/scripts/live_validation_step.py
+++ b/plugins/development-harness/scripts/live_validation_step.py
@@ -63,8 +63,12 @@ def check_live_validation(project_root: Path) -> LiveValidationOutcome:
 
     - Sentinel ``agent-browser`` → DEFERRED_BROWSER (no gap).
     - Sentinel ``claude-skill``  → DEFERRED_SKILL (no gap). The caller is responsible
-      for invoking ``run_live_validation_skill.py --skill-path <path> --query <prompt>``
-      manually; this function does not call it automatically.
+      for invoking the script manually from the project root::
+
+          ./plugins/development-harness/scripts/run_live_validation_skill.py \
+              --skill-path <path> --query <prompt>
+
+      This function does not call it automatically.
     - Absent live_validation     → GAPS_FOUND with gap message.
     - No quality_gates section   → SKIPPED.
     - Command exits 0            → PASS (no gap).
@@ -97,9 +101,10 @@ def check_live_validation(project_root: Path) -> LiveValidationOutcome:
         return LiveValidationOutcome(result=LiveValidationResult.DEFERRED_BROWSER, command=live_val)
 
     # DEFERRED_SKILL is intentional: the claude-skill sentinel signals that live validation
-    # is delegated to a separate manual invocation of run_live_validation_skill.py.
-    # The caller is responsible for supplying --skill-path and --query; those arguments
-    # are not available at this call site and are outside this function's contract.
+    # is delegated to a separate manual invocation of the script at:
+    #   ./plugins/development-harness/scripts/run_live_validation_skill.py
+    # The caller supplies --skill-path and --query; those arguments are not available
+    # at this call site and are outside this function's contract.
     if live_val == SENTINEL_CLAUDE_SKILL:
         return LiveValidationOutcome(result=LiveValidationResult.DEFERRED_SKILL, command=live_val)
 

--- a/plugins/development-harness/scripts/live_validation_step.py
+++ b/plugins/development-harness/scripts/live_validation_step.py
@@ -62,7 +62,9 @@ def check_live_validation(project_root: Path) -> LiveValidationOutcome:
     following the feature verifier Step 8 protocol:
 
     - Sentinel ``agent-browser`` → DEFERRED_BROWSER (no gap).
-    - Sentinel ``claude-skill``  → DEFERRED_SKILL (no gap).
+    - Sentinel ``claude-skill``  → DEFERRED_SKILL (no gap). The caller is responsible
+      for invoking ``run_live_validation_skill.py --skill-path <path> --query <prompt>``
+      manually; this function does not call it automatically.
     - Absent live_validation     → GAPS_FOUND with gap message.
     - No quality_gates section   → SKIPPED.
     - Command exits 0            → PASS (no gap).
@@ -94,6 +96,10 @@ def check_live_validation(project_root: Path) -> LiveValidationOutcome:
     if live_val == SENTINEL_AGENT_BROWSER:
         return LiveValidationOutcome(result=LiveValidationResult.DEFERRED_BROWSER, command=live_val)
 
+    # DEFERRED_SKILL is intentional: the claude-skill sentinel signals that live validation
+    # is delegated to a separate manual invocation of run_live_validation_skill.py.
+    # The caller is responsible for supplying --skill-path and --query; those arguments
+    # are not available at this call site and are outside this function's contract.
     if live_val == SENTINEL_CLAUDE_SKILL:
         return LiveValidationOutcome(result=LiveValidationResult.DEFERRED_SKILL, command=live_val)
 


### PR DESCRIPTION
## Summary

- Adds a docstring note to `check_live_validation()` clarifying that `claude-skill` defers to manual invocation of `run_live_validation_skill.py --skill-path <path> --query <prompt>`
- Adds an inline comment above the `SENTINEL_CLAUDE_SKILL` branch (lines 97-98) explaining `DEFERRED_SKILL` is intentional design — the caller supplies `--skill-path` and `--query`, which are unavailable at the `check_live_validation()` call site
- No logic changes; no changes to `LiveValidationResult` enum or `run_live_validation_skill.py`

## Test plan

- [x] `uv run prek run --files plugins/development-harness/scripts/live_validation_step.py` exits 0
- [x] `test_claude_skill_sentinel_deferred_no_gap` passes unchanged

Closes #1545

https://claude.ai/code/session_01C3aK5sxTuLzRuYzvfB5dxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3aK5sxTuLzRuYzvfB5dxx)_