### PR TITLE
docs(development-harness): add explicit artifact type ownership table to CLAUDE.md

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.8.13",
+  "version": "8.8.14",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CLAUDE.md
+++ b/plugins/development-harness/CLAUDE.md
@@ -138,7 +138,20 @@ Plan artifacts are registered in a structured manifest stored in the GitHub Issu
 - `artifact_get` — Get metadata for a specific artifact type on an issue
 - `artifact_read` — Read artifact file content from root worktree path (with path safety validation)
 
-**Artifact types:** `feature-context`, `architect`, `task-plan`, `codebase-analysis`, `T0-baseline`, `TN-verification`, `dispatch-plan`, `audit-report`
+**Artifact types and owners:**
+
+| Type | Owner agent | Notes |
+|---|---|---|
+| `feature-context` | `@dh:feature-researcher` | S1 discovery output |
+| `architect` | `@dh:swarm-task-planner` | S2 architecture output |
+| `task-plan` | SAM (`sam_plan create`) | Auto-registered on plan creation |
+| `codebase-analysis` | **`@dh:code-reviewer`** | Code review verdict; read by `complete-implementation` Phase T1 |
+| `T0-baseline` | `@dh:t0-baseline-capture` | Pre-implementation baseline |
+| `TN-verification` | `@dh:tn-verification-gate` | Post-implementation verification |
+| `dispatch-plan` | `dispatch_create_plan` | Milestone dispatch plan |
+| `audit-report` | **`@dh:doc-drift-auditor`** | Documentation drift audit; NOT used by `@dh:code-reviewer` |
+
+**CRITICAL — type ownership is exclusive:** `codebase-analysis` is owned by `@dh:code-reviewer`. `audit-report` is owned by `@dh:doc-drift-auditor`. These types must not be cross-assigned. `complete-implementation` reads the code review verdict via `artifact_read(item_id, artifact_type="codebase-analysis")` — a wrong type silently skips the quality gate.
 
 **Registration:** Producers call `artifact_register` after creation. Auto-registration is built into `sam_create` and `backlog_update(plan=...)`.
 


### PR DESCRIPTION
## Summary

- Adds a type-ownership table to the Artifact Manifest System section of `CLAUDE.md` mapping each artifact type to its authoritative producer agent
- Adds a CRITICAL note making ownership exclusive: `codebase-analysis` → `@dh:code-reviewer`; `audit-report` → `@dh:doc-drift-auditor`
- Prevents recurrence of the cross-type confusion that caused #2458 (code-reviewer registering `audit-report` instead of `codebase-analysis`)

## Root cause addressed

The original bug (#2458): `complete-implementation` reads the code review verdict via `artifact_read(item_id, artifact_type="codebase-analysis")`. The `dh:code-reviewer` agent had been registering its output as `audit-report`, causing the read to fail and fall through to a SAM search fallback. The agent file was already fixed (lines 169, 177 of `code-reviewer.md`). This PR adds the missing documentation guardrail so the ownership contract is explicit and visible to any agent editing the system.

## Acceptance criteria verification

- [x] `code-reviewer.md` line 169: `type="codebase-analysis"` confirmed
- [x] `code-reviewer.md`: no occurrence of `type="audit-report"`
- [x] `complete-implementation/SKILL.md` line 571: reads `codebase-analysis`
- [x] `complete-implementation/SKILL.md` lines 574–578: fallback path present and emits WARNING
- [x] `CLAUDE.md` Artifact Manifest System: explicit ownership table added

## Test plan

- [ ] Confirm rendered table in `CLAUDE.md` is readable and unambiguous
- [ ] Verify `@dh:code-reviewer` dispatch on any plan-linked issue registers `codebase-analysis` and `complete-implementation` Phase T1 reads it without WARNING

https://claude.ai/code/session_013Tw35EyaNGGNiAJ6w36JDH

---
_Generated by [Claude Code](https://claude.ai/code/session_013Tw35EyaNGGNiAJ6w36JDH)_