### PR TITLE
fix(tests): strengthen _load_json return type from object to JsonValue

### DIFF
--- a/plugins/development-harness/tests_backlog/test_beads_models.py
+++ b/plugins/development-harness/tests_backlog/test_beads_models.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from backlog_core.backends.beads_models import (
@@ -29,6 +30,9 @@ from backlog_core.backends.beads_models import (
 from hypothesis import given, settings, strategies as st
 from pydantic import ValidationError
 
+if TYPE_CHECKING:
+    from backlog_core.backends.bd_runner import JsonValue
+
 # ---------------------------------------------------------------------------
 # Fixture helpers
 # ---------------------------------------------------------------------------
@@ -36,7 +40,7 @@ from pydantic import ValidationError
 _FIXTURES = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "beads"
 
 
-def _load_json(filename: str) -> object:
+def _load_json(filename: str) -> JsonValue:
     """Load a JSON fixture file from the beads fixtures directory."""
     return json.loads((_FIXTURES / filename).read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary

- `_load_json` in `tests_backlog/test_beads_models.py` was annotated `-> object` — the widest possible Python type
- `json.loads()` returns exactly `JsonValue` (`str | int | float | bool | list | dict | None`)
- Every callsite passed the result directly to `parse_issue`, `parse_issue_list`, `parse_ready_list`, `parse_dependency_list` — all typed `data: JsonValue`
- `ty` reported `invalid-argument-type` on every such callsite (5 warnings)

**Design flaw (not just a lint fix):** The test helper mis-typed the data it produces, severing the type contract between fixture loading and the production parse functions it exercises. The fix makes the test boundary accurately reflect what `BdRunner.run_json` returns in production — `JsonValue`.

The import is placed under `TYPE_CHECKING` because `from __future__ import annotations` makes all annotations strings at runtime; the import is only evaluated by the type checker.

## Test plan

- [x] `ty check` — clean (`All checks passed!`)
- [x] `pytest tests_backlog/test_beads_models.py` — 45 passed
- [x] `ruff check` — clean on modified file
- [x] All pre-commit hooks passed

https://claude.ai/code/session_01UmfRoNrhr4ddmHBPQGJGE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmfRoNrhr4ddmHBPQGJGE9)_