### PR TITLE
feat(plugin-creator): add ensemble-rule-review skill-design pattern

### DIFF
--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "14.3.2",
+  "version": "14.4.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/agents/focused-reviewer.md
+++ b/plugins/plugin-creator/agents/focused-reviewer.md
@@ -18,10 +18,13 @@ No creativity, no scope expansion, no extra analysis.
 ## Inputs the spawning prompt gives you
 
 - `TARGET` — the exact input to review (a file path, a set of paths, or a diff). Review ONLY this.
-- `RULE SLICE` — your partial, assigned rules (often a `group` id plus the rule text or a pointer
-  to where the rules are written). Apply ONLY these. Ignore every rule outside your slice.
-- `GROUP` — your assigned stable group id. Emit it verbatim on every finding. It is the
-  corroboration key — other workers share it, your free-form rule name does not.
+- `RULE SLICE` — your partial, assigned rules. Each rule carries its own stable `group` id (the
+  same id the other worker assigned to that group uses). You may hold rules from more than one
+  group. Apply ONLY these rules. Ignore every rule outside your slice.
+- `group` (per finding) — emit the group id of the SPECIFIC rule each finding violates, not one
+  fixed worker-level id. If your slice spans groups 1 and 2, a group-1 violation emits `group: 1`
+  and a group-2 violation emits `group: 2`. The group id is the corroboration key; your free-form
+  rule name is not, and may differ from the other worker's name for the same rule.
 - `OUTFILE` — an absolute path to write your report to.
 
 If any of these is missing, do not guess. Emit `STATUS: BLOCKED` naming what is absent, and stop.
@@ -41,7 +44,7 @@ If any of these is missing, do not guess. Emit `STATUS: BLOCKED` naming what is 
 The reducer parses this literally. Do not rename fields or change the leading `- group:`.
 
 ```text
-- group: {GROUP — your assigned id, verbatim, identical across workers}
+- group: {the group id of the rule THIS finding violates — per finding, not one fixed id}
   rule: {short free-form kebab slug naming the specific rule — descriptive only}
   location: {path:line}
   verdict: VIOLATION
@@ -50,10 +53,10 @@ The reducer parses this literally. Do not rename fields or change the leading `-
   fix: "{one concrete remediation}"
 ```
 
-`location` must be `path:line`. `group` is the corroboration key — keep it identical to what the
-prompt assigned, even when your `rule` slug differs from another worker's for the same line. That
-is intended: the reducer keys on `(group, location)`, so two workers corroborate a shared line
-even with different slugs.
+`location` must be `path:line` — keep the directory, not just the filename, so two files sharing a
+basename do not collide. `group` is the corroboration key: emit the id of the specific rule this
+finding violates. The reducer keys on `(group, location)`, so two workers corroborate a shared
+line even when their `rule` slugs differ — provided both emit the same group id for that rule.
 
 ## Terminal output (always emit, even with zero findings)
 

--- a/plugins/plugin-creator/agents/focused-reviewer.md
+++ b/plugins/plugin-creator/agents/focused-reviewer.md
@@ -1,0 +1,73 @@
+---
+name: focused-reviewer
+description: "Lean haiku worker for the ensemble-rule-review pattern. Reviews ONE input against ONE partial rule slice passed in the prompt, emits findings in the fixed (group, location) schema to an absolute output path, then stops. Deliberately minimal — few tools, no skills, no creativity — so many run cheaply in parallel and the reducer denoises by corroboration. Spawn one per rotating rule group. Trigger: dispatched by ensemble-rule-review orchestrator or any fan-out review needing a rigid checklist worker. For web/API review targets, the spawner adds the specific MCP tool to the invocation; do not grant all tools."
+model: haiku
+tools: Read, Grep, Glob, Bash, Write
+user-invocable: false
+color: cyan
+---
+
+# Focused Reviewer
+
+You are a rigid, single-pass review worker. You apply ONE partial rule slice to ONE input and
+emit findings in a fixed schema. You are cheap and fast by design: many copies of you run in
+parallel and an orchestrator averages your findings against the other workers', so a single
+miss or false positive from you is corrected by corroboration. Do exactly what the prompt says.
+No creativity, no scope expansion, no extra analysis.
+
+## Inputs the spawning prompt gives you
+
+- `TARGET` — the exact input to review (a file path, a set of paths, or a diff). Review ONLY this.
+- `RULE SLICE` — your partial, assigned rules (often a `group` id plus the rule text or a pointer
+  to where the rules are written). Apply ONLY these. Ignore every rule outside your slice.
+- `GROUP` — your assigned stable group id. Emit it verbatim on every finding. It is the
+  corroboration key — other workers share it, your free-form rule name does not.
+- `OUTFILE` — an absolute path to write your report to.
+
+If any of these is missing, do not guess. Emit `STATUS: BLOCKED` naming what is absent, and stop.
+
+## Modus operandi
+
+1. Read `TARGET` in full.
+2. Read your `RULE SLICE`.
+3. For each rule, scan `TARGET` for real violations you can point to a specific line for. Decide
+   VIOLATION or PASS strictly against the rule text. Do not infer, extrapolate, or judge anything
+   outside your slice. When unsure, do NOT invent — omit it; another worker's overlap covers you.
+4. Write one block per finding to `OUTFILE` in the fixed schema below.
+5. Emit the terminal STATUS block and stop. Do not fix anything. Do not edit `TARGET`.
+
+## Fixed output schema (write to OUTFILE — emit this EXACT block shape)
+
+The reducer parses this literally. Do not rename fields or change the leading `- group:`.
+
+```text
+- group: {GROUP — your assigned id, verbatim, identical across workers}
+  rule: {short free-form kebab slug naming the specific rule — descriptive only}
+  location: {path:line}
+  verdict: VIOLATION
+  severity: critical | high | medium | low
+  evidence: "{exact short quote from that line}"
+  fix: "{one concrete remediation}"
+```
+
+`location` must be `path:line`. `group` is the corroboration key — keep it identical to what the
+prompt assigned, even when your `rule` slug differs from another worker's for the same line. That
+is intended: the reducer keys on `(group, location)`, so two workers corroborate a shared line
+even with different slugs.
+
+## Terminal output (always emit, even with zero findings)
+
+```text
+STATUS: DONE
+File: {OUTFILE}
+Count: {n violations}
+```
+
+If zero findings: `STATUS: DONE`, `File: {OUTFILE}`, `Count: 0`, and a final line `Findings: None`.
+Never exit silently — a silent worker is indistinguishable from a crash to the orchestrator.
+
+## Tool discipline
+
+You have only `Read, Grep, Glob, Bash, Write`. That is deliberate — it keeps you cheap and your
+context lean. Do not request more. If your `TARGET` is a website or API endpoint, the spawning
+prompt will have added the one specific MCP tool you need to the invocation; use only that.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
@@ -161,6 +161,11 @@ Two procedures and one reusable contract turn this pattern from concept into act
 - **Reusable worker contract** — copy
   [./assets/worker-prompt-skeleton.md](./assets/worker-prompt-skeleton.md): the rigid worker
   prompt and the fixed candidate schema both procedures share.
+- **Reducer script** — run `./scripts/reduce.py` (tested; `./scripts/test_reduce.py`) over the
+  worker output files to dedup, corroboration-weight on `(group, location)`, drop the tail, and
+  rank. Workers emit a stable `group` id (the corroboration key) plus a free-form `rule` slug
+  (descriptive only) — keying on the slug would never corroborate, since workers name rules
+  differently.
 
 ### Partition the ruleset, not the input
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
@@ -167,6 +167,14 @@ Two procedures and one reusable contract turn this pattern from concept into act
   (descriptive only) — keying on the slug would never corroborate, since workers name rules
   differently.
 
+### The worker agent
+
+Spawn the `plugin-creator:focused-reviewer` agent as each map worker — a lean haiku agent with
+minimal tools (`Read, Grep, Glob, Bash, Write`) and no inherited skills, built to apply one rule
+slice and emit the fixed schema. Do NOT use `general-purpose` workers: they inherit every skill
+and MCP tool description, adding a large constant token cost to every one of the N parallel
+workers. For web/API targets, the spawner adds the one specific MCP tool to the worker's tools.
+
 ### Partition the ruleset, not the input
 
 Every worker reviews the SAME input; only its rule slice differs. The denoising comes from

--- a/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
@@ -127,6 +127,11 @@ make it explicit, then split. Examples:
 **The tell:** any instruction containing "ensure … follows", "review for", "look for …
 opportunities", or a named framework is an implicit (or pre-partitioned) checklist.
 
+For the full typology of implicit-checklist patterns grouped by partition-readiness — named
+principle sets, "modernization / idiomatic / pythonic", "review X for quality", and
+prompt-engineering / skill-quality self-review (with per-pattern examples) — load
+[./references/partitioning-patterns.md](./references/partitioning-patterns.md).
+
 ## Prior Art and Reference Implementation
 
 The pattern is already running in-repo as a partial implementation:

--- a/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
@@ -132,6 +132,30 @@ principle sets, "modernization / idiomatic / pythonic", "review X for quality", 
 prompt-engineering / skill-quality self-review (with per-pattern examples) — load
 [./references/partitioning-patterns.md](./references/partitioning-patterns.md).
 
+## Operational Use
+
+Two procedures and one reusable contract turn this pattern from concept into action:
+
+- **Convert an existing single-pass skill into the ensemble form** — follow
+  [./references/conversion-workflow.md](./references/conversion-workflow.md). (Also the recipe for
+  standardizing the `multi-perspective-review` prior art below.)
+- **Run an ensemble ad hoc, mid-task, as an orchestrator** — follow
+  [./references/orchestrator-playbook.md](./references/orchestrator-playbook.md): the
+  recognize → decompose → dispatch → reduce loop, the partition knobs, and the
+  corroboration-weighting reducer algorithm.
+- **Reusable worker contract** — copy
+  [./assets/worker-prompt-skeleton.md](./assets/worker-prompt-skeleton.md): the rigid worker
+  prompt and the fixed candidate schema both procedures share.
+
+### Partition the ruleset, not the input
+
+Every worker reviews the SAME input; only its rule slice differs. The denoising comes from
+overlapping rule coverage on shared input — multiple workers independently reaching the same
+finding, which the reducer counts as corroboration. Sharding the input instead (different files
+per worker) buys speed but NOT denoising, because no two workers can corroborate the same
+location. Shard input only as a secondary axis when one worker cannot hold the whole input, and
+keep rule-overlap within each shard.
+
 ## Prior Art and Reference Implementation
 
 The pattern is already running in-repo as a partial implementation:

--- a/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: ensemble-rule-review
+description: "Design pattern for converting rule-following, checklist, or rubric skills into a fan-out map-reduce ensemble of cheap parallel sub-agents with corroboration-weighted merge. Apply when creating or refactoring a skill or agent that applies 10+ independent criteria in a single pass. Triggers on: 'review against a checklist', 'fan out', 'map reduce review', 'ensemble', 'split the rules', 'apply rubric', or any large ruleset being applied by one agent in one pass. NOT for tight single-pass transforms or rulesets under 5 criteria."
+user-invocable: true
+---
+
+# Ensemble Rule Review
+
+A skill-design pattern for rule-following work. Instead of one agent holding the whole ruleset
+in a single pass, partition the ruleset across multiple cheap, rigid, parallel sub-agents whose
+coverage deliberately overlaps. Collect findings in a fixed schema, then weight by
+cross-agent corroboration and drop the low-weight tail.
+
+## The Problem It Solves
+
+A single agent holding a large ruleset (10+ criteria) and reviewing non-trivial input:
+
+- Is slow (it reasons across the whole rubric serially).
+- Silently drops criteria — attention degrades as the rule list grows, so coverage is
+  incomplete and you cannot tell which rules were actually applied.
+
+This is the same failure mode as instruction bloat: more rules in one context window means
+higher probability each individual rule is under-applied.
+
+## The Mechanism (6 Parts)
+
+1. **Control header.** One line at the top compiles an effort/scale parameter into concrete
+   knobs: worker count, candidates per worker, verify policy, output cap. The same skill body
+   scales rigor by the parameter.
+
+2. **Deliberate overlap, not just partition.** Worker scenarios are engineered so their goals
+   INTERSECT. A genuine finding falls inside multiple workers' coverage and is reported more
+   than once. A hallucination falls inside one worker's blank-filling and is reported once.
+   Overlap converts N cheap opinions into a signal-to-noise instrument. Pure non-overlapping
+   partition gives speed but NOT denoising.
+
+3. **Zero-creativity workers.** Each sub-agent gets a rigid, explicit process and a PARTIAL
+   rule set — stated methodology, fixed output schema, no interpretation latitude. Shrink each
+   worker's job until it is mechanical matching, which is the band where a cheap model is
+   reliable.
+
+4. **Cheap/fast model on purpose.** Haiku (or cheapest tier) is unreliable when forced to
+   infer or fill blanks — so the design removes the inference. Cheap and fast is what makes
+   running several workers over the same input affordable.
+
+5. **Fixed candidate schema.** Every worker emits the same shape (e.g., `rule_id, location,
+   verdict, evidence`). This contract makes dedup, corroboration counting, and merge possible.
+
+6. **Corroboration weighting + drop the tail (the reducer).** The orchestrator collects all
+   findings, deduplicates near-identical ones, raises weight for findings corroborated across
+   overlapping workers and sinks lone-worker findings, trashes the low-weight tail, keeps the
+   high-weight set. A single worker's hallucination sinks below the keep threshold.
+
+## Why It Works
+
+More total facts pass through cheap/fast workers; corroboration weighting cancels the noise;
+the surviving set is MORE reliable than one expensive agent, not less. This is bagging /
+majority-vote ensembling applied to LLM rule-checking.
+
+SOURCE: User-reported result (conversation 2026-05-30, not independently reproduced): a
+scientific-journal review skill — one Sonnet agent holding the full ruleset took 14-18 minutes
+on a 300-line file and returned 13 findings. Splitting the rules into 4 categories and running
+4 Haiku agents (each with a partial rule list) on the same file returned 14 findings in
+25 seconds — comparable recall, ~35x faster.
+
+## Pipeline Phases
+
+```mermaid
+flowchart TD
+    P0["Phase 0 — Scope<br>Deterministically define the exact<br>input set (script / git diff / file)<br>No reasoning yet"] --> P1
+    P1["Phase 1 — Fan-out (map)<br>Dispatch N rigid workers<br>Each has a partial overlapping rule set<br>Each emits up to K candidates<br>in the fixed schema<br>Recall comes from here"] --> P2
+    P2["Phase 2 — Reduce<br>Dedup → weight by corroboration<br>→ drop low-weight tail<br>Optional: one-vote verifier per<br>surviving candidate<br>(CONFIRMED / PLAUSIBLE / REFUTED)<br>Precision comes from here"] --> OUT
+    OUT["Output<br>Ranked, capped, structured<br>Empty result is a valid terminal"]
+```
+
+## Degrees of Freedom
+
+| Component | Freedom | Reason |
+|-----------|---------|--------|
+| Workers | HIGH rigidity / LOW freedom | Rigid rule list, fixed schema; shrinks job to mechanical matching |
+| Reducer + output contract | LOW freedom | Fixed verdict set, fixed schema, hard cap |
+
+## Model and Effort Guidance
+
+- **Workers:** cheapest tier (haiku), effort low. The job is reduced to mechanical matching
+  and the overlap denoises single-worker errors.
+- **Reducer / orchestrator:** mid tier (sonnet), effort medium. It weights and merges.
+- Do NOT run an expensive model on a job a rigid cheap worker can do.
+
+SOURCE: `/plugin-creator:agentskills` — degrees-of-freedom guidance and model selection by
+task cognitive requirement.
+
+## When to Use / When Not to Use
+
+**Use when:**
+
+- Rule-following / checklist / rubric work with 10+ independent criteria.
+- A single agent currently applies the whole ruleset in one pass (slow + silent drops).
+- The ruleset can be split into scenario-bound jobs with some overlap.
+
+**Do NOT use when:**
+
+- Tight deterministic pipelines or single-pass transforms (map-reduce overhead exceeds the return).
+- Tasks needing one coherent creative judgment that cannot be partitioned without losing whole-picture context.
+- Rulesets under ~5 criteria (splitting yields little).
+
+## How to Partition the Ruleset
+
+**Explicit lists — partition is free.** When the ruleset already names its categories, those
+categories ARE the worker boundaries. Examples:
+
+- Named principle frameworks: the 12 factors of twelve-factor; the 5 SOLID principles;
+  OWASP categories for a security review; WCAG criteria for accessibility; Nielsen's 10
+  usability heuristics for a UI critique.
+- An enumerated `## Checklist` or `## Quality Criteria` section.
+
+**Implicit lists — enumerate first, then partition.** A rubric is named but not enumerated;
+make it explicit, then split. Examples:
+
+- "look for modernization opportunities" → an explicit PEP roster (585 generics, 604 unions,
+  572 walrus, 634 match, 673 Self, StrEnum, tomllib, pathlib, dataclasses) → buckets.
+- "ensure it's pythonic / idiomatic" → comprehensions, context managers, EAFP,
+  enumerate/zip, mutable-default-arg, truthiness.
+- "review for quality" → correctness / error-handling / naming / dead-code / structure.
+- "follow best practices" / "avoid anti-patterns" → enumerate the named patterns.
+
+**The tell:** any instruction containing "ensure … follows", "review for", "look for …
+opportunities", or a named framework is an implicit (or pre-partitioned) checklist.
+
+## Prior Art and Reference Implementation
+
+The pattern is already running in-repo as a partial implementation:
+
+- `plugins/development-harness/skills/multi-perspective-review/SKILL.md` — a working 4-worker
+  parallel review fan-out (Security, Performance, Quality, Accessibility) with per-worker SOPs
+  and a merge gate.
+- `plugins/development-harness/agents/reviewer-{security,quality,performance,accessibility}.md`
+  — the rigid worker agents.
+
+It lacks two pieces vs the full pattern: a fixed candidate schema and an explicit
+corroboration-weight reducer (it merges by any-REJECT, not corroboration weighting).
+
+The control-header + finder-angles + constrained-verdict-verify + capped-output structure
+originates in the Anthropic-bundled `/code-review` built-in skill.
+
+SOURCE: `/plugin-creator:agentskills` — progressive disclosure, lean SKILL.md, skill packaging
+discipline.
+
+For the ranked catalog of in-repo conversion candidates (Tier 0-3, clusters C1-C9), load
+[./references/conversion-candidates.md](./references/conversion-candidates.md).

--- a/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
@@ -161,11 +161,19 @@ Two procedures and one reusable contract turn this pattern from concept into act
 - **Reusable worker contract** — copy
   [./assets/worker-prompt-skeleton.md](./assets/worker-prompt-skeleton.md): the rigid worker
   prompt and the fixed candidate schema both procedures share.
+- **Planner script** — run `./scripts/plan_ensemble.py RULES.json --report-dir /abs/dir` (tested;
+  `./scripts/test_plan_ensemble.py`) to compute the rotating-overlap assignment deterministically.
+  It assigns each worker its groups + an absolute OUTFILE, tags rules per-group, verifies uniform
+  redundancy, and prints the recommended `--keep-threshold` — removing the manual bookkeeping that
+  caused this session's bugs (wrong paths, drifted group ids, ad-hoc overlap, per-worker tagging).
 - **Reducer script** — run `./scripts/reduce.py` (tested; `./scripts/test_reduce.py`) over the
   worker output files to dedup, corroboration-weight on `(group, location)`, drop the tail, and
   rank. Workers emit a stable `group` id (the corroboration key) plus a free-form `rule` slug
   (descriptive only) — keying on the slug would never corroborate, since workers name rules
   differently.
+
+The two scripts are deterministic bookends around the only fuzzy step (the LLM workers' rule
+matching): **plan_ensemble.py → spawn focused-reviewer ×N → reduce.py**.
 
 ### The worker agent
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
@@ -100,9 +100,22 @@ task cognitive requirement.
 
 **Do NOT use when:**
 
-- Tight deterministic pipelines or single-pass transforms (map-reduce overhead exceeds the return).
+- Single-pass transforms with no ruleset (map-reduce overhead exceeds the return).
 - Tasks needing one coherent creative judgment that cannot be partitioned without losing whole-picture context.
 - Rulesets under ~5 criteria (splitting yields little).
+
+**Multi-phase / sequential workflows are NOT disqualified.** Do not score the whole pipeline as
+one unit — score each phase. A sequential workflow is the conductor; each rule-following phase
+becomes its own internal ensemble and each independent-work phase becomes a work-partition
+fan-out, while the phase ordering stays sequential. There are two fan-out flavors:
+
+- **Ensemble-denoising** (this skill's core) — same input, overlapping rule slices, corroboration
+  weighting. For checking / review / rubric phases.
+- **Work-partition** — disjoint independent work items in parallel, no corroboration, pure
+  speedup. For generative phases (implement N functions, write N test files, scan N docs).
+
+See [./references/composing-in-workflows.md](./references/composing-in-workflows.md) for the
+per-phase classification rule and a worked map of a 9-phase workflow.
 
 ## How to Partition the Ruleset
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/SKILL.md
@@ -32,7 +32,9 @@ higher probability each individual rule is under-applied.
    INTERSECT. A genuine finding falls inside multiple workers' coverage and is reported more
    than once. A hallucination falls inside one worker's blank-filling and is reported once.
    Overlap converts N cheap opinions into a signal-to-noise instrument. Pure non-overlapping
-   partition gives speed but NOT denoising.
+   partition gives speed but NOT denoising. For the overlap construction, use a balanced rotating
+   assignment (cyclic block design — N groups, N agents, each agent a window of w groups) so every
+   rule gets equal redundancy; see the playbook's "Balanced rotating overlap" section.
 
 3. **Zero-creativity workers.** Each sub-agent gets a rigid, explicit process and a PARTIAL
    rule set — stated methodology, fixed output schema, no interpretation latitude. Shrink each

--- a/plugins/plugin-creator/skills/ensemble-rule-review/assets/worker-prompt-skeleton.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/assets/worker-prompt-skeleton.md
@@ -23,15 +23,24 @@ STEP 2 — For each location, decide VIOLATION or PASS strictly against the rule
          Do NOT infer, extrapolate, or judge anything outside your rule slice.
 STEP 3 — Emit one block per finding in the FIXED SCHEMA below. No prose outside the blocks.
 
-FIXED CANDIDATE SCHEMA (emit this exact shape — the reducer depends on it):
-- rule_id: {{stable id of the rule}}
-  location: {{file:line or section anchor}}
+FIXED CANDIDATE SCHEMA (emit this EXACT block shape, one block per finding — the reducer
+parses it literally, so do not rename fields or change the leading "- group:"):
+- group: {{YOUR ASSIGNED GROUP ID — the stable rule-group number, identical across all workers}}
+  rule: {{free-form descriptive slug — for humans only, NOT used to match findings}}
+  location: {{file:line}}
   verdict: VIOLATION | PASS
+  severity: {{critical | high | medium | low}}
   evidence: "{{exact short quote from the input}}"
-  severity: {{high | med | low}}
+
+CORROBORATION KEY — the reducer dedups on (group, location), NOT on your rule slug. Two workers
+who both hold this group and flag the same line corroborate each other even if they name the rule
+differently. That is why `group` MUST be the orchestrator-assigned id, identical across workers,
+and `rule` is descriptive only.
 
 OUTPUT CONTRACT:
-Write all findings to {{OUTFILE}}.
+Write all findings to {{OUTFILE}}. {{OUTFILE}} MUST be an ABSOLUTE path (e.g.
+/home/user/project/.tmp/scratch/reports/worker-{{ID}}.md). Do NOT use a relative path — workers
+may resolve a different cwd, scattering outputs the reducer cannot find.
 FINAL MESSAGE:
 STATUS: DONE
 File: {{OUTFILE}}
@@ -51,6 +60,11 @@ Trace every finding to a real located hit. No invented locations or quotes.
 
 ## Reducer input contract
 
-The reducer (see `../references/orchestrator-playbook.md`) consumes the worker output files and
-keys on `(rule_id, location)` to count corroboration. Keep `rule_id` and `location` stable and
-normalized across workers so the same finding from two workers collides into one weighted entry.
+The reducer script `../scripts/reduce.py` consumes the worker output files and keys corroboration
+on `(group, location)` — never the free-form `rule` slug. Keep `group` identical across all
+workers who hold that group, and write `location` as `file:line`; the reducer normalizes it to
+`basename:line` so two workers collide into one weighted entry. Run it with:
+
+```bash
+uv run ../scripts/reduce.py {{ABSOLUTE_REPORT_DIR}} --glob 'worker-*.md' [--keep-threshold N]
+```

--- a/plugins/plugin-creator/skills/ensemble-rule-review/assets/worker-prompt-skeleton.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/assets/worker-prompt-skeleton.md
@@ -1,0 +1,56 @@
+# Worker Prompt Skeleton
+
+Copy this template once per rule slice, fill every `{{PLACEHOLDER}}`, and dispatch the workers
+in parallel (cheapest tier, low effort). Every worker shares the SAME input and the SAME fixed
+schema; only `YOUR RULE SLICE` differs between workers, and slices deliberately overlap.
+
+## Worker prompt template
+
+```text
+You are a rigid {{WORKER_ROLE}}. cwd: {{WORKING_DIR}}. NO creativity — follow these steps exactly.
+
+GOAL: {{ONE_SENTENCE_GOAL}}
+
+INPUT — review ONLY this (identical for every worker): {{INPUT_SCOPE}}
+
+YOUR RULE SLICE — apply ONLY these rules (your partial, deliberately-overlapping ruleset):
+- {{RULE_1}}
+- {{RULE_2}}
+- {{RULE_3}}
+
+STEP 1 — For each rule, locate every place in the input where it applies ({{DETECTION_METHOD}}).
+STEP 2 — For each location, decide VIOLATION or PASS strictly against the rule text.
+         Do NOT infer, extrapolate, or judge anything outside your rule slice.
+STEP 3 — Emit one block per finding in the FIXED SCHEMA below. No prose outside the blocks.
+
+FIXED CANDIDATE SCHEMA (emit this exact shape — the reducer depends on it):
+- rule_id: {{stable id of the rule}}
+  location: {{file:line or section anchor}}
+  verdict: VIOLATION | PASS
+  evidence: "{{exact short quote from the input}}"
+  severity: {{high | med | low}}
+
+OUTPUT CONTRACT:
+Write all findings to {{OUTFILE}}.
+FINAL MESSAGE:
+STATUS: DONE
+File: {{OUTFILE}}
+Count: <total>, violations: <n>
+Then inline every VIOLATION block. If none, state that explicitly.
+
+Trace every finding to a real located hit. No invented locations or quotes.
+```
+
+## Dispatch checklist
+
+- One worker per rule slice; slices overlap so each genuine finding sits in 2+ workers' coverage.
+- Model: cheapest tier (haiku). Effort: low. Run all workers in one parallel batch.
+- Keep each slice small enough that the job is mechanical matching, not inference.
+- Give every worker the identical `INPUT_SCOPE`. (Shard input only as a secondary axis when one
+  worker cannot hold it — keep rule-overlap within each shard.)
+
+## Reducer input contract
+
+The reducer (see `../references/orchestrator-playbook.md`) consumes the worker output files and
+keys on `(rule_id, location)` to count corroboration. Keep `rule_id` and `location` stable and
+normalized across workers so the same finding from two workers collides into one weighted entry.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/assets/worker-prompt-skeleton.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/assets/worker-prompt-skeleton.md
@@ -13,10 +13,11 @@ GOAL: {{ONE_SENTENCE_GOAL}}
 
 INPUT — review ONLY this (identical for every worker): {{INPUT_SCOPE}}
 
-YOUR RULE SLICE — apply ONLY these rules (your partial, deliberately-overlapping ruleset):
-- {{RULE_1}}
-- {{RULE_2}}
-- {{RULE_3}}
+YOUR RULE SLICE — apply ONLY these rules. Each rule carries its OWN stable group id (the same id
+the other worker assigned to that group also uses). You may hold rules from more than one group:
+- [group {{GROUP_OF_RULE_1}}] {{RULE_1}}
+- [group {{GROUP_OF_RULE_2}}] {{RULE_2}}
+- [group {{GROUP_OF_RULE_3}}] {{RULE_3}}
 
 STEP 1 — For each rule, locate every place in the input where it applies ({{DETECTION_METHOD}}).
 STEP 2 — For each location, decide VIOLATION or PASS strictly against the rule text.
@@ -25,17 +26,19 @@ STEP 3 — Emit one block per finding in the FIXED SCHEMA below. No prose outsid
 
 FIXED CANDIDATE SCHEMA (emit this EXACT block shape, one block per finding — the reducer
 parses it literally, so do not rename fields or change the leading "- group:"):
-- group: {{YOUR ASSIGNED GROUP ID — the stable rule-group number, identical across all workers}}
+- group: {{THE GROUP ID OF THE RULE THIS FINDING VIOLATES — per finding, NOT a fixed worker id}}
   rule: {{free-form descriptive slug — for humans only, NOT used to match findings}}
   location: {{file:line}}
   verdict: VIOLATION | PASS
   severity: {{critical | high | medium | low}}
   evidence: "{{exact short quote from the input}}"
 
-CORROBORATION KEY — the reducer dedups on (group, location), NOT on your rule slug. Two workers
-who both hold this group and flag the same line corroborate each other even if they name the rule
-differently. That is why `group` MUST be the orchestrator-assigned id, identical across workers,
-and `rule` is descriptive only.
+CORROBORATION KEY — the reducer dedups on (group, location), NOT on your rule slug. `group` MUST
+be the id of the specific RULE that this finding violates — not a single per-worker constant. If
+you hold rules from two groups (e.g. groups 1 and 2 under rotating overlap), a finding against a
+group-1 rule emits `group: 1` and a finding against a group-2 rule emits `group: 2`. Tagging every
+finding with one worker-level id would mislabel the second group and break corroboration with the
+other worker assigned to it. The rule slug may differ between workers; only the group id must match.
 
 OUTPUT CONTRACT:
 Write all findings to {{OUTFILE}}. {{OUTFILE}} MUST be an ABSOLUTE path (e.g.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/assets/worker-prompt-skeleton.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/assets/worker-prompt-skeleton.md
@@ -52,6 +52,11 @@ Trace every finding to a real located hit. No invented locations or quotes.
 
 ## Dispatch checklist
 
+- Spawn the `plugin-creator:focused-reviewer` agent (lean, haiku, minimal tools) — NOT
+  `general-purpose`, which inherits every skill and MCP tool description and burns tokens on
+  every worker. Fill this skeleton into its prompt as the TARGET / RULE SLICE / GROUP / OUTFILE.
+- If the target is a website or API endpoint, add the ONE specific MCP tool the worker needs to
+  the spawn `tools` list — do not grant all tools.
 - One worker per rule slice; slices overlap so each genuine finding sits in 2+ workers' coverage.
 - Model: cheapest tier (haiku). Effort: low. Run all workers in one parallel batch.
 - Keep each slice small enough that the job is mechanical matching, not inference.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/composing-in-workflows.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/composing-in-workflows.md
@@ -1,0 +1,52 @@
+# Composing the Pattern Inside Multi-Phase Workflows
+
+A sequential or multi-phase workflow is NOT disqualified from this pattern. The whole pipeline
+is not the unit of conversion — each PHASE is. Keep the sequential outer control flow; convert
+each phase that does rule-following or independent parallel work into its own fan-out agent set.
+The workflow is the conductor; each phase is its own fan-out.
+
+Do NOT score a multi-phase skill against the "When to Use" gate as one unit. Score EACH phase.
+
+## Two flavors of fan-out
+
+| Flavor | Input | Corroboration | Use for |
+|--------|-------|---------------|---------|
+| **Ensemble-denoising** (this skill's core) | SAME input to every worker; overlapping rule slices | yes — weighting denoises cheap workers | rule-following / review / rubric phases |
+| **Work-partition** | disjoint, independent work items | no — pure speedup | generative / independent-work phases |
+
+A phase picks its flavor by what it does:
+
+- **Checking against a ruleset** → ensemble-denoising (overlap + corroboration).
+- **Producing independent artifacts** → work-partition (parallelize the items).
+- **One coherent creative judgment** → neither; keep a single agent (partitioning loses the
+  whole-picture context the judgment needs).
+
+## Worked map: stinkysnake's 9 phases
+
+SOURCE: `plugins/python-engineering/skills/stinkysnake/SKILL.md` (verified 2026-05-30).
+
+| Phase | What it does | Fan-out flavor |
+|-------|--------------|----------------|
+| 1 Static analysis | runs ruff/ty (deterministic tools) | a script, not an agent fan-out; manual-issue triage is a mild ensemble |
+| 2 Type analysis | inventory `Any`, map type deps, find gaps | ensemble-denoising — one worker per gap-criterion, overlapping |
+| 3 Modernization planning | per-`Any` construct selection + PEP/library roster | ensemble-denoising — one worker per construct/PEP scanning for opportunities (strongest) |
+| 4 Plan review | review plan vs pythonic / feasibility / breaking changes | ensemble-denoising — multi-dimension review (this is code-review) |
+| 5 Refinement | edit the plan per review feedback | neither — sequential edit |
+| 6 Docs discovery | find docs needing update | work-partition — each doc independent |
+| 7 Interface design | design protocols/types | neither — coherent creative judgment |
+| 8 Test-first | write failing tests per interface | work-partition — parallel by interface |
+| 9 Implementation | implement functions in dependency order | work-partition — independent functions, bounded by dependency order |
+
+The conversion targets inside this workflow are the rule-bearing phases (2, 3, 4), each becoming
+an internal ensemble; the producing phases (6, 8, 9) become work-partition fan-outs; the outer
+phase ordering stays sequential.
+
+## Conversion rule for multi-phase skills
+
+1. List the phases.
+2. Classify each: rule-following (ensemble), independent-work (work-partition), or
+   creative-coherence (single agent).
+3. Convert each ensemble phase per [./conversion-workflow.md](./conversion-workflow.md) and each
+   independent-work phase as a parallel work split.
+4. Preserve the sequential ordering and the artifact each phase passes to the next.
+5. Validate per-phase against its single-pass baseline, not the pipeline as a whole.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-candidates.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-candidates.md
@@ -1,0 +1,295 @@
+# Fan-Out Conversion Candidates — Ranked Synthesis
+
+Catalog of in-repo rule-following work suitable for restructuring into the fan-out map-reduce
+ensemble (partition ruleset across overlapping cheap parallel sub-agents → fixed-schema findings
+→ weight-by-corroboration → drop the tail).
+
+## Table of Contents
+
+- [Weighting Criteria](#weighting-criteria)
+- [Tier 0 — Already a Partial Implementation](#tier-0--already-a-partial-implementation-reference--standardize)
+- [Tier 1 — Highest Payoff](#tier-1--highest-payoff-large--partition-ready--replicated--single-pass)
+  - [C1 Generic Multi-Dimension Code Review](#c1-generic-multi-dimension-code-review--most-replicated-cluster)
+  - [C2 Plugin-Creator Audit/Assessor Family](#c2-plugin-creator-auditassessor-family--tier-partitioned-convert-once-cascades)
+  - [C3 Holistic-Linting](#c3-holistic-linting--largest-raw-ruleset-user-flagged)
+- [Tier 2 — Strong, Mostly Partition-Ready](#tier-2--strong-mostly-partition-ready)
+  - [C4 Summarizer Fidelity Rules](#c4-summarizer-fidelity-rules--7-rule-canonical-replicated-5x)
+  - [C5 CLI/UI Design Review](#c5-cliui-design-review-python-engineeringdesigning-ui-for-cli--textbook-pre-partition)
+  - [C6 Verification / Done Gates](#c6-verification--done-gates--pre-partitioned-single-pass)
+  - [C7 Named-Framework Compliance](#c7-named-framework-compliance--partitions-handed-to-you-free-quick-wins)
+- [Tier 3 — Solid, Smaller or Needs Enumeration](#tier-3--solid-smaller-or-needs-enumeration)
+  - [C8 Language-Specialist Review Agents](#c8-language-specialist-review-agents)
+  - [C9 Orchestration / Hallucination Detection](#c9-orchestration--hallucination-detection)
+- [Explicit vs Implicit Split](#explicit-vs-implicit-split)
+- [Meta-Findings](#meta-findings-observed-act-worthy)
+- [Recommended Pilots](#recommended-pilots)
+- [Second-Pass Additions](#second-pass-additions)
+
+---
+
+**Method:** 7 territory finders over the 30-plugin tree plus `.claude/`, identical detection
+checklist plus fixed schema plus 1-5 fit rubric. Per-finder reports in
+`.tmp/scratch/reports/finder-{ab,cd,efg,hl,m,nop,qrs,tz}.md`.
+
+**Counts (finder-reported):** a-b 12/6 · c-d 16/8 · e-g 7/5 · h-l 7/4 · m 0/0 ·
+n-p 18/12 · q-s 10/8 · t-z 15/10 → ~85 candidates, ~53 at fit≥4.
+
+**Verification caveat:** ruleset-size numbers below are finder estimates relayed from
+sub-agents. They are not independently re-read by the orchestrator. Treat as ranking
+signal, not ground truth, until the pilot conversion reads the canonical file.
+
+---
+
+## Weighting Criteria
+
+A candidate converts well when it scores on:
+
+1. **Ruleset size** — more independent rules = more to parallelize = bigger speed gain.
+2. **Partition-readiness** — named categories/dimensions/principles = the split is free.
+   Implicit rubrics ("pythonic", "modernization") must be enumerated first = design cost.
+3. **Current cost** — a single Sonnet/Opus pass holding the whole ruleset is the expensive
+   baseline the user's journal-review result improved ~35x. Already-parallel = low payoff.
+4. **Replication** — the same ruleset recurring across N files means one conversion plus a
+   shared template cascades. This is the repo-level corroboration signal.
+
+---
+
+## Tier 0 — Already a Partial Implementation (reference + standardize)
+
+**`development-harness/skills/multi-perspective-review` + `agents/reviewer-{security,quality,performance,accessibility}`**
+
+- This is the user's pattern already running: a 4-worker parallel review fan-out with
+  per-worker SOPs and a merge gate. It is the in-repo proof the pattern fits.
+- Opportunity: it is the reference implementation to standardize from — extract its structure
+  into the shared template, then add the two pieces it lacks vs `/code-review`:
+  a fixed candidate schema and an explicit weight-by-corroboration reducer (today it
+  merges by any-REJECT, not by corroboration weighting).
+- Note: each reviewer agent still applies its own checklist serially — a second-level
+  fan-out inside each worker is available if needed.
+
+---
+
+## Tier 1 — Highest Payoff (large + partition-ready + replicated + single-pass)
+
+### C1 Generic Multi-Dimension Code Review — most replicated cluster
+
+Same "review code against N quality dimensions in one pass" ruleset, duplicated:
+
+- `.claude/agents/code-review.md` — ~25-35 criteria, 3 severity tiers (~78 bullets) — fit5
+- `development-harness/agents/code-reviewer.md` — 7 universal dims + stack rules — fit5
+- `python-engineering/skills/review/SKILL.md` — 9 dimensions, 36 items — fit5
+- `.claude/templates/code-review-checklist.md` — 15 items, 4 sections — fit4
+- `python3-development/skills/python3-review` — near-duplicate of python-engineering
+
+Partition: one worker per dimension (correctness / security / perf / error-handling /
+naming / tests / docs), merge by severity plus corroboration.
+
+Why top: biggest replication; the reviewer-* agents above already prove the split works.
+
+### C2 Plugin-Creator Audit/Assessor Family — tier-partitioned, convert-once cascades
+
+- `skills/audit-skill-completeness` — 20+ (5 agentskills checks + 8 scored categories) — fit5
+- `skills/assessor` + `references/scoring-criteria.md` — 4 tiers, 15-20 — fit5
+- `agents/skill-auditor` — 12-15 — fit5
+- `agents/plugin-assessor` — 4 assessment tiers — fit5
+- `skills/audit-agent-lifecycle` — 8 dimensions — fit4
+- `skills/audit-skill-lifecycle` — 7 dimensions — fit4
+- `agents/refactor-validator` — 5 phases, 15+ — fit4
+
+Partition: one worker per tier/dimension; reducer = weighted score. The whole family
+shares the tier structure → one template stamps all 7.
+
+### C3 Holistic-Linting — largest raw ruleset; user-flagged
+
+- `agents/post-linting-architecture-reviewer` — 30 items / 7 architectural categories — fit5
+- `skills/holistic-linting/SKILL.md` — 12 imperatives + 1000+ backing rules (ruff/bandit/
+  mypy across 51 reference files) — fit5
+- `agents/linting-root-cause-resolver` — 15+ — fit4
+- `skills/holistic-linting-resolver` — 22+ procedural across ruff/mypy/pyright — fit4
+
+Partition: by linter family (ruff / bandit / mypy / pyright) for detection; by the 7
+architectural categories for the post-review. Biggest ruleset → biggest raw parallelism.
+
+Caveat: resolution mutates files → the verify gate matters more here than in read-only
+reviews; corroboration must run before any write.
+
+---
+
+## Tier 2 — Strong, Mostly Partition-Ready
+
+### C4 Summarizer Fidelity Rules — 7-rule canonical replicated 5x
+
+- `skills/summarizer/references/fidelity-rules.md` — 7 rules (canonical) — fit5
+- `skills/agent-result-relay` — 12 — fit5
+- `skills/file-summarization` — 20 — fit4
+- `skills/multi-source-synthesis` — 17 — fit4
+- `skills/url-summarization` — 14 — fit4
+- `skills/image-summarization` — 14 — fit4
+
+Nature: the fan-out here is the fidelity check on a produced summary, not the summary
+generation — i.e. the verify-gate half of the framework. Strong template for that half.
+
+Convert canonical `fidelity-rules.md` once; the 5 consuming skills inherit it.
+
+### C5 CLI/UI Design Review (`python-engineering/designing-ui-for-cli`) — textbook pre-partition
+
+- `references/critique-checklist.md` — Nielsen's 10 heuristics, each scored 0-4 — fit5
+- `references/polish-checklist.md` — 22 items — fit4
+- `references/audit-checklist.md` — 5 scored dimensions — fit4
+
+Nielsen 10 = 10 ready-made overlapping jobs. Near-zero partition design cost.
+
+### C6 Verification / Done Gates — pre-partitioned, single-pass
+
+- `agent-orchestration/.../post-completion-validation-protocol.md` — 44 (11 commit types x4) — fit5
+- `scientific-method/skills/evidence-first-debugging` — 13 (5 rules + 8 checklist) — fit5
+- `development-harness/skills/verify-done` — 8 sections — fit4
+- `development-harness/skills/final-verification` — 5 dimensions — fit4
+- `verification-gate/skills/verification-gate` — 4 checkpoints, ~25 sub-questions — fit4
+
+### C7 Named-Framework Compliance — partitions handed to you free (quick wins)
+
+- `twelve-factor-app/SKILL.md` — 15 factors — fit5
+- `.claude/skills/design-anti-patterns/references/uncodixfy-rules.md` — 50+ rules — fit5
+- `gitlab-skill/SKILL.md` — 24 checklist across 3 gates — fit5
+- `fastmcp-creator/.../typescript-mcp-server.md` — 12 RULE statements — fit5
+- `the-rewrite-room/.../quality-criteria.md` — 40 items / 8 categories — fit5
+- `.claude/skills/evaluate-sdlc-layers` — 29 items / 6 sub-checklists — fit5
+
+Each names its own categories → those categories ARE the worker boundaries.
+
+---
+
+## Tier 3 — Solid, Smaller or Needs Enumeration
+
+### C8 Language-Specialist Review Agents
+
+- `bash-development/agents/bash-script-auditor` — 18-22 — fit5
+- `.claude/agents/c-systems-programmer` — 26 — fit4
+- `.claude/agents/javascript-pro` — 22+ — fit4
+- `.claude/agents/typescript-pro` — 14+ — fit4
+- `perl-development/agents/perl-script-auditor` — 6 categories, ~20 — fit4
+
+### C9 Orchestration / Hallucination Detection
+
+- `agent-orchestration/.../hallucination-triggers.md` — 4 categories, ~35-40 rules — fit5
+- `agent-orchestration/skills/agent-orchestration/SKILL.md` — 6-8 gates — fit4
+- `agent-orchestration/skills/how-to-delegate` — 6 pre-flight + 10 step gates — fit4
+- `agentskill-kaizen/references/arl-qa-expert-panel.md` — R1-R10 — fit4
+- `scientific-method/agents/retrospective-analyst` — 3 artifacts x sub-sections — fit4
+
+---
+
+## Explicit vs Implicit Split
+
+**Partition-ready now (explicit lists):** C2, C5, C6, C7, C4 — categories already named.
+
+**Needs enumeration first (implicit rubrics → make explicit, then partition):**
+
+- `python-engineering/skills/modernpython` "modernization opportunities" → PEP roster
+- `python-engineering/skills/snakepolish` + `review` "Modern Patterns" / "pythonic"
+- `c-systems-programmer` "Common Pitfalls", `javascript-pro` "Anti-Patterns to Reject"
+- `holistic-linting` SKILL "best-practice imperatives"
+
+These carry the higher design cost but also the higher reliability gain (the implicit
+list is where a single Sonnet pass silently drops criteria).
+
+---
+
+## Meta-Findings (observed, act-worthy)
+
+1. **`python-engineering` and `python3-development` are near-duplicate plugins** — both
+   carry analyze-test-failures, comprehensive-test-review, modernpython, review/python3-review,
+   snakepolish, test-failure-mindset, typer, ty, etc. Converting one and not the other
+   duplicates the work. Decide dedup/canonicalization before converting either.
+2. **The framework already exists in-repo** (Tier 0). Standardize from it rather than
+   designing from scratch.
+3. **Replication is the corroboration signal at repo scale** — code-review (C1), summarizer
+   fidelity (C4), and the audit family (C2) each recur; a shared template plus one canonical
+   conversion cascades across the cluster.
+
+---
+
+## Recommended Pilots
+
+- **Fastest proof, lowest design cost:** C7 named-framework (12-factor / uncodixfy / gitlab)
+  — partitions are free, output is a compliance matrix.
+- **Highest cascade:** C2 plugin-creator audit family — tier-partitioned, one template → 7 targets.
+- **User-flagged + biggest ruleset:** C3 holistic-linting — partition by linter; verify gate
+  guards the file mutations.
+- **Standardize the existing pattern:** Tier 0 multi-perspective-review — turn the working
+  4-way fan-out into the canonical template (add fixed schema + corroboration-weight reducer).
+
+---
+
+## Second-Pass Additions
+
+A narrow single-plugin re-scan of the four densest plugins (after the first pass overloaded its
+wide-territory finders) roughly doubled the fit>=4 set in the overloaded zones and surfaced four
+clusters the first pass missed. Marked NEW (missed by pass 1) or CONFIRMED.
+
+### development-harness — skills
+
+- complete-implementation — 5 sequential quality-gate stages — fit5 — NEW
+- clear-cove-task-design — CLEAR framework + CoVe — fit5 — NEW
+- generate-task — CLEAR ordering + CoVe verification — fit5 — NEW
+- add-new-feature — quality vigilance + AC extraction + phase gates — fit5 — NEW
+- find-cause — disambiguation + root-cause hypothesis branches (implicit) — fit5 — NEW
+- forensic-review — requirement tracing + property checking — fit5 — NEW
+- code-review-llm / code-review-nodejs / code-review-architecture — per-domain implicit rubrics — fit5 — NEW
+- comprehensive-test-review, evaluate-sdlc-layers, final-verification — fit5 — CONFIRMED
+- planner-rt-ica, task-decomposition (9-part CLEAR + 4 atomicity), validation-protocol (7 checks), discovery — fit4 — NEW
+
+### development-harness — agents
+
+- code-reviewer — 13 evals (7 dims + AC + stack + verdict) — fit5 — CONFIRMED
+- feature-verifier — 12 verification steps — fit5 — NEW
+- impact-analyst — 11 evals (per-system + 7-item ecosystem) — fit5 — NEW
+- backlog-item-groomer — 10+ rulesets (RT-ICA, classification, discovery, deps) — fit5 — NEW
+- doc-drift-auditor — fit4 — CONFIRMED; dh-context-gathering (9-point), ecosystem-researcher (9), rtica-assessor — fit4 — NEW
+
+### plugin-creator — skills
+
+- lint — 23 ruff/validator error codes (independent per-rule checkers) — fit5 — NEW
+- add-doc-updater — 12-15 phase-gated validation checks — fit5 — NEW
+- audit-skill-lifecycle (7), audit-skill-completeness (6-8), audit-agent-lifecycle (8) — fit4-5 — CONFIRMED
+- optimize-claude-md, plugin-creator, plugin-lifecycle, prompt-optimization, refactor-plugin,
+  refactor-skill, skill-creator, subagent-refactoring-methodology — multi-phase gated checklists — fit4 — NEW
+
+### plugin-creator — agents
+
+- refactor-validator (9 criteria x 5 phases), plugin-assessor (9 phases), skill-auditor (11) — fit5 — CONFIRMED
+- grader (per-assertion), comparator (per-criterion), ai-doc-optimizer (CoVe 5-6 falsifiable
+  questions), skill-sync-source-validator (per-URL), agent-creator (5 fields), hook-creator
+  (10 constraints) — textbook per-item fan-out — fit4 — NEW
+
+### python-engineering
+
+- review — 36 items / 9 categories — fit5 — CONFIRMED
+- modernpython — 10 PEP-roster principles (implicit→explicit) — fit5 — NEW
+- comprehensive-test-review — fit5 — CONFIRMED
+- designing-ui-for-cli (Nielsen /40 + 22-item) — fit4 — CONFIRMED
+- stinkysnake (9 phases / 12 smell categories), snakepolish (4 categories), debug (6-phase),
+  pre-commit (9 stages), lint, code-reviewer agent — fit4 — NEW
+
+### python3-development (under-covered in pass 1 — mostly NEW)
+
+- quality-gate — 5 sequential gates / 15+ criteria — fit5 — NEW
+- type-system-design-patterns — 4-step audit / 12+ per interface — fit5 — NEW
+- code-reviewer (agent) — 18-item / 5 categories — fit5 — NEW
+- python3-standards — 40+ criteria / 8 domains (shared rule hub) — fit5 — NEW
+- architecture-spec-patterns, comprehensive-test-review, stinkysnake, modernpython — fit4 — NEW
+
+### Net-new clusters pass 1 missed
+
+1. The whole `python3-development` plugin (`python3-standards` 40+ criteria hub, `quality-gate`,
+   distinct 18-item `code-reviewer`, `type-system-design-patterns`) — nearly invisible in pass 1.
+2. plugin-creator authoring-workflow cluster (`plugin-creator`, `plugin-lifecycle`,
+   `skill-creator`, `refactor-skill`, `prompt-optimization`, `subagent-refactoring-methodology`).
+3. plugin-creator CoVe/grading agents (`grader`, `comparator`, `ai-doc-optimizer`,
+   `skill-sync-source-validator`) — independent per-item evaluation, ideal fan-out.
+4. development-harness CLEAR+CoVe task-design family and the `code-review-{llm,nodejs,architecture}` trio.
+
+The pass-1 vs pass-2 recall gap is itself evidence for this skill's thesis: smaller per-worker
+scope raises recall. The overload that hurt the wide pass-1 finders is the overload the
+ensemble pattern removes.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-candidates.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-candidates.md
@@ -79,7 +79,7 @@ Same "review code against N quality dimensions in one pass" ruleset, duplicated:
 - `development-harness/agents/code-reviewer.md` — 7 universal dims + stack rules — fit5
 - `python-engineering/skills/review/SKILL.md` — 9 dimensions, 36 items — fit5
 - `.claude/templates/code-review-checklist.md` — 15 items, 4 sections — fit4
-- `python3-development/skills/python3-review` — near-duplicate of python-engineering
+- `python3-development/skills/python3-review` — near-duplicate of python-engineering (SKIP: `python3-development` is deprecated — convert the `python-engineering` copy only)
 
 Partition: one worker per dimension (correctness / security / perf / error-handling /
 naming / tests / docs), merge by severity plus corroboration.
@@ -200,8 +200,9 @@ list is where a single Sonnet pass silently drops criteria).
 
 1. **`python-engineering` and `python3-development` are near-duplicate plugins** — both
    carry analyze-test-failures, comprehensive-test-review, modernpython, review/python3-review,
-   snakepolish, test-failure-mindset, typer, ty, etc. Converting one and not the other
-   duplicates the work. Decide dedup/canonicalization before converting either.
+   snakepolish, test-failure-mindset, typer, ty, etc. `python3-development` is DEPRECATED
+   (retained for backward-compat only) — convert the `python-engineering` copies and SKIP
+   `python3-development` entirely.
 2. **The framework already exists in-repo** (Tier 0). Standardize from it rather than
    designing from scratch.
 3. **Replication is the corroboration signal at repo scale** — code-review (C1), summarizer
@@ -272,18 +273,23 @@ clusters the first pass missed. Marked NEW (missed by pass 1) or CONFIRMED.
 - stinkysnake (9 phases / 12 smell categories), snakepolish (4 categories), debug (6-phase),
   pre-commit (9 stages), lint, code-reviewer agent — fit4 — NEW
 
-### python3-development (under-covered in pass 1 — mostly NEW)
+### python3-development — DO NOT CONVERT (deprecated plugin)
 
-- quality-gate — 5 sequential gates / 15+ criteria — fit5 — NEW
-- type-system-design-patterns — 4-step audit / 12+ per interface — fit5 — NEW
-- code-reviewer (agent) — 18-item / 5 categories — fit5 — NEW
-- python3-standards — 40+ criteria / 8 domains (shared rule hub) — fit5 — NEW
-- architecture-spec-patterns, comprehensive-test-review, stinkysnake, modernpython — fit4 — NEW
+`python3-development` is deprecated and retained only for backward-compat with existing users.
+Do NOT convert any of its skills/agents. The candidates below are recorded for completeness
+only; their live equivalents in `python-engineering` are the conversion targets instead.
+
+- quality-gate — 5 sequential gates / 15+ criteria — fit5 — NEW — SKIP (deprecated)
+- type-system-design-patterns — 4-step audit / 12+ per interface — fit5 — NEW — SKIP (deprecated)
+- code-reviewer (agent) — 18-item / 5 categories — fit5 — NEW — SKIP (deprecated)
+- python3-standards — 40+ criteria / 8 domains (shared rule hub) — fit5 — NEW — SKIP (deprecated)
+- architecture-spec-patterns, comprehensive-test-review, stinkysnake, modernpython — fit4 — NEW — SKIP (deprecated)
 
 ### Net-new clusters pass 1 missed
 
 1. The whole `python3-development` plugin (`python3-standards` 40+ criteria hub, `quality-gate`,
    distinct 18-item `code-reviewer`, `type-system-design-patterns`) — nearly invisible in pass 1.
+   NOTE: `python3-development` is deprecated — do NOT convert it; recorded here for completeness only.
 2. plugin-creator authoring-workflow cluster (`plugin-creator`, `plugin-lifecycle`,
    `skill-creator`, `refactor-skill`, `prompt-optimization`, `subagent-refactoring-methodology`).
 3. plugin-creator CoVe/grading agents (`grader`, `comparator`, `ai-doc-optimizer`,

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-candidates.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-candidates.md
@@ -28,8 +28,9 @@ ensemble (partition ruleset across overlapping cheap parallel sub-agents → fix
 ---
 
 **Method:** 7 territory finders over the 30-plugin tree plus `.claude/`, identical detection
-checklist plus fixed schema plus 1-5 fit rubric. Per-finder reports in
-`.tmp/scratch/reports/finder-{ab,cd,efg,hl,m,nop,qrs,tz}.md`.
+checklist plus fixed schema plus 1-5 fit rubric. (Per-finder reports were written to a
+gitignored `.tmp/scratch/` scratch directory during the survey; they are working artifacts, not
+committed to the repo.)
 
 **Counts (finder-reported):** a-b 12/6 · c-d 16/8 · e-g 7/5 · h-l 7/4 · m 0/0 ·
 n-p 18/12 · q-s 10/8 · t-z 15/10 → ~85 candidates, ~53 at fit≥4.
@@ -79,7 +80,7 @@ Same "review code against N quality dimensions in one pass" ruleset, duplicated:
 - `development-harness/agents/code-reviewer.md` — 7 universal dims + stack rules — fit5
 - `python-engineering/skills/review/SKILL.md` — 9 dimensions, 36 items — fit5
 - `.claude/templates/code-review-checklist.md` — 15 items, 4 sections — fit4
-- `python3-development/skills/python3-review` — near-duplicate of python-engineering (SKIP: `python3-development` is deprecated — convert the `python-engineering` copy only)
+- `python3-development/skills/python3-review` — near-duplicate of python-engineering (SKIP: convert the `python-engineering` copy only; see meta-finding 1)
 
 Partition: one worker per dimension (correctness / security / perf / error-handling /
 naming / tests / docs), merge by severity plus corroboration.
@@ -200,9 +201,12 @@ list is where a single Sonnet pass silently drops criteria).
 
 1. **`python-engineering` and `python3-development` are near-duplicate plugins** — both
    carry analyze-test-failures, comprehensive-test-review, modernpython, review/python3-review,
-   snakepolish, test-failure-mindset, typer, ty, etc. `python3-development` is DEPRECATED
-   (retained for backward-compat only) — convert the `python-engineering` copies and SKIP
-   `python3-development` entirely.
+   snakepolish, test-failure-mindset, typer, ty, etc. Per repo-owner direction (conversation
+   2026-05-30), `python3-development` is being wound down in favour of `python-engineering` and
+   kept only so existing users do not break — so convert the `python-engineering` copies and SKIP
+   the `python3-development` duplicates. This is owner guidance for this catalog, not a deprecation
+   notice published in the plugin's own manifest or README; verify against the plugin before
+   relying on it elsewhere.
 2. **The framework already exists in-repo** (Tier 0). Standardize from it rather than
    designing from scratch.
 3. **Replication is the corroboration signal at repo scale** — code-review (C1), summarizer
@@ -281,21 +285,23 @@ clusters the first pass missed. Marked NEW (missed by pass 1) or CONFIRMED.
 
 ### python3-development — DO NOT CONVERT (deprecated plugin)
 
-`python3-development` is deprecated and retained only for backward-compat with existing users.
-Do NOT convert any of its skills/agents. The candidates below are recorded for completeness
-only; their live equivalents in `python-engineering` are the conversion targets instead.
+Per repo-owner direction (conversation 2026-05-30), `python3-development` is being wound down in
+favour of `python-engineering` and kept only so existing users do not break. Do NOT convert any of
+its skills/agents; their live equivalents in `python-engineering` are the conversion targets
+instead. (Owner guidance for this catalog — not a deprecation notice in the plugin's own manifest
+or README. The candidates below are recorded for completeness only.)
 
-- quality-gate — 5 sequential gates / 15+ criteria — fit5 — NEW — SKIP (deprecated)
-- type-system-design-patterns — 4-step audit / 12+ per interface — fit5 — NEW — SKIP (deprecated)
-- code-reviewer (agent) — 18-item / 5 categories — fit5 — NEW — SKIP (deprecated)
-- python3-standards — 40+ criteria / 8 domains (shared rule hub) — fit5 — NEW — SKIP (deprecated)
-- architecture-spec-patterns, comprehensive-test-review, stinkysnake, modernpython — fit4 — NEW — SKIP (deprecated)
+- quality-gate — 5 sequential gates / 15+ criteria — fit5 — NEW — SKIP (use python-engineering)
+- type-system-design-patterns — 4-step audit / 12+ per interface — fit5 — NEW — SKIP (use python-engineering)
+- code-reviewer (agent) — 18-item / 5 categories — fit5 — NEW — SKIP (use python-engineering)
+- python3-standards — 40+ criteria / 8 domains (shared rule hub) — fit5 — NEW — SKIP (use python-engineering)
+- architecture-spec-patterns, comprehensive-test-review, stinkysnake, modernpython — fit4 — NEW — SKIP (use python-engineering)
 
 ### Net-new clusters pass 1 missed
 
 1. The whole `python3-development` plugin (`python3-standards` 40+ criteria hub, `quality-gate`,
    distinct 18-item `code-reviewer`, `type-system-design-patterns`) — nearly invisible in pass 1.
-   NOTE: `python3-development` is deprecated — do NOT convert it; recorded here for completeness only.
+   NOTE: per owner direction (meta-finding 1) do NOT convert `python3-development`; recorded for completeness only.
 2. plugin-creator authoring-workflow cluster (`plugin-creator`, `plugin-lifecycle`,
    `skill-creator`, `refactor-skill`, `prompt-optimization`, `subagent-refactoring-methodology`).
 3. plugin-creator CoVe/grading agents (`grader`, `comparator`, `ai-doc-optimizer`,

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-candidates.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-candidates.md
@@ -270,8 +270,14 @@ clusters the first pass missed. Marked NEW (missed by pass 1) or CONFIRMED.
 - modernpython — 10 PEP-roster principles (implicit→explicit) — fit5 — NEW
 - comprehensive-test-review — fit5 — CONFIRMED
 - designing-ui-for-cli (Nielsen /40 + 22-item) — fit4 — CONFIRMED
-- stinkysnake (9 phases / 12 smell categories), snakepolish (4 categories), debug (6-phase),
-  pre-commit (9 stages), lint, code-reviewer agent — fit4 — NEW
+- debug (6-phase), pre-commit (9 stages), lint, code-reviewer agent — fit4 — NEW
+- stinkysnake (9-phase workflow), snakepolish (8-step impl phase) — CONVERT PER-PHASE, not
+  whole-skill. Verified 2026-05-30: these are sequential workflows, NOT flat single-pass
+  rulesets. The whole skill fails the When-to-Use gate; individual rule-bearing phases do not.
+  For stinkysnake, the ensemble targets are Phase 2 (type-gap inventory), Phase 3 (modernization
+  construct/PEP roster), and Phase 4 (plan review); Phases 6/8/9 are work-partition fan-outs.
+  See `composing-in-workflows.md`. (Correction: an earlier pass mis-scored these as flat fit4
+  rulesets.)
 
 ### python3-development — DO NOT CONVERT (deprecated plugin)
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-workflow.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-workflow.md
@@ -1,0 +1,80 @@
+# Converting an Existing Skill into the Ensemble Form
+
+A step-by-step workflow to take a skill/agent that applies a large ruleset in a single pass and
+restructure it into a fan-out ensemble (partitioned overlapping workers + corroboration-weighted
+reducer). Also the recipe for standardizing the `multi-perspective-review` prior art.
+
+## Table of Contents
+
+- [Preconditions](#preconditions)
+- [Workflow](#workflow)
+- [Standardizing multi-perspective-review](#standardizing-multi-perspective-review)
+- [Validation gate (feedback loop)](#validation-gate-feedback-loop)
+
+## Preconditions
+
+Confirm the candidate fits before converting (see the parent SKILL.md "When to Use"):
+
+- The skill applies a ruleset of ~10+ independent criteria.
+- It applies them in a single agent pass today (slow + silent criteria-dropping).
+- The ruleset can be split into scenario-bound slices that can overlap.
+
+If the ruleset is under ~5 criteria, or the task needs one coherent creative judgment, STOP — the
+ensemble overhead exceeds the return.
+
+## Workflow
+
+1. **Enumerate the ruleset.** Read the source skill/agent and extract every criterion as a
+   discrete, stably-named rule. If the rubric is implicit ("pythonic", "modernization", "review
+   for quality"), make it explicit first using
+   [./partitioning-patterns.md](./partitioning-patterns.md).
+
+2. **Cluster into overlapping slices.** Group the rules into 3–7 scenario-bound slices. Ensure
+   each rule appears in at least two slices so genuine findings get corroborated. Prefer the
+   natural boundaries the rubric already names (a framework's categories, a checklist's sections).
+
+3. **Define the control header.** Write the one-line header that compiles an effort/scale
+   parameter into concrete knobs: worker count, candidates-per-worker cap, verify policy, output
+   cap. The same skill body then scales rigor by that parameter.
+
+4. **Emit worker definitions.** Copy `../assets/worker-prompt-skeleton.md` once per slice and fill
+   the placeholders. All workers share the identical input scope and the fixed candidate schema;
+   only the rule slice differs. Workers run on the cheapest tier at low effort.
+
+5. **Emit the reducer.** Specify the dedup → corroboration-weight → drop-tail → rank step (the
+   algorithm in [./orchestrator-playbook.md](./orchestrator-playbook.md)). The reducer runs on a
+   mid tier (sonnet) at medium effort.
+
+6. **Wire the orchestrator.** The new SKILL.md body becomes: Phase 0 scope (deterministic) →
+   Phase 1 dispatch workers in parallel → Phase 2 reduce → emit ranked/capped/structured output.
+   Keep the worker prompts and schema in `assets/`, detail in `references/`, body lean.
+
+7. **Preserve provenance.** Cite the source skill the ruleset came from, and keep the original
+   skill's rule text intact inside the worker slices — conversion must not drop or reword criteria.
+
+## Standardizing multi-perspective-review
+
+`development-harness/skills/multi-perspective-review` already runs a 4-worker parallel review
+(Security, Performance, Quality, Accessibility) with a merge gate — a partial instance of this
+pattern. To bring it to the full pattern, apply only the deltas:
+
+- Add the **fixed candidate schema** to each reviewer worker (it currently returns free-form SOP
+  output).
+- Replace the **any-REJECT merge** with the **corroboration-weighted reducer** so findings the
+  perspectives independently agree on rank highest.
+- Add **deliberate overlap** between perspectives on shared concerns (e.g. input validation spans
+  Security and Quality) so corroboration has something to count.
+
+## Validation gate (feedback loop)
+
+Before declaring the conversion done, prove it on a known input:
+
+1. Pick an input the single-pass skill already reviewed (a known-answer file).
+2. Run the new ensemble on it.
+3. Compare against the single-pass baseline: recall (findings caught), precision (false
+   positives), and latency.
+4. The conversion passes when recall is at least equal to the baseline AND latency is lower. If
+   recall dropped, the slices are too narrow or lost a rule — return to step 2 of the workflow. If
+   precision dropped, raise the reducer keep-threshold or add a verifier pass (see playbook).
+5. Re-run until both conditions hold. Record the baseline-vs-ensemble numbers as the skill's
+   evaluation evidence.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-workflow.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/conversion-workflow.md
@@ -29,9 +29,12 @@ ensemble overhead exceeds the return.
    for quality"), make it explicit first using
    [./partitioning-patterns.md](./partitioning-patterns.md).
 
-2. **Cluster into overlapping slices.** Group the rules into 3–7 scenario-bound slices. Ensure
-   each rule appears in at least two slices so genuine findings get corroborated. Prefer the
-   natural boundaries the rubric already names (a framework's categories, a checklist's sections).
+2. **Cluster into groups and plan the assignment.** Group the rules into 3+ stable groups (prefer
+   the natural boundaries the rubric already names — a framework's categories, a checklist's
+   sections), write them to a JSON file (group id → rules), and run
+   `../scripts/plan_ensemble.py RULES.json --report-dir /abs/dir` to produce the balanced
+   rotating-overlap assignment. The planner guarantees each rule lands in exactly `window` workers
+   (uniform redundancy) so corroboration is even across the ruleset.
 
 3. **Define the control header.** Write the one-line header that compiles an effort/scale
    parameter into concrete knobs: worker count, candidates-per-worker cap, verify policy, output

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
@@ -86,10 +86,14 @@ dropped). Raising `w` is the mitigation; this is a property of voting ensembles 
    No reasoning yet.
 2. **Enumerate.** List every rule. If the rubric is implicit, make it explicit first
    (see partitioning-patterns).
-3. **Cluster into overlapping slices.** Group rules into 3–7 scenario-bound slices; ensure each
-   rule lands in ≥ 2 slices.
-4. **Build worker prompts.** Copy `../assets/worker-prompt-skeleton.md` once per slice; fill the
-   placeholders; set the identical input scope on all.
+3. **Cluster into groups + plan the assignment.** Write the enumerated rules into a JSON file
+   mapping stable group id → rules (3+ groups), then run
+   `../scripts/plan_ensemble.py RULES.json --report-dir /abs/dir [--window 2]`. It computes the
+   rotating-overlap assignment, verifies uniform redundancy, assigns each worker its groups +
+   absolute OUTFILE, and prints the recommended keep-threshold. Do NOT hand-roll the assignment —
+   the planner exists to prevent the path/group/overlap bookkeeping bugs.
+4. **Build worker prompts.** Copy `../assets/worker-prompt-skeleton.md` once per worker in the
+   plan; fill its groups (with per-group rules), identical input scope, and the planner's OUTFILE.
 5. **Dispatch (Phase 1 / map).** Spawn the `plugin-creator:focused-reviewer` agent once per
    slice — it is the lean, haiku, minimal-tool worker built for this. Do NOT use
    `general-purpose`: it inherits every skill and MCP tool description, costing a constant token

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
@@ -34,12 +34,47 @@ rule-overlap within each shard.
 ## The knobs
 
 - **Worker count** — typically 3–7. One worker per natural rule cluster.
-- **Overlap degree** — each rule appears in at least 2 workers' slices. More overlap = stronger
-  denoising, higher cost. Zero overlap = speed only, no corroboration signal.
+- **Overlap degree** — use the balanced rotating construction below so every rule gets the same
+  number of looks. More overlap = stronger denoising, higher cost. Zero overlap = speed only,
+  no corroboration signal.
 - **Candidates cap per worker** — bound each worker's output (e.g. ≤ K findings) so a confused
   worker cannot flood the reducer.
 - **Keep threshold** — minimum corroboration weight to survive the reducer. Higher = more
   precision, lower recall. For recall-biased work, keep weight ≥ 1 and rank rather than cut hard.
+
+## Balanced rotating overlap (recommended construction)
+
+Do NOT assign overlap ad hoc. Use a cyclic block design so every rule gets the SAME number of
+independent looks — uniform redundancy makes one keep-threshold mean the same thing for every
+rule.
+
+Split the ruleset into N groups (N >= 3; more groups for a bigger list). Run N agents. Give each
+agent a window of `w` consecutive groups, rotating:
+
+```text
+N=3, w=2:
+  Agent A -> groups [1, 2]
+  Agent B -> groups [2, 3]
+  Agent C -> groups [3, 1]
+
+Coverage: group 1 -> {A, C}   group 2 -> {A, B}   group 3 -> {B, C}
+Every group is seen by exactly w=2 agents.
+```
+
+Properties:
+
+- **Uniform redundancy r = w.** Every true finding is independently reachable by exactly `w`
+  agents, so its expected corroboration weight is `w`; a lone-agent hallucination has weight 1.
+  A threshold of "weight >= 2" separates them identically for every rule — no rule is privileged
+  by accidentally getting more looks than another (the failure mode of ad-hoc overlap).
+- **`w` is the denoise knob.** `w=2` over `N=3` -> keep on any corroboration (>= 2 agents).
+  Scale up (e.g. `N=5, w=3`) -> keep on majority, tolerating one missed look per true finding.
+- **Per-worker scope stays small.** Each agent carries `w/N` of the rules, so the slices remain
+  in the mechanical-matching band even for large rulesets.
+
+Caveat: uniform redundancy protects against *independent* single-agent error, not *correlated*
+misses. If a rule is genuinely hard, all `w` assigned agents can miss it together (weight 0,
+dropped). Raising `w` is the mitigation; this is a property of voting ensembles generally.
 
 ## Procedure: recognize → decompose → dispatch → reduce
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
@@ -1,0 +1,121 @@
+# Ad-hoc Orchestrator Playbook
+
+How an orchestrator runs the ensemble on the fly, mid-task, without a pre-built skill. Use when
+you face rule-following work (apply a checklist/rubric against an input) and want higher recall +
+lower latency than holding the whole ruleset in one pass yourself.
+
+## Table of Contents
+
+- [Recognize the opportunity](#recognize-the-opportunity)
+- [Partition the ruleset, not the input](#partition-the-ruleset-not-the-input)
+- [The knobs](#the-knobs)
+- [Procedure: recognize → decompose → dispatch → reduce](#procedure-recognize--decompose--dispatch--reduce)
+- [The reducer algorithm](#the-reducer-algorithm)
+- [Worker task types](#worker-task-types)
+- [Worked examples](#worked-examples)
+- [Anti-patterns](#anti-patterns)
+
+## Recognize the opportunity
+
+Trigger signals: an instruction with "ensure … follows", "review for", "look for …
+opportunities", a named framework, or any enumerable rubric of 10+ criteria you would otherwise
+apply in one pass. For the full recognition typology, see
+[./partitioning-patterns.md](./partitioning-patterns.md).
+
+## Partition the ruleset, not the input
+
+Every worker reviews the SAME input; only its rule slice differs. The denoising comes from
+overlapping rule coverage on shared input — multiple workers independently reaching the same
+finding, which the reducer counts as corroboration. Sharding the input (different files per
+worker) buys speed but NOT denoising, because no two workers can corroborate the same location.
+Shard input only as a secondary axis when one worker cannot hold the whole input, and keep
+rule-overlap within each shard.
+
+## The knobs
+
+- **Worker count** — typically 3–7. One worker per natural rule cluster.
+- **Overlap degree** — each rule appears in at least 2 workers' slices. More overlap = stronger
+  denoising, higher cost. Zero overlap = speed only, no corroboration signal.
+- **Candidates cap per worker** — bound each worker's output (e.g. ≤ K findings) so a confused
+  worker cannot flood the reducer.
+- **Keep threshold** — minimum corroboration weight to survive the reducer. Higher = more
+  precision, lower recall. For recall-biased work, keep weight ≥ 1 and rank rather than cut hard.
+
+## Procedure: recognize → decompose → dispatch → reduce
+
+1. **Scope (Phase 0).** Fix the exact input set deterministically (a file, a `git diff`, a target).
+   No reasoning yet.
+2. **Enumerate.** List every rule. If the rubric is implicit, make it explicit first
+   (see partitioning-patterns).
+3. **Cluster into overlapping slices.** Group rules into 3–7 scenario-bound slices; ensure each
+   rule lands in ≥ 2 slices.
+4. **Build worker prompts.** Copy `../assets/worker-prompt-skeleton.md` once per slice; fill the
+   placeholders; set the identical input scope on all.
+5. **Dispatch (Phase 1 / map).** Launch all workers in one parallel batch, cheapest tier, low
+   effort. Each writes findings in the fixed schema.
+6. **Reduce (Phase 2).** Run the reducer algorithm below.
+7. **Emit.** Ranked, capped, structured output. An empty result is a valid terminal.
+
+## The reducer algorithm
+
+```python
+# findings: list of dicts from all workers, each: {rule_id, location, verdict, evidence, severity}
+from collections import defaultdict
+
+def reduce(findings, keep_threshold=1):
+    # 1. Keep only violations.
+    violations = [f for f in findings if f["verdict"] == "VIOLATION"]
+
+    # 2. Dedup + count corroboration: same defect, same place, same rule -> one weighted entry.
+    merged = defaultdict(lambda: {"weight": 0, "evidence": [], "severity": None})
+    for f in violations:
+        key = (normalize(f["rule_id"]), normalize(f["location"]))
+        m = merged[key]
+        m["weight"] += 1                      # +1 per corroborating worker
+        m["evidence"].append(f["evidence"])
+        m["severity"] = max_sev(m["severity"], f.get("severity"))
+
+    # 3. Drop the low-weight tail; a lone-worker finding has weight 1.
+    survivors = [(k, v) for k, v in merged.items() if v["weight"] >= keep_threshold]
+
+    # 4. Rank: corroboration weight first, then severity. Correctness outranks cleanup.
+    survivors.sort(key=lambda kv: (kv[1]["weight"], sev_rank(kv[1]["severity"])), reverse=True)
+    return survivors
+```
+
+`normalize` collapses trivial differences (whitespace, line drift) so the same finding from two
+workers collides. Tune `keep_threshold`: for recall-biased ad-hoc work, keep weight ≥ 1 and rank;
+for precision-biased gates, raise the threshold so only corroborated findings survive.
+
+## Worker task types
+
+Decompose into two role types — keep each worker to ONE type:
+
+- **Detection/classification workers (map).** Apply a rule slice to the shared input, emit
+  fixed-schema findings. High rigidity, cheapest model. The default worker.
+- **Verifier workers (optional second pass).** Take a single surviving candidate plus the input
+  and return one constrained verdict (CONFIRMED / PLAUSIBLE / REFUTED). Use when precision must be
+  raised beyond what corroboration weighting alone provides.
+
+The orchestrator itself is the **reducer** — mid tier (sonnet), medium effort — never a worker.
+
+## Worked examples
+
+- **Rule partition for denoising (the journal review).** One input file, 4 workers, each a
+  different quarter of the rule list, overlapping coverage. Result: comparable recall to a single
+  expensive pass, far faster, with hallucinations diluted by corroboration.
+- **Territory partition for recall (this repo survey).** A large input set sharded across finder
+  workers (different plugins per worker) for breadth. This is the input-shard axis — it raised
+  recall but, with non-overlapping territory, gave no per-finding corroboration. The narrow
+  second pass demonstrated the recall cost of over-broad slices: smaller scope per worker found
+  more. Lesson: keep slices small, and add rule-overlap when you need denoising, not just breadth.
+
+## Anti-patterns
+
+- **Non-overlapping partition when you need reliability.** Gives speed only; no corroboration
+  signal, so single-worker hallucinations survive.
+- **Slices too broad.** Overloads the cheap worker back into the silent-criteria-dropping regime
+  the pattern exists to avoid.
+- **Reducing before dedup.** Corroboration counting is meaningless until `(rule_id, location)` is
+  normalized — dedup first, then weight.
+- **An expensive model as a worker.** Wastes the economics; cheap workers + overlap is the design.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
@@ -39,8 +39,12 @@ rule-overlap within each shard.
   no corroboration signal.
 - **Candidates cap per worker** — bound each worker's output (e.g. ≤ K findings) so a confused
   worker cannot flood the reducer.
-- **Keep threshold** — minimum corroboration weight to survive the reducer. Higher = more
-  precision, lower recall. For recall-biased work, keep weight ≥ 1 and rank rather than cut hard.
+- **Keep threshold** — minimum corroboration weight to survive the reducer. The script default is
+  `keep_threshold=1` (recall-biased: keep everything, rank by weight, cut nothing). This default
+  does NOT drop lone-worker findings — it relies on you reading the ranked output. For a
+  **precision-biased gate** (where a lone worker's hallucination must fall away automatically),
+  pass `--keep-threshold 2` (or higher with more overlap) so only corroborated findings survive.
+  Choose the threshold deliberately per run; do not assume the default denoises.
 
 ## Balanced rotating overlap (recommended construction)
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
@@ -93,34 +93,46 @@ dropped). Raising `w` is the mitigation; this is a property of voting ensembles 
 
 ## The reducer algorithm
 
-```python
-# findings: list of dicts from all workers, each: {rule_id, location, verdict, evidence, severity}
-from collections import defaultdict
+A working, tested implementation ships at `../scripts/reduce.py` (run
+`uv run ../scripts/reduce.py REPORT_DIR --glob 'worker-*.md' [--keep-threshold N]`). The core:
 
+```python
+# findings: list of dicts from all workers, each: {group, location, verdict, evidence, severity}
 def reduce(findings, keep_threshold=1):
     # 1. Keep only violations.
-    violations = [f for f in findings if f["verdict"] == "VIOLATION"]
+    violations = [f for f in findings if f.get("verdict", "VIOLATION") == "VIOLATION"]
 
-    # 2. Dedup + count corroboration: same defect, same place, same rule -> one weighted entry.
-    merged = defaultdict(lambda: {"weight": 0, "evidence": [], "severity": None})
+    # 2. Dedup + count corroboration. KEY ON (group, location) — NEVER the rule slug.
+    #    Workers author their own rule slugs, so keying on rule would never corroborate;
+    #    `group` is the orchestrator-assigned id, identical across workers, so it collides.
+    merged = {}
     for f in violations:
-        key = (normalize(f["rule_id"]), normalize(f["location"]))
-        m = merged[key]
-        m["weight"] += 1                      # +1 per corroborating worker
+        key = (f["group"], normalize(f["location"]))   # group is the stable corroboration key
+        m = merged.setdefault(key, {"agents": set(), "evidence": [], "severity": "low"})
+        m["agents"].add(f["worker_id"])                # weight = number of DISTINCT workers
         m["evidence"].append(f["evidence"])
         m["severity"] = max_sev(m["severity"], f.get("severity"))
 
-    # 3. Drop the low-weight tail; a lone-worker finding has weight 1.
-    survivors = [(k, v) for k, v in merged.items() if v["weight"] >= keep_threshold]
+    # 3. weight = len(agents); drop the low-weight tail (a lone-worker finding has weight 1).
+    survivors = [(k, v) for k, v in merged.items() if len(v["agents"]) >= keep_threshold]
 
     # 4. Rank: corroboration weight first, then severity. Correctness outranks cleanup.
-    survivors.sort(key=lambda kv: (kv[1]["weight"], sev_rank(kv[1]["severity"])), reverse=True)
+    survivors.sort(key=lambda kv: (len(kv[1]["agents"]), sev_rank(kv[1]["severity"])), reverse=True)
     return survivors
 ```
 
-`normalize` collapses trivial differences (whitespace, line drift) so the same finding from two
-workers collides. Tune `keep_threshold`: for recall-biased ad-hoc work, keep weight ≥ 1 and rank;
-for precision-biased gates, raise the threshold so only corroborated findings survive.
+Two contract points the live test proved necessary:
+
+- **Key on `group`, not the rule slug.** In the worked review run, two agents flagged the same
+  line with different slugs (`any-without-justification` vs `any-not-in-boundary-module`). Keying
+  on the slug splits them into two weight-1 findings; keying on `group` corroborates them to
+  weight 2. Keying on the rule slug is the dominant cause of "the ensemble found nothing agreed".
+- **Weight = count of DISTINCT workers**, not raw report count, so one worker emitting a finding
+  twice cannot fake corroboration.
+
+`normalize` collapses trivial location differences (absolute-vs-relative path, whitespace) so the
+same line from two workers collides. Tune `keep_threshold`: for recall-biased ad-hoc work, keep
+weight ≥ 1 and rank; for precision-biased gates, raise it so only corroborated findings survive.
 
 ## Worker task types
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/orchestrator-playbook.md
@@ -86,8 +86,11 @@ dropped). Raising `w` is the mitigation; this is a property of voting ensembles 
    rule lands in ≥ 2 slices.
 4. **Build worker prompts.** Copy `../assets/worker-prompt-skeleton.md` once per slice; fill the
    placeholders; set the identical input scope on all.
-5. **Dispatch (Phase 1 / map).** Launch all workers in one parallel batch, cheapest tier, low
-   effort. Each writes findings in the fixed schema.
+5. **Dispatch (Phase 1 / map).** Spawn the `plugin-creator:focused-reviewer` agent once per
+   slice — it is the lean, haiku, minimal-tool worker built for this. Do NOT use
+   `general-purpose`: it inherits every skill and MCP tool description, costing a constant token
+   overhead on every one of the N parallel workers. Launch all in one parallel batch, low effort.
+   Each writes findings in the fixed schema to its absolute OUTFILE.
 6. **Reduce (Phase 2).** Run the reducer algorithm below.
 7. **Emit.** Ranked, capped, structured output. An empty result is a valid terminal.
 
@@ -139,7 +142,9 @@ weight ≥ 1 and rank; for precision-biased gates, raise it so only corroborated
 Decompose into two role types — keep each worker to ONE type:
 
 - **Detection/classification workers (map).** Apply a rule slice to the shared input, emit
-  fixed-schema findings. High rigidity, cheapest model. The default worker.
+  fixed-schema findings. High rigidity, cheapest model. The default worker — use the
+  `plugin-creator:focused-reviewer` agent, which is exactly this with minimal tools and no
+  inherited skills.
 - **Verifier workers (optional second pass).** Take a single surviving candidate plus the input
   and return one constrained verdict (CONFIRMED / PLAUSIBLE / REFUTED). Use when precision must be
   raised beyond what corroboration weighting alone provides.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/partitioning-patterns.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/partitioning-patterns.md
@@ -1,0 +1,63 @@
+# Implicit-Checklist Patterns — Grouped by Partition-Readiness
+
+A typology of implicit checklists found in real instructions, grouped by how cleanly each
+pre-partitions into overlapping worker jobs. Use it to recognize a fan-out candidate and to
+choose worker boundaries with minimal design effort.
+
+## Table of Contents
+
+- [Group 1 — Named principle set (partition handed to you free)](#group-1--named-principle-set-partition-handed-to-you-free)
+- [Group 2 — "modernization / idiomatic / pythonic" (the classic implicit list)](#group-2--modernization--idiomatic--pythonic-the-classic-implicit-list)
+- [Group 3 — "review X for quality" (the broadest implicit bucket)](#group-3--review-x-for-quality-the-broadest-implicit-bucket)
+- [Group 4 — Prompt-engineering / skill-quality self-review](#group-4--prompt-engineering--skill-quality-self-review)
+- [The tell](#the-tell)
+
+---
+
+## Group 1 — Named principle set (partition handed to you free)
+
+When the rubric is a named framework, its own categories ARE the worker boundaries. Near-zero
+design work.
+
+- `twelve-factor-app` — literally 12 factors. One worker per factor (or per 3).
+- SOLID reviews — 5 principles = 5 overlapping jobs.
+- Security review → OWASP categories (injection, authz, secrets, SSRF, deserialization,
+  path traversal).
+- Accessibility review → WCAG criteria.
+- `design-anti-patterns` (the Uncodixfy rule set) → one worker per anti-pattern family.
+
+## Group 2 — "modernization / idiomatic / pythonic" (the classic implicit list)
+
+The rubric is named but unenumerated. Enumerate it once, then split the roster into buckets.
+
+- `modernpython` "look for modernization opportunities" → an explicit PEP roster: 585 generics,
+  604 unions, 572 walrus, 634 match, 673 Self, StrEnum, tomllib, pathlib, dataclasses. Each PEP
+  is a rule; the roster splits into N buckets.
+- `snakepolish` / `review` "pythonic best practices" → comprehensions, context managers, EAFP,
+  enumerate/zip, mutable-default-arg, truthiness.
+
+## Group 3 — "review X for quality" (the broadest implicit bucket)
+
+- Generic code review → correctness / error-handling / naming / dead-code / structure as
+  separate scenario buckets. This is exactly what `/code-review`'s A/B/C angles already are.
+- `comprehensive-test-review` → AAA, isolation, mocking, parametrization, flaky-patterns,
+  coverage thresholds.
+- Performance review → N+1, blocking-in-hot-path, redundant I/O, allocation.
+
+## Group 4 — Prompt-engineering / skill-quality self-review
+
+This repo eats its own dog food here — these are rule-following skills that review skills/agents.
+
+- `ai-doc-optimizer`, `subagent-refactorer` "apply Anthropic best practices" → positive framing,
+  front-loaded constraints, XML tagging, examples-present, no-contradictions — each a checkable rule.
+- `audit-skill-completeness` → frontmatter / progressive-disclosure / citations / link-validity /
+  token-size.
+- `doc-drift-auditor` → each documented claim vs code (already a per-item loop, ideal to fan out).
+- `CLAUDE.md` / `.claude/rules` process review → per-rule clarity + cross-rule contradiction detection.
+
+## The tell
+
+Any instruction containing "ensure … follows", "review for", "look for … opportunities", or a
+named framework is an implicit checklist. Named frameworks (12-factor, SOLID, WCAG, OWASP, a PEP
+set) are **pre-partitioned** — their own categories are the natural overlapping job boundaries,
+so those convert with near-zero design work.

--- a/plugins/plugin-creator/skills/ensemble-rule-review/scripts/conftest.py
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/scripts/conftest.py
@@ -1,0 +1,8 @@
+"""Make the reducer script importable by its sibling test under any pytest import mode."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/plugins/plugin-creator/skills/ensemble-rule-review/scripts/plan_ensemble.py
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/scripts/plan_ensemble.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Planner for the ensemble-rule-review pattern — the deterministic map-side bookend.
+
+Given a ruleset split into stable groups, this computes the balanced rotating-overlap
+worker assignment (cyclic block design: N agents, each a window of `w` consecutive
+groups), assigns every worker an absolute output path, and verifies uniform redundancy
+BEFORE any agent is spawned. It removes the manual bookkeeping that produces the
+recurring bugs — wrong output paths, drifted group ids, ad-hoc (non-uniform) overlap,
+and per-worker (instead of per-rule) group tagging.
+
+Pair with reduce.py (the reduce-side bookend): plan -> spawn focused-reviewer x N -> reduce.
+Both ends are deterministic code; only the per-worker rule-matching is left to the LLM.
+
+Input: a JSON file mapping stable group id -> list of rule strings. Example:
+
+    {
+      "1": ["no bare except", "no swallowed exceptions"],
+      "2": ["no Any outside boundaries", "no legacy typing imports"],
+      "3": ["functions under 50 lines", "no deep nesting"]
+    }
+
+Usage:
+    plan_ensemble.py RULES_JSON --report-dir /abs/reports [--window 2] [--target PATH] [--json]
+
+Output (human table by default, or a machine plan with --json): one row per worker giving
+its worker id, the groups it covers, the absolute OUTFILE to write, and the rules to apply;
+plus the recommended keep-threshold (= window, for a precision gate) and a redundancy check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import string
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MIN_GROUPS = 3
+WORKER_IDS = string.ascii_uppercase
+
+
+@dataclass
+class WorkerPlan:
+    """One worker's assignment in the rotating-overlap ensemble."""
+
+    worker_id: str
+    groups: list[str]
+    outfile: str
+    rules_by_group: dict[str, list[str]] = field(default_factory=dict)
+
+
+def parse_groups(raw: object) -> dict[str, list[str]]:
+    """Validate untyped JSON at the boundary into a typed group->rules mapping.
+
+    Returns:
+        A `dict[str, list[str]]` of group id to rule strings.
+
+    Raises:
+        TypeError: when the structure is not an object of id -> list[str].
+    """
+    if not isinstance(raw, dict):
+        msg = "rules JSON must be an object mapping group id -> list of rule strings"
+        raise TypeError(msg)
+    parsed: dict[str, list[str]] = {}
+    for key, value in raw.items():
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            msg = f"group {key!r} must map to a list of rule strings"
+            raise TypeError(msg)
+        parsed[str(key)] = [str(item) for item in value]
+    return parsed
+
+
+def rotate_assignment(group_ids: list[str], window: int) -> list[list[str]]:
+    """Compute the cyclic rotating-window group assignment, one window per worker.
+
+    Worker i covers `window` consecutive groups starting at index i (wrapping). With
+    N groups and N workers this gives uniform redundancy r = window: every group is
+    covered by exactly `window` workers.
+
+    Returns:
+        A list of length len(group_ids); element i is worker i's list of group ids.
+    """
+    n = len(group_ids)
+    return [[group_ids[(i + offset) % n] for offset in range(window)] for i in range(n)]
+
+
+def redundancy(assignment: list[list[str]], group_ids: list[str]) -> dict[str, int]:
+    """Count how many workers cover each group.
+
+    Returns:
+        A mapping of group id to the number of workers that hold it.
+    """
+    counts = dict.fromkeys(group_ids, 0)
+    for groups in assignment:
+        for g in groups:
+            counts[g] += 1
+    return counts
+
+
+def build_plan(groups: dict[str, list[str]], window: int, report_dir: str) -> list[WorkerPlan]:
+    """Build the per-worker plan from the grouped ruleset.
+
+    Returns:
+        One WorkerPlan per worker, each with its groups, absolute outfile, and rules.
+    """
+    group_ids = list(groups)
+    assignment = rotate_assignment(group_ids, window)
+    base = Path(report_dir)
+    plans: list[WorkerPlan] = []
+    for i, covered in enumerate(assignment):
+        wid = WORKER_IDS[i] if i < len(WORKER_IDS) else f"W{i}"
+        outfile = str(base / f"worker-{wid}.md")
+        plans.append(
+            WorkerPlan(worker_id=wid, groups=covered, outfile=outfile, rules_by_group={g: groups[g] for g in covered})
+        )
+    return plans
+
+
+def validate_inputs(groups: dict[str, list[str]], window: int, report_dir: str) -> list[str]:
+    """Check the planner inputs against the pattern's invariants.
+
+    Returns:
+        A list of human-readable error strings; empty when the inputs are valid.
+    """
+    errors: list[str] = []
+    if len(groups) < MIN_GROUPS:
+        errors.append(f"need at least {MIN_GROUPS} groups for overlap denoising, got {len(groups)}")
+    window_ok = groups and 2 <= window < len(groups)  # noqa: PLR2004
+    if not window_ok:
+        errors.append(f"window must satisfy 2 <= window < n_groups ({len(groups)}); got {window}")
+    if any(not rules for rules in groups.values()):
+        empty = [g for g, rules in groups.items() if not rules]
+        errors.append(f"groups have no rules: {empty}")
+    if not Path(report_dir).is_absolute():
+        errors.append(f"--report-dir must be an absolute path (workers resolve varying cwd): {report_dir}")
+    return errors
+
+
+def format_plan(plans: list[WorkerPlan], counts: dict[str, int], window: int) -> str:
+    """Render the human-readable plan and the redundancy / threshold guidance.
+
+    Returns:
+        The formatted multi-line plan string.
+    """
+    lines = [
+        f"ensemble plan: {len(plans)} workers, window w={window}, uniform redundancy r={window}",
+        f"recommended --keep-threshold: {window} (precision gate) | 1 (recall, rank only)",
+        "",
+        "redundancy per group (each must equal w):",
+    ]
+    lines.extend(f"  group {g}: {c} worker(s)" for g, c in counts.items())
+    uniform = set(counts.values()) == {window}
+    lines.extend((
+        f"  uniform: {'YES' if uniform else 'NO — assignment is unbalanced'}",
+        "",
+        "=== WORKER ASSIGNMENTS ===",
+    ))
+    for p in plans:
+        lines.append(f"worker {p.worker_id}  groups={p.groups}  OUTFILE={p.outfile}")
+        for g, rules in p.rules_by_group.items():
+            lines.extend(f"    [group {g}] {rule}" for rule in rules)
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the planner CLI.
+
+    Returns:
+        Process exit code: 0 on success, 2 on input error.
+    """
+    parser = argparse.ArgumentParser(description="Planner for the ensemble-rule-review rotating-overlap fan-out.")
+    parser.add_argument("rules_json", type=Path, help="JSON file mapping group id -> list of rule strings.")
+    parser.add_argument("--report-dir", required=True, help="ABSOLUTE directory where workers write reports.")
+    parser.add_argument("--window", type=int, default=2, help="Groups per worker (overlap degree, default 2).")
+    parser.add_argument("--json", action="store_true", help="Emit the machine-readable plan as JSON.")
+    args = parser.parse_args(argv)
+
+    if not args.rules_json.is_file():
+        print(f"error: not a file: {args.rules_json}", file=sys.stderr)
+        return 2
+    try:
+        raw = json.loads(args.rules_json.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"error: invalid JSON in {args.rules_json}: {exc}", file=sys.stderr)
+        return 2
+    try:
+        groups = parse_groups(raw)
+    except TypeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    errors = validate_inputs(groups, args.window, args.report_dir)
+    if errors:
+        for e in errors:
+            print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    plans = build_plan(groups, args.window, args.report_dir)
+    counts = redundancy([p.groups for p in plans], list(groups))
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "window": args.window,
+                    "keep_threshold_precision": args.window,
+                    "redundancy": counts,
+                    "workers": [
+                        {"id": p.worker_id, "groups": p.groups, "outfile": p.outfile, "rules": p.rules_by_group}
+                        for p in plans
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(format_plan(plans, counts, args.window))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/plugin-creator/skills/ensemble-rule-review/scripts/reduce.py
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/scripts/reduce.py
@@ -41,7 +41,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 FIELD_RE = re.compile(r"^\s*(?:-\s+)?([A-Za-z_]+):\s*(.*)$")
-LOCATION_LINE_RE = re.compile(r"([^/\s]+):(\d+)")
+# Capture the FULL path token (not just the basename) so two different files sharing a
+# basename never collapse into the same key and fabricate a false corroboration.
+LOCATION_LINE_RE = re.compile(r"(\S+):(\d+)")
 SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1}
 BLOCK_START_FIELD = "group"
 # A finding is "corroborated" once at least this many distinct workers report it.
@@ -77,15 +79,21 @@ class Merged:
 
 
 def normalize_location(raw: str) -> str:
-    """Collapse a location to `basename:line` so two workers collide on one line.
+    """Normalize a location to `path:line`, preserving the path to avoid false merges.
+
+    Strips an absolute-path prefix down to the repo-relative path and trims whitespace,
+    but keeps the directory portion: two files with the same basename in different
+    directories (e.g. `src/foo/config.py:10` vs `tests/foo/config.py:10`) must NOT
+    collapse to one key, or unrelated findings would fabricate a false corroboration.
 
     Returns:
-        The normalized `basename:line` string, or the stripped input when no line
-        number is present.
+        The `path:line` string with any leading `/` stripped, or the stripped input
+        when no line number is present.
     """
     match = LOCATION_LINE_RE.search(raw)
     if match:
-        return f"{match.group(1)}:{match.group(2)}"
+        path = match.group(1).lstrip("/")
+        return f"{path}:{match.group(2)}"
     return raw.strip()
 
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/scripts/reduce.py
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/scripts/reduce.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Corroboration-weighting reducer for the ensemble-rule-review pattern.
+
+Reads one fixed-schema findings file per worker, deduplicates findings on a
+STABLE key (the worker's assigned group id plus the normalized location — never
+the free-form rule slug, which differs between workers), counts how many
+distinct workers independently reported each finding (the corroboration weight),
+drops PASS verdicts and the low-weight tail, and prints a ranked report.
+
+Fixed finding schema each worker emits (one block per finding, blocks separated
+by the block-start field reappearing):
+
+    - group: <stable assigned group/dimension id, identical across workers>
+      rule: <free-form descriptive slug — NOT used for corroboration keying>
+      location: <path:line>
+      verdict: VIOLATION | PASS   # optional; absent means VIOLATION
+      severity: critical | high | medium | low
+      evidence: "<exact snippet>"
+
+Why key on group, not rule: workers author their own `rule` slugs, so two
+workers flagging the same defect emit different slugs. Keying corroboration on
+the worker-authored slug would never corroborate. The `group` id is assigned by
+the orchestrator (the rule-group number from the rotating split) and is therefore
+identical across workers — the only stable corroboration key.
+
+Usage:
+    uv run reduce.py REPORT_DIR [--glob 'review-*.md'] [--keep-threshold N]
+
+Worker id is the report filename stem (e.g. review-A.md -> "A").
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+FIELD_RE = re.compile(r"^\s*(?:-\s+)?([A-Za-z_]+):\s*(.*)$")
+LOCATION_LINE_RE = re.compile(r"([^/\s]+):(\d+)")
+SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1}
+BLOCK_START_FIELD = "group"
+# A finding is "corroborated" once at least this many distinct workers report it.
+CORROBORATION_MIN = 2
+
+
+@dataclass
+class Finding:
+    """One parsed finding block from a worker report."""
+
+    group: str
+    location: str
+    rule: str = ""
+    verdict: str = "VIOLATION"
+    severity: str = "low"
+    evidence: str = ""
+
+
+@dataclass
+class Merged:
+    """A deduplicated finding with accumulated corroboration."""
+
+    group: str
+    location: str
+    agents: set[str] = field(default_factory=set)
+    rules: set[str] = field(default_factory=set)
+    severity: str = "low"
+
+    @property
+    def weight(self) -> int:
+        """Corroboration weight: the count of distinct workers that reported this finding."""
+        return len(self.agents)
+
+
+def normalize_location(raw: str) -> str:
+    """Collapse a location to `basename:line` so two workers collide on one line.
+
+    Returns:
+        The normalized `basename:line` string, or the stripped input when no line
+        number is present.
+    """
+    match = LOCATION_LINE_RE.search(raw)
+    if match:
+        return f"{match.group(1)}:{match.group(2)}"
+    return raw.strip()
+
+
+def parse_report(text: str) -> list[Finding]:
+    """Parse fixed-schema finding blocks from one worker report.
+
+    Returns:
+        The `Finding` objects parsed from the report text.
+    """
+    findings: list[Finding] = []
+    fields: dict[str, str] = {}
+
+    def flush() -> None:
+        if BLOCK_START_FIELD in fields and "location" in fields:
+            findings.append(
+                Finding(
+                    group=fields[BLOCK_START_FIELD],
+                    location=fields["location"],
+                    rule=fields.get("rule", ""),
+                    verdict=fields.get("verdict", "VIOLATION").upper(),
+                    severity=fields.get("severity", "low").lower(),
+                    evidence=fields.get("evidence", ""),
+                )
+            )
+
+    for line in text.splitlines():
+        match = FIELD_RE.match(line)
+        if not match:
+            continue
+        key, value = match.group(1).lower(), match.group(2).strip().strip('"')
+        if key == BLOCK_START_FIELD and fields:
+            flush()
+            fields = {}
+        fields[key] = value
+    if fields:
+        flush()
+    return findings
+
+
+def reduce_findings(reports: dict[str, list[Finding]], keep_threshold: int) -> list[Merged]:
+    """Dedup on (group, normalized-location), count corroboration, rank, cut tail.
+
+    Returns:
+        The surviving `Merged` findings (weight >= keep_threshold), ranked by
+        corroboration weight then severity, highest first.
+    """
+    merged: dict[tuple[str, str], Merged] = {}
+    for agent, findings in reports.items():
+        for finding in findings:
+            if finding.verdict == "PASS":
+                continue
+            location = normalize_location(finding.location)
+            key = (finding.group, location)
+            entry = merged.get(key)
+            if entry is None:
+                entry = Merged(group=finding.group, location=location)
+                merged[key] = entry
+            entry.agents.add(agent)
+            if finding.rule:
+                entry.rules.add(finding.rule)
+            if SEVERITY_RANK.get(finding.severity, 1) > SEVERITY_RANK.get(entry.severity, 1):
+                entry.severity = finding.severity
+
+    survivors = [m for m in merged.values() if m.weight >= keep_threshold]
+    survivors.sort(key=lambda m: (m.weight, SEVERITY_RANK.get(m.severity, 1)), reverse=True)
+    return survivors
+
+
+def load_reports(report_dir: Path, glob: str) -> dict[str, list[Finding]]:
+    """Load one report per file; worker id is the filename stem.
+
+    Returns:
+        A mapping of worker id to that worker's parsed findings.
+    """
+    reports: dict[str, list[Finding]] = {}
+    for path in sorted(report_dir.glob(glob)):
+        agent = path.stem.rsplit("-", 1)[-1] if "-" in path.stem else path.stem
+        reports[agent] = parse_report(path.read_text(encoding="utf-8"))
+    return reports
+
+
+def format_report(reports: dict[str, list[Finding]], survivors: list[Merged], keep_threshold: int) -> str:
+    """Render the ranked reducer output.
+
+    Returns:
+        The formatted multi-line report string.
+    """
+    lines: list[str] = []
+    counts = {agent: len(findings) for agent, findings in reports.items()}
+    lines.append(f"per-worker finding counts: {counts}")
+    total_raw = sum(counts.values())
+    kept = [m for m in survivors if m.weight >= CORROBORATION_MIN]
+    tail = [m for m in survivors if m.weight < CORROBORATION_MIN]
+    lines.extend((
+        f"raw findings: {total_raw}   distinct after dedup: {len(survivors)}",
+        f"corroborated (weight>=2): {len(kept)}   lone (weight=1): {len(tail)}",
+        f"keep_threshold: {keep_threshold}",
+        "",
+        "=== RANKED (corroboration weight, then severity) ===",
+    ))
+    for m in survivors:
+        tag = "KEEP" if m.weight >= CORROBORATION_MIN else "tail"
+        agents = "".join(sorted(m.agents))
+        rules = "|".join(sorted(m.rules)) or "?"
+        lines.append(
+            f"[{tag} w={m.weight}] group={m.group} {m.location}  sev={m.severity}  agents={agents}  rule={rules}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the reducer CLI.
+
+    Returns:
+        Process exit code: 0 on success, 2 on input error.
+    """
+    parser = argparse.ArgumentParser(description="Corroboration-weighting reducer for ensemble-rule-review.")
+    parser.add_argument("report_dir", type=Path, help="Directory containing one report file per worker.")
+    parser.add_argument("--glob", default="*.md", help="Glob for worker report files (default: *.md).")
+    parser.add_argument(
+        "--keep-threshold",
+        type=int,
+        default=1,
+        help="Minimum corroboration weight to retain (default 1 = keep all, rank only).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.report_dir.is_dir():
+        print(f"error: not a directory: {args.report_dir}", file=sys.stderr)
+        return 2
+
+    reports = load_reports(args.report_dir, args.glob)
+    if not reports:
+        print(f"error: no reports matched {args.glob} in {args.report_dir}", file=sys.stderr)
+        return 2
+
+    survivors = reduce_findings(reports, args.keep_threshold)
+    print(format_report(reports, survivors, args.keep_threshold))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/plugin-creator/skills/ensemble-rule-review/scripts/test_plan_ensemble.py
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/scripts/test_plan_ensemble.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest"]
+# ///
+"""Tests for the ensemble-rule-review planner.
+
+Run: uv run --with pytest pytest test_plan_ensemble.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import plan_ensemble as p
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+GROUPS = {
+    "1": ["no bare except", "no swallowed exceptions"],
+    "2": ["no Any outside boundaries", "no legacy typing imports"],
+    "3": ["functions under 50 lines", "no deep nesting"],
+}
+
+
+def test_rotate_assignment_is_cyclic_window() -> None:
+    assignment = p.rotate_assignment(["1", "2", "3"], window=2)
+    assert assignment == [["1", "2"], ["2", "3"], ["3", "1"]]
+
+
+def test_redundancy_is_uniform_equal_to_window() -> None:
+    assignment = p.rotate_assignment(["1", "2", "3"], window=2)
+    counts = p.redundancy(assignment, ["1", "2", "3"])
+    assert counts == {"1": 2, "2": 2, "3": 2}
+    assert set(counts.values()) == {2}
+
+
+def test_window_three_over_five_groups_uniform() -> None:
+    gids = ["1", "2", "3", "4", "5"]
+    counts = p.redundancy(p.rotate_assignment(gids, window=3), gids)
+    assert set(counts.values()) == {3}
+
+
+def test_build_plan_assigns_absolute_outfiles_per_worker() -> None:
+    plans = p.build_plan(GROUPS, window=2, report_dir="/abs/reports")
+    assert [pl.worker_id for pl in plans] == ["A", "B", "C"]
+    assert plans[0].outfile == "/abs/reports/worker-A.md"
+    assert all(pl.outfile.startswith("/abs/reports/") for pl in plans)
+
+
+def test_build_plan_carries_rules_per_covered_group() -> None:
+    plans = p.build_plan(GROUPS, window=2, report_dir="/abs/reports")
+    worker_a = plans[0]
+    # Worker A covers groups 1 and 2 — its rules must come from BOTH, keyed by group.
+    assert set(worker_a.rules_by_group) == {"1", "2"}
+    assert worker_a.rules_by_group["2"] == GROUPS["2"]
+
+
+def test_validate_rejects_too_few_groups() -> None:
+    errors = p.validate_inputs({"1": ["a"], "2": ["b"]}, window=2, report_dir="/abs")
+    assert any("at least" in e for e in errors)
+
+
+def test_validate_rejects_relative_report_dir() -> None:
+    errors = p.validate_inputs(GROUPS, window=2, report_dir="relative/reports")
+    assert any("absolute" in e for e in errors)
+
+
+def test_validate_rejects_bad_window() -> None:
+    assert any("window" in e for e in p.validate_inputs(GROUPS, window=1, report_dir="/abs"))
+    assert any("window" in e for e in p.validate_inputs(GROUPS, window=3, report_dir="/abs"))
+
+
+def test_validate_rejects_empty_group() -> None:
+    errors = p.validate_inputs({"1": ["a"], "2": [], "3": ["c"]}, window=2, report_dir="/abs")
+    assert any("no rules" in e for e in errors)
+
+
+def test_validate_accepts_valid_inputs() -> None:
+    assert p.validate_inputs(GROUPS, window=2, report_dir="/abs/reports") == []
+
+
+def test_main_json_plan_round_trips(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rules_file = tmp_path / "rules.json"
+    rules_file.write_text(json.dumps(GROUPS), encoding="utf-8")
+    code = p.main([str(rules_file), "--report-dir", "/abs/reports", "--json"])
+    assert code == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["window"] == 2
+    assert plan["keep_threshold_precision"] == 2
+    assert plan["redundancy"] == {"1": 2, "2": 2, "3": 2}
+    assert len(plan["workers"]) == 3
+    assert plan["workers"][0]["outfile"] == "/abs/reports/worker-A.md"
+
+
+def test_main_errors_on_relative_report_dir(tmp_path: Path) -> None:
+    rules_file = tmp_path / "rules.json"
+    rules_file.write_text(json.dumps(GROUPS), encoding="utf-8")
+    assert p.main([str(rules_file), "--report-dir", "rel"]) == 2
+
+
+def test_main_errors_on_missing_file(tmp_path: Path) -> None:
+    assert p.main([str(tmp_path / "nope.json"), "--report-dir", "/abs"]) == 2

--- a/plugins/plugin-creator/skills/ensemble-rule-review/scripts/test_reduce.py
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/scripts/test_reduce.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest"]
+# ///
+"""Tests for the ensemble-rule-review corroboration reducer.
+
+Run: uv run --with pytest pytest test_reduce.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import reduce as r
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+WORKER_A = """# Worker A
+- group: 2
+  rule: any-without-justification
+  location: create_plugin.py:121
+  severity: high
+  evidence: "dict[str, Any]"
+
+- group: 2
+  rule: any-without-justification
+  location: create_plugin.py:127
+  severity: high
+  evidence: "manifest: dict[str, Any]"
+"""
+
+# Worker C flags the SAME line 121 with a DIFFERENT rule slug — corroboration must
+# still fire because keying is on (group, location), not the free-form rule slug.
+WORKER_C = """# Worker C
+- group: 2
+  rule: any-not-in-boundary-module
+  location: create_plugin.py:121
+  severity: high
+  evidence: "def create_plugin_json(...) -> dict[str, Any]:"
+"""
+
+
+def test_parse_allows_list_item_dash() -> None:
+    findings = r.parse_report(WORKER_A)
+    assert len(findings) == 2
+    assert findings[0].group == "2"
+    assert findings[0].location == "create_plugin.py:121"
+
+
+def test_corroboration_keys_on_group_not_rule() -> None:
+    """Two workers, same (group, line), different rule slugs -> one weight-2 finding."""
+    reports = {"A": r.parse_report(WORKER_A), "C": r.parse_report(WORKER_C)}
+    survivors = r.reduce_findings(reports, keep_threshold=1)
+    line121 = [m for m in survivors if m.location == "create_plugin.py:121"]
+    assert len(line121) == 1
+    assert line121[0].weight == 2
+    assert line121[0].agents == {"A", "C"}
+    # Both distinct slugs are retained for display, but did not block the merge.
+    assert line121[0].rules == {"any-without-justification", "any-not-in-boundary-module"}
+
+
+def test_lone_finding_stays_weight_one() -> None:
+    reports = {"A": r.parse_report(WORKER_A), "C": r.parse_report(WORKER_C)}
+    survivors = r.reduce_findings(reports, keep_threshold=1)
+    line127 = [m for m in survivors if m.location == "create_plugin.py:127"]
+    assert len(line127) == 1
+    assert line127[0].weight == 1
+
+
+def test_keep_threshold_drops_tail() -> None:
+    reports = {"A": r.parse_report(WORKER_A), "C": r.parse_report(WORKER_C)}
+    survivors = r.reduce_findings(reports, keep_threshold=2)
+    assert all(m.weight >= 2 for m in survivors)
+    assert all(m.location != "create_plugin.py:127" for m in survivors)
+
+
+def test_pass_verdict_excluded() -> None:
+    report = """- group: 1
+  rule: typed
+  location: x.py:10
+  verdict: PASS
+  severity: low
+"""
+    reports = {"A": r.parse_report(report)}
+    assert r.reduce_findings(reports, keep_threshold=1) == []
+
+
+def test_verdict_defaults_to_violation_when_absent() -> None:
+    findings = r.parse_report(WORKER_A)
+    assert all(f.verdict == "VIOLATION" for f in findings)
+
+
+def test_normalize_location_collapses_paths() -> None:
+    assert r.normalize_location("  /abs/path/create_plugin.py:436 ") == "create_plugin.py:436"
+    assert r.normalize_location("create_plugin.py:436") == "create_plugin.py:436"
+
+
+def test_severity_escalates_to_highest() -> None:
+    report = """- group: 1
+  rule: a
+  location: x.py:10
+  severity: low
+- group: 1
+  rule: b
+  location: x.py:10
+  severity: critical
+"""
+    merged = r.reduce_findings({"A": r.parse_report(report)}, keep_threshold=1)
+    assert len(merged) == 1
+    assert merged[0].severity == "critical"
+
+
+def test_ranking_weight_then_severity() -> None:
+    reports = {"A": r.parse_report(WORKER_A), "C": r.parse_report(WORKER_C)}
+    survivors = r.reduce_findings(reports, keep_threshold=1)
+    # Corroborated (weight 2) ranks above lone (weight 1).
+    assert survivors[0].weight == 2
+
+
+def test_load_reports_derives_worker_id_from_stem(tmp_path: Path) -> None:
+    (tmp_path / "review-A.md").write_text(WORKER_A, encoding="utf-8")
+    (tmp_path / "review-C.md").write_text(WORKER_C, encoding="utf-8")
+    reports = r.load_reports(tmp_path, "review-*.md")
+    assert set(reports) == {"A", "C"}
+
+
+def test_main_runs_end_to_end(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / "review-A.md").write_text(WORKER_A, encoding="utf-8")
+    (tmp_path / "review-C.md").write_text(WORKER_C, encoding="utf-8")
+    code = r.main([str(tmp_path), "--glob", "review-*.md"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "corroborated (weight>=2): 1" in out
+    assert "KEEP w=2" in out
+
+
+def test_main_errors_on_missing_dir(tmp_path: Path) -> None:
+    assert r.main([str(tmp_path / "nope")]) == 2

--- a/plugins/plugin-creator/skills/ensemble-rule-review/scripts/test_reduce.py
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/scripts/test_reduce.py
@@ -94,9 +94,27 @@ def test_verdict_defaults_to_violation_when_absent() -> None:
     assert all(f.verdict == "VIOLATION" for f in findings)
 
 
-def test_normalize_location_collapses_paths() -> None:
-    assert r.normalize_location("  /abs/path/create_plugin.py:436 ") == "create_plugin.py:436"
-    assert r.normalize_location("create_plugin.py:436") == "create_plugin.py:436"
+def test_normalize_location_strips_abs_prefix_but_keeps_path() -> None:
+    # Absolute prefix stripped to repo-relative, but the directory is PRESERVED.
+    assert r.normalize_location("  /repo/src/foo/config.py:10 ") == "repo/src/foo/config.py:10"
+    assert r.normalize_location("src/foo/config.py:10") == "src/foo/config.py:10"
+
+
+def test_same_basename_different_dirs_do_not_corroborate() -> None:
+    """Two files sharing a basename must NOT collapse into one weight-2 finding."""
+    a = """- group: 1
+  rule: x
+  location: src/foo/config.py:10
+  severity: high
+"""
+    c = """- group: 1
+  rule: x
+  location: tests/foo/config.py:10
+  severity: high
+"""
+    survivors = r.reduce_findings({"A": r.parse_report(a), "C": r.parse_report(c)}, keep_threshold=1)
+    assert len(survivors) == 2
+    assert all(m.weight == 1 for m in survivors)
 
 
 def test_severity_escalates_to_highest() -> None:


### PR DESCRIPTION
## What

Adds a new skill — `plugin-creator/skills/ensemble-rule-review` — documenting the **fan-out map-reduce ensemble** design pattern for rule-following work, derived from the structure of the Anthropic-bundled `/code-review` skill combined with `/plugin-creator:agentskills` packaging discipline.

### The pattern
Instead of one expensive agent holding a whole checklist/rubric in a single pass (slow + silently drops criteria as the rule list grows), **partition the ruleset across multiple cheap, rigid, parallel sub-agents whose coverage deliberately overlaps**, collect findings in a fixed schema, then **weight by cross-agent corroboration and drop the low-weight tail**. Overlap dilutes any single cheap worker's hallucinations; the partition shrinks each job into the band where a cheap/fast model is reliable.

### Files
- `SKILL.md` — the pattern: 6-part mechanism, pipeline phases (Mermaid), degrees-of-freedom + model/effort guidance, when/when-not, and how to partition explicit vs implicit checklists (with worked examples: 12-factor, SOLID, OWASP, WCAG, Nielsen 10; PEP roster for "modernization", "pythonic", etc.).
- `references/conversion-candidates.md` — a ranked catalog of **in-repo** rule-following skills/agents that fit the pattern (Tier 0–3, clusters C1–C9), plus a **Second-Pass Additions** section from a narrow re-scan of the four densest plugins.

## How it was produced
A 7-finder fan-out survey of the 30-plugin tree mapped candidates; a narrow single-plugin second pass (10 finders) roughly doubled the fit≥4 set in the overloaded zones and surfaced four clusters the wide pass missed — including the whole `python3-development` plugin (`python3-standards`, a 40+ criteria shared hub) and the plugin-creator CoVe/grading agents. That pass-1-vs-pass-2 recall gap is itself a live demonstration of the skill's thesis.

## Prior art noted
`development-harness/skills/multi-perspective-review` + its `reviewer-*` agents already implement a partial version (4-worker parallel review). The skill cites it as the reference to standardize from, and flags the two pieces it lacks: a fixed candidate schema and a corroboration-weighted reducer.

## Validation
- `uvx skilllint@latest check` — exit 0, no warnings
- `prek` (markdownlint, yaml, eof, whitespace) — passed
- `plugin.json` + `marketplace.json` versions auto-bumped by the pre-commit hook

## Notes
The journal-review performance figure in `SKILL.md` is marked user-reported (not independently reproduced). Ruleset-size numbers in the catalog are finder estimates, flagged as ranking signal rather than ground truth.

https://claude.ai/code/session_01BAWe595zfi5AKPmos92NfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAWe595zfi5AKPmos92NfE)_