### PR TITLE
refactor(add-new-feature): Phase 3 architect agent writes spec to disk and self-registers artifact

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.21",
+  "version": "8.6.22",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.18",
+  "version": "8.6.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.16",
+  "version": "8.6.17",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.20",
+  "version": "8.6.21",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.17",
+  "version": "8.6.18",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.12",
+  "version": "8.6.13",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.11",
+  "version": "8.6.12",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.15",
+  "version": "8.6.16",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.13",
+  "version": "8.6.14",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.14",
+  "version": "8.6.15",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.6.19",
+  "version": "8.6.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -123,7 +123,7 @@ to detect or recover from concurrent appends. Behavior under concurrent writes i
 Two distinct types of plan data exist:
 
 - **SAM task plan YAML files** (`P{id}-{slug}.yaml`, `T0-baseline-*.yaml`, etc.) — stored in `~/.dh/projects/{slug}/plan/` by the SAM MCP. Access via `sam_read`, `sam_list`, `sam_update` — never via direct filesystem path.
-- **Plan artifact markdown files** (`plan/feature-context-{slug}.md`, `plan/architect-{slug}.md`, etc.) — written to the repo root worktree's `plan/` directory. Not visible from isolated worktrees. Access via `artifact_read(issue_number, artifact_type)` — not filesystem path.
+- **Plan artifact markdown files** (`plan/feature-context-{slug}.md`, `plan/architect-{slug}.md`, etc.) — written to the repo root worktree's `plan/` directory. Not visible from isolated worktrees. Access via `artifact_read(item_id, artifact_type)` — not filesystem path.
 
 ---
 
@@ -133,7 +133,7 @@ Plan artifacts are registered in a structured manifest stored in the GitHub Issu
 
 **MCP tools (on backlog server) — Artifact Management:**
 
-- `artifact_register` — Register or update an artifact entry (issue_number, type, path, status, agent)
+- `artifact_register` — Register or update an artifact entry (item_id, type, path, status, agent)
 - `artifact_list` — List all artifacts for an issue, optionally filtered by type
 - `artifact_get` — Get metadata for a specific artifact type on an issue
 - `artifact_read` — Read artifact file content from root worktree path (with path safety validation)
@@ -148,8 +148,8 @@ Plan artifacts are registered in a structured manifest stored in the GitHub Issu
 
 **Prohibited patterns — do not write these in agent instructions or tool calls:**
 
-- `Write(file_path="~/.dh/...")` for any artifact — use `artifact_register(issue_number, type, content=..., path=logical_id)` instead
-- `Read(file_path="~/.dh/.../T0-baseline-*.yaml")` — use `artifact_read(issue_number, "T0-baseline")` instead
+- `Write(file_path="~/.dh/...")` for any artifact — use `artifact_register(item_id, type, content=..., path=logical_id)` instead
+- `Read(file_path="~/.dh/.../T0-baseline-*.yaml")` — use `artifact_read(item_id, "T0-baseline")` instead
 - `artifact_register(...)` without `content=` — path-only registration stores a pointer to a local file that is unreachable from worktree-isolated agents and CI environments
 
 ## Dispatch Orchestration System

--- a/plugins/development-harness/agents/code-reviewer.md
+++ b/plugins/development-harness/agents/code-reviewer.md
@@ -165,7 +165,7 @@ Register via MCP:
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
-  item_id={issue_number},
+  item_id={item_id},
   type="codebase-analysis",
   artifact_id="code-review-{task_id}-{slug}",
   content={report_markdown},
@@ -242,7 +242,7 @@ Return this as your final response after registering the artifact:
 STATUS: DONE
 SUMMARY: {one paragraph — verdict, criteria status, key findings}
 ARTIFACTS:
-  - Review report: registered as artifact codebase-analysis / code-review-{task_id}-{slug} on item {issue_number}
+  - Review report: registered as artifact codebase-analysis / code-review-{task_id}-{slug} on item {item_id}
   - Verdict: PASS | FAIL | NEEDS-WORK
   - Criteria met: {N}/{total}
   - Blocking findings: {count}

--- a/plugins/development-harness/agents/code-reviewer.md
+++ b/plugins/development-harness/agents/code-reviewer.md
@@ -44,9 +44,9 @@ Read the SAM task file using `mcp__plugin_dh_sam__sam_task`. Extract:
 - `acceptance_criteria` — the explicit success conditions to verify
 - `verification_steps` — commands or checks to run
 - `body` — any additional scope or constraints
-- `issue_number` — required for artifact registration (`str | int`: GitHub issue number or beads item ID)
+- `item_id` — required for artifact registration (`str | int`: GitHub issue number or beads item ID)
 
-If `issue_number` is not provided in the delegation prompt, return STATUS: BLOCKED immediately.
+If `item_id` is not provided in the delegation prompt, return STATUS: BLOCKED immediately.
 
 ### Step 2: Identify Files Under Review
 
@@ -165,7 +165,7 @@ Register via MCP:
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
-  issue_number={issue_number},
+  item_id={issue_number},
   type="codebase-analysis",
   artifact_id="code-review-{task_id}-{slug}",
   content={report_markdown},
@@ -259,7 +259,7 @@ NOTES:
 STATUS: BLOCKED
 SUMMARY: {what is blocking the review}
 NEEDED:
-  - {missing input — e.g., issue_number, file paths, task plan reference}
+  - {missing input — e.g., item_id, file paths, task plan reference}
 SUGGESTED NEXT STEP:
   - {what the orchestrator should provide to unblock}
 ```

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -765,7 +765,7 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 
 **Level 3: Wired**
 
-- [ ] Document retrievable by downstream consumers via `artifact_read(issue_number, "codebase-analysis")`
+- [ ] Document retrievable by downstream consumers via `artifact_read(item_id, "codebase-analysis")`
 - [ ] Document format compatible with agent consumption (design-spec, implementation, and test-architect agents provided by the active language plugin)
 - [ ] Confirmation returned to orchestrator (not document contents)
 - [ ] ARTIFACTS in DONE response uses logical id: `type=codebase-analysis, issue={issue_number}, artifact_id=codebase-{focus}-{slug}` (no filesystem path)

--- a/plugins/development-harness/agents/doc-drift-auditor.md
+++ b/plugins/development-harness/agents/doc-drift-auditor.md
@@ -164,7 +164,7 @@ Assemble the audit report content in memory, then register it via:
 
 ```text
 artifact_register(
-  item_id={issue_number},
+  item_id={item_id},
   type="audit-report",
   artifact_id="doc-drift-audit-{slug}",
   content={report_markdown},

--- a/plugins/development-harness/agents/doc-drift-auditor.md
+++ b/plugins/development-harness/agents/doc-drift-auditor.md
@@ -19,7 +19,7 @@ Audit documentation against actual implementation to identify drift and produce 
 
 **Required inputs:**
 
-- `issue_number` — the backlog item ID (GitHub issue number, or bead ID when using beads backend) to register the audit report against (REQUIRED)
+- `item_id` — the backlog item ID (GitHub issue number, or bead ID when using beads backend) to register the audit report against (REQUIRED)
 - `project_root` — absolute path to the project root being audited
 
 **You do:**
@@ -164,7 +164,7 @@ Assemble the audit report content in memory, then register it via:
 
 ```text
 artifact_register(
-  issue_number={issue_number},
+  item_id={issue_number},
   type="audit-report",
   artifact_id="doc-drift-audit-{slug}",
   content={report_markdown},
@@ -204,7 +204,7 @@ SUGGESTED NEXT STEP:
 
 Block immediately if:
 
-- `issue_number` was not provided — cannot register artifact without it
+- `item_id` was not provided — cannot register artifact without it
 - `artifact_register` returns an error — report the exact error text and do not fall back to writing to disk
 
 ## Report Structure

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -181,7 +181,7 @@ and `github_url` fields.
 ```python
 # Pseudocode — detect and follow upstream URLs
 if prior_artifacts contains artifact_type="research":
-    content = artifact_read(issue_number, "research")
+    content = artifact_read(item_id, "research")
     frontmatter = parse_yaml_frontmatter(content)
     resource_url = frontmatter.get("resource_url")
     github_url   = frontmatter.get("github_url")

--- a/plugins/development-harness/agents/feature-verifier.md
+++ b/plugins/development-harness/agents/feature-verifier.md
@@ -81,8 +81,8 @@ Read the architecture spec and task file to understand:
 - What did the tasks claim to deliver (artifacts)?
 
 ```bash
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="architect")
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="task-plan")
+mcp__plugin_dh_backlog__artifact_read(item_id={issue_number}, artifact_type="architect")
+mcp__plugin_dh_backlog__artifact_read(item_id={issue_number}, artifact_type="task-plan")
 ```
 
 > **Backend note**: When `BACKLOG_BACKEND=beads`, `issue_number` is a bead ID (string, e.g. `bd-a3f8`), not a GitHub issue number (integer). The MCP layer accepts both types transparently.

--- a/plugins/development-harness/agents/integration-checker.md
+++ b/plugins/development-harness/agents/integration-checker.md
@@ -75,7 +75,7 @@ For each module in the feature, extract what it provides and what it should cons
 **From task file, extract:**
 
 ```bash
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="task-plan")
+mcp__plugin_dh_backlog__artifact_read(item_id={issue_number}, artifact_type="task-plan")
 ```
 
 > **Backend note**: When `BACKLOG_BACKEND=beads`, `issue_number` is a bead ID (string, e.g. `bd-a3f8`), not a GitHub issue number (integer). The MCP layer accepts both types transparently.

--- a/plugins/development-harness/agents/plan-validator.md
+++ b/plugins/development-harness/agents/plan-validator.md
@@ -484,11 +484,11 @@ When delegated with a plan path like `plan/Pa5b6c7d8-some-slug.yaml`, extract th
 Read the architect spec and feature context via artifact MCP tools:
 
 ```text
-artifact_read(issue_number={N}, artifact_type="architect")
-artifact_read(issue_number={N}, artifact_type="feature-context")
+artifact_read(item_id={N}, artifact_type="architect")
+artifact_read(item_id={N}, artifact_type="feature-context")
 ```
 
-If no issue number is available, read them via `artifact_list(issue_number={N})` first to discover paths, then `artifact_read`.
+If no issue number is available, read them via `artifact_list(item_id={N})` first to discover paths, then `artifact_read`.
 
 ## Step 2: Extract Feature Goals
 

--- a/plugins/development-harness/agents/reviewer-accessibility.md
+++ b/plugins/development-harness/agents/reviewer-accessibility.md
@@ -134,7 +134,7 @@ Register via MCP:
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
-  issue_number={issue_number},
+  item_id={issue_number},
   artifact_type="codebase-analysis",
   content={verdict_block_json},
   status="complete",
@@ -142,7 +142,7 @@ mcp__plugin_dh_backlog__artifact_register(
 )
 ```
 
-Where `{issue_number}` is provided in the task context. If not provided, skip registration and note in STATUS.
+Where `{issue_number}` is the item ID provided in the task context. If not provided, skip registration and note in STATUS.
 
 </workflow>
 

--- a/plugins/development-harness/agents/reviewer-performance.md
+++ b/plugins/development-harness/agents/reviewer-performance.md
@@ -122,12 +122,12 @@ whether minor issues were observed in config files.
 
 ### Step 5: Register Artifact
 
-Register the verdict as a `codebase-analysis` artifact if an `issue_number` is available in
+Register the verdict as a `codebase-analysis` artifact if an `item_id` is available in
 the task or delegation prompt:
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
-  issue_number={issue_number},
+  item_id={issue_number},
   artifact_type="codebase-analysis",
   content={structured_verdict_json},
   status="complete",
@@ -135,7 +135,7 @@ mcp__plugin_dh_backlog__artifact_register(
 )
 ```
 
-If no issue_number is available, skip registration and include the verdict JSON only in the
+If no item_id is available, skip registration and include the verdict JSON only in the
 SendMessage body.
 
 ### Step 6: Send Verdict to Team Lead
@@ -187,7 +187,7 @@ Perspective: performance
 Verdict: APPROVE | REJECT | SKIP
 Findings: {count BLOCKER} blocker(s), {count MINOR} minor
 Summary line: Performance: {token per §2.2}
-Artifact: registered as codebase-analysis on issue {N} | no issue_number — not registered
+Artifact: registered as codebase-analysis on issue {N} | no item_id — not registered
 ```
 
 ## STATUS Output (MANDATORY)
@@ -200,7 +200,7 @@ SUMMARY: {one sentence — verdict, key findings, basis for decision}
 VERDICT_JSON:
 {paste the full structured verdict block}
 ARTIFACTS:
-  - codebase-analysis registered on issue {N} | not registered (no issue_number)
+  - codebase-analysis registered on issue {N} | not registered (no item_id)
 NOTES:
   - {files inspected vs skipped}
   - {any scope limitations}

--- a/plugins/development-harness/agents/reviewer-quality.md
+++ b/plugins/development-harness/agents/reviewer-quality.md
@@ -123,7 +123,7 @@ Register the verdict as a `codebase-analysis` artifact via MCP. Use `issue_numbe
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
-  issue_number={issue_number},
+  item_id={issue_number},
   artifact_type="codebase-analysis",
   content={verdict_block_json},
   status="complete",

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -374,7 +374,7 @@ Run all structured acceptance criteria commands and record baseline results via 
 
 ## Inputs
 - Plan file: the task file containing `acceptance-criteria-structured` entries
-- `issue_number`: `str | int` — GitHub integer issue number or beads string ID (e.g., `bd-a3f8`); obtained from the plan's `issue` field
+- `item_id`: `str | int` — GitHub integer issue number or beads string ID (e.g., `bd-a3f8`); obtained from the plan's `issue` field
 
 ## Requirements
 1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
@@ -416,7 +416,7 @@ Re-run acceptance criteria and compare against T0 baseline; register verdict via
 
 ## Inputs
 - Plan file: the task file containing `acceptance-criteria-structured` entries
-- `issue_number`: `str | int` — GitHub integer issue number or beads string ID (e.g., `bd-a3f8`); obtained from the plan's `issue` field
+- `item_id`: `str | int` — GitHub integer issue number or beads string ID (e.g., `bd-a3f8`); obtained from the plan's `issue` field
 - T0 baseline: retrieved via `artifact_read(item_id, "T0-baseline")`
 
 ## Requirements

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -379,17 +379,17 @@ Run all structured acceptance criteria commands and record baseline results via 
 ## Requirements
 1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
 2. Record exit code, stdout, stderr, and timestamp per criterion
-3. Register results via `artifact_register(issue_number, artifact_type="T0-baseline", content=..., status="complete", agent="t0-baseline-capture")`
+3. Register results via `artifact_register(item_id, artifact_type="T0-baseline", content=..., status="complete", agent="t0-baseline-capture")`
 
 ## Expected Outputs
-- T0-baseline artifact registered and retrievable via `artifact_read(issue_number, "T0-baseline")`
+- T0-baseline artifact registered and retrievable via `artifact_read(item_id, "T0-baseline")`
 
 ## Acceptance Criteria
-1. `artifact_read(issue_number, "T0-baseline")` returns content
+1. `artifact_read(item_id, "T0-baseline")` returns content
 2. Content contains one entry per structured criterion with exit code, stdout, stderr, timestamp
 
 ## Verification Steps
-1. Call `artifact_read(issue_number, "T0-baseline")` and confirm `criteria_count` matches plan
+1. Call `artifact_read(item_id, "T0-baseline")` and confirm `criteria_count` matches plan
 ```
 
 ### TN Task Template
@@ -417,12 +417,12 @@ Re-run acceptance criteria and compare against T0 baseline; register verdict via
 ## Inputs
 - Plan file: the task file containing `acceptance-criteria-structured` entries
 - `issue_number`: `str | int` — GitHub integer issue number or beads string ID (e.g., `bd-a3f8`); obtained from the plan's `issue` field
-- T0 baseline: retrieved via `artifact_read(issue_number, "T0-baseline")`
+- T0 baseline: retrieved via `artifact_read(item_id, "T0-baseline")`
 
 ## Requirements
 1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
 2. Compare exit code against T0 baseline using the 4-cell status matrix
-3. Assemble per-criterion verdict and overall verdict in memory; register via `artifact_register(issue_number, artifact_type="TN-verification", content=...)`
+3. Assemble per-criterion verdict and overall verdict in memory; register via `artifact_register(item_id, artifact_type="TN-verification", content=...)`
 4. Overall verdict is PASS only when no criterion has status `regressed`
 
 ## Expected Outputs
@@ -433,7 +433,7 @@ Re-run acceptance criteria and compare against T0 baseline; register verdict via
 2. No criterion has status `regressed`
 
 ## Verification Steps
-1. Read TN-verification artifact via `artifact_read(issue_number, "TN-verification")` and confirm `verdict` is `PASS`
+1. Read TN-verification artifact via `artifact_read(item_id, "TN-verification")` and confirm `verdict` is `PASS`
 ```
 
 ### Dependency Rule

--- a/plugins/development-harness/agents/t0-baseline-capture.md
+++ b/plugins/development-harness/agents/t0-baseline-capture.md
@@ -121,8 +121,8 @@ Register the assembled YAML content in the backlog item's artifact manifest so i
 
 ```bash
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number={item_id},
-    type="T0-baseline",
+    item_id={item_id},
+    artifact_type="T0-baseline",
     artifact_id="T0-baseline-{slug}",
     content={yaml_string},
     status="complete",

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -39,13 +39,13 @@ The `item_id` and plan path are provided in your task delegation prompt. The slu
 Retrieve T0 baseline and read plan file:
 
 ```bash
-mcp__plugin_dh_backlog__artifact_read(issue_number={item_id}, artifact_type="T0-baseline")
-mcp__plugin_dh_backlog__artifact_read(issue_number={item_id}, artifact_type="task-plan")
+mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="T0-baseline")
+mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="task-plan")
 ```
 
 Parse the content returned by `artifact_read` as YAML to extract the T0 results.
 
-If `artifact_read` returns an error or empty result for type `T0-baseline`, return STATUS: BLOCKED with: "T0 baseline not found — `artifact_read(issue_number={item_id}, artifact_type='T0-baseline')` returned no content. T0 agent must run first."
+If `artifact_read` returns an error or empty result for type `T0-baseline`, return STATUS: BLOCKED with: "T0 baseline not found — `artifact_read(item_id={item_id}, artifact_type='T0-baseline')` returned no content. T0 agent must run first."
 
 ## Step 2: Re-Run Each Check Command
 

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -138,8 +138,8 @@ Register the assembled YAML string directly via `artifact_register` with `conten
 
 ```bash
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number={item_id},
-    type="TN-verification",
+    item_id={item_id},
+    artifact_type="TN-verification",
     artifact_id="TN-verification-{slug}",
     content={yaml_string},
     status="complete",

--- a/plugins/development-harness/backlog_core/artifact_provider.py
+++ b/plugins/development-harness/backlog_core/artifact_provider.py
@@ -28,7 +28,7 @@ import sys
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, TypeAlias, cast, runtime_checkable
 
 from github import Auth, Github, GithubException, InputFileContent
 
@@ -44,6 +44,11 @@ from .gitlab_client import (
 )
 from .linear_client import linear_create_attachment, linear_get_attachments
 from .models import ArtifactManifest, BacklogError
+
+#: Type alias for a backlog item identifier.
+#: GitHub and GitLab backends use a positive integer IID; the beads backend
+#: uses a nanoid string (e.g. ``"bd-a3f8"``); Linear uses a UUID string.
+ItemId: TypeAlias = str | int
 
 # dh_paths lives one level above backlog_core (at plugin root).
 _plugin_root = Path(__file__).parent.parent
@@ -124,30 +129,32 @@ def _make_github_client() -> Github:
     return Github(auth=Auth.Token(token))
 
 
-def _reject_beads_issue_number(cls_name: str, issue_number: str | int) -> int:
-    """Raise ``TypeError`` when *issue_number* is a string (beads identifier).
+def _require_int_item_id(cls_name: str, item_id: ItemId) -> int:
+    """Raise ``TypeError`` when *item_id* is a string.
 
-    All non-beads providers require a positive integer issue number.  Beads
-    nanoid strings (e.g. ``"bd-a3f8"``) are only valid for
-    ``BeadsArtifactProvider``.
+    GitHub and GitLab providers require a positive integer item ID.  String
+    identifiers (beads nanoid ``"bd-a3f8"``) are only valid for
+    ``BeadsArtifactProvider``.  Linear UUID strings must NOT pass through
+    this helper — ``LinearArtifactProvider`` accepts strings natively and
+    does not call this function.
 
     Args:
         cls_name: Name of the calling provider class, used in the error message.
-        issue_number: The value passed by the caller — rejected when it is a ``str``.
+        item_id: The value passed by the caller — rejected when it is a ``str``.
 
     Returns:
-        The validated integer issue number.
+        The validated integer item ID.
 
     Raises:
-        TypeError: When *issue_number* is a ``str`` instance.
+        TypeError: When *item_id* is a ``str`` instance.
     """
-    if isinstance(issue_number, str):
+    if isinstance(item_id, str):
         msg = (
-            f"{cls_name} requires an integer issue number, got {issue_number!r}. "
-            "Use BeadsArtifactProvider for string (beads) issue identifiers."
+            f"{cls_name} requires an integer item ID, got {item_id!r}. "
+            "Use BeadsArtifactProvider for string (beads) item identifiers."
         )
         raise TypeError(msg)
-    return issue_number
+    return item_id
 
 
 # ---------------------------------------------------------------------------
@@ -273,28 +280,30 @@ class ArtifactBackend(Protocol):
     ``asyncio.to_thread()`` when needed.
     """
 
-    def get_manifest(self, issue_number: str | int) -> ArtifactManifest:
-        """Retrieve the artifact manifest for *issue_number*.
+    def get_manifest(self, item_id: ItemId) -> ArtifactManifest:
+        """Retrieve the artifact manifest for *item_id*.
 
         Args:
-            issue_number: Issue number — positive integer for GitHub backends
-                or beads nanoid string (e.g. ``"bd-a3f8"``) for the beads backend.
+            item_id: Backlog item identifier — positive integer for GitHub/GitLab
+                backends, UUID string for Linear, or beads nanoid string
+                (e.g. ``"bd-a3f8"``) for the beads backend.
 
         Returns:
-            ``ArtifactManifest`` for the issue.  Returns an empty manifest
-            (no artifacts) when the issue has no manifest section — this is
+            ``ArtifactManifest`` for the item.  Returns an empty manifest
+            (no artifacts) when the item has no manifest section — this is
             not an error.
         """
         ...
 
-    def set_manifest(self, issue_number: str | int, manifest: ArtifactManifest) -> None:
-        """Persist *manifest* for *issue_number*.
+    def set_manifest(self, item_id: ItemId, manifest: ArtifactManifest) -> None:
+        """Persist *manifest* for *item_id*.
 
         Replaces any existing manifest section; creates one if absent.
 
         Args:
-            issue_number: Issue number — positive integer for GitHub backends
-                or beads nanoid string (e.g. ``"bd-a3f8"``) for the beads backend.
+            item_id: Backlog item identifier — positive integer for GitHub/GitLab
+                backends, UUID string for Linear, or beads nanoid string
+                (e.g. ``"bd-a3f8"``) for the beads backend.
             manifest: Updated manifest to persist.
         """
         ...
@@ -319,7 +328,7 @@ class ArtifactBackend(Protocol):
         """
         ...
 
-    def store_artifact_content(self, issue_number: str | int, artifact_type: str, path: str, content: str) -> None:
+    def store_artifact_content(self, item_id: ItemId, artifact_type: str, path: str, content: str) -> None:
         """Store artifact content as a GitHub issue comment.
 
         Creates a structured collapsible comment identified by
@@ -332,7 +341,7 @@ class ArtifactBackend(Protocol):
         notice is appended.
 
         Args:
-            issue_number: Issue number — positive integer for GitHub backends
+            item_id: Backlog item identifier — positive integer for GitHub backends
                 or beads nanoid string for the beads backend.
             artifact_type: Artifact type string, e.g. ``"research"``.
             path: Repo-relative path used as the comment identifier.
@@ -340,14 +349,14 @@ class ArtifactBackend(Protocol):
         """
         ...
 
-    def read_artifact_content_from_remote(self, issue_number: str | int, artifact_type: str, path: str) -> str | None:
-        """Search issue comments for stored artifact content.
+    def read_artifact_content_from_remote(self, item_id: ItemId, artifact_type: str, path: str) -> str | None:
+        """Search item comments for stored artifact content.
 
-        Scans the issue's comments for an artifact content block whose
+        Scans the item's comments for an artifact content block whose
         ``type`` and ``path`` match the given arguments.
 
         Args:
-            issue_number: Issue number — positive integer for GitHub backends
+            item_id: Backlog item identifier — positive integer for GitHub backends
                 or beads nanoid string for the beads backend.
             artifact_type: Artifact type string to match.
             path: Repo-relative path to match.
@@ -433,8 +442,8 @@ class GitHubGistArtifactProvider:
     # ArtifactBackend implementation
     # ------------------------------------------------------------------
 
-    def get_manifest(self, issue_number: str | int) -> ArtifactManifest:
-        """Retrieve the artifact manifest for *issue_number*.
+    def get_manifest(self, item_id: ItemId) -> ArtifactManifest:
+        """Retrieve the artifact manifest for *item_id*.
 
         Fetches the issue body via GraphQL and checks for a Gist sentinel
         comment.  If found, loads ``manifest.json`` from the Gist.  Legacy
@@ -443,7 +452,7 @@ class GitHubGistArtifactProvider:
         Returns an empty manifest when no manifest data is present.
 
         Args:
-            issue_number: GitHub Issue number (positive integer).
+            item_id: GitHub Issue number (positive integer).
 
         Returns:
             Parsed ``ArtifactManifest``.  Empty when no manifest is stored.
@@ -454,43 +463,43 @@ class GitHubGistArtifactProvider:
             backlog_core.models.BacklogError: On GraphQL API or gist-scope
                 failures.
         """
-        issue_number = _reject_beads_issue_number("GitHubGistArtifactProvider", issue_number)
+        item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         try:
             repo = get_github(self._repo)
             owner, repo_name = self._repo.split("/", 1)
-            issue = _fetch_issue_graphql(repo, owner, repo_name, issue_number)
+            issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
             body = issue.get("body") or ""
 
             # Current format: Gist-backed manifest.
-            gist = self._get_gist(issue_number, body)
+            gist = self._get_gist(item_id, body)
             if gist is not None:
                 gist_file = gist.files.get("manifest.json")
                 if gist_file is not None:
                     return ArtifactManifest.model_validate_json(gist_file.content)
-                return ArtifactManifest(issue_number=issue_number)
+                return ArtifactManifest(issue_number=item_id)
 
             # Legacy inline manifest — lazy migration to Gist storage.
             if "<!-- artifact-manifest:begin -->" in body:
-                manifest = parse_manifest_section(body, issue_number)
+                manifest = parse_manifest_section(body, item_id)
                 manifest_json = manifest.model_dump_json(by_alias=True)
                 self._create_and_link_gist(
-                    issue_number, issue["id"], body, {"manifest.json": InputFileContent(manifest_json)}
+                    item_id, issue["id"], body, {"manifest.json": InputFileContent(manifest_json)}
                 )
                 return manifest
 
-            return ArtifactManifest(issue_number=issue_number)
+            return ArtifactManifest(issue_number=item_id)
         except GithubException as exc:
-            msg = f"GitHub API error retrieving artifact manifest for issue #{issue_number}: {exc}"
+            msg = f"GitHub API error retrieving artifact manifest for item #{item_id}: {exc}"
             raise BacklogError(msg) from exc
 
-    def set_manifest(self, issue_number: str | int, manifest: ArtifactManifest) -> None:
+    def set_manifest(self, item_id: ItemId, manifest: ArtifactManifest) -> None:
         """Persist *manifest* by writing it to the linked Gist.
 
         If no Gist exists yet, one is created and the issue body is updated
         with a sentinel comment ``<!-- artifact-gist:{gist_id} -->``.
 
         Args:
-            issue_number: GitHub Issue number (positive integer).
+            item_id: GitHub Issue number (positive integer).
             manifest: Updated manifest to persist.
 
         Raises:
@@ -499,27 +508,25 @@ class GitHubGistArtifactProvider:
             backlog_core.models.BacklogError: On GraphQL API or gist-scope
                 failures.
         """
-        issue_number = _reject_beads_issue_number("GitHubGistArtifactProvider", issue_number)
+        item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         try:
             repo = get_github(self._repo)
             owner, repo_name = self._repo.split("/", 1)
-            issue = _fetch_issue_graphql(repo, owner, repo_name, issue_number)
+            issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
             body = issue.get("body") or ""
 
             # Stamp last_updated before serialising.
             manifest = manifest.model_copy(update={"last_updated": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")})
             manifest_json = manifest.model_dump_json(by_alias=True)
 
-            gist = self._get_gist(issue_number, body)
+            gist = self._get_gist(item_id, body)
             if gist is not None:
                 gist.edit(files={"manifest.json": InputFileContent(manifest_json)})
                 return
 
-            self._create_and_link_gist(
-                issue_number, issue["id"], body, {"manifest.json": InputFileContent(manifest_json)}
-            )
+            self._create_and_link_gist(item_id, issue["id"], body, {"manifest.json": InputFileContent(manifest_json)})
         except GithubException as exc:
-            msg = f"GitHub API error persisting artifact manifest for issue #{issue_number}: {exc}"
+            msg = f"GitHub API error persisting artifact manifest for item #{item_id}: {exc}"
             raise BacklogError(msg) from exc
 
     def read_artifact_content(self, path: str) -> str:
@@ -546,7 +553,7 @@ class GitHubGistArtifactProvider:
         resolved = (self._root_worktree / path).resolve()
         return resolved.read_text(encoding="utf-8")
 
-    def store_artifact_content(self, issue_number: str | int, artifact_type: str, path: str, content: str) -> None:
+    def store_artifact_content(self, item_id: ItemId, artifact_type: str, path: str, content: str) -> None:
         """Store artifact content as a file in the linked Gist.
 
         The artifact *path* is sanitised for use as a Gist filename by
@@ -554,28 +561,26 @@ class GitHubGistArtifactProvider:
         linked to the issue body before the file is added.
 
         Args:
-            issue_number: GitHub Issue number (positive integer).
+            item_id: GitHub Issue number (positive integer).
             artifact_type: Artifact type string (e.g. ``"research"``).
                 Not used in the Gist filename — *path* is the unique key.
             path: Repo-relative artifact path, e.g. ``plan/architect-foo.md``.
             content: Full artifact content to store.
         """
-        issue_number = _reject_beads_issue_number("GitHubGistArtifactProvider", issue_number)
+        item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         repo = get_github(self._repo)
         owner, repo_name = self._repo.split("/", 1)
-        issue = _fetch_issue_graphql(repo, owner, repo_name, issue_number)
+        issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
         body = issue.get("body") or ""
 
-        gist = self._get_gist(issue_number, body)
+        gist = self._get_gist(item_id, body)
         if gist is None:
-            gist = self._create_and_link_gist(
-                issue_number, issue["id"], body, {"manifest.json": InputFileContent("{}")}
-            )
+            gist = self._create_and_link_gist(item_id, issue["id"], body, {"manifest.json": InputFileContent("{}")})
 
         filename = _sanitize_gist_filename(path)
         gist.edit(files={filename: InputFileContent(content)})
 
-    def read_artifact_content_from_remote(self, issue_number: str | int, artifact_type: str, path: str) -> str | None:
+    def read_artifact_content_from_remote(self, item_id: ItemId, artifact_type: str, path: str) -> str | None:
         """Read artifact content from the linked Gist.
 
         Sanitises *path* to a Gist filename and looks it up in the Gist file
@@ -583,7 +588,7 @@ class GitHubGistArtifactProvider:
         absent.
 
         Args:
-            issue_number: GitHub Issue number (positive integer).
+            item_id: GitHub Issue number (positive integer).
             artifact_type: Artifact type string (not used for lookup — *path*
                 is the unique key in the Gist).
             path: Repo-relative artifact path, e.g. ``plan/architect-foo.md``.
@@ -591,13 +596,13 @@ class GitHubGistArtifactProvider:
         Returns:
             Stored content string, or ``None`` when not found.
         """
-        issue_number = _reject_beads_issue_number("GitHubGistArtifactProvider", issue_number)
+        item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         repo = get_github(self._repo)
         owner, repo_name = self._repo.split("/", 1)
-        issue = _fetch_issue_graphql(repo, owner, repo_name, issue_number)
+        issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
         body = issue.get("body") or ""
 
-        gist = self._get_gist(issue_number, body)
+        gist = self._get_gist(item_id, body)
         if gist is None:
             return None
 
@@ -663,28 +668,28 @@ class GitHubGistArtifactProvider:
             msg = f"Path traversal detected: {path!r} resolves outside the repository root."
             raise ValueError(msg) from None
 
-    def _get_gist(self, issue_number: int, body: str) -> Gist | None:
-        """Load the Gist for *issue_number* from the cache or sentinel in *body*.
+    def _get_gist(self, item_id: int, body: str) -> Gist | None:
+        """Load the Gist for *item_id* from the cache or sentinel in *body*.
 
         Args:
-            issue_number: GitHub Issue number (positive integer).
+            item_id: GitHub Issue number (positive integer).
             body: Current GitHub Issue body text to search for the sentinel.
 
         Returns:
             The Gist object, or ``None`` when no Gist is linked to this issue.
         """
-        if issue_number in self._gist_cache:
-            return self._gist_cache[issue_number]
+        if item_id in self._gist_cache:
+            return self._gist_cache[item_id]
         match = _GIST_SENTINEL_RE.search(body)
         if match:
             gh = _make_github_client()
             gist = gh.get_gist(match.group("gist_id"))
-            self._gist_cache[issue_number] = gist
+            self._gist_cache[item_id] = gist
             return gist
         return None
 
     def _create_and_link_gist(
-        self, issue_number: int, issue_id: str, body: str, initial_files: dict[str, InputFileContent]
+        self, item_id: int, issue_id: str, body: str, initial_files: dict[str, InputFileContent]
     ) -> Gist:
         """Create a new private Gist, cache it, and write the sentinel to the issue.
 
@@ -693,7 +698,7 @@ class GitHubGistArtifactProvider:
         appending otherwise — via a GraphQL ``updateIssue`` mutation.
 
         Args:
-            issue_number: GitHub Issue number (used for the Gist description
+            item_id: GitHub Issue number (used for the Gist description
                 and instance cache key).
             issue_id: GitHub GraphQL node ID for the issue (used by
                 :func:`_update_issue_graphql`).
@@ -713,15 +718,13 @@ class GitHubGistArtifactProvider:
         gh = _make_github_client()
         user = cast("AuthenticatedUser", gh.get_user())
         try:
-            gist = user.create_gist(
-                public=False, files=initial_files, description=f"artifact-manifest-issue-{issue_number}"
-            )
+            gist = user.create_gist(public=False, files=initial_files, description=f"artifact-manifest-item-{item_id}")
         except GithubException as exc:
             if exc.status == _GIST_FORBIDDEN_STATUS:
                 msg = "GitHub token missing 'gist' scope — grant it at https://github.com/settings/tokens"
                 raise BacklogError(msg) from exc
             raise
-        self._gist_cache[issue_number] = gist
+        self._gist_cache[item_id] = gist
         sentinel = f"<!-- artifact-gist:{gist.id} -->"
         new_body = _replace_old_manifest_with_sentinel(body, sentinel)
         repo = get_github(self._repo)
@@ -796,16 +799,17 @@ class LinearArtifactProvider:
     # ArtifactBackend implementation
     # ------------------------------------------------------------------
 
-    def get_manifest(self, issue_number: str | int) -> ArtifactManifest:
-        """Retrieve the artifact manifest for *issue_number*.
+    def get_manifest(self, item_id: ItemId) -> ArtifactManifest:
+        """Retrieve the artifact manifest for *item_id*.
 
         Fetches all Linear attachments for the issue and looks for one
-        whose URL matches ``dh://artifact-manifest/{issue_number}``.
+        whose URL matches ``dh://artifact-manifest/{item_id}``.
         Parses ``metadata["manifest_json"]`` and returns the result.
         Returns an empty manifest when no matching attachment exists.
 
         Args:
-            issue_number: Issue identifier passed as the Linear issue UUID.
+            item_id: Issue identifier — Linear issue UUID (string) or
+                integer coerced to string via ``str(item_id)``.
 
         Returns:
             Parsed ``ArtifactManifest``.  Empty when no manifest attachment
@@ -814,9 +818,8 @@ class LinearArtifactProvider:
         Raises:
             backlog_core.models.BacklogError: On Linear API failures.
         """
-        issue_number = _reject_beads_issue_number("LinearArtifactProvider", issue_number)
-        target_url = f"dh://artifact-manifest/{issue_number}"
-        nodes = linear_get_attachments(self._api_key, str(issue_number))
+        target_url = f"dh://artifact-manifest/{item_id}"
+        nodes = linear_get_attachments(self._api_key, str(item_id))
         for node in nodes:
             if node.get("url") == target_url:
                 raw_metadata = node.get("metadata")
@@ -825,13 +828,13 @@ class LinearArtifactProvider:
                     manifest_json = metadata.get("manifest_json")
                     if isinstance(manifest_json, str):
                         return ArtifactManifest.model_validate_json(manifest_json)
-        return ArtifactManifest(issue_number=issue_number)
+        return ArtifactManifest(issue_number=item_id)
 
-    def set_manifest(self, issue_number: str | int, manifest: ArtifactManifest) -> None:
-        """Persist *manifest* as a Linear attachment on *issue_number*.
+    def set_manifest(self, item_id: ItemId, manifest: ArtifactManifest) -> None:
+        """Persist *manifest* as a Linear attachment on *item_id*.
 
         Serialises the manifest to JSON and creates (or upserts) a Linear
-        attachment with URL ``dh://artifact-manifest/{issue_number}``.
+        attachment with URL ``dh://artifact-manifest/{item_id}``.
         Linear treats the same URL on the same issue as idempotent — the
         existing attachment is updated rather than duplicated.
 
@@ -840,33 +843,34 @@ class LinearArtifactProvider:
         metadata has undocumented size limits.
 
         Args:
-            issue_number: Issue identifier passed as the Linear issue UUID.
+            item_id: Issue identifier — Linear issue UUID (string) or
+                integer coerced to string via ``str(item_id)``.
             manifest: Updated manifest to persist.
 
         Raises:
             backlog_core.models.BacklogError: On Linear API failures.
         """
-        issue_number = _reject_beads_issue_number("LinearArtifactProvider", issue_number)
         manifest_json = manifest.model_dump_json(by_alias=True)
         if len(manifest_json) > _LINEAR_MANIFEST_WARN_CHARS:
             logger.warning("Linear manifest exceeds 10K chars; truncation risk (size=%d)", len(manifest_json))
         linear_create_attachment(
             self._api_key,
-            str(issue_number),
-            url=f"dh://artifact-manifest/{issue_number}",
+            str(item_id),
+            url=f"dh://artifact-manifest/{item_id}",
             title="DH Artifact Manifest",
             metadata={"manifest_json": manifest_json},
         )
 
-    def store_artifact_content(self, issue_number: str | int, artifact_type: str, path: str, content: str) -> None:
-        """Store artifact content as a Linear attachment on *issue_number*.
+    def store_artifact_content(self, item_id: ItemId, artifact_type: str, path: str, content: str) -> None:
+        """Store artifact content as a Linear attachment on *item_id*.
 
         Creates (or upserts) a Linear attachment using the URL scheme
-        ``dh://artifact-content/{issue_number}/{artifact_type}/{safe_path}``
+        ``dh://artifact-content/{item_id}/{artifact_type}/{safe_path}``
         where ``safe_path`` has ``/`` replaced with ``--``.
 
         Args:
-            issue_number: Issue identifier passed as the Linear issue UUID.
+            item_id: Issue identifier — Linear issue UUID (string) or
+                integer coerced to string via ``str(item_id)``.
             artifact_type: Artifact type string, e.g. ``"research"``.
             path: Repo-relative artifact path, e.g.
                 ``plan/architect-foo.md``.
@@ -875,18 +879,17 @@ class LinearArtifactProvider:
         Raises:
             backlog_core.models.BacklogError: On Linear API failures.
         """
-        issue_number = _reject_beads_issue_number("LinearArtifactProvider", issue_number)
         safe_path = path.replace("/", "--")
-        url = f"dh://artifact-content/{issue_number}/{artifact_type}/{safe_path}"
+        url = f"dh://artifact-content/{item_id}/{artifact_type}/{safe_path}"
         linear_create_attachment(
             self._api_key,
-            str(issue_number),
+            str(item_id),
             url=url,
             title=f"DH Artifact: {artifact_type}/{path}",
             metadata={"content": content},
         )
 
-    def read_artifact_content_from_remote(self, issue_number: str | int, artifact_type: str, path: str) -> str | None:
+    def read_artifact_content_from_remote(self, item_id: ItemId, artifact_type: str, path: str) -> str | None:
         """Read artifact content from a Linear attachment.
 
         Sanitises *path* to the ``dh://`` URL form and scans all
@@ -894,7 +897,8 @@ class LinearArtifactProvider:
         ``metadata["content"]`` value when found.
 
         Args:
-            issue_number: Issue identifier passed as the Linear issue UUID.
+            item_id: Issue identifier — Linear issue UUID (string) or
+                integer coerced to string via ``str(item_id)``.
             artifact_type: Artifact type string to match.
             path: Repo-relative artifact path to match.
 
@@ -905,10 +909,9 @@ class LinearArtifactProvider:
         Raises:
             backlog_core.models.BacklogError: On Linear API failures.
         """
-        issue_number = _reject_beads_issue_number("LinearArtifactProvider", issue_number)
         safe_path = path.replace("/", "--")
-        target_url = f"dh://artifact-content/{issue_number}/{artifact_type}/{safe_path}"
-        nodes = linear_get_attachments(self._api_key, str(issue_number))
+        target_url = f"dh://artifact-content/{item_id}/{artifact_type}/{safe_path}"
+        nodes = linear_get_attachments(self._api_key, str(item_id))
         for node in nodes:
             if node.get("url") == target_url:
                 raw_metadata = node.get("metadata")
@@ -1057,15 +1060,15 @@ class GitLabArtifactProvider:
     # ArtifactBackend implementation
     # ------------------------------------------------------------------
 
-    def get_manifest(self, issue_number: str | int) -> ArtifactManifest:
-        """Retrieve the artifact manifest for *issue_number*.
+    def get_manifest(self, item_id: ItemId) -> ArtifactManifest:
+        """Retrieve the artifact manifest for *item_id*.
 
         Lists issue notes and scans for a snippet sentinel comment.  If found,
         loads ``manifest.json`` from the linked snippet.  Returns an empty
         manifest when no manifest data is present.
 
         Args:
-            issue_number: GitLab issue IID (positive integer).
+            item_id: GitLab issue IID (positive integer).
 
         Returns:
             Parsed ``ArtifactManifest``.  Empty when no manifest is stored.
@@ -1073,34 +1076,34 @@ class GitLabArtifactProvider:
         Raises:
             backlog_core.models.BacklogError: On GitLab API failures.
         """
-        issue_number = _reject_beads_issue_number("GitLabArtifactProvider", issue_number)
-        snippet_id = self._get_snippet_id_from_notes(issue_number)
+        item_id = _require_int_item_id("GitLabArtifactProvider", item_id)
+        snippet_id = self._get_snippet_id_from_notes(item_id)
         if snippet_id is None:
-            return ArtifactManifest(issue_number=issue_number)
+            return ArtifactManifest(issue_number=item_id)
 
-        self._snippet_cache[issue_number] = snippet_id
+        self._snippet_cache[item_id] = snippet_id
         snippet = gitlab_get_snippet(self._project_id, snippet_id, self._private_token, self._gitlab_url)
         manifest_json = snippet["files_content"].get("manifest.json")
         if manifest_json is None:
-            return ArtifactManifest(issue_number=issue_number)
+            return ArtifactManifest(issue_number=item_id)
         return ArtifactManifest.model_validate_json(manifest_json)
 
-    def set_manifest(self, issue_number: str | int, manifest: ArtifactManifest) -> None:
+    def set_manifest(self, item_id: ItemId, manifest: ArtifactManifest) -> None:
         """Persist *manifest* by writing it to the linked snippet.
 
         If no snippet exists yet, one is created and a sentinel note is posted
         on the issue.
 
         Args:
-            issue_number: GitLab issue IID (positive integer).
+            item_id: GitLab issue IID (positive integer).
             manifest: Updated manifest to persist.
 
         Raises:
             backlog_core.models.BacklogError: On GitLab API failures.
         """
-        issue_number = _reject_beads_issue_number("GitLabArtifactProvider", issue_number)
+        item_id = _require_int_item_id("GitLabArtifactProvider", item_id)
         manifest_json = manifest.model_dump_json(by_alias=True)
-        snippet_id = self._get_or_create_snippet(issue_number)
+        snippet_id = self._get_or_create_snippet(item_id)
         gitlab_update_snippet(
             self._project_id,
             snippet_id,
@@ -1109,7 +1112,7 @@ class GitLabArtifactProvider:
             files=[{"action": "update", "file_path": "manifest.json", "content": manifest_json}],
         )
 
-    def store_artifact_content(self, issue_number: str | int, artifact_type: str, path: str, content: str) -> None:
+    def store_artifact_content(self, item_id: ItemId, artifact_type: str, path: str, content: str) -> None:
         """Store artifact content as a file in the linked snippet.
 
         The artifact *path* is sanitised for use as a snippet filename by
@@ -1118,7 +1121,7 @@ class GitLabArtifactProvider:
         added.
 
         Args:
-            issue_number: GitLab issue IID (positive integer).
+            item_id: GitLab issue IID (positive integer).
             artifact_type: Artifact type string (e.g. ``"research"``).
                 Not used in the snippet filename — *path* is the unique key.
             path: Repo-relative artifact path, e.g. ``plan/architect-foo.md``.
@@ -1127,9 +1130,9 @@ class GitLabArtifactProvider:
         Raises:
             backlog_core.models.BacklogError: On GitLab API failures.
         """
-        issue_number = _reject_beads_issue_number("GitLabArtifactProvider", issue_number)
+        item_id = _require_int_item_id("GitLabArtifactProvider", item_id)
         safe_path = path.replace("/", "--") + ".txt"
-        snippet_id = self._get_or_create_snippet(issue_number)
+        snippet_id = self._get_or_create_snippet(item_id)
         # Attempt update; if the file does not yet exist, create it instead.
         try:
             gitlab_update_snippet(
@@ -1148,7 +1151,7 @@ class GitLabArtifactProvider:
                 files=[{"action": "create", "file_path": safe_path, "content": content}],
             )
 
-    def read_artifact_content_from_remote(self, issue_number: str | int, artifact_type: str, path: str) -> str | None:
+    def read_artifact_content_from_remote(self, item_id: ItemId, artifact_type: str, path: str) -> str | None:
         """Read artifact content from the linked snippet.
 
         Sanitises *path* to the snippet filename form and looks it up in the
@@ -1156,7 +1159,7 @@ class GitLabArtifactProvider:
         the file is absent.
 
         Args:
-            issue_number: GitLab issue IID (positive integer).
+            item_id: GitLab issue IID (positive integer).
             artifact_type: Artifact type string (not used for lookup — *path*
                 is the unique key in the snippet).
             path: Repo-relative artifact path, e.g. ``plan/architect-foo.md``.
@@ -1167,9 +1170,9 @@ class GitLabArtifactProvider:
         Raises:
             backlog_core.models.BacklogError: On GitLab API failures.
         """
-        issue_number = _reject_beads_issue_number("GitLabArtifactProvider", issue_number)
+        item_id = _require_int_item_id("GitLabArtifactProvider", item_id)
         safe_path = path.replace("/", "--") + ".txt"
-        snippet_id = self._get_snippet_id_from_notes(issue_number)
+        snippet_id = self._get_snippet_id_from_notes(item_id)
         if snippet_id is None:
             return None
         snippet = gitlab_get_snippet(self._project_id, snippet_id, self._private_token, self._gitlab_url)
@@ -1246,11 +1249,11 @@ class GitLabArtifactProvider:
     # Snippet linkage helpers
     # ------------------------------------------------------------------
 
-    def _get_snippet_id_from_notes(self, issue_number: int) -> int | None:
+    def _get_snippet_id_from_notes(self, item_id: int) -> int | None:
         """Scan issue notes for the snippet sentinel and return the snippet ID.
 
         Args:
-            issue_number: GitLab issue IID (positive integer).
+            item_id: GitLab issue IID (positive integer).
 
         Returns:
             Integer snippet ID when found, or ``None`` when no sentinel note
@@ -1259,27 +1262,27 @@ class GitLabArtifactProvider:
         Raises:
             backlog_core.models.BacklogError: On GitLab API failures.
         """
-        if issue_number in self._snippet_cache:
-            return self._snippet_cache[issue_number]
-        notes = gitlab_list_issue_notes(self._project_id, issue_number, self._private_token, self._gitlab_url)
+        if item_id in self._snippet_cache:
+            return self._snippet_cache[item_id]
+        notes = gitlab_list_issue_notes(self._project_id, item_id, self._private_token, self._gitlab_url)
         for note in notes:
             body = note.get("body") or ""
             match = _SNIPPET_SENTINEL_RE.search(body)
             if match:
                 snippet_id = int(match.group("snippet_id"))
-                self._snippet_cache[issue_number] = snippet_id
+                self._snippet_cache[item_id] = snippet_id
                 return snippet_id
         return None
 
-    def _get_or_create_snippet(self, issue_number: int) -> int:
-        """Return the snippet ID for *issue_number*, creating one if absent.
+    def _get_or_create_snippet(self, item_id: int) -> int:
+        """Return the snippet ID for *item_id*, creating one if absent.
 
         Checks the in-memory cache first, then scans issue notes.  When no
         snippet exists, creates a new private snippet with an empty
         ``manifest.json`` and posts a sentinel note on the issue.
 
         Args:
-            issue_number: GitLab issue IID (positive integer).
+            item_id: GitLab issue IID (positive integer).
 
         Returns:
             Integer snippet ID.
@@ -1287,7 +1290,7 @@ class GitLabArtifactProvider:
         Raises:
             backlog_core.models.BacklogError: On GitLab API failures.
         """
-        cached = self._get_snippet_id_from_notes(issue_number)
+        cached = self._get_snippet_id_from_notes(item_id)
         if cached is not None:
             return cached
 
@@ -1295,15 +1298,15 @@ class GitLabArtifactProvider:
             self._project_id,
             self._private_token,
             self._gitlab_url,
-            title=f"dh-artifact-manifest-issue-{issue_number}",
+            title=f"dh-artifact-manifest-item-{item_id}",
             files=[{"file_path": "manifest.json", "content": "{}"}],
             visibility="private",
         )
         snippet_id: int = result["id"]
-        self._snippet_cache[issue_number] = snippet_id
+        self._snippet_cache[item_id] = snippet_id
 
         sentinel = f"<!-- artifact-snippet:{snippet_id} -->"
-        gitlab_create_issue_note(self._project_id, issue_number, self._private_token, self._gitlab_url, body=sentinel)
+        gitlab_create_issue_note(self._project_id, item_id, self._private_token, self._gitlab_url, body=sentinel)
         return snippet_id
 
 

--- a/plugins/development-harness/backlog_core/artifact_provider_local.py
+++ b/plugins/development-harness/backlog_core/artifact_provider_local.py
@@ -98,7 +98,7 @@ class LocalFilesystemArtifactProvider:
         guarantees a reader sees either the old or new file, never torn data).
 
         Args:
-            item_id: Issue number (positive integer).
+            item_id: Issue number or beads string identifier (``str | int``).
 
         Returns:
             ``ArtifactManifest`` for the issue.  Empty manifest when no file
@@ -110,10 +110,7 @@ class LocalFilesystemArtifactProvider:
         """
         manifest_path = self._manifest_path(item_id)
         if not manifest_path.exists():
-            # Use 0 as a sentinel when item_id is a beads string — the manifest
-            # field is typed int, but the local provider stores by filename stem only.
-            issue_int = item_id if isinstance(item_id, int) else 0
-            return ArtifactManifest(issue_number=issue_int)
+            return ArtifactManifest(issue_number=item_id)
         content = manifest_path.read_text(encoding="utf-8")
         # json.loads raises json.JSONDecodeError (a ValueError subclass) for corrupt JSON.
         # Using two-step parse so corrupt JSON raises ValueError, not pydantic.ValidationError.
@@ -132,7 +129,7 @@ class LocalFilesystemArtifactProvider:
         ensures all entries carry ``storage_tier='local'`` before writing.
 
         Args:
-            item_id: Issue number (positive integer).
+            item_id: Issue number or beads string identifier (``str | int``).
             manifest: Updated manifest to persist.
         """
         manifest_path = self._manifest_path(item_id)

--- a/plugins/development-harness/backlog_core/artifact_provider_local.py
+++ b/plugins/development-harness/backlog_core/artifact_provider_local.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     # Imported for type annotations only.  At runtime this module may be loaded
     # before artifact_provider.py (T03 wires the two together), so the runtime
     # import is deferred to TYPE_CHECKING to avoid a circular import.
-    from backlog_core.artifact_provider import ArtifactBackend
+    from backlog_core.artifact_provider import ArtifactBackend, ItemId
 
 
 class LocalFilesystemArtifactProvider:
@@ -90,15 +90,15 @@ class LocalFilesystemArtifactProvider:
     # ArtifactBackend protocol implementation
     # ------------------------------------------------------------------
 
-    def get_manifest(self, issue_number: str | int) -> ArtifactManifest:
-        """Retrieve the artifact manifest for *issue_number*.
+    def get_manifest(self, item_id: ItemId) -> ArtifactManifest:
+        """Retrieve the artifact manifest for *item_id*.
 
         Returns an empty manifest when no manifest file exists for the issue —
         this is not an error.  Reads are lock-free (``os.replace`` atomicity
         guarantees a reader sees either the old or new file, never torn data).
 
         Args:
-            issue_number: Issue number (positive integer).
+            item_id: Issue number (positive integer).
 
         Returns:
             ``ArtifactManifest`` for the issue.  Empty manifest when no file
@@ -108,11 +108,11 @@ class LocalFilesystemArtifactProvider:
             ValueError: When the manifest file exists but contains invalid JSON
                 (``json.JSONDecodeError`` is a subclass of ``ValueError``).
         """
-        manifest_path = self._manifest_path(issue_number)
+        manifest_path = self._manifest_path(item_id)
         if not manifest_path.exists():
-            # Use 0 as a sentinel when issue_number is a beads string — the manifest
+            # Use 0 as a sentinel when item_id is a beads string — the manifest
             # field is typed int, but the local provider stores by filename stem only.
-            issue_int = issue_number if isinstance(issue_number, int) else 0
+            issue_int = item_id if isinstance(item_id, int) else 0
             return ArtifactManifest(issue_number=issue_int)
         content = manifest_path.read_text(encoding="utf-8")
         # json.loads raises json.JSONDecodeError (a ValueError subclass) for corrupt JSON.
@@ -120,8 +120,8 @@ class LocalFilesystemArtifactProvider:
         data = json.loads(content)
         return ArtifactManifest.model_validate(data)
 
-    def set_manifest(self, issue_number: str | int, manifest: ArtifactManifest) -> None:
-        """Persist *manifest* for *issue_number* atomically.
+    def set_manifest(self, item_id: ItemId, manifest: ArtifactManifest) -> None:
+        """Persist *manifest* for *item_id* atomically.
 
         Acquires an exclusive advisory lock on the per-issue lock file before
         writing, then writes to a temporary file and replaces the target
@@ -132,11 +132,11 @@ class LocalFilesystemArtifactProvider:
         ensures all entries carry ``storage_tier='local'`` before writing.
 
         Args:
-            issue_number: Issue number (positive integer).
+            item_id: Issue number (positive integer).
             manifest: Updated manifest to persist.
         """
-        manifest_path = self._manifest_path(issue_number)
-        lock_path = self._lock_path(issue_number)
+        manifest_path = self._manifest_path(item_id)
+        lock_path = self._lock_path(item_id)
 
         # Create the manifest directory on first write (mode 0o700 — not world-readable).
         manifest_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -190,7 +190,7 @@ class LocalFilesystemArtifactProvider:
         resolved = self._validate_artifact_path(path)
         return resolved.read_text(encoding="utf-8")
 
-    def store_artifact_content(self, issue_number: str | int, artifact_type: str, path: str, content: str) -> None:
+    def store_artifact_content(self, item_id: ItemId, artifact_type: str, path: str, content: str) -> None:
         """Store artifact content as a file in the repository worktree.
 
         Writes content only when the target file does **not** already exist.
@@ -198,7 +198,7 @@ class LocalFilesystemArtifactProvider:
         Manifest updates are the caller's responsibility via :meth:`set_manifest`.
 
         Args:
-            issue_number: Issue number (positive integer or beads string).  Not used by this
+            item_id: Issue number (positive integer or beads string).  Not used by this
                 provider — included to satisfy the :class:`ArtifactBackend`
                 protocol.
             artifact_type: Artifact type string (e.g. ``"research"``).  Not
@@ -215,14 +215,14 @@ class LocalFilesystemArtifactProvider:
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
 
-    def read_artifact_content_from_remote(self, issue_number: str | int, artifact_type: str, path: str) -> str | None:
+    def read_artifact_content_from_remote(self, item_id: ItemId, artifact_type: str, path: str) -> str | None:
         """Read artifact content.
 
         This provider has no remote backend.  Delegates to
         :meth:`read_local_artifact_content`.
 
         Args:
-            issue_number: Issue number (positive integer or beads string).  Not used.
+            item_id: Issue number (positive integer or beads string).  Not used.
             artifact_type: Artifact type string.  Not used.
             path: Repo-relative path to the artifact file.
 
@@ -274,30 +274,30 @@ class LocalFilesystemArtifactProvider:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _manifest_path(self, issue_number: str | int) -> Path:
-        """Return the path to the manifest JSON file for *issue_number*.
+    def _manifest_path(self, item_id: ItemId) -> Path:
+        """Return the path to the manifest JSON file for *item_id*.
 
         Args:
-            issue_number: Issue number (integer or beads string — used as filename stem).
+            item_id: Issue number (integer or beads string — used as filename stem).
 
         Returns:
-            Absolute path: ``{manifest_dir}/{issue_number}.json``.
+            Absolute path: ``{manifest_dir}/{item_id}.json``.
         """
-        return self._manifest_dir / f"{issue_number}.json"
+        return self._manifest_dir / f"{item_id}.json"
 
-    def _lock_path(self, issue_number: str | int) -> Path:
-        """Return the path to the advisory lock file for *issue_number*.
+    def _lock_path(self, item_id: ItemId) -> Path:
+        """Return the path to the advisory lock file for *item_id*.
 
         Lock files are created on first acquire and **never** deleted
         (TOCTOU risk per architect ADR-003).
 
         Args:
-            issue_number: Issue number.
+            item_id: Issue number.
 
         Returns:
-            Absolute path: ``{manifest_dir}/{issue_number}.lock``.
+            Absolute path: ``{manifest_dir}/{item_id}.lock``.
         """
-        return self._manifest_dir / f"{issue_number}.lock"
+        return self._manifest_dir / f"{item_id}.lock"
 
     def _validate_artifact_path(self, path: str) -> Path:
         """Resolve *path* relative to the root worktree and check for traversal.

--- a/plugins/development-harness/backlog_core/artifact_registry.py
+++ b/plugins/development-harness/backlog_core/artifact_registry.py
@@ -30,8 +30,12 @@ from __future__ import annotations
 
 import re
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from .models import ArtifactEntry, ArtifactManifest, ArtifactStatus, ArtifactType
+
+if TYPE_CHECKING:
+    from .artifact_provider import ItemId
 
 # ---------------------------------------------------------------------------
 # Manifest section constants
@@ -115,7 +119,7 @@ def _extract_table_from_rendered(rendered: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def parse_manifest_section(issue_body: str, issue_number: int) -> ArtifactManifest:
+def parse_manifest_section(issue_body: str, item_id: ItemId) -> ArtifactManifest:
     """Extract and parse the artifact manifest section from an issue body.
 
     Returns an empty ``ArtifactManifest`` when no manifest section is found —
@@ -124,7 +128,7 @@ def parse_manifest_section(issue_body: str, issue_number: int) -> ArtifactManife
 
     Args:
         issue_body: Full GitHub Issue body text.
-        issue_number: Issue number for the returned manifest object.
+        item_id: Item identifier for the returned manifest object (``str | int``).
 
     Returns:
         ``ArtifactManifest`` parsed from the delimited section, or an empty
@@ -132,7 +136,7 @@ def parse_manifest_section(issue_body: str, issue_number: int) -> ArtifactManife
     """
     match = _MANIFEST_SECTION_RE.search(issue_body)
     if not match:
-        return ArtifactManifest(issue_number=issue_number)
+        return ArtifactManifest(issue_number=item_id)
 
     section = match.group(0)
     artifacts: list[ArtifactEntry] = []
@@ -140,7 +144,7 @@ def parse_manifest_section(issue_body: str, issue_number: int) -> ArtifactManife
         entry = _parse_table_row(line)
         if entry is not None:
             artifacts.append(entry)
-    return ArtifactManifest(issue_number=issue_number, artifacts=artifacts)
+    return ArtifactManifest(issue_number=item_id, artifacts=artifacts)
 
 
 def render_manifest_section(manifest: ArtifactManifest) -> str:

--- a/plugins/development-harness/backlog_core/backends/beads_artifact_provider.py
+++ b/plugins/development-harness/backlog_core/backends/beads_artifact_provider.py
@@ -32,15 +32,16 @@ in-place; otherwise it is appended to the notes.
 ADR-002 type widening
 ---------------------
 The :class:`~backlog_core.artifact_provider.ArtifactBackend` Protocol defines
-``issue_number: int`` parameters, but the beads backend uses string issue IDs
-(e.g. ``bd-a3f8``).  The Protocol methods raise :exc:`NotImplementedError`
-when called with an actual ``int``.  All beads-aware callers should use the
-shadow ``*_bd(issue_id: str)`` methods directly.
+``item_id: ItemId`` parameters (``ItemId = str | int``), but the beads backend
+uses string issue IDs (e.g. ``bd-a3f8``).  The Protocol methods raise
+:exc:`NotImplementedError` when called with an actual ``int``.  All
+beads-aware callers should use the shadow ``*_bd(issue_id: str)`` methods
+directly.
 
-At runtime the Protocol methods also accept ``str`` values transparently (type
+At runtime the Protocol methods accept ``str`` values transparently (type
 widening), so code that has already resolved a beads ID string and stores it
-in a variable typed as ``int`` will work correctly — this matches the widened
-behaviour described in ADR-002.
+in a variable typed as ``ItemId`` will work correctly — this matches the
+widened behaviour described in ADR-002.
 """
 
 from __future__ import annotations

--- a/plugins/development-harness/backlog_core/backends/beads_artifact_provider.py
+++ b/plugins/development-harness/backlog_core/backends/beads_artifact_provider.py
@@ -50,7 +50,7 @@ import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from backlog_core.backends.bd_runner import BdRunner
 from backlog_core.backends.beads_models import BeadsIssueRaw, parse_issue
@@ -62,6 +62,9 @@ if str(_plugin_root) not in sys.path:
     sys.path.insert(0, str(_plugin_root))
 
 import dh_paths as _dh_paths
+
+if TYPE_CHECKING:
+    from backlog_core.artifact_provider import ItemId
 
 __all__ = ["BeadsArtifactProvider"]
 
@@ -218,7 +221,7 @@ class BeadsArtifactProvider:
     # ArtifactBackend Protocol implementation
     # -----------------------------------------------------------------------
 
-    def get_manifest(self, issue_number: str | int) -> ArtifactManifest:
+    def get_manifest(self, item_id: ItemId) -> ArtifactManifest:
         """Retrieve the artifact manifest.
 
         Accepts a beads string ID at runtime (ADR-002 type widening).
@@ -226,7 +229,7 @@ class BeadsArtifactProvider:
         integer issue numbers.
 
         Args:
-            issue_number: Beads string ID accepted at runtime (e.g.
+            item_id: Beads string ID accepted at runtime (e.g.
                 ``"bd-a3f8"``).  Actual ``int`` values raise
                 :exc:`NotImplementedError`.
 
@@ -235,32 +238,32 @@ class BeadsArtifactProvider:
             manifest is stored — this is not an error.
 
         Raises:
-            NotImplementedError: When *issue_number* is an actual ``int``.
+            NotImplementedError: When *item_id* is an actual ``int``.
         """
-        if isinstance(issue_number, str):
-            return self.get_manifest_bd(issue_number)
+        if isinstance(item_id, str):
+            return self.get_manifest_bd(item_id)
         msg = (
             "BeadsArtifactProvider does not support integer issue numbers. "
             "Call get_manifest_bd(issue_id: str) with a beads ID instead."
         )
         raise NotImplementedError(msg)
 
-    def set_manifest(self, issue_number: str | int, manifest: ArtifactManifest) -> None:
+    def set_manifest(self, item_id: ItemId, manifest: ArtifactManifest) -> None:
         """Persist *manifest*.
 
         Accepts a beads string ID at runtime (ADR-002 type widening).
         Raises when called with an actual ``int``.
 
         Args:
-            issue_number: Beads string ID accepted at runtime.  Actual
+            item_id: Beads string ID accepted at runtime.  Actual
                 ``int`` values raise :exc:`NotImplementedError`.
             manifest: Updated manifest to persist.
 
         Raises:
-            NotImplementedError: When *issue_number* is an actual ``int``.
+            NotImplementedError: When *item_id* is an actual ``int``.
         """
-        if isinstance(issue_number, str):
-            self.set_manifest_bd(issue_number, manifest)
+        if isinstance(item_id, str):
+            self.set_manifest_bd(item_id, manifest)
             return
         msg = (
             "BeadsArtifactProvider does not support integer issue numbers. "
@@ -288,24 +291,24 @@ class BeadsArtifactProvider:
         resolved = (self._resolved_root_worktree / path).resolve()
         return resolved.read_text(encoding="utf-8")
 
-    def store_artifact_content(self, issue_number: str | int, artifact_type: str, path: str, content: str) -> None:
+    def store_artifact_content(self, item_id: ItemId, artifact_type: str, path: str, content: str) -> None:
         """Store artifact content in bd notes as a sentinel-delimited block.
 
         Accepts a beads string ID at runtime (ADR-002 type widening).
         Raises when called with an actual ``int``.
 
         Args:
-            issue_number: Beads string ID accepted at runtime.  Actual
+            item_id: Beads string ID accepted at runtime.  Actual
                 ``int`` values raise :exc:`NotImplementedError`.
             artifact_type: Artifact type string (e.g. ``"research"``).
             path: Logical artifact identifier used as the block ``id``.
             content: Full artifact content to store.
 
         Raises:
-            NotImplementedError: When *issue_number* is an actual ``int``.
+            NotImplementedError: When *item_id* is an actual ``int``.
         """
-        if isinstance(issue_number, str):
-            self.store_artifact_content_bd(issue_number, artifact_type, path, content)
+        if isinstance(item_id, str):
+            self.store_artifact_content_bd(item_id, artifact_type, path, content)
             return
         msg = (
             "BeadsArtifactProvider does not support integer issue numbers. "
@@ -313,14 +316,14 @@ class BeadsArtifactProvider:
         )
         raise NotImplementedError(msg)
 
-    def read_artifact_content_from_remote(self, issue_number: str | int, artifact_type: str, path: str) -> str | None:
+    def read_artifact_content_from_remote(self, item_id: ItemId, artifact_type: str, path: str) -> str | None:
         """Search bd notes for a stored artifact content block.
 
         Accepts a beads string ID at runtime (ADR-002 type widening).
         Raises when called with an actual ``int``.
 
         Args:
-            issue_number: Beads string ID accepted at runtime.  Actual
+            item_id: Beads string ID accepted at runtime.  Actual
                 ``int`` values raise :exc:`NotImplementedError`.
             artifact_type: Artifact type string to match.
             path: Logical artifact identifier to match.
@@ -330,10 +333,10 @@ class BeadsArtifactProvider:
             matching block exists.
 
         Raises:
-            NotImplementedError: When *issue_number* is an actual ``int``.
+            NotImplementedError: When *item_id* is an actual ``int``.
         """
-        if isinstance(issue_number, str):
-            return self.read_artifact_content_from_remote_bd(issue_number, artifact_type, path)
+        if isinstance(item_id, str):
+            return self.read_artifact_content_from_remote_bd(item_id, artifact_type, path)
         msg = (
             "BeadsArtifactProvider does not support integer issue numbers. "
             "Call read_artifact_content_from_remote_bd(issue_id: str, ...) with a beads ID instead."
@@ -471,23 +474,23 @@ class BeadsArtifactProvider:
         notes = issue.notes or ""
         return _extract_content_block(notes, artifact_type, path)
 
-    def delete_entry(self, issue_number: str | int, artifact_type: str, path: str) -> None:
+    def delete_entry(self, item_id: ItemId, artifact_type: str, path: str) -> None:
         """Remove an artifact entry from the manifest and its content block from notes.
 
         Accepts a beads string ID at runtime (ADR-002 type widening).
         Raises when called with an actual ``int``.
 
         Args:
-            issue_number: Beads string ID accepted at runtime.  Actual
+            item_id: Beads string ID accepted at runtime.  Actual
                 ``int`` values raise :exc:`NotImplementedError`.
             artifact_type: Artifact type string to match.
             path: Logical artifact identifier to match.
 
         Raises:
-            NotImplementedError: When *issue_number* is an actual ``int``.
+            NotImplementedError: When *item_id* is an actual ``int``.
         """
-        if isinstance(issue_number, str):
-            self.delete_entry_bd(issue_number, artifact_type, path)
+        if isinstance(item_id, str):
+            self.delete_entry_bd(item_id, artifact_type, path)
             return
         msg = (
             "BeadsArtifactProvider does not support integer issue numbers. "

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -1378,6 +1378,10 @@ class ArtifactManifest(BaseModel):
     ``backlog_core.artifact_registry``.
     """
 
+    # Intentional mismatch: ArtifactBackend Protocol uses `item_id` as the parameter name;
+    # this internal model field keeps `issue_number` because it is never serialized to an
+    # external format (manifests live in GitHub Issue body markdown, not JSON files) and
+    # renaming would touch 97 call sites across 11 files for zero functional gain.
     issue_number: str | int = Field(
         ...,
         description="Issue identifier this manifest belongs to (int for GitHub/GitLab, str UUID for Linear, str nanoid for beads).",

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -28,7 +28,7 @@ from pydantic import Field
 from ruamel.yaml import YAML as _YAML, YAMLError as _YAMLError
 
 from . import models as _models, operations
-from .artifact_provider import ArtifactBackend, create_artifact_provider
+from .artifact_provider import ArtifactBackend, ItemId, create_artifact_provider
 from .artifact_provider_local import LocalFilesystemArtifactProvider
 from .artifact_registry import ArtifactRegistry
 from .backend_protocol import IssueNode as _IssueNode, get_config as _get_config
@@ -3169,15 +3169,15 @@ def _dispatch_plan_path(milestone_number: int) -> Path:
     return _ds.dispatch_plan_path(milestone_number, _models.get_repo_root())
 
 
-def _try_register_dispatch_plan_artifact(issue_number: int, plan_path: Path) -> None:
+def _try_register_dispatch_plan_artifact(item_id: ItemId, plan_path: Path) -> None:
     """Register the newly written dispatch plan file as a dispatch-plan artifact.
 
     Best-effort: logs a warning on any failure but never raises.  Called after
     ``dispatch_create_plan`` writes the plan file when the caller provides an
-    associated GitHub issue number.
+    associated issue identifier.
 
     Args:
-        issue_number: GitHub issue number to register the artifact against.
+        item_id: Issue number or beads string identifier to register the artifact against.
         plan_path: Absolute or repo-relative path to the created plan file.
     """
     log = _logging.getLogger(__name__)
@@ -3193,16 +3193,13 @@ def _try_register_dispatch_plan_artifact(issue_number: int, plan_path: Path) -> 
             status=ArtifactStatus.CURRENT,
             agent="dispatch_create_plan",
         )
-        manifest = provider.get_manifest(issue_number)
+        manifest = provider.get_manifest(item_id)
         updated_manifest = _artifact_registry.register(manifest, entry)
-        provider.set_manifest(issue_number, updated_manifest)
-        log.info("dispatch_create_plan: registered dispatch-plan artifact %s for issue #%d", plan_path, issue_number)
+        provider.set_manifest(item_id, updated_manifest)
+        log.info("dispatch_create_plan: registered dispatch-plan artifact %s for item %s", plan_path, item_id)
     except (BacklogError, _GithubException) as exc:
         log.warning(
-            "dispatch_create_plan: artifact registration failed for issue #%d (path=%s): %s",
-            issue_number,
-            plan_path,
-            exc,
+            "dispatch_create_plan: artifact registration failed for item %s (path=%s): %s", item_id, plan_path, exc
         )
 
 
@@ -3659,7 +3656,7 @@ def _migrate_classify_plan_file(file_path: Path) -> ArtifactType | None:
     return None
 
 
-_MigrateCandidate = tuple[str, ArtifactType, int | None, str | None]
+_MigrateCandidate = tuple[str, ArtifactType, ItemId | None, str | None]
 
 #: Return type for candidate discovery — (actionable candidates, filtered-out count).
 _MigrateDiscoveryResult = tuple[list[_MigrateCandidate], int]
@@ -3811,7 +3808,7 @@ def _migrate_discover_candidates(
 
 
 def _migrate_register_one(
-    provider: ArtifactBackend, rel_path: str, artifact_type: ArtifactType, issue_number: int
+    provider: ArtifactBackend, rel_path: str, artifact_type: ArtifactType, item_id: ItemId
 ) -> tuple[bool, str]:
     """Register a single artifact, uploading content when available.
 
@@ -3821,7 +3818,7 @@ def _migrate_register_one(
         provider: Initialised ``ArtifactBackend`` instance.
         rel_path: Repo-relative path string.
         artifact_type: Resolved artifact type.
-        issue_number: GitHub issue number (must be positive).
+        item_id: Issue number or beads string identifier.
 
     Returns:
         Tuple of ``(success: bool, message: str)``.
@@ -3833,14 +3830,14 @@ def _migrate_register_one(
         created_at=_datetime.now(UTC).isoformat(),
         agent="artifact-migrate",
     )
-    manifest = provider.get_manifest(issue_number)
+    manifest = provider.get_manifest(item_id)
     existed = any(e.artifact_type == artifact_type and e.artifact_id == rel_path for e in manifest.artifacts)
     updated_manifest = _artifact_registry.register(manifest, entry)
-    provider.set_manifest(issue_number, updated_manifest)
+    provider.set_manifest(item_id, updated_manifest)
 
     local_content = provider.read_local_artifact_content(rel_path)
     if local_content is not None:
-        provider.store_artifact_content(issue_number, str(artifact_type), rel_path, local_content)
+        provider.store_artifact_content(item_id, str(artifact_type), rel_path, local_content)
         content_note = " (content uploaded)"
     else:
         content_note = " (no local file — manifest-only)"
@@ -3898,16 +3895,16 @@ def _migrate_dry_run(issue_number: int | None) -> dict:
 
 
 def _migrate_queue_manifest_only(
-    provider: ArtifactBackend, issue_number: int, candidates: list[_MigrateCandidate], out: Output
+    provider: ArtifactBackend, item_id: ItemId, candidates: list[_MigrateCandidate], out: Output
 ) -> list[_MigrateCandidate]:
     """Append manifest-only entries (content_stored=False) to the candidate list.
 
-    Called when ``issue_number`` is provided so already-registered entries
+    Called when ``item_id`` is provided so already-registered entries
     without uploaded content are re-processed to trigger the auto-upload path.
 
     Args:
         provider: Initialised provider used to read the manifest.
-        issue_number: Issue whose manifest to inspect.
+        item_id: Issue number or beads string identifier whose manifest to inspect.
         candidates: Existing candidate list (may be mutated by extension).
         out: Output accumulator for warnings.
 
@@ -3915,9 +3912,9 @@ def _migrate_queue_manifest_only(
         Extended candidate list.
     """
     try:
-        manifest = provider.get_manifest(issue_number)
+        manifest = provider.get_manifest(item_id)
     except (BacklogError, _GithubException):
-        out.warn(f"Could not read existing manifest for issue #{issue_number}. Skipping manifest check.")
+        out.warn(f"Could not read existing manifest for item {item_id!r}. Skipping manifest check.")
         return candidates
 
     result = list(candidates)
@@ -3931,7 +3928,7 @@ def _migrate_queue_manifest_only(
             if skip_reason is None
         )
         if not already_queued:
-            result.append((entry.artifact_id, entry.artifact_type, issue_number, None))
+            result.append((entry.artifact_id, entry.artifact_type, item_id, None))
             out.warn(f"Queued manifest-only entry for re-registration: {entry.artifact_id!r}")
     return result
 

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2468,8 +2468,11 @@ def _get_artifact_provider() -> ArtifactBackend:
     )
 )
 async def artifact_register(
-    issue_number: Annotated[
-        str | int, Field(description="GitHub issue number or beads nanoid string (e.g. 'bd-a3f8')")
+    item_id: Annotated[
+        str | int,
+        Field(
+            description="Backlog item identifier — GitHub issue number (int) or beads nanoid string (e.g. 'bd-a3f8')"
+        ),
     ],
     artifact_type: Annotated[
         str,
@@ -2542,9 +2545,9 @@ async def artifact_register(
         )
 
         def _run() -> RegisterResult:
-            manifest = provider.get_manifest(issue_number)
+            manifest = provider.get_manifest(item_id)
             updated_manifest = _artifact_registry.register(manifest, entry)
-            provider.set_manifest(issue_number, updated_manifest)
+            provider.set_manifest(item_id, updated_manifest)
             # Determine action: "updated" if entry pre-existed, "added" otherwise.
             existed = any(
                 e.artifact_type == artifact_type_enum and e.artifact_id == artifact_id for e in manifest.artifacts
@@ -2566,7 +2569,7 @@ async def artifact_register(
 
             content_stored = False
             if upload_content is not None:
-                provider.store_artifact_content(issue_number, artifact_type, artifact_id, upload_content)
+                provider.store_artifact_content(item_id, artifact_type, artifact_id, upload_content)
                 content_stored = True
 
             return RegisterResult(
@@ -2590,12 +2593,15 @@ async def artifact_register(
     )
 )
 async def artifact_list(
-    issue_number: Annotated[
-        str | int, Field(description="GitHub issue number or beads nanoid string (e.g. 'bd-a3f8')")
+    item_id: Annotated[
+        str | int,
+        Field(
+            description="Backlog item identifier — GitHub issue number (int) or beads nanoid string (e.g. 'bd-a3f8')"
+        ),
     ],
     artifact_type: Annotated[str | None, Field(description="Filter by artifact type (optional)")] = None,
 ) -> dict:
-    """Return all artifacts registered for a GitHub issue.
+    """Return all artifacts registered for a backlog item.
 
     Optionally filter by artifact type. Returns an empty list when no
     manifest section exists yet — this is not an error.
@@ -2612,7 +2618,7 @@ async def artifact_list(
         type_filter: ArtifactType | None = ArtifactType(artifact_type) if artifact_type else None
 
         def _run() -> list[dict]:
-            manifest = provider.get_manifest(issue_number)
+            manifest = provider.get_manifest(item_id)
             if type_filter is not None:
                 entries = _artifact_registry.get_by_type(manifest, type_filter)
             else:
@@ -2633,12 +2639,15 @@ async def artifact_list(
     )
 )
 async def artifact_get(
-    issue_number: Annotated[
-        str | int, Field(description="GitHub issue number or beads nanoid string (e.g. 'bd-a3f8')")
+    item_id: Annotated[
+        str | int,
+        Field(
+            description="Backlog item identifier — GitHub issue number (int) or beads nanoid string (e.g. 'bd-a3f8')"
+        ),
     ],
     artifact_type: Annotated[str, Field(description="Artifact type to retrieve")],
 ) -> dict:
-    """Return metadata for a specific artifact type registered on a GitHub issue.
+    """Return metadata for a specific artifact type registered on a backlog item.
 
     If multiple artifacts of the same type exist (e.g. multiple
     codebase-analysis files), all are returned.
@@ -2655,13 +2664,13 @@ async def artifact_get(
         type_enum = ArtifactType(artifact_type)
 
         def _run() -> list[dict]:
-            manifest = provider.get_manifest(issue_number)
+            manifest = provider.get_manifest(item_id)
             entries = _artifact_registry.get_by_type(manifest, type_enum)
             return [e.model_dump(mode="json") for e in entries]
 
         artifacts = await asyncio.to_thread(_run)
         if not artifacts:
-            return {"error": f"No artifacts of type '{artifact_type}' found for issue #{issue_number}", **out.to_dict()}
+            return {"error": f"No artifacts of type '{artifact_type}' found for item #{item_id}", **out.to_dict()}
         return {"artifacts": artifacts, "count": len(artifacts), **out.to_dict()}
     except (ValueError, KeyError) as e:
         return {"error": f"Invalid parameter: {e}", **out.to_dict()}
@@ -2675,12 +2684,15 @@ async def artifact_get(
     )
 )
 async def artifact_read(
-    issue_number: Annotated[
-        str | int, Field(description="GitHub issue number or beads nanoid string (e.g. 'bd-a3f8')")
+    item_id: Annotated[
+        str | int,
+        Field(
+            description="Backlog item identifier — GitHub issue number (int) or beads nanoid string (e.g. 'bd-a3f8')"
+        ),
     ],
     artifact_type: Annotated[str, Field(description="Artifact type whose content to read")],
 ) -> dict:
-    """Read the file content for an artifact registered on a GitHub issue.
+    """Read the file content for an artifact registered on a backlog item.
 
     Content retrieval order:
 
@@ -2706,11 +2718,9 @@ async def artifact_read(
         type_enum = ArtifactType(artifact_type)
 
         def _run() -> ArtifactContent:
-            manifest = provider.get_manifest(issue_number)
+            manifest = provider.get_manifest(item_id)
             entries = _artifact_registry.get_by_type(manifest, type_enum)
-            _require_artifact_entries(
-                entries, f"No artifacts of type '{artifact_type}' found for issue #{issue_number}"
-            )
+            _require_artifact_entries(entries, f"No artifacts of type '{artifact_type}' found for item #{item_id}")
             # Sort by created_at desc so the most recently registered entry comes first.
             # Entries without a timestamp sort last (empty string is smallest; stable sort
             # preserves insertion order among multiple undated entries).
@@ -2724,7 +2734,7 @@ async def artifact_read(
                 )
 
             # 1. Try GitHub comment storage first.
-            github_content = provider.read_artifact_content_from_remote(issue_number, artifact_type, entry.artifact_id)
+            github_content = provider.read_artifact_content_from_remote(item_id, artifact_type, entry.artifact_id)
             if github_content is not None:
                 return ArtifactContent(
                     artifact_type=entry.artifact_type,
@@ -3874,9 +3884,9 @@ def _migrate_dry_run(issue_number: int | None) -> dict:
             would_register += 1
 
     verify = (
-        f"Use artifact_list(issue_number={issue_number}) to verify registered entries"
+        f"Use artifact_list(item_id={issue_number}) to verify registered entries"
         if issue_number is not None
-        else "Use artifact_list(issue_number=<N>) per issue to verify registered entries"
+        else "Use artifact_list(item_id=<N>) per item to verify registered entries"
     )
     return {
         "dry_run": True,
@@ -3980,10 +3990,10 @@ def _migrate_live_run(issue_number: int | None, out: Output) -> dict:
             run_details.append({"path": rel_path, "type": str(atype), "issue": issue, "outcome": f"FAILED: {exc}"})
 
     verify = (
-        f"Use artifact_read(issue_number={issue_number}, artifact_type='<type>') "
-        f"or artifact_list(issue_number={issue_number}) to verify"
+        f"Use artifact_read(item_id={issue_number}, artifact_type='<type>') "
+        f"or artifact_list(item_id={issue_number}) to verify"
         if issue_number is not None
-        else "Use artifact_list(issue_number=<N>) per issue to verify registered entries"
+        else "Use artifact_list(item_id=<N>) per item to verify registered entries"
     )
     return {"migrated": migrated, "skipped": skipped, "failed": failed, "details": run_details, "verify": verify}
 
@@ -3999,10 +4009,10 @@ def _migrate_live_run(issue_number: int | None, out: Output) -> dict:
     )
 )
 async def artifact_migrate(
-    issue_number: Annotated[
+    item_id: Annotated[
         str | int | None,
         Field(
-            description="Migrate artifacts for a specific issue number only (integer for GitHub, beads nanoid string for beads backend). Omit to scan all issues."
+            description="Migrate artifacts for a specific item only (integer for GitHub, beads nanoid string for beads backend). Omit to scan all items."
         ),
     ] = None,
     dry_run: Annotated[
@@ -4017,8 +4027,8 @@ async def artifact_migrate(
     matching against backlog items), and calls the artifact_register logic
     for each discovered file.
 
-    When ``issue_number`` is provided the tool also checks the existing
-    manifest for that issue: any already-registered entry that has
+    When ``item_id`` is provided the tool also checks the existing
+    manifest for that item: any already-registered entry that has
     ``content_stored=False`` is re-registered so the auto-upload path can
     run and upload the local file content.
 
@@ -4036,10 +4046,10 @@ async def artifact_migrate(
     # artifact_migrate scans plan/research directories by GitHub issue number.
     # Beads string IDs are not supported by the migration scanner — reject early
     # so the caller gets a clear message rather than a type error downstream.
-    if isinstance(issue_number, str):
+    if isinstance(item_id, str):
         return {
             "error": (
-                f"artifact_migrate requires an integer issue number, got {issue_number!r}. "
+                f"artifact_migrate requires an integer item ID, got {item_id!r}. "
                 "Beads string ID filtering is not supported by the migration scanner."
             ),
             **out.to_dict(),
@@ -4047,13 +4057,13 @@ async def artifact_migrate(
 
     if dry_run:
         try:
-            result = await asyncio.to_thread(_migrate_dry_run, issue_number)
+            result = await asyncio.to_thread(_migrate_dry_run, item_id)
         except OSError as exc:
             return {"error": f"Discovery failed: {exc}", **out.to_dict()}
         return {**result, **out.to_dict()}
 
     try:
-        result = await asyncio.to_thread(_migrate_live_run, issue_number, out)
+        result = await asyncio.to_thread(_migrate_live_run, item_id, out)
     except GitHubUnavailableError as exc:
         return {"error": str(exc), **out.to_dict()}
     except (BacklogError, _GithubException, OSError) as exc:

--- a/plugins/development-harness/docs/backlog-item-lifecycle.md
+++ b/plugins/development-harness/docs/backlog-item-lifecycle.md
@@ -313,7 +313,7 @@ flowchart TD
     P3_RTICA_GATE -->|APPROVED| P3_COMPOSE["work-backlog-item Step 5:<br>Compose feature request<br>Carry DERIVABLE items as<br>'Assumptions to confirm'"]
     P3_COMPOSE --> P3_INVOKE["work-backlog-item Step 6:<br>Skill(skill='add-new-feature',<br>args='{composed feature request}')<br>Direct skill call — not a suggestion"]
 
-    P3_INVOKE --> P3_ARTIFACT_DISCOVER{"Pre-Phase:<br>Artifact Discovery<br>artifact_list(issue_number=N)<br>Existing artifacts?"}
+    P3_INVOKE --> P3_ARTIFACT_DISCOVER{"Pre-Phase:<br>Artifact Discovery<br>artifact_list(item_id=N)<br>Existing artifacts?"}
     P3_ARTIFACT_DISCOVER -->|"Artifacts exist —<br>inject into delegation prompts"| P3_ARTIFACT_APPEND["Append prior_artifacts block<br>to each phase delegation prompt"]
     P3_ARTIFACT_DISCOVER -->|"No artifacts —<br>start fresh"| P3_RESEARCH
     P3_ARTIFACT_APPEND --> P3_RESEARCH
@@ -340,7 +340,7 @@ flowchart TD
 | P3_BLOCKED | orchestrator | MISSING conditions list | user-facing report, skill NOT invoked | terminal |
 | P3_COMPOSE | orchestrator (`work-backlog-item` Step 5) | groomed item, DERIVABLE items | composed feature request with 'Assumptions to confirm' | always → P3_INVOKE |
 | P3_INVOKE | orchestrator (`work-backlog-item` Step 6) | composed feature request | `Skill()` call to `add-new-feature` | always → P3_ARTIFACT_DISCOVER |
-| P3_ARTIFACT_DISCOVER | `artifact_list` MCP | `issue_number` | existing artifact manifest (or empty) | artifacts exist → P3_ARTIFACT_APPEND, none → P3_RESEARCH |
+| P3_ARTIFACT_DISCOVER | `artifact_list` MCP | `item_id` | existing artifact manifest (or empty) | artifacts exist → P3_ARTIFACT_APPEND, none → P3_RESEARCH |
 | P3_ARTIFACT_APPEND | orchestrator | artifact manifest | `prior_artifacts` block added to delegation prompts | always → P3_RESEARCH |
 | P3_RESEARCH | `@dh:feature-researcher` | composed feature request, prior artifacts (if any) | `plan/feature-context-{slug}.md`, `artifact_register(type='feature-context')` | always → P3_CODEBASE |
 | P3_CODEBASE | orchestrator | feature context, codebase state | codebase analysis decision | invoked → P3_CODEBASE_OUT, skipped → P3_ARCHITECT |
@@ -349,11 +349,11 @@ flowchart TD
 
 **Agent selection for architecture**: The skill does NOT hardcode `@python3-development:python-cli-design-spec`. It resolves the `design-spec` role from the language manifest at runtime based on project detection markers (`pyproject.toml` → Python, `package.json` → TypeScript, `Cargo.toml` → Rust, none → general-purpose fallback).
 
-**Artifact registration**: Each phase calls `artifact_register` after writing its file, with `issue_number`, `artifact_type`, `path` (state-relative), and `agent` fields.
+**Artifact registration**: Each phase calls `artifact_register` after writing its file, with `item_id`, `artifact_type`, `path` (state-relative), and `agent` fields.
 
 **Storage**: Feature context and architecture specs are registered as Documents via the artifact manifest system. See [Backend Providers — SAM Storage Model](./backend-providers.md#sam-storage-model) for the document lifecycle.
 
-**Artifact access is MCP-first**: Consumers retrieve artifacts via `artifact_read(issue_number, artifact_type)` and register them via `artifact_register(issue_number, artifact_type, path, agent, content)`. Task plans are accessed via `sam_read(plan, task)`. The MCP servers resolve storage internally — consumers never construct filesystem paths.
+**Artifact access is MCP-first**: Consumers retrieve artifacts via `artifact_read(item_id, artifact_type)` and register them via `artifact_register(item_id, artifact_type, path, agent, content)`. Task plans are accessed via `sam_read(plan, task)`. The MCP servers resolve storage internally — consumers never construct filesystem paths.
 
 **No feasibility gate exists** between RT-ICA APPROVED and SAM planning invocation. The transition from "do we have enough information?" to "start planning" is direct — no assessment of technical feasibility, effort/value, risk, or alternative approaches (audit Finding 1).
 
@@ -544,7 +544,7 @@ flowchart TD
     P6_TN_CHECK -->|"Any regressed"| P6_TN_BLOCK(["STOP — list each criterion<br>with check_command, T0/TN stdout<br>Block completion"])
     P6_TN_CHECK -->|"All passed or file absent"| P6_ARTIFACT_DISCOVER
 
-    P6_ARTIFACT_DISCOVER["Pre-Phase 1a: Artifact Discovery<br>artifact_list(issue_number=N)<br>when parent issue number is known<br>Pass manifest to QG agents"]
+    P6_ARTIFACT_DISCOVER["Pre-Phase 1a: Artifact Discovery<br>artifact_list(item_id=N)<br>when parent issue number is known<br>Pass manifest to QG agents"]
 
     P6_ARTIFACT_DISCOVER --> P6_CONCERNS{"Pre-Phase 1b: Process Concerns<br>backlog_view — does item have<br>## Concerns section with<br>unchecked items?"}
     P6_CONCERNS -->|"Unchecked concerns exist"| P6_CONCERNS_VERIFY["For each concern:<br>Verify by reading file/running check<br>If verified: check off + create backlog item<br>If not verified: check off as 'Not confirmed'<br>Update via backlog_groom section='Concerns'"]
@@ -603,7 +603,7 @@ flowchart TD
 | P6_START | orchestrator | task file path (from P5_INVOKE_QG) | skill invocation | always → P6_TN_CHECK |
 | P6_TN_CHECK | orchestrator | `TN-verification-{slug}.yaml` | aggregated TN result (pass/regressed) | any regressed → P6_TN_BLOCK, all passed or file absent → P6_ARTIFACT_DISCOVER |
 | P6_TN_BLOCK | orchestrator | per-criterion regression details (check_command, T0/TN stdout) | regression report | terminal (blocks completion) |
-| P6_ARTIFACT_DISCOVER | `artifact_list` MCP | `issue_number` | artifact manifest for QG agents | always → P6_CONCERNS |
+| P6_ARTIFACT_DISCOVER | `artifact_list` MCP | `item_id` | artifact manifest for QG agents | always → P6_CONCERNS |
 | P6_CONCERNS | `backlog_view` MCP | item selector | `## Concerns` section with unchecked items | unchecked concerns → P6_CONCERNS_VERIFY, no concerns → P6_QG_CREATE |
 | P6_CONCERNS_VERIFY | orchestrator | unchecked concern items | per-concern: verified → backlog item created, not verified → checked off as 'Not confirmed'; `backlog_groom(section='Concerns')` | always → P6_QG_CREATE |
 | P6_QG_CREATE | `sam_list` MCP | `search='qg-{slug}'` | existing QG plan presence check | no plan → P6_QG_BUILD, plan with remaining tasks → P6_QG_RESET, all terminal → P6_VERIFY_GATE |

--- a/plugins/development-harness/docs/backlog-lifecycle.md
+++ b/plugins/development-harness/docs/backlog-lifecycle.md
@@ -506,4 +506,4 @@ SOURCE: Architect spec Issue #398, Section 9 (AC7 severity policy decision) (acc
 - [Backend Providers](./backend-providers.md) — BacklogBackend Protocol, available backends, configuration
 - [State Machine](../skills/backlog/references/state-machine.md) — canonical state DAG source
 - [Feasibility Gate](../skills/work-backlog-item/references/feasibility-gate.md) — work stage feasibility check
-- Architect Spec — access via `artifact_read(issue_number=398, artifact_type="architect")` — authoritative design decisions
+- Architect Spec — access via `artifact_read(item_id=398, artifact_type="architect")` — authoritative design decisions

--- a/plugins/development-harness/docs/plan-artifact-lifecycle.md
+++ b/plugins/development-harness/docs/plan-artifact-lifecycle.md
@@ -50,9 +50,9 @@ These artifacts are produced by agents during planning phases. They may be updat
 
 | Artifact | Access | Created by | Updated by |
 |---|---|---|---|
-| Feature context | `artifact_read(issue_number, 'feature-context')` | `feature-researcher` agent | `context-refinement` agent |
-| Codebase analysis | `artifact_read(issue_number, 'codebase-analysis')` | `codebase-analyzer` agent | Not updated (informational snapshot) |
-| Architecture spec | `artifact_read(issue_number, 'architect')` | `python-cli-design-spec` agent | `context-refinement` agent |
+| Feature context | `artifact_read(item_id, 'feature-context')` | `feature-researcher` agent | `context-refinement` agent |
+| Codebase analysis | `artifact_read(item_id, 'codebase-analysis')` | `codebase-analyzer` agent | Not updated (informational snapshot) |
+| Architecture spec | `artifact_read(item_id, 'architect')` | `python-cli-design-spec` agent | `context-refinement` agent |
 | Task plan | `sam_read(plan="P{id}")` | `swarm-task-planner` agent | Status fields by hooks; Context Manifest by `context-refinement` |
 | Context Manifest | Embedded in task file (via `sam_read`) | `context-gathering` agent | `context-refinement` agent (existing behavior) |
 
@@ -139,7 +139,7 @@ During task execution, agents record divergence observations in the task file un
 
 ### DN-1: {Brief title}
 
-- **Plan artifact**: `artifact_read(issue_number={N}, artifact_type="architect")`, section "{section name}"
+- **Plan artifact**: `artifact_read(item_id={N}, artifact_type="architect")`, section "{section name}"
 - **Plan claim**: "{quoted text from plan artifact}"
 - **Actual implementation**: "{what was actually done and why}"
 - **Classification**: design-refinement | intent-divergence

--- a/plugins/development-harness/scripts/dh_migrate.py
+++ b/plugins/development-harness/scripts/dh_migrate.py
@@ -361,8 +361,8 @@ def _update_artifact_manifests(project_root: Path, out: Console) -> None:
     out.print("[yellow]:warning:  Artifact manifests in GitHub Issue bodies may contain old path prefixes.[/yellow]")
     out.print(
         "Run the following via the backlog MCP server for each affected issue:\n"
-        "  [dim]artifact_list(issue_number=N)[/dim] — find entries with old prefixes\n"
-        "  [dim]artifact_register(issue_number=N, type=T, path=<new_relative_path>)[/dim]"
+        "  [dim]artifact_list(item_id=N)[/dim] — find entries with old prefixes\n"
+        "  [dim]artifact_register(item_id=N, artifact_type=T, artifact_id=<new_relative_path>)[/dim]"
         " — re-register with new path\n"
     )
     out.print("[dim]Old prefixes to look for:[/dim]")

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -224,11 +224,15 @@ flowchart TD
     Py --> ManifestFound{Manifest exists?}
     TS --> ManifestFound
     Rust --> ManifestFound
-    ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python: @python3-development:python-cli-design-spec)"]
+    ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python: python-engineering:python-cli-design-spec)"]
     ManifestFound -->|No| FB
-    Resolve --> Delegate[Delegate to resolved agent]
-    FB --> Delegate
+    Resolve --> Store["Store as {resolved_agent}<br>Use as subagent_type when dispatching"]
+    Store --> Delegate[Delegate to resolved agent]
+    FB --> FBStore["Store {resolved_agent} = 'dh:task-worker'"]
+    FBStore --> Delegate
 ```
+
+After resolution, `{resolved_agent}` holds the fully-qualified agent name (e.g., `python-engineering:python-cli-design-spec` for Python). Pass `subagent_type="{resolved_agent}"` when dispatching. Use it as the `agent=` metadata value in `artifact_register` so the artifact manifest records which agent produced the spec.
 
 ### Domain Signal Detection — Config-Driven (`.dh/skill_discovery.yaml`)
 
@@ -361,11 +365,11 @@ Register your deliverable and return:
 1. Call `artifact_register` with the full spec content:
 
        mcp__plugin_dh_backlog__artifact_register(
-           issue_number={issue},
+           item_id={issue},
            artifact_type="architect",
            artifact_id="plan/architect-{slug}.md",
            content="<full spec markdown>",
-           agent="python-cli-design-spec"
+           agent="{resolved_agent}"
        )
 
 2. Return:
@@ -522,7 +526,5 @@ When all phases complete, provide the user:
 **Architect specs routinely exceed 32KB.** A real-world architect spec for a non-trivial feature can reach 32KB or more of markdown. The problem with the pre-#1527 pattern was that the orchestrator received the content inline in the agent response — the JSONL session output grew to 300KB or more, which the orchestrator cannot process. The fix is for the architect agent to call `artifact_register(content=...)` directly: the content stays within the agent's context window and is uploaded to the artifact backend (GitHub Gist); the orchestrator receives only `STATUS: DONE`. No Write tool step is needed or correct.
 
 **`artifact_register` without `content=` is a prohibited pattern.** Calling `artifact_register` with a path but no `content=` stores only a pointer to a local file. That file is unreachable from worktree-isolated agents, CI environments, and any other machine. Always pass `content=` explicitly. Source: `plugins/development-harness/CLAUDE.md` — "Prohibited patterns" section.
-
-**`agent="python-cli-design-spec"` in `artifact_register` is Python-specific.** The Phase 3 delegation prompt hardcodes this value. It is correct for the Python workflow but incorrect for non-Python projects. A future improvement should resolve the agent name dynamically from the language manifest's role mapping.
 
 **Phase 4 (`sam_plan(action='create')`) auto-registers the `task-plan` artifact** — no separate `artifact_register` call is needed or valid for that type.

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -31,7 +31,7 @@ Before starting any phase, check whether the feature request references a tracke
 ```mermaid
 flowchart TD
     Start([Parse feature_request]) --> Q{"Contains 'GitHub Issue: #N' / '#N'<br>OR 'Beads Issue: bd-ID' / bare beads ID?"}
-    Q -->|Yes — issue selector found| List["Call artifact_list(issue_number=N)<br>to discover registered artifacts<br>(N may be int for GitHub or str for beads)"]
+    Q -->|Yes — issue selector found| List["Call artifact_list(item_id=N)<br>to discover registered artifacts<br>(N may be int for GitHub or str for beads)"]
     Q -->|No — no issue reference| Skip[Skip artifact discovery<br>Proceed normally]
     List --> Found{Artifacts returned?}
     Found -->|Yes| Store["Store artifact list as discovered_artifacts<br>Include paths and types in each<br>phase delegation prompt"]
@@ -45,7 +45,7 @@ When `discovered_artifacts` is non-empty, append this block to each phase delega
 ```text
 <prior_artifacts>
 The following artifacts are already registered for this issue. Read any relevant
-ones via artifact_read(issue_number={issue}, artifact_type="{type}") before
+ones via artifact_read(item_id={issue}, artifact_type="{type}") before
 starting your work — they contain prior research and analysis that should
 inform your output.
 
@@ -120,7 +120,7 @@ Read the details about the milestone and plan you are a part of at backlog_view(
 
 Research #{issue}: "{title}".
 If research artifacts exist for this issue, read them via
-artifact_read(issue_number={issue}, artifact_type="research") before starting
+artifact_read(item_id={issue}, artifact_type="research") before starting
 discovery — they contain prior investigation findings that should be incorporated.
 IMPORTANT: Research artifacts are discovery pointers, not authoritative documents.
 After reading the research artifact, inspect its YAML frontmatter for `resource_url`
@@ -142,14 +142,14 @@ document. Surface any PARTIAL or MISSING capabilities as questions.
 Register your deliverable with:
     artifact_type="feature-context"
     artifact_id="plan/feature-context-{slug}.md"
-    issue_number={issue}
+    item_id={issue}
     agent="feature-researcher"
 ```
 
 After the agent completes, verify the artifact was registered:
 
 ```text
-mcp__plugin_dh_backlog__artifact_list(issue_number={issue}, artifact_type="feature-context")
+mcp__plugin_dh_backlog__artifact_list(item_id={issue}, artifact_type="feature-context")
 ```
 
 If `count == 0`, the agent did not register the artifact. Re-dispatch with an explicit
@@ -188,7 +188,7 @@ Do NOT prescribe changes.
 Register each document with:
     artifact_type="codebase-analysis"
     artifact_id="codebase-{focus}-{slug}"  (logical id — use lowercase focus area, e.g. codebase-patterns-{slug})
-    issue_number={issue}
+    item_id={issue}
     agent="codebase-analyzer"
 
 A single invocation covering multiple focus areas issues one artifact_register call per
@@ -198,7 +198,7 @@ focus area with a distinct artifact_id per focus.
 After the agent completes, verify the artifact was registered:
 
 ```text
-mcp__plugin_dh_backlog__artifact_list(issue_number={issue}, artifact_type="codebase-analysis")
+mcp__plugin_dh_backlog__artifact_list(item_id={issue}, artifact_type="codebase-analysis")
 ```
 
 If `count == 0`, the agent did not register the artifact. Re-dispatch with an explicit
@@ -339,10 +339,10 @@ Read the details about the milestone and plan you are a part of at backlog_view(
 {quality_vigilance}
 
 Design the implementation for #{issue}: "{title}".
-Read the feature context via artifact_read(issue_number={issue}, artifact_type="feature-context").
-[If codebase analysis exists: Read via artifact_read(issue_number={issue}, artifact_type="codebase-analysis").]
+Read the feature context via artifact_read(item_id={issue}, artifact_type="feature-context").
+[If codebase analysis exists: Read via artifact_read(item_id={issue}, artifact_type="codebase-analysis").]
 If research artifacts exist for this issue, read them via
-artifact_read(issue_number={issue}, artifact_type="research") for prior research
+artifact_read(item_id={issue}, artifact_type="research") for prior research
 findings that should inform the architecture.
 IMPORTANT: Research artifacts are discovery pointers, not authoritative documents.
 After reading any research artifact, inspect its YAML frontmatter for `resource_url`
@@ -377,7 +377,7 @@ Register your deliverable and return:
 After the agent completes, verify the artifact was registered:
 
 ```text
-mcp__plugin_dh_backlog__artifact_list(issue_number={issue}, artifact_type="architect")
+mcp__plugin_dh_backlog__artifact_list(item_id={issue}, artifact_type="architect")
 ```
 
 If `count == 0`, the agent did not register the artifact. Re-dispatch with an explicit
@@ -406,8 +406,8 @@ Read the details about the milestone and plan you are a part of at backlog_view(
 {quality_vigilance}
 
 Decompose #{issue}: "{title}" into executable tasks.
-Read the architecture spec via artifact_read(issue_number={issue}, artifact_type="architect").
-Read the feature context via artifact_read(issue_number={issue}, artifact_type="feature-context").
+Read the architecture spec via artifact_read(item_id={issue}, artifact_type="architect").
+Read the feature context via artifact_read(item_id={issue}, artifact_type="feature-context").
 Goal: {goal_from_feature_request}
 Create the plan via sam_plan with CLEAR+CoVe task definitions.
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -220,17 +220,17 @@ flowchart TD
     Found -->|pyproject.toml| Py[Search Python language manifest]
     Found -->|package.json| TS[Search TypeScript language manifest]
     Found -->|Cargo.toml| Rust[Search Rust language manifest]
-    Found -->|None| FB["Fallback: subagent_type='general-purpose'"]
+    Found -->|None| FB["No manifest — fallback path"]
     Py --> ManifestFound{Manifest exists?}
     TS --> ManifestFound
     Rust --> ManifestFound
     ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python: python-engineering:python-cli-design-spec)"]
     ManifestFound -->|No| FB
-    Resolve --> Delegate["Dispatch subagent_type='{resolved_agent}' directly"]
-    FB --> FBDelegate["Dispatch subagent_type='general-purpose'"]
+    Resolve --> Delegate["Dispatch dh:task-worker<br>specialist_skill_block = profile_load('{resolved_agent}')"]
+    FB --> FBDelegate["Dispatch dh:task-worker<br>specialist_skill_block = '' (executes directly)"]
 ```
 
-Phase 3 dispatches the resolved specialist **directly** — not through `dh:task-worker`. `task-worker` requires a SAM task reference (`P{N}/T{M}`) to execute its lifecycle (read, claim, start-task). Phase 3 is an orchestrator-level delegation with no SAM task, matching the same pattern as Phases 1, 2, and 4. When a specialist is resolved (e.g. `python-engineering:python-cli-design-spec`), dispatch it with `subagent_type="{resolved_agent}"`. When no manifest exists, fall back to `subagent_type="general-purpose"`. Use `{resolved_agent}` (or `"general-purpose"` for the fallback) as the `agent=` metadata in `artifact_register` to record which specialist produced the spec.
+Phase 3 always dispatches `dh:task-worker` (`subagent_type="dh:task-worker"`). Unlike Phases 1, 2, and 4 — which use native DH agents for process steps that are not stack-specific (`@dh:feature-researcher`, `@dh:codebase-analyzer`, `@dh:swarm-task-planner`) — Phase 3 is language-specific. The architect role is resolved from the language manifest and the specialist is loaded into task-worker via `profile_load`. When a specialist is resolved (e.g. `python-engineering:python-cli-design-spec`), the `{specialist_skill_block}` contains `profile_load(agent_name='{resolved_agent}')`. When no manifest exists, `{specialist_skill_block}` is empty and task-worker executes directly as the fallback architect. Use `{resolved_agent}` (or `"dh:task-worker"` for the fallback) as the `agent=` metadata in `artifact_register`.
 
 ### Domain Signal Detection — Config-Driven (`.dh/skill_discovery.yaml`)
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -220,17 +220,18 @@ flowchart TD
     Found -->|pyproject.toml| Py[Search Python language manifest]
     Found -->|package.json| TS[Search TypeScript language manifest]
     Found -->|Cargo.toml| Rust[Search Rust language manifest]
-    Found -->|None| FB["No manifest — fallback path"]
+    Found -->|None| FB["Fallback: dh:task-worker<br>(no specialist profile loaded)"]
     Py --> ManifestFound{Manifest exists?}
     TS --> ManifestFound
     Rust --> ManifestFound
-    ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python: python-engineering:python-cli-design-spec)"]
-    ManifestFound -->|No| FB
-    Resolve --> Delegate["Dispatch dh:task-worker<br>specialist_skill_block = profile_load('{resolved_agent}')"]
-    FB --> FBDelegate["Dispatch dh:task-worker<br>specialist_skill_block = '' (executes directly)"]
+    ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python example: python-engineering:python-cli-design-spec)"]
+    ManifestFound -->|No| FB["Fallback: dispatch dh:task-worker<br>no specialist profile loaded"]
+    Resolve --> Store["Store as {resolved_agent}<br>profile_load(agent_name='{resolved_agent}') in delegation prompt"]
+    Store --> Delegate["Dispatch subagent_type='dh:task-worker'"]
+    FB --> Delegate
 ```
 
-Phase 3 always dispatches `dh:task-worker` (`subagent_type="dh:task-worker"`). Unlike Phases 1, 2, and 4 — which use native DH agents for process steps that are not stack-specific (`@dh:feature-researcher`, `@dh:codebase-analyzer`, `@dh:swarm-task-planner`) — Phase 3 is language-specific. The architect role is resolved from the language manifest and the specialist is loaded into task-worker via `profile_load`. When a specialist is resolved (e.g. `python-engineering:python-cli-design-spec`), the `{specialist_skill_block}` contains `profile_load(agent_name='{resolved_agent}')`. When no manifest exists, `{specialist_skill_block}` is empty and task-worker executes directly as the fallback architect. Use `{resolved_agent}` (or `"dh:task-worker"` for the fallback) as the `agent=` metadata in `artifact_register`.
+Phase 3 always dispatches `subagent_type="dh:task-worker"`. When a specialist is resolved from the language manifest, the orchestrator instructs task-worker to call `mcp__plugin_dh_backlog__profile_load(agent_name="{resolved_agent}")` at the start of its prompt — this is the `agent_profile` MCP tool on the backlog server and is how task-worker loads specialist behavior when no SAM task `agent:` field is available. Use `{resolved_agent}` as the `agent=` metadata in `artifact_register` to record which specialist produced the spec.
 
 ### Domain Signal Detection — Config-Driven (`.dh/skill_discovery.yaml`)
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -356,11 +356,24 @@ finalizing the architecture. Training data is stale; current community practice 
 Produce architect-{slug}.md content with interfaces, contracts, data models, module boundaries.
 Do NOT implement — define WHAT to build, not the code.
 
-Register your deliverable with:
-    artifact_type="architect"
-    artifact_id="plan/architect-{slug}.md"
-    issue_number={issue}
-    agent="python-cli-design-spec"
+Write your deliverable to disk, register it, then return:
+
+1. Write the spec to `plan/architect-{slug}.md` using the `Write` tool.
+   Large-file rule: if the spec exceeds 25 000 characters, use Strategy B from
+   `.claude/rules/large-file-write-strategy.md` — write a skeleton first, then
+   fill each section with separate `Edit` calls, before proceeding to step 2.
+
+2. Register the artifact (the server auto-reads the file you wrote in step 1):
+       mcp__plugin_dh_backlog__artifact_register(
+           issue_number={issue},
+           artifact_type="architect",
+           artifact_id="plan/architect-{slug}.md",
+           agent="python-cli-design-spec"
+       )
+
+3. Return:
+       STATUS: DONE
+       path: plan/architect-{slug}.md
 ```
 
 After the agent completes, verify the artifact was registered:
@@ -370,9 +383,9 @@ mcp__plugin_dh_backlog__artifact_list(issue_number={issue}, artifact_type="archi
 ```
 
 If `count == 0`, the agent did not register the artifact. Re-dispatch with an explicit
-reminder that `artifact_register(content=...)` is the agent's responsibility, not the
-orchestrator's. The orchestrator MUST NOT call `artifact_register` as a workaround —
-the MCP-native rule is that agents own their artifact storage.
+reminder that the agent must write the file to `plan/architect-{slug}.md` and call
+`artifact_register` itself — the orchestrator MUST NOT call `artifact_register` as a
+workaround. The MCP-native rule is that agents own their artifact storage.
 
 ---
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -224,15 +224,14 @@ flowchart TD
     Py --> ManifestFound{Manifest exists?}
     TS --> ManifestFound
     Rust --> ManifestFound
-    ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python: python-engineering:python-cli-design-spec)"]
-    ManifestFound -->|No| FB
-    Resolve --> Store["Store as {resolved_agent}<br>Use as subagent_type when dispatching"]
-    Store --> Delegate[Delegate to resolved agent]
-    FB --> FBStore["Store {resolved_agent} = 'dh:task-worker'"]
-    FBStore --> Delegate
+    ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python example: python-engineering:python-cli-design-spec)"]
+    ManifestFound -->|No| FB["Fallback: dispatch dh:task-worker<br>no specialist skill loaded"]
+    Resolve --> Store["Store as {resolved_agent}<br>Load inside dh:task-worker via Skill()"]
+    Store --> Delegate["Dispatch subagent_type='dh:task-worker'<br>Prompt includes: Skill(skill='{resolved_agent}')"]
+    FB --> Delegate
 ```
 
-After resolution, `{resolved_agent}` holds the fully-qualified agent name (e.g., `python-engineering:python-cli-design-spec` for Python). Pass `subagent_type="{resolved_agent}"` when dispatching. Use it as the `agent=` metadata value in `artifact_register` so the artifact manifest records which agent produced the spec.
+Phase 3 always dispatches `subagent_type="dh:task-worker"`. The resolved specialist from the language manifest is loaded inside task-worker via a `Skill()` call at the top of the delegation prompt — it is never the `subagent_type`. Use `{resolved_agent}` as the `agent=` metadata in `artifact_register` to record which specialist produced the spec.
 
 ### Domain Signal Detection — Config-Driven (`.dh/skill_discovery.yaml`)
 
@@ -334,9 +333,12 @@ documentation loaded by these skills.
 If `{domain_skills}` is empty, do not add any skill-loading block — proceed directly to
 the delegation prompt below without modification.
 
+Dispatch: `subagent_type="dh:task-worker"`. Build the delegation prompt from the template below.
+
 Delegation prompt template:
 
 ```text
+{specialist_skill_block}
 You are part of a team that is currently working on the {work_type} {feature_name}.
 Read the details about the milestone and plan you are a part of at backlog_view(selector="#{issue}").
 
@@ -377,6 +379,11 @@ Register your deliverable and return:
        STATUS: DONE
        path: plan/architect-{slug}.md
 ```
+
+`{specialist_skill_block}` is built by the orchestrator before dispatch:
+
+- When `{resolved_agent}` is set (manifest found): `"Load your specialist skill before starting: Skill(skill='{resolved_agent}'). This is a BLOCKING prerequisite — complete it before reading any artifacts or designing.\n\n"`
+- When no manifest found (fallback): `""` (empty string — task-worker needs no specialist loading)
 
 After the agent completes, verify the artifact was registered:
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -514,3 +514,29 @@ When all phases complete, provide the user:
 - the feature slug
 - the task file path
 - next step: run the `implement-feature` skill with the slug or task file path
+
+---
+
+### Discovered During Implementation
+
+[Date: 2026-05-23 / Session: issue #1527 — Phase 3 write-to-disk refactor]
+
+During implementation of issue #1527, Phase 3's architect delegation prompt was changed from returning full spec content inline to a three-step write-to-disk + register + return-path pattern. This change revealed several constraints and alignment points that are not obvious from reading the skill in isolation.
+
+**Architect specs routinely exceed 32KB.** A real-world architect spec for a non-trivial feature can reach 32KB or more of markdown. When returned inline from the agent, the JSONL session output grows to 300KB or more. The orchestrator cannot read this back — it exceeds what can be reasoned about in a single context window. The write-to-disk pattern is not an optimization; it is mandatory for specs of this size. Future implementors should not revert to inline return regardless of apparent simplicity of a given feature.
+
+**Phase 4 already established this pattern via `sam_create`.** The swarm-task-planner (Phase 4) has always written its output to disk as a YAML plan file and registered it via `sam_plan(action='create')`. Phase 3 now aligns with this established write-then-register pattern. When extending the skill with new phases, the presumption should be that all artifact-producing phases follow write-to-disk + register, not inline return.
+
+**`artifact_register` tier-2 auto-read works in main worktree context.** When Phase 3 runs in the main worktree (the normal case for `add-new-feature`), `artifact_register` with a path pointing to `plan/architect-{slug}.md` triggers the server to auto-read the file. This works correctly because the file is in the root worktree path. Worktree-isolated contexts (e.g., parallel dispatch in `work-milestone`) cannot see root worktree `plan/` files — this is a future concern tracked as a concern in issue #1527 and is not addressed by the Phase 3 change.
+
+**`agent="python-cli-design-spec"` in `artifact_register` is Python-specific.** The Phase 3 delegation prompt hardcodes `agent="python-cli-design-spec"` in the `artifact_register` call. This is intentional for the Python workflow (the language manifest maps the architect role to `@python3-development:python-cli-design-spec`) but is incorrect for non-Python projects. A future improvement should resolve the agent name dynamically from the manifest's role mapping rather than hardcoding it. This is logged as a future concern in issue #1527 and does not affect the current Python-first deployment.
+
+**The large-file write strategy (Strategy B) is the correct fallback for oversized specs.** The reference at `.claude/rules/large-file-write-strategy.md` describes a skeleton + Edit-fill pattern for files exceeding 25,000 characters. This integrates correctly with the Phase 3 three-step flow: the agent writes the skeleton with `Write`, fills sections with `Edit`, then calls `artifact_register` in step 2. The 25,000-character threshold in the Phase 3 instruction is correct and matches the strategy document.
+
+#### Updated Technical Details
+
+- Phase 3 architect agent must write to `plan/architect-{slug}.md` before calling `artifact_register` — inline `content=` return is not viable for real-world spec sizes
+- The `artifact_register` call uses `artifact_id="plan/architect-{slug}.md"` as the logical path; the server auto-reads from the root worktree at that path
+- `agent="python-cli-design-spec"` in the `artifact_register` call is a Python-language-specific hardcode; non-Python projects will need this resolved from the language manifest
+- Spec size threshold for Strategy B (skeleton + Edit-fill): 25,000 characters, per `.claude/rules/large-file-write-strategy.md`
+- Phase 4 (`sam_plan(action='create')`) auto-registers the `task-plan` artifact — no separate `artifact_register` call is needed or valid for that type

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -220,18 +220,17 @@ flowchart TD
     Found -->|pyproject.toml| Py[Search Python language manifest]
     Found -->|package.json| TS[Search TypeScript language manifest]
     Found -->|Cargo.toml| Rust[Search Rust language manifest]
-    Found -->|None| FB["Fallback: dh:task-worker<br>(no specialist profile loaded)"]
+    Found -->|None| FB["Fallback: subagent_type='general-purpose'"]
     Py --> ManifestFound{Manifest exists?}
     TS --> ManifestFound
     Rust --> ManifestFound
-    ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python example: python-engineering:python-cli-design-spec)"]
-    ManifestFound -->|No| FB["Fallback: dispatch dh:task-worker<br>no specialist profile loaded"]
-    Resolve --> Store["Store as {resolved_agent}<br>profile_load(agent_name='{resolved_agent}') in delegation prompt"]
-    Store --> Delegate["Dispatch subagent_type='dh:task-worker'"]
-    FB --> Delegate
+    ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python: python-engineering:python-cli-design-spec)"]
+    ManifestFound -->|No| FB
+    Resolve --> Delegate["Dispatch subagent_type='{resolved_agent}' directly"]
+    FB --> FBDelegate["Dispatch subagent_type='general-purpose'"]
 ```
 
-Phase 3 always dispatches `subagent_type="dh:task-worker"`. When a specialist is resolved from the language manifest, the orchestrator instructs task-worker to call `mcp__plugin_dh_backlog__profile_load(agent_name="{resolved_agent}")` at the start of its prompt — this is the `agent_profile` MCP tool on the backlog server and is how task-worker loads specialist behavior when no SAM task `agent:` field is available. Use `{resolved_agent}` as the `agent=` metadata in `artifact_register` to record which specialist produced the spec.
+Phase 3 dispatches the resolved specialist **directly** — not through `dh:task-worker`. `task-worker` requires a SAM task reference (`P{N}/T{M}`) to execute its lifecycle (read, claim, start-task). Phase 3 is an orchestrator-level delegation with no SAM task, matching the same pattern as Phases 1, 2, and 4. When a specialist is resolved (e.g. `python-engineering:python-cli-design-spec`), dispatch it with `subagent_type="{resolved_agent}"`. When no manifest exists, fall back to `subagent_type="general-purpose"`. Use `{resolved_agent}` (or `"general-purpose"` for the fallback) as the `agent=` metadata in `artifact_register` to record which specialist produced the spec.
 
 ### Domain Signal Detection — Config-Driven (`.dh/skill_discovery.yaml`)
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -225,13 +225,13 @@ flowchart TD
     TS --> ManifestFound
     Rust --> ManifestFound
     ManifestFound -->|Yes| Resolve["Resolve design-spec role from manifest<br>(Python example: python-engineering:python-cli-design-spec)"]
-    ManifestFound -->|No| FB["Fallback: dispatch dh:task-worker<br>no specialist skill loaded"]
-    Resolve --> Store["Store as {resolved_agent}<br>Load inside dh:task-worker via Skill()"]
-    Store --> Delegate["Dispatch subagent_type='dh:task-worker'<br>Prompt includes: Skill(skill='{resolved_agent}')"]
+    ManifestFound -->|No| FB["Fallback: dispatch dh:task-worker<br>no specialist profile loaded"]
+    Resolve --> Store["Store as {resolved_agent}<br>profile_load(agent_name='{resolved_agent}') in delegation prompt"]
+    Store --> Delegate["Dispatch subagent_type='dh:task-worker'"]
     FB --> Delegate
 ```
 
-Phase 3 always dispatches `subagent_type="dh:task-worker"`. The resolved specialist from the language manifest is loaded inside task-worker via a `Skill()` call at the top of the delegation prompt — it is never the `subagent_type`. Use `{resolved_agent}` as the `agent=` metadata in `artifact_register` to record which specialist produced the spec.
+Phase 3 always dispatches `subagent_type="dh:task-worker"`. When a specialist is resolved from the language manifest, the orchestrator instructs task-worker to call `mcp__plugin_dh_backlog__profile_load(agent_name="{resolved_agent}")` at the start of its prompt — this is the `agent_profile` MCP tool on the backlog server and is how task-worker loads specialist behavior when no SAM task `agent:` field is available. Use `{resolved_agent}` as the `agent=` metadata in `artifact_register` to record which specialist produced the spec.
 
 ### Domain Signal Detection — Config-Driven (`.dh/skill_discovery.yaml`)
 
@@ -382,8 +382,8 @@ Register your deliverable and return:
 
 `{specialist_skill_block}` is built by the orchestrator before dispatch:
 
-- When `{resolved_agent}` is set (manifest found): `"Load your specialist skill before starting: Skill(skill='{resolved_agent}'). This is a BLOCKING prerequisite — complete it before reading any artifacts or designing.\n\n"`
-- When no manifest found (fallback): `""` (empty string — task-worker needs no specialist loading)
+- When `{resolved_agent}` is set (manifest found): `"Load your specialist profile before starting: mcp__plugin_dh_backlog__profile_load(agent_name='{resolved_agent}'). This is a BLOCKING prerequisite — complete it before reading any artifacts or designing.\n\n"`
+- When no manifest found (fallback): `""` (empty string — task-worker executes directly without a specialist profile)
 
 After the agent completes, verify the artifact was registered:
 

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -356,22 +356,20 @@ finalizing the architecture. Training data is stale; current community practice 
 Produce architect-{slug}.md content with interfaces, contracts, data models, module boundaries.
 Do NOT implement — define WHAT to build, not the code.
 
-Write your deliverable to disk, register it, then return:
+Register your deliverable and return:
 
-1. Write the spec to `plan/architect-{slug}.md` using the `Write` tool.
-   Large-file rule: if the spec exceeds 25 000 characters, use Strategy B from
-   `.claude/rules/large-file-write-strategy.md` — write a skeleton first, then
-   fill each section with separate `Edit` calls, before proceeding to step 2.
+1. Call `artifact_register` with the full spec content:
 
-2. Register the artifact (the server auto-reads the file you wrote in step 1):
        mcp__plugin_dh_backlog__artifact_register(
            issue_number={issue},
            artifact_type="architect",
            artifact_id="plan/architect-{slug}.md",
+           content="<full spec markdown>",
            agent="python-cli-design-spec"
        )
 
-3. Return:
+2. Return:
+
        STATUS: DONE
        path: plan/architect-{slug}.md
 ```
@@ -383,9 +381,9 @@ mcp__plugin_dh_backlog__artifact_list(issue_number={issue}, artifact_type="archi
 ```
 
 If `count == 0`, the agent did not register the artifact. Re-dispatch with an explicit
-reminder that the agent must write the file to `plan/architect-{slug}.md` and call
-`artifact_register` itself — the orchestrator MUST NOT call `artifact_register` as a
-workaround. The MCP-native rule is that agents own their artifact storage.
+reminder that the agent must call `artifact_register(content=...)` itself — the
+orchestrator MUST NOT call `artifact_register` as a workaround. The MCP-native rule
+is that agents own their artifact storage.
 
 ---
 
@@ -519,24 +517,12 @@ When all phases complete, provide the user:
 
 ### Discovered During Implementation
 
-[Date: 2026-05-23 / Session: issue #1527 — Phase 3 write-to-disk refactor]
+[Date: 2026-05-23 / Session: issue #1527]
 
-During implementation of issue #1527, Phase 3's architect delegation prompt was changed from returning full spec content inline to a three-step write-to-disk + register + return-path pattern. This change revealed several constraints and alignment points that are not obvious from reading the skill in isolation.
+**Architect specs routinely exceed 32KB.** A real-world architect spec for a non-trivial feature can reach 32KB or more of markdown. The problem with the pre-#1527 pattern was that the orchestrator received the content inline in the agent response — the JSONL session output grew to 300KB or more, which the orchestrator cannot process. The fix is for the architect agent to call `artifact_register(content=...)` directly: the content stays within the agent's context window and is uploaded to the artifact backend (GitHub Gist); the orchestrator receives only `STATUS: DONE`. No Write tool step is needed or correct.
 
-**Architect specs routinely exceed 32KB.** A real-world architect spec for a non-trivial feature can reach 32KB or more of markdown. When returned inline from the agent, the JSONL session output grows to 300KB or more. The orchestrator cannot read this back — it exceeds what can be reasoned about in a single context window. The write-to-disk pattern is not an optimization; it is mandatory for specs of this size. Future implementors should not revert to inline return regardless of apparent simplicity of a given feature.
+**`artifact_register` without `content=` is a prohibited pattern.** Calling `artifact_register` with a path but no `content=` stores only a pointer to a local file. That file is unreachable from worktree-isolated agents, CI environments, and any other machine. Always pass `content=` explicitly. Source: `plugins/development-harness/CLAUDE.md` — "Prohibited patterns" section.
 
-**Phase 4 already established this pattern via `sam_create`.** The swarm-task-planner (Phase 4) has always written its output to disk as a YAML plan file and registered it via `sam_plan(action='create')`. Phase 3 now aligns with this established write-then-register pattern. When extending the skill with new phases, the presumption should be that all artifact-producing phases follow write-to-disk + register, not inline return.
+**`agent="python-cli-design-spec"` in `artifact_register` is Python-specific.** The Phase 3 delegation prompt hardcodes this value. It is correct for the Python workflow but incorrect for non-Python projects. A future improvement should resolve the agent name dynamically from the language manifest's role mapping.
 
-**`artifact_register` tier-2 auto-read works in main worktree context.** When Phase 3 runs in the main worktree (the normal case for `add-new-feature`), `artifact_register` with a path pointing to `plan/architect-{slug}.md` triggers the server to auto-read the file. This works correctly because the file is in the root worktree path. Worktree-isolated contexts (e.g., parallel dispatch in `work-milestone`) cannot see root worktree `plan/` files — this is a future concern tracked as a concern in issue #1527 and is not addressed by the Phase 3 change.
-
-**`agent="python-cli-design-spec"` in `artifact_register` is Python-specific.** The Phase 3 delegation prompt hardcodes `agent="python-cli-design-spec"` in the `artifact_register` call. This is intentional for the Python workflow (the language manifest maps the architect role to `@python3-development:python-cli-design-spec`) but is incorrect for non-Python projects. A future improvement should resolve the agent name dynamically from the manifest's role mapping rather than hardcoding it. This is logged as a future concern in issue #1527 and does not affect the current Python-first deployment.
-
-**The large-file write strategy (Strategy B) is the correct fallback for oversized specs.** The reference at `.claude/rules/large-file-write-strategy.md` describes a skeleton + Edit-fill pattern for files exceeding 25,000 characters. This integrates correctly with the Phase 3 three-step flow: the agent writes the skeleton with `Write`, fills sections with `Edit`, then calls `artifact_register` in step 2. The 25,000-character threshold in the Phase 3 instruction is correct and matches the strategy document.
-
-#### Updated Technical Details
-
-- Phase 3 architect agent must write to `plan/architect-{slug}.md` before calling `artifact_register` — inline `content=` return is not viable for real-world spec sizes
-- The `artifact_register` call uses `artifact_id="plan/architect-{slug}.md"` as the logical path; the server auto-reads from the root worktree at that path
-- `agent="python-cli-design-spec"` in the `artifact_register` call is a Python-language-specific hardcode; non-Python projects will need this resolved from the language manifest
-- Spec size threshold for Strategy B (skeleton + Edit-fill): 25,000 characters, per `.claude/rules/large-file-write-strategy.md`
-- Phase 4 (`sam_plan(action='create')`) auto-registers the `task-plan` artifact — no separate `artifact_register` call is needed or valid for that type
+**Phase 4 (`sam_plan(action='create')`) auto-registers the `task-plan` artifact** — no separate `artifact_register` call is needed or valid for that type.

--- a/plugins/development-harness/skills/code-review-architecture/SKILL.md
+++ b/plugins/development-harness/skills/code-review-architecture/SKILL.md
@@ -457,7 +457,7 @@ Register one artifact:
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
-  issue_number={issue_number},
+  item_id={issue_number},
   type="codebase-analysis",
   artifact_id="architecture-graph-{slug}",
   content={report_markdown},
@@ -473,7 +473,7 @@ Register each diagram as a separate artifact. Register the parent first, then ea
 ```text
 %% Parent
 mcp__plugin_dh_backlog__artifact_register(
-  issue_number={issue_number},
+  item_id={issue_number},
   type="codebase-analysis",
   artifact_id="architecture-graph-{slug}",
   content={parent_report_markdown},
@@ -483,7 +483,7 @@ mcp__plugin_dh_backlog__artifact_register(
 
 %% Each child cluster
 mcp__plugin_dh_backlog__artifact_register(
-  issue_number={issue_number},
+  item_id={issue_number},
   type="codebase-analysis",
   artifact_id="architecture-graph-{slug}-{cluster-name}",
   content={child_report_markdown},
@@ -492,7 +492,7 @@ mcp__plugin_dh_backlog__artifact_register(
 )
 ```
 
-If `issue_number` is not available, output all reports inline (parent first, then children) and note that artifact registration was skipped.
+If `item_id` is not available, output all reports inline (parent first, then children) and note that artifact registration was skipped.
 
 </workflow>
 

--- a/plugins/development-harness/skills/complete-implementation/SKILL.md
+++ b/plugins/development-harness/skills/complete-implementation/SKILL.md
@@ -272,7 +272,7 @@ Before invoking Phase 1, check for a TN verification report produced by `tn-veri
 
 Extract `{slug}` from the task file path (`plan/P{id}-{slug}.yaml` — strip the `P{id}-` prefix and `.yaml` suffix).
 
-Read the TN-verification artifact via `artifact_read(issue_number={N}, artifact_type="TN-verification")`.
+Read the TN-verification artifact via `artifact_read(item_id={N}, artifact_type="TN-verification")`.
 
 The file contains a list of per-criterion `BookendVerification` records — one per `acceptance-criteria-structured` entry. There is no top-level `verdict` field. Aggregate the verdict by scanning all records: the overall result is FAIL if any record has `status: regressed`; otherwise PASS.
 
@@ -280,7 +280,7 @@ The following diagram is the authoritative procedure for Pre-Phase 1 TN Verifica
 
 ```mermaid
 flowchart TD
-    Read["artifact_read(issue_number, 'TN-verification')"] --> Exists{Artifact exists?}
+    Read["artifact_read(item_id, 'TN-verification')"] --> Exists{Artifact exists?}
     Exists -->|No| Proceed["No structured criteria — proceed to Phase 1"]
     Exists -->|Yes| Scan["Scan all per-criterion records<br>for status: regressed"]
     Scan --> AnyRegressed{Any criterion<br>has status: regressed?}
@@ -332,7 +332,7 @@ If signal found — confirm all four fidelity items from the reference before pr
 When the parent story issue number is known (from the plan's `issue` field or the backlog item), query the artifact manifest to discover all plan artifacts for this feature:
 
 ```text
-mcp__plugin_dh_backlog__artifact_list(issue_number=N)
+mcp__plugin_dh_backlog__artifact_list(item_id=N)
 ```
 
 If the response contains artifacts, pass the manifest to quality gate agents (Phases T0-T6) so they can access plan artifacts via `artifact_read` instead of filesystem paths. This is critical for worktree-isolated agents.
@@ -581,7 +581,7 @@ After all phases complete, route any follow-up task files created by Phase 1 (co
 Retrieve the review report registered by `@dh:code-reviewer` during Phase 1:
 
 ```text
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type="codebase-analysis")
+mcp__plugin_dh_backlog__artifact_read(item_id={issue_number}, artifact_type="codebase-analysis")
 ```
 
 Check the `verdict` field in the report:

--- a/plugins/development-harness/skills/context-integration/SKILL.md
+++ b/plugins/development-harness/skills/context-integration/SKILL.md
@@ -74,7 +74,7 @@ Re-register the updated plan via MCP:
 
 ```text
 artifact_register(
-  issue_number={issue},
+  item_id={issue},
   artifact_type="architect",
   path="plan/architect-{slug}.md",
   agent="context-integration",
@@ -87,12 +87,12 @@ Add the Contextualization section and mark the status checkbox as complete.
 
 ## Input
 
-- `ARTIFACT:PLAN` via `artifact_read(issue_number={issue}, artifact_type="architect")`
+- `ARTIFACT:PLAN` via `artifact_read(item_id={issue}, artifact_type="architect")`
 - Read access to the codebase
 
 ## Output
 
-Updated `ARTIFACT:PLAN` re-registered via `artifact_register(issue_number={issue}, artifact_type="architect", path="plan/architect-{slug}.md", agent="context-integration", content="{full_updated_plan_markdown}")` with the following section appended:
+Updated `ARTIFACT:PLAN` re-registered via `artifact_register(item_id={issue}, artifact_type="architect", path="plan/architect-{slug}.md", agent="context-integration", content="{full_updated_plan_markdown}")` with the following section appended:
 
 ```markdown
 ## Contextualization

--- a/plugins/development-harness/skills/create-artifact/SKILL.md
+++ b/plugins/development-harness/skills/create-artifact/SKILL.md
@@ -13,7 +13,7 @@ inline.
 
 - **Disk writes** produce a file only accessible from the root worktree. Worktree-isolated agents
   and CI environments cannot reach `~/.dh/...` paths via filesystem — they must use
-  `artifact_read(issue_number, artifact_type)` over MCP.
+  `artifact_read(item_id, artifact_type)` over MCP.
 - **Inline returns** are truncated by the task-notification summary when the agent runs as a
   background-dispatched task. The orchestrator receives a partial summary, not the full document.
 
@@ -24,7 +24,7 @@ worktree or environment — can retrieve it via `artifact_read`.
 
 ```python
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number=<int>,           # GitHub issue number — REQUIRED
+    item_id=<int>,                # GitHub issue number — REQUIRED
     artifact_type=<str>,          # Artifact type string — REQUIRED (see table below)
     artifact_id=<str>,            # Logical identifier — REQUIRED (see path format below)
     status="current",             # Lifecycle status: draft | current | superseded | archived
@@ -71,7 +71,7 @@ Do NOT use `~/.dh/...` paths — these are MCP-server internals, not stable agen
 ### `content`
 
 Pass the full markdown string. When `content` is provided, it is stored as a structured GitHub
-issue comment retrievable via `artifact_read(issue_number, artifact_type)` from any environment.
+issue comment retrievable via `artifact_read(item_id, artifact_type)` from any environment.
 
 When `content` is `None`: the server attempts to read a local file at `artifact_id` (resolved
 against the root worktree). If no file exists, a manifest-only entry is registered and a warning
@@ -83,7 +83,7 @@ is emitted. For background-dispatched agents, always pass `content=` explicitly.
 
 ```python
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number=1770,
+    item_id=1770,
     artifact_type="feature-context",
     artifact_id="plan/feature-context-my-feature.md",
     content=feature_context_markdown,
@@ -95,7 +95,7 @@ mcp__plugin_dh_backlog__artifact_register(
 
 ```python
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number=1770,
+    item_id=1770,
     artifact_type="codebase-analysis",
     artifact_id="codebase-patterns-my-feature",  # logical id: codebase-{focus}-{slug}
     content=patterns_markdown,
@@ -103,7 +103,7 @@ mcp__plugin_dh_backlog__artifact_register(
 )
 
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number=1770,
+    item_id=1770,
     artifact_type="codebase-analysis",
     artifact_id="codebase-architecture-my-feature",  # logical id: codebase-{focus}-{slug}
     content=architecture_markdown,
@@ -115,7 +115,7 @@ mcp__plugin_dh_backlog__artifact_register(
 
 ```python
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number=1770,
+    item_id=1770,
     artifact_type="architect",
     artifact_id="plan/architect-my-feature.md",
     content=architect_markdown,
@@ -132,7 +132,7 @@ mcp__plugin_dh_backlog__artifact_register(
 
 ```python
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number=1770,
+    item_id=1770,
     artifact_type="research",
     artifact_id="plan/swarm-rationale-my-feature.md",
     content=rationale_markdown,

--- a/plugins/development-harness/skills/development-harness/references/artifact-conventions.md
+++ b/plugins/development-harness/skills/development-harness/references/artifact-conventions.md
@@ -47,9 +47,9 @@ Artifacts are stored and retrieved via two distinct MCP systems. No stage reads 
 
 Document-level artifacts (discovery, plan, context integration) are managed by the backlog MCP server:
 
-- **Write:** `artifact_register(issue_number, artifact_type, path, agent, content)` — registers the artifact and uploads content to a GitHub Issue comment for worktree-isolated access.
-- **Read:** `artifact_read(issue_number, artifact_type)` — returns `{type, path, content, status}`. Resolves from GitHub Issue comments first, filesystem fallback second.
-- **List:** `artifact_list(issue_number, artifact_type=None)` — enumerates registered artifacts for an issue.
+- **Write:** `artifact_register(item_id, artifact_type, path, agent, content)` — registers the artifact and uploads content to a GitHub Issue comment for worktree-isolated access.
+- **Read:** `artifact_read(item_id, artifact_type)` — returns `{type, path, content, status}`. Resolves from GitHub Issue comments first, filesystem fallback second.
+- **List:** `artifact_list(item_id, artifact_type=None)` — enumerates registered artifacts for an issue.
 
 Artifact types used in the S1–S7 pipeline:
 

--- a/plugins/development-harness/skills/development-harness/references/sdlc-stage-taxonomy.md
+++ b/plugins/development-harness/skills/development-harness/references/sdlc-stage-taxonomy.md
@@ -29,7 +29,7 @@ skill_activation: /dh:discovery
 purpose: Understand the feature request, identify constraints, and survey the codebase state before any planning occurs.
 inputs: Feature description, codebase root path, any prior context files
 outputs: DISCOVERY artifact containing problem framing, constraint inventory, affected surfaces, and open questions
-artifact_access: artifact_register(issue_number, "feature-context", path, agent, content=...) / artifact_read(issue_number, "feature-context")
+artifact_access: artifact_register(item_id, "feature-context", path, agent, content=...) / artifact_read(item_id, "feature-context")
 ```
 
 #### S2 — `planning`
@@ -41,7 +41,7 @@ skill_activation: /dh:planning
 purpose: Produce a structured plan covering solution architecture, acceptance tests, risk assessment, and RT-ICA completeness gate.
 inputs: DISCOVERY artifact, codebase context
 outputs: PLAN artifact with architecture, acceptance tests in Given/When/Then format, risk assessment, task skeletons, and RT-ICA gate result
-artifact_access: artifact_register(issue_number, "architect", path, agent, content=...) / artifact_read(issue_number, "architect")
+artifact_access: artifact_register(item_id, "architect", path, agent, content=...) / artifact_read(item_id, "architect")
 ```
 
 #### S3 — `context-integration`
@@ -53,7 +53,7 @@ skill_activation: /dh:context-integration
 purpose: Validate the S2 plan against actual codebase state, resolving gaps and updating the plan artifact before task decomposition.
 inputs: PLAN artifact, live codebase read access
 outputs: Amended PLAN artifact with resolved gaps, confirmed assumptions, and updated constraints
-artifact_access: artifact_read(issue_number, "architect") / artifact_register(issue_number, "architect", path, agent, content=...)
+artifact_access: artifact_read(item_id, "architect") / artifact_register(item_id, "architect", path, agent, content=...)
 ```
 
 #### S4 — `task-decomposition`

--- a/plugins/development-harness/skills/discovery/SKILL.md
+++ b/plugins/development-harness/skills/discovery/SKILL.md
@@ -106,7 +106,7 @@ Artifact registered via MCP:
 
 ```text
 artifact_register(
-    issue_number={issue},
+    item_id={issue},
     artifact_type="feature-context",
     path="plan/feature-context-{slug}.md",
     agent="discovery",

--- a/plugins/development-harness/skills/final-verification/SKILL.md
+++ b/plugins/development-harness/skills/final-verification/SKILL.md
@@ -44,7 +44,7 @@ flowchart TD
 
 ### Step 1 — Extract Original Goals
 
-Read the feature-context artifact via `artifact_read(issue_number={issue}, artifact_type="feature-context")` and extract:
+Read the feature-context artifact via `artifact_read(item_id={issue}, artifact_type="feature-context")` and extract:
 
 - All goals from the Goals section
 - All anti-goals from the Anti-Goals section
@@ -81,7 +81,7 @@ Document evidence for each truth — file paths, test output, observed behavior.
 
 ### Step 4 — Check Acceptance Tests
 
-Read the architect artifact via `artifact_read(issue_number={issue}, artifact_type="architect")` and extract the acceptance tests (Given/When/Then).
+Read the architect artifact via `artifact_read(item_id={issue}, artifact_type="architect")` and extract the acceptance tests (Given/When/Then).
 For each acceptance test:
 
 - Verify the precondition (Given) can be established
@@ -103,8 +103,8 @@ For the quality gate protocol, reference `/dh:validation-protocol`.
 ## Input
 
 - All review results via `sam_task(plan="{plan_id}", task="{task_id}", config={"action": "read"})` per task — review content is stored in task body sections
-- Feature-context artifact via `artifact_read(issue_number={issue}, artifact_type="feature-context")`
-- Architect artifact via `artifact_read(issue_number={issue}, artifact_type="architect")`
+- Feature-context artifact via `artifact_read(item_id={issue}, artifact_type="feature-context")`
+- Architect artifact via `artifact_read(item_id={issue}, artifact_type="architect")`
 - Read access to the codebase
 
 ## Output

--- a/plugins/development-harness/skills/forensic-review/SKILL.md
+++ b/plugins/development-harness/skills/forensic-review/SKILL.md
@@ -54,7 +54,7 @@ sam_task(plan="{plan_id}", task="{task_id}", config={"action": "read"})
 Extract:
 
 - `task_file_path` — the path to the task YAML file (e.g., `plan/P{id}-{slug}.yaml`)
-- `issue_number` — required for artifact registration; if absent, BLOCK immediately
+- `item_id` — required for artifact registration; if absent, BLOCK immediately
 - `expected_outputs` — the implementation files produced by Stage 5 (listed in the task's
   "Files Changed" or "Expected Outputs" section)
 - `acceptance_criteria` — the explicit success conditions to verify
@@ -67,14 +67,14 @@ Context to include in the prompt:
 
 - `task_file_path` — path to the SAM task file
 - `implementation_files` — the files from the task's Expected Outputs
-- `issue_number` — required for `artifact_register` inside the agent
+- `item_id` — required for `artifact_register` inside the agent
 
 ```text
 Task is S6 forensic review with subagent_type="dh:code-reviewer"
-Context: task_file_path={task_file_path}, issue_number={issue_number},
+Context: task_file_path={task_file_path}, item_id={item_id},
   implementation_files={expected_outputs}
 Output: STATUS block containing Verdict (PASS / FAIL / NEEDS-WORK) and ARTIFACTS
-  section confirming codebase-analysis artifact registered on issue #{issue_number}
+  section confirming codebase-analysis artifact registered on issue #{item_id}
 ```
 
 The agent independently reads the task, detects the stack, verifies acceptance criteria,
@@ -96,7 +96,7 @@ NEEDED section as the reason.
 Retrieve the registered review report:
 
 ```text
-artifact_read(issue_number={issue_number}, artifact_type="codebase-analysis")
+artifact_read(item_id={item_id}, artifact_type="codebase-analysis")
 ```
 
 Use this to populate the SAM task's Review Results section and to extract blocking findings
@@ -115,7 +115,7 @@ sam_task(
 ## Input
 
 - `ARTIFACT:EXECUTION` + `ARTIFACT:TASK` via `sam_task(plan="{plan_id}", task="{task_id}", config={"action": "read"})`
-- `issue_number` — must be present; used by `@dh:code-reviewer` for `artifact_register` and
+- `item_id` — must be present; used by `@dh:code-reviewer` for `artifact_register` and
   by this skill for `artifact_read`
 
 ## NEEDS_WORK Remediation Loop
@@ -152,6 +152,6 @@ Remediation tasks follow the same CLEAR format as original tasks. They:
 ## Success Criteria
 
 - `@dh:code-reviewer` returns STATUS: DONE with a PASS, FAIL, or NEEDS-WORK verdict
-- `codebase-analysis` artifact is registered on issue #{issue_number}
+- `codebase-analysis` artifact is registered on issue #{item_id}
 - Review Results appended to the SAM task via `sam_task(action='update')`
 - Blocking findings (if any) have concrete remediation tasks created

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -161,7 +161,7 @@ Concerns accumulate across all task agents. They feed into the validation stage 
 4a. If a parent issue number is known (`str | int` — GitHub integer ID or beads string ID), attempt contract verification against the architect spec:
 
 ```text
-mcp__plugin_dh_backlog__artifact_read(issue_number=N, artifact_type="architect")
+mcp__plugin_dh_backlog__artifact_read(item_id=N, artifact_type="architect")
 ```
 
 If `artifact_read` returns content (architect spec exists), resolve the files modified by the just-completed task:
@@ -318,14 +318,14 @@ When the parent story issue number is known (`str | int` — GitHub integer ID o
 
 ```text
 After writing plan/T0-baseline-{slug}.yaml, register it:
-  mcp__plugin_dh_backlog__artifact_register(issue_number=N, artifact_type="T0-baseline", path="plan/T0-baseline-{slug}.yaml", agent="t0-baseline-capture")
+  mcp__plugin_dh_backlog__artifact_register(item_id=N, artifact_type="T0-baseline", path="plan/T0-baseline-{slug}.yaml", agent="t0-baseline-capture")
 ```
 
 **TN delegation prompt addition:**
 
 ```text
 After writing plan/TN-verification-{slug}.yaml, register it:
-  mcp__plugin_dh_backlog__artifact_register(issue_number=N, artifact_type="TN-verification", path="plan/TN-verification-{slug}.yaml", agent="tn-verification-gate")
+  mcp__plugin_dh_backlog__artifact_register(item_id=N, artifact_type="TN-verification", path="plan/TN-verification-{slug}.yaml", agent="tn-verification-gate")
 ```
 
 If the issue number is not known, skip registration. The artifacts remain discoverable via filesystem conventions.

--- a/plugins/development-harness/skills/planning/SKILL.md
+++ b/plugins/development-harness/skills/planning/SKILL.md
@@ -79,7 +79,7 @@ For each identified risk:
 
 ## Input
 
-- `ARTIFACT:DISCOVERY` via `artifact_read(issue_number={issue}, artifact_type="feature-context")`
+- `ARTIFACT:DISCOVERY` via `artifact_read(item_id={issue}, artifact_type="feature-context")`
 
 ## Output
 
@@ -87,7 +87,7 @@ Artifact registered via MCP:
 
 ```text
 artifact_register(
-    issue_number={issue},
+    item_id={issue},
     artifact_type="architect",
     path="plan/architect-{slug}.md",
     agent="planning",

--- a/plugins/development-harness/skills/start-task/SKILL.md
+++ b/plugins/development-harness/skills/start-task/SKILL.md
@@ -59,14 +59,14 @@ $ARGUMENTS
    If the `TaskAssignment` JSON contains a `parent_issue_number` or the plan has an `issue` field, query the artifact manifest to discover available plan artifacts:
 
    ```text
-   mcp__plugin_dh_backlog__artifact_list(issue_number=N)
+   mcp__plugin_dh_backlog__artifact_list(item_id=N)
    ```
 
    If the response contains artifacts (non-empty `artifacts` list), use `artifact_read` to fetch the architect spec and feature context content:
 
    ```text
-   mcp__plugin_dh_backlog__artifact_read(issue_number=N, artifact_type="architect")
-   mcp__plugin_dh_backlog__artifact_read(issue_number=N, artifact_type="feature-context")
+   mcp__plugin_dh_backlog__artifact_read(item_id=N, artifact_type="architect")
+   mcp__plugin_dh_backlog__artifact_read(item_id=N, artifact_type="feature-context")
    ```
 
    Use the returned content as context for implementation instead of reading filesystem paths directly. This is especially important for worktree-isolated agents that cannot access uncommitted plan files from the root worktree.
@@ -143,7 +143,7 @@ handles any external tracker sync on task completion. No additional call is requ
 
 ### DN-1: {Brief title}
 
-- **Plan artifact**: `artifact_read(issue_number={N}, artifact_type="architect")`, section "{section name}"
+- **Plan artifact**: `artifact_read(item_id={N}, artifact_type="architect")`, section "{section name}"
 - **Plan claim**: "{quoted text from plan artifact}"
 - **Actual implementation**: "{what was actually done and why}"
 - **Classification**: design-refinement | intent-divergence

--- a/plugins/development-harness/skills/task-decomposition/SKILL.md
+++ b/plugins/development-harness/skills/task-decomposition/SKILL.md
@@ -111,7 +111,7 @@ Role-to-agent resolution happens at execution time via the language manifest.
 Retrieve the contextualized plan via MCP:
 
 ```text
-artifact_read(issue_number={issue}, artifact_type="architect")
+artifact_read(item_id={issue}, artifact_type="architect")
 ```
 
 Returns `{type, path, content, status, messages, warnings}`. The `content`

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/groom/analyze.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/groom/analyze.md
@@ -15,13 +15,13 @@ Runs after `intake.md` completes with PROCEED.
 1. Check for existing discovery artifact:
 
 ```text
-mcp__plugin_dh_backlog__artifact_list(issue_number={issue_number}, artifact_type='feature-context')
+mcp__plugin_dh_backlog__artifact_list(item_id={issue_number}, artifact_type='feature-context')
 ```
 
 2. If `count > 0`: load the artifact and pass it to swarm agents as prior context.
 
 ```text
-mcp__plugin_dh_backlog__artifact_read(issue_number={issue_number}, artifact_type='feature-context')
+mcp__plugin_dh_backlog__artifact_read(item_id={issue_number}, artifact_type='feature-context')
 ```
 
 → **CONTINUE** to RT-ICA snapshot.
@@ -41,7 +41,7 @@ Inspect `response["sections"]`. If **all three** of the following are non-empty:
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
-    issue_number={issue_number},
+    item_id={issue_number},
     artifact_type='feature-context',
     path='plan/feature-context-{slug}.md',
     agent='discovery',
@@ -61,7 +61,7 @@ Skill(skill='dh:discovery', args='{item_ref}')
 5. Verify artifact was registered:
 
 ```text
-mcp__plugin_dh_backlog__artifact_list(issue_number={issue_number}, artifact_type='feature-context')
+mcp__plugin_dh_backlog__artifact_list(item_id={issue_number}, artifact_type='feature-context')
 ```
 
 - `count > 0` → load artifact via `artifact_read`, **CONTINUE**.
@@ -69,7 +69,7 @@ mcp__plugin_dh_backlog__artifact_list(issue_number={issue_number}, artifact_type
 
 ```text
 Skill(skill='dh:discovery', args='{item_ref}')
-mcp__plugin_dh_backlog__artifact_list(issue_number={issue_number}, artifact_type='feature-context')
+mcp__plugin_dh_backlog__artifact_list(item_id={issue_number}, artifact_type='feature-context')
 ```
 
 - `count > 0` after retry → load artifact, **CONTINUE**.

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/sam-definition.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/sam-definition.md
@@ -68,7 +68,7 @@ Each artifact type uses the token pattern `ARTIFACT:{TYPE}({SCOPE_OR_ID})`. Stor
 
 2. **Produce artifacts at every stage**
    - Use `ARTIFACT:{TYPE}({ID})` tokens in artifact headers; cross-reference predecessor/successor.
-   - In claude_skills: Register via MCP — `artifact_register(issue_number, artifact_type, path, agent, content)` for discovery and plan artifacts. For task plans, choose a creation path based on plan size:
+   - In claude_skills: Register via MCP — `artifact_register(item_id, artifact_type, path, agent, content)` for discovery and plan artifacts. For task plans, choose a creation path based on plan size:
 
      **Monolithic path** (fewer than 16 tasks):
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/validate.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/validate.md
@@ -32,15 +32,15 @@ flowchart TD
     HasIssue -->|"No"| SkipGate["Skip discovery gate<br>Proceed to Step 3.1"]
     HasIssue -->|"Yes — issue #{N}"| TypeCheck{"Labels include<br>'type:fix' or 'type:bug'?"}
     TypeCheck -->|"Yes — fix/bug type"| SkipGate
-    TypeCheck -->|"No — feature/refactor/other"| CheckArtifact["artifact_list(<br>issue_number={N},<br>artifact_type='feature-context')"]
+    TypeCheck -->|"No — feature/refactor/other"| CheckArtifact["artifact_list(<br>item_id={N},<br>artifact_type='feature-context')"]
     CheckArtifact --> HasDiscovery{"count > 0?"}
     HasDiscovery -->|"Yes"| Proceed["Discovery exists<br>Proceed to Step 3.1"]
     HasDiscovery -->|"No"| InvokeDiscovery["Invoke: Skill(skill='dh:discovery')"]
-    InvokeDiscovery --> VerifyDiscovery["Call artifact_list(<br>issue_number={N},<br>artifact_type='feature-context')"]
+    InvokeDiscovery --> VerifyDiscovery["Call artifact_list(<br>item_id={N},<br>artifact_type='feature-context')"]
     VerifyDiscovery --> DiscoveryConfirmed{"count > 0?"}
     DiscoveryConfirmed -->|"Yes — artifact registered"| Continue
     DiscoveryConfirmed -->|"No — retry once"| RetryDiscovery["Re-invoke: Skill(skill='dh:discovery')<br>(max 1 retry)"]
-    RetryDiscovery --> VerifyRetry["Call artifact_list(<br>issue_number={N},<br>artifact_type='feature-context')"]
+    RetryDiscovery --> VerifyRetry["Call artifact_list(<br>item_id={N},<br>artifact_type='feature-context')"]
     VerifyRetry --> RetryConfirmed{"count > 0?"}
     RetryConfirmed -->|"Yes"| Continue
     RetryConfirmed -->|"No — still 0 after retry"| DiscoveryFail(["STOP — report to user:<br>dh:discovery completed but no feature-context<br>artifact was registered for issue #{N}.<br>Re-run /dh:discovery manually and retry."])
@@ -50,7 +50,7 @@ flowchart TD
 
 The discovery skill gathers WHO/WHAT/WHEN/WHY requirements and registers the result as a
 `feature-context` artifact. The exit signal is a non-zero count from
-`artifact_list(issue_number={N}, artifact_type='feature-context')`.
+`artifact_list(item_id={N}, artifact_type='feature-context')`.
 
 **When <mode/> is `auto`**: After `dh:discovery` returns, do NOT yield to the user. Immediately
 call `artifact_list` to verify the artifact was registered, then proceed to Step 3.1 without

--- a/plugins/development-harness/skills/work-milestone/SKILL.md
+++ b/plugins/development-harness/skills/work-milestone/SKILL.md
@@ -172,7 +172,7 @@ done
 **Via self-discovery (the session does this itself):**
 
 - Groomed description and acceptance criteria — via `backlog_view(selector="#{issue}")`
-- Plan artifacts — via `artifact_list(issue_number={issue})` then `artifact_read(...)`
+- Plan artifacts — via `artifact_list(item_id={issue})` then `artifact_read(...)`
 - SAM task plan — via `sam_plan` if a plan exists
 - Skills to load — from `skills` field in SAM task metadata
 

--- a/plugins/development-harness/tests/test_artifact_content_storage.py
+++ b/plugins/development-harness/tests/test_artifact_content_storage.py
@@ -492,7 +492,7 @@ async def test_artifact_register_without_content_and_no_local_file_registers_man
         )
         # Act
         result = await _call(
-            "artifact_register", {"issue_number": 42, "artifact_type": "research", "artifact_id": "plan/r.md"}
+            "artifact_register", {"item_id": 42, "artifact_type": "research", "artifact_id": "plan/r.md"}
         )
 
     # Assert
@@ -528,12 +528,7 @@ async def test_artifact_register_with_content_stores_to_github() -> None:
         # Act
         result = await _call(
             "artifact_register",
-            {
-                "issue_number": 42,
-                "artifact_type": "research",
-                "artifact_id": "plan/r.md",
-                "content": "# Research content",
-            },
+            {"item_id": 42, "artifact_type": "research", "artifact_id": "plan/r.md", "content": "# Research content"},
         )
 
     # Assert
@@ -567,7 +562,7 @@ async def test_artifact_register_without_content_reads_local_file_and_uploads() 
         )
         # Act
         result = await _call(
-            "artifact_register", {"issue_number": 42, "artifact_type": "research", "artifact_id": "plan/r.md"}
+            "artifact_register", {"item_id": 42, "artifact_type": "research", "artifact_id": "plan/r.md"}
         )
 
     # Assert
@@ -589,7 +584,7 @@ async def test_artifact_register_with_invalid_type_returns_error() -> None:
     """
     # Arrange / Act
     result = await _call(
-        "artifact_register", {"issue_number": 42, "artifact_type": "not-a-real-type", "artifact_id": "plan/foo.md"}
+        "artifact_register", {"item_id": 42, "artifact_type": "not-a-real-type", "artifact_id": "plan/foo.md"}
     )
 
     # Assert
@@ -621,7 +616,7 @@ async def test_artifact_read_returns_github_content_when_available() -> None:
     ):
         mock_registry.get_by_type.return_value = [entry]
         # Act
-        result = await _call("artifact_read", {"issue_number": 42, "artifact_type": "research"})
+        result = await _call("artifact_read", {"item_id": 42, "artifact_type": "research"})
 
     # Assert
     assert result.get("error") is None
@@ -650,7 +645,7 @@ async def test_artifact_read_falls_back_to_filesystem_when_github_returns_none(t
     ):
         mock_registry.get_by_type.return_value = [entry]
         # Act
-        result = await _call("artifact_read", {"issue_number": 42, "artifact_type": "research"})
+        result = await _call("artifact_read", {"item_id": 42, "artifact_type": "research"})
 
     # Assert
     assert result.get("error") is None
@@ -676,7 +671,7 @@ async def test_artifact_read_returns_error_when_type_not_found() -> None:
     ):
         mock_registry.get_by_type.return_value = []
         # Act
-        result = await _call("artifact_read", {"issue_number": 42, "artifact_type": "research"})
+        result = await _call("artifact_read", {"item_id": 42, "artifact_type": "research"})
 
     # Assert
     assert "error" in result
@@ -690,7 +685,7 @@ async def test_artifact_read_returns_error_for_invalid_type() -> None:
     Why: Input validation must reject invalid types before touching GitHub.
     """
     # Arrange / Act
-    result = await _call("artifact_read", {"issue_number": 42, "artifact_type": "not-real"})
+    result = await _call("artifact_read", {"item_id": 42, "artifact_type": "not-real"})
 
     # Assert
     assert "error" in result
@@ -728,7 +723,7 @@ async def test_artifact_read_multi_entry_returns_most_recent_and_warns() -> None
         # Registry returns insertion-order list (older first)
         mock_registry.get_by_type.return_value = [older_entry, newer_entry]
         # Act
-        result = await _call("artifact_read", {"issue_number": 42, "artifact_type": "research"})
+        result = await _call("artifact_read", {"item_id": 42, "artifact_type": "research"})
 
     # Assert: most recent returned
     assert result.get("error") is None

--- a/plugins/development-harness/tests/test_artifact_provider_fallback.py
+++ b/plugins/development-harness/tests/test_artifact_provider_fallback.py
@@ -236,7 +236,7 @@ async def test_warning_surfaces_in_artifact_register_response(active_fallback: L
     result = await _call(
         "artifact_register",
         {
-            "issue_number": 9999,
+            "item_id": 9999,
             "artifact_type": "research",
             "artifact_id": "research-fallback-warning-test",
             "content": "test content for warning merge test",
@@ -247,17 +247,17 @@ async def test_warning_surfaces_in_artifact_register_response(active_fallback: L
 
 async def test_warning_surfaces_in_artifact_list_response(active_fallback: LocalFilesystemArtifactProvider) -> None:
     """artifact_list response warnings list contains the local-provider warning."""
-    result = await _call("artifact_list", {"issue_number": 9999})
+    result = await _call("artifact_list", {"item_id": 9999})
     assert _EXPECTED_WARNING in result.get("warnings", [])
 
 
 async def test_warning_surfaces_in_artifact_get_response(active_fallback: LocalFilesystemArtifactProvider) -> None:
     """artifact_get response warnings list contains the local-provider warning."""
-    result = await _call("artifact_get", {"issue_number": 9999, "artifact_type": "research"})
+    result = await _call("artifact_get", {"item_id": 9999, "artifact_type": "research"})
     assert _EXPECTED_WARNING in result.get("warnings", [])
 
 
 async def test_warning_surfaces_in_artifact_read_response(active_fallback: LocalFilesystemArtifactProvider) -> None:
     """artifact_read response warnings list contains the local-provider warning."""
-    result = await _call("artifact_read", {"issue_number": 9999, "artifact_type": "research"})
+    result = await _call("artifact_read", {"item_id": 9999, "artifact_type": "research"})
     assert _EXPECTED_WARNING in result.get("warnings", [])

--- a/plugins/development-harness/tests/test_artifact_provider_local.py
+++ b/plugins/development-harness/tests/test_artifact_provider_local.py
@@ -211,10 +211,7 @@ class TestStoreArtifactContent:
     def test_writes_new_file(self, provider: LocalFilesystemArtifactProvider, root_worktree: Path) -> None:
         """store_artifact_content creates the file with the given content."""
         provider.store_artifact_content(
-            issue_number=1,
-            artifact_type=ArtifactType.ARCHITECT,
-            path="plan/new-artifact.md",
-            content="# Architect Spec\n",
+            item_id=1, artifact_type=ArtifactType.ARCHITECT, path="plan/new-artifact.md", content="# Architect Spec\n"
         )
         target = root_worktree / "plan" / "new-artifact.md"
         assert target.exists()
@@ -227,7 +224,7 @@ class TestStoreArtifactContent:
         target.write_text("original content", encoding="utf-8")
 
         provider.store_artifact_content(
-            issue_number=1, artifact_type=ArtifactType.ARCHITECT, path="plan/existing.md", content="new content"
+            item_id=1, artifact_type=ArtifactType.ARCHITECT, path="plan/existing.md", content="new content"
         )
         assert target.read_text(encoding="utf-8") == "original content"
 

--- a/plugins/development-harness/tests_backlog/test_artifact_provider.py
+++ b/plugins/development-harness/tests_backlog/test_artifact_provider.py
@@ -765,7 +765,7 @@ class TestMCPToolArtifactRegister:
             result = await client.call_tool(
                 "artifact_register",
                 {
-                    "issue_number": 965,
+                    "item_id": 965,
                     "artifact_type": "feature-context",
                     "artifact_id": "plan/feature-context-foo.md",
                     "status": "current",
@@ -796,7 +796,7 @@ class TestMCPToolArtifactRegister:
             await client.call_tool(
                 "artifact_register",
                 {
-                    "issue_number": 965,
+                    "item_id": 965,
                     "artifact_type": "architect",
                     "artifact_id": "plan/architect-foo.md",
                     "status": "draft",
@@ -808,7 +808,7 @@ class TestMCPToolArtifactRegister:
             result = await client.call_tool(
                 "artifact_register",
                 {
-                    "issue_number": 965,
+                    "item_id": 965,
                     "artifact_type": "architect",
                     "artifact_id": "plan/architect-foo.md",
                     "status": "current",
@@ -835,7 +835,7 @@ class TestMCPToolArtifactRegister:
         async with Client(patched_mcp_server) as client:
             result = await client.call_tool(
                 "artifact_register",
-                {"issue_number": 100, "artifact_type": "not-a-real-type", "artifact_id": "plan/something.md"},
+                {"item_id": 100, "artifact_type": "not-a-real-type", "artifact_id": "plan/something.md"},
             )
 
         # Assert
@@ -855,7 +855,7 @@ class TestMCPToolArtifactRegister:
             result = await client.call_tool(
                 "artifact_register",
                 {
-                    "issue_number": 100,
+                    "item_id": 100,
                     "artifact_type": "architect",
                     "artifact_id": "plan/architect-foo.md",
                     "status": "not-a-real-status",
@@ -897,7 +897,7 @@ class TestMCPToolArtifactList:
 
         # Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool("artifact_list", {"issue_number": 965})
+            result = await client.call_tool("artifact_list", {"item_id": 965})
 
         # Assert
         data = result.data
@@ -928,7 +928,7 @@ class TestMCPToolArtifactList:
 
         # Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool("artifact_list", {"issue_number": 10, "artifact_type": "architect"})
+            result = await client.call_tool("artifact_list", {"item_id": 10, "artifact_type": "architect"})
 
         # Assert
         data = result.data
@@ -948,7 +948,7 @@ class TestMCPToolArtifactList:
 
         # Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool("artifact_list", {"issue_number": 999})
+            result = await client.call_tool("artifact_list", {"item_id": 999})
 
         # Assert
         data = result.data
@@ -987,7 +987,7 @@ class TestMCPToolArtifactGet:
 
         # Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool("artifact_get", {"issue_number": 50, "artifact_type": "architect"})
+            result = await client.call_tool("artifact_get", {"item_id": 50, "artifact_type": "architect"})
 
         # Assert
         data = result.data
@@ -1015,7 +1015,7 @@ class TestMCPToolArtifactGet:
 
         # Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool("artifact_get", {"issue_number": 51, "artifact_type": "task-plan"})
+            result = await client.call_tool("artifact_get", {"item_id": 51, "artifact_type": "task-plan"})
 
         # Assert
         assert "error" in result.data
@@ -1053,7 +1053,7 @@ class TestMCPToolArtifactRead:
 
         # Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool("artifact_read", {"issue_number": 200, "artifact_type": "feature-context"})
+            result = await client.call_tool("artifact_read", {"item_id": 200, "artifact_type": "feature-context"})
 
         # Assert
         data = result.data
@@ -1076,7 +1076,7 @@ class TestMCPToolArtifactRead:
 
         # Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool("artifact_read", {"issue_number": 300, "artifact_type": "architect"})
+            result = await client.call_tool("artifact_read", {"item_id": 300, "artifact_type": "architect"})
 
         # Assert
         assert "error" in result.data
@@ -1118,7 +1118,7 @@ class TestMCPToolArtifactRead:
         # Act / Assert — FileNotFoundError propagates as ToolError
         with pytest.raises(ToolError):
             async with Client(patched_mcp_server) as client:
-                await client.call_tool("artifact_read", {"issue_number": 400, "artifact_type": "task-plan"})
+                await client.call_tool("artifact_read", {"item_id": 400, "artifact_type": "task-plan"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix Phase 3 of `add-new-feature/SKILL.md`: architect agent calls `artifact_register(content=...)` directly and self-registers the artifact (eliminates JSONL extraction workaround for large specs)
- Fix Phase 3 dispatch: specialist loading uses `mcp__plugin_dh_backlog__profile_load(agent_name='{resolved_agent}')` — the `agent_profile` MCP tool on the backlog server — not `Skill()`. Phase 3 has no SAM task YAML so the orchestrator includes an explicit `profile_load` call in the delegation prompt.
- Fix `agent="python-cli-design-spec"` in `artifact_register`: replaced with `{resolved_agent}` variable populated at dispatch time from the language manifest role resolution
- Rename `issue_number` → `item_id` across `ArtifactBackend` Protocol method signatures (structural typing conformance for ty); `ArtifactManifest.issue_number` field intentionally kept
- Update 32 markdown files: `issue_number=` → `item_id=` in all `artifact_register`, `artifact_read`, `artifact_list`, `artifact_get` call examples

**Additional fixes from big-picture flow analysis:**
- `artifact_provider_local.py`: remove beads sentinel (`issue_int = 0` coercion) — beads string IDs now preserved correctly in `ArtifactManifest`
- `server.py`: three migration helpers (`_try_register_dispatch_plan_artifact`, `_migrate_register_one`, `_migrate_queue_manifest_only`) had `issue_number: int` signatures left over from incomplete Protocol rename — all updated to `item_id: ItemId`
- `code-reviewer.md`: fix template variables `{issue_number}` → `{item_id}` in `artifact_register` call and STATUS block (agent's input is `item_id` per its Required Inputs section)
- `swarm-task-planner.md`: fix T0/TN bookend input label `issue_number` → `item_id` (consistent with `artifact_register` parameter name)
- `doc-drift-auditor.md`: fix `{issue_number}` → `{item_id}` in `artifact_register` call (input explicitly defined as `item_id`)

**Files left unchanged** (use `{issue_number}` as intentional working variable, `item_id={issue_number}` is correct MCP parameter passing):
- `feature-verifier.md`, `integration-checker.md`, `reviewer-accessibility.md`, `work-backlog-item/groom/analyze.md`

## Test plan

- [ ] `uv run prek run --files plugins/development-harness/skills/add-new-feature/SKILL.md` passes
- [ ] `uv run prek run --files plugins/development-harness/backlog_core/artifact_provider.py plugins/development-harness/backlog_core/artifact_provider_local.py plugins/development-harness/backlog_core/backends/beads_artifact_provider.py plugins/development-harness/backlog_core/artifact_registry.py` passes (ty Protocol conformance)
- [ ] Phase 3 Mermaid shows `subagent_type='dh:task-worker'` and `profile_load` — not `Skill()` and not the resolved agent as `subagent_type`
- [ ] `artifact_provider_local.py`: beads string IDs preserved (not coerced to 0)
- [ ] `server.py` migration helpers: `item_id: ItemId` signatures match Protocol

https://claude.ai/code/session_0166C2xQGc2pugYt4ZWL5Kpd