### PR TITLE
Add workshop-question-framing skill

### DIFF
--- a/.agents/skills/workshop-question-framing/SKILL.md
+++ b/.agents/skills/workshop-question-framing/SKILL.md
@@ -295,17 +295,46 @@ Gap it opens: the gap between their predicted answer and what the magnet actuall
 3. Is there a metal here you think will NOT stick?
 
 ## Commitment Questions (2 to 4)
-1. Circle your prediction for each object before we test anything.
+1. Which objects did you circle, and which one are you least sure about?
 2. What rule are you using to decide?
 
 ## Hold Questions (2 to 4)
 1. Who circled the coin? Who didn't? What made you decide?
 2. What result would prove your rule wrong?
 
+## Teaching Bridge Questions (2 to 4)
+1. We tested it: the paperclip and safety pin stuck, the coin did not. What do the ones that stuck share that the coin does not?
+2. What would the explanation have to account for to resolve this?
+
 ## Return Questions (3 to 5)
 1. You predicted the coin would stick. It didn't. What was your rule before?
 2. What is your rule now?
 3. Where else would your old rule have failed?
+
+## Alternative Frames
+
+### Option 1
+Move: Contradiction
+Best when: participants are sure every metal is magnetic.
+Opening question: A steel paperclip and a copper coin are both metal. The magnet grabs one and ignores the other. Why?
+Participant commitment: write which metal the magnet grabs, and why.
+What to hold back: do not name which metals are magnetic, or the word ferromagnetic.
+How to return: You believed every metal is magnetic. Which metals actually were? What is your rule now?
+
+### Option 2
+Move: Real-Life Connection
+Best when: you want relevance before the science.
+Opening question: Where at home does something stick to metal on its own, and where does it refuse to? Why those spots and not others?
+Participant commitment: name one place a magnet sticks and one metal place it does not.
+What to hold back: do not explain which materials are magnetic yet.
+How to return: You named the fridge door but not the copper pipe. What made the difference?
+
+## Facilitator Notes
+- Best opening question: "Which of these will the magnet pick up?" with the objects in their hands.
+- What not to explain too early: that only some metals (iron, steel) are magnetic, not metal in general.
+- Likely participant first answers: "all the metal ones," so the coin gets circled.
+- How to protect wrong answers: "That makes complete sense. Most metals feel like they should stick. Let's see what changes it."
+- When to reveal the explanation: after the coin prediction is tested and visibly fails.
 ```
 
 For three more subject worked examples (magnets, fractions, descriptive writing) and the stimulus-and-question library for every move, load [curiosity-by-design.md](./references/curiosity-by-design.md).

--- a/.agents/skills/workshop-question-framing/SKILL.md
+++ b/.agents/skills/workshop-question-framing/SKILL.md
@@ -41,7 +41,7 @@ The user may provide any of the following:
 - Existing opening activity
 - Slides, outline, or agenda
 
-If topic or explanation is missing, ask for it. If audience is missing, make a reasonable assumption and label it as an assumption.
+The topic (or title) is the one required input. If it is missing, ask for it. If the explanation, teaching notes, audience, duration, or other inputs are missing, do not stall: infer a reasonable teaching core from the topic and label each inferred element as an assumption. Ask a follow-up only when the topic itself is too vague to identify a core concept.
 
 ## Method
 

--- a/.agents/skills/workshop-question-framing/SKILL.md
+++ b/.agents/skills/workshop-question-framing/SKILL.md
@@ -49,6 +49,7 @@ The topic (or title) is the one required input. If it is missing, ask for it. If
 
 From the user's topic and explanation, identify:
 
+- The audience, and their level or context (if not given, assume one and label it as an assumption)
 - The core concept
 - The thing participants usually misunderstand
 - The belief, habit, assumption, or mental model the workshop is trying to change
@@ -58,6 +59,7 @@ From the user's topic and explanation, identify:
 Write this as:
 
 ```text
+Audience:
 Core concept:
 Participants may currently think:
 The workshop needs them to understand:
@@ -213,6 +215,7 @@ Use this structure every time:
 # Workshop Question Frame
 
 ## Extracted Teaching Core
+Audience:
 Core concept:
 Participants may currently think:
 The workshop needs them to understand:
@@ -279,6 +282,7 @@ A filled frame for a primary-science topic, "which materials a magnet attracts,"
 # Workshop Question Frame
 
 ## Extracted Teaching Core
+Audience: primary-science class, ages 7 to 9 (assumed — not specified in the request).
 Core concept: magnets attract some metals (iron, steel) but not all materials, and not all metals.
 Participants may currently think: a magnet picks up anything metal, or anything shiny or heavy.
 The workshop needs them to understand: magnetism is a property of specific materials, not "metalness" in general.

--- a/.agents/skills/workshop-question-framing/SKILL.md
+++ b/.agents/skills/workshop-question-framing/SKILL.md
@@ -41,7 +41,7 @@ The user may provide any of the following:
 - Existing opening activity
 - Slides, outline, or agenda
 
-The topic (or title) is the one required input. If it is missing, ask for it. If the explanation, teaching notes, audience, duration, or other inputs are missing, do not stall: infer a reasonable teaching core from the topic and label each inferred element as an assumption. Ask a follow-up only when the topic itself is too vague to identify a core concept.
+The one thing required is enough material to identify a core concept. That can come from any input above: a topic, title, learning objective, explanation or teaching notes, slides, outline, or an existing opening activity. Extract the teaching core from whatever the user supplies — a review or improvement request that provides only teaching notes or an objective is enough to proceed. Ask a follow-up only when nothing provided is sufficient to identify a core concept. For any other missing input (audience, duration, desired outcome), do not stall: infer a reasonable value and label it as an assumption.
 
 ## Method
 

--- a/.agents/skills/workshop-question-framing/SKILL.md
+++ b/.agents/skills/workshop-question-framing/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: workshop-question-framing
+description: "Use this skill when reviewing, designing, or improving a workshop, lesson, training session, facilitation plan, talk, or educational explanation. Use it when the user provides a topic, concept, or explanation and wants better framing questions, curiosity hooks, opening prompts, discussion questions, learner reflection prompts, or ways to make participants think before being taught."
+metadata:
+  version: 1.0.0
+---
+# Workshop Question Framing Skill
+
+## Purpose
+
+Turn a workshop topic and explanation into a set of questions that make participants think before they are taught.
+
+The goal is not to create generic discussion questions. The goal is to create a felt need to understand.
+
+Use this skill to help the user open a topic with curiosity, cognitive tension, relevance, and participant commitment before explanation arrives.
+
+## Core Principle
+
+Do not start with the explanation.
+
+Start by designing the moment thinking begins.
+
+The explanation should arrive after the participant has already:
+
+1. Noticed a gap
+2. Formed a theory, prediction, position, or question
+3. Put some thinking on the line
+4. Felt a reason to care about the explanation
+
+## Required Input
+
+The user may provide any of the following:
+
+- Workshop topic
+- Workshop title
+- Learning objective
+- Explanation or teaching notes
+- Audience
+- Duration
+- Desired outcome
+- Existing opening activity
+- Slides, outline, or agenda
+
+If topic or explanation is missing, ask for it. If audience is missing, make a reasonable assumption and label it as an assumption.
+
+## Method
+
+### Step 1: Extract the Teaching Core
+
+From the user's topic and explanation, identify:
+
+- The core concept
+- The thing participants usually misunderstand
+- The belief, habit, assumption, or mental model the workshop is trying to change
+- The decision, behavior, or capability participants should leave with
+- The explanation that should not arrive too early
+
+Write this as:
+
+```text
+Core concept:
+Participants may currently think:
+The workshop needs them to understand:
+The explanation should land after they have wondered:
+```
+
+### Step 2: Choose the Thinking Before Choosing the Question
+
+Before generating questions, decide what kind of thinking the workshop needs first.
+
+Use this mapping:
+
+| If participants need to…                          | Use this move         | It creates |
+| ------------------------------------------------- | --------------------- | ---------- |
+| Commit before they know the answer                | Prediction            | Ownership  |
+| Explain incomplete information                    | Mystery               | A gap      |
+| Reconsider a belief                               | Contradiction         | Conflict   |
+| Look closely before interpretation                | Close Observation     | Attention  |
+| Weigh two imperfect options                       | Dilemma and Decision  | Reasoning  |
+| Find a pattern or rule                            | Puzzle                | Search     |
+| Recognize the concept in their own work or life   | Real-Life Connection  | Relevance  |
+| Reason backward from an outcome                   | Cause and Effect      | Causality  |
+
+Default to Real-Life Connection if the best move is unclear.
+
+### Step 3: Generate Question Sets
+
+Produce questions in these categories.
+
+#### A. Opening Spark Questions
+
+Create 3 to 5 questions that can open the workshop before explanation.
+
+Each question must:
+
+- Create a gap, tension, decision, prediction, or puzzle
+- Be answerable before the participant knows the formal content
+- Avoid asking for definitions
+- Avoid asking "what do you know about…"
+- Avoid sounding like a quiz unless prediction is intentional
+- Be short enough to say out loud
+
+#### B. Commitment Questions
+
+Create 2 to 4 questions that require participants to commit to an answer, position, prediction, or explanation.
+
+Examples:
+
+- "Which option would you choose, and why?"
+- "What do you think is happening here?"
+- "What would you expect to happen next?"
+- "Which of these is most likely to fail first?"
+- "What rule do you think explains this pattern?"
+
+#### C. Hold Questions
+
+Create 2 to 4 questions the facilitator can use before revealing the explanation.
+
+These should keep uncertainty alive without frustrating participants.
+
+Examples:
+
+- "What makes you say that?"
+- "What would change your mind?"
+- "What evidence would you want before deciding?"
+- "Where might your first answer break?"
+- "Who has a different theory?"
+
+#### D. Teaching Bridge Questions
+
+Create 2 to 4 questions that transition from participant thinking into the explanation.
+
+Examples:
+
+- "What would we need to know to resolve this?"
+- "What principle would explain both examples?"
+- "What assumption is doing the most work here?"
+- "What pattern are we now ready to name?"
+- "What does this make the explanation responsible for answering?"
+
+#### E. Return Questions
+
+Create 3 to 5 questions that bring participants back to their original thinking after the explanation.
+
+These questions should make learning visible.
+
+Examples:
+
+- "What did you initially think?"
+- "What changed?"
+- "What would you now explain differently?"
+- "Where would your first answer have failed?"
+- "What will you watch for next time?"
+
+### Step 4: Provide Move Options
+
+Offer 2 or 3 possible curiosity moves for the same topic.
+
+For each move, include:
+
+```text
+Move:
+Best when:
+Opening question:
+Participant commitment:
+What the facilitator should hold back:
+How to return:
+```
+
+### Step 5: Recommend the Strongest Frame
+
+Choose the strongest framing option.
+
+Explain briefly:
+
+- Why this move fits the topic
+- What gap it opens
+- Why the explanation will land better after it
+- What facilitator risk to watch for
+
+Keep this concise.
+
+### Step 6: Safety and Facilitation Rules
+
+When generating questions, protect participant thinking.
+
+Do:
+
+- Treat wrong answers as useful data
+- Make first answers feel reasonable
+- Ask participants to explain their reasoning
+- Let uncertainty sit briefly
+- Return to earlier answers after teaching
+
+Do not:
+
+- Trick participants
+- Shame naive answers
+- Reveal the explanation too early
+- Use curiosity as decoration
+- Add an opening question that can be removed without changing the workshop
+- Create questions unrelated to the core concept
+
+## Output Format
+
+Use this structure every time:
+
+```text
+# Workshop Question Frame
+
+## Extracted Teaching Core
+Core concept:
+Participants may currently think:
+The workshop needs them to understand:
+The explanation should land after they have wondered:
+
+## Recommended Curiosity Move
+Move:
+Why this move:
+Gap it opens:
+
+## Opening Spark Questions
+1.
+2.
+3.
+4.
+5.
+
+## Commitment Questions
+1.
+2.
+3.
+
+## Hold Questions
+1.
+2.
+3.
+
+## Teaching Bridge Questions
+1.
+2.
+3.
+
+## Return Questions
+1.
+2.
+3.
+4.
+5.
+
+## Alternative Frames
+
+### Option 1
+Move:
+Best when:
+Opening question:
+Participant commitment:
+What to hold back:
+How to return:
+
+### Option 2
+Move:
+Best when:
+Opening question:
+Participant commitment:
+What to hold back:
+How to return:
+
+## Facilitator Notes
+- Best opening question:
+- What not to explain too early:
+- Likely participant first answers:
+- How to protect wrong answers:
+- When to reveal the explanation:
+```
+
+## Quality Check
+
+Before finalizing, check:
+
+- Does the opening question create a real need for the explanation?
+- Could participants answer before being taught?
+- Does the question connect directly to the workshop's core concept?
+- Is there a commitment moment?
+- Is there a hold moment before explanation?
+- Is there a return moment after explanation?
+- Would removing the opening weaken the workshop? If not, revise it.

--- a/.agents/skills/workshop-question-framing/SKILL.md
+++ b/.agents/skills/workshop-question-framing/SKILL.md
@@ -2,7 +2,7 @@
 name: workshop-question-framing
 description: "Use this skill when reviewing, designing, or improving a workshop, lesson, training session, facilitation plan, talk, or educational explanation. Use it when the user provides a topic, concept, or explanation and wants better framing questions, curiosity hooks, opening prompts, discussion questions, learner reflection prompts, or ways to make participants think before being taught."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 # Workshop Question Framing Skill
 
@@ -82,6 +82,8 @@ Use this mapping:
 | Reason backward from an outcome                   | Cause and Effect      | Causality  |
 
 Default to Real-Life Connection if the best move is unclear.
+
+For a concrete stimulus-and-question phrasing for each of the eight moves, a fully worked end-to-end frame, and facilitator language for protecting wrong answers, load [curiosity-by-design.md](./references/curiosity-by-design.md).
 
 ### Step 3: Generate Question Sets
 
@@ -201,6 +203,8 @@ Do not:
 - Add an opening question that can be removed without changing the workshop
 - Create questions unrelated to the core concept
 
+For ready-to-use facilitator phrasing that protects participants the moment they answer wrong, load [curiosity-by-design.md](./references/curiosity-by-design.md).
+
 ## Output Format
 
 Use this structure every time:
@@ -219,34 +223,27 @@ Move:
 Why this move:
 Gap it opens:
 
-## Opening Spark Questions
-1.
-2.
-3.
-4.
-5.
-
-## Commitment Questions
+## Opening Spark Questions (3 to 5)
 1.
 2.
 3.
 
-## Hold Questions
+## Commitment Questions (2 to 4)
 1.
 2.
-3.
 
-## Teaching Bridge Questions
+## Hold Questions (2 to 4)
 1.
 2.
-3.
 
-## Return Questions
+## Teaching Bridge Questions (2 to 4)
+1.
+2.
+
+## Return Questions (3 to 5)
 1.
 2.
 3.
-4.
-5.
 
 ## Alternative Frames
 
@@ -273,6 +270,45 @@ How to return:
 - How to protect wrong answers:
 - When to reveal the explanation:
 ```
+
+## Worked Example
+
+A filled frame for a primary-science topic, "which materials a magnet attracts," using the Prediction move. It shows what a completed Output Format looks like end to end.
+
+```text
+# Workshop Question Frame
+
+## Extracted Teaching Core
+Core concept: magnets attract some metals (iron, steel) but not all materials, and not all metals.
+Participants may currently think: a magnet picks up anything metal, or anything shiny or heavy.
+The workshop needs them to understand: magnetism is a property of specific materials, not "metalness" in general.
+The explanation should land after they have wondered: why the coin (a metal) was not picked up but the paperclip and safety pin were.
+
+## Recommended Curiosity Move
+Move: Prediction
+Why this move: a concrete, testable claim each participant can commit to before any teaching.
+Gap it opens: the gap between their predicted answer and what the magnet actually does.
+
+## Opening Spark Questions (3 to 5)
+1. Which of these will the magnet pick up: paperclip, coin, eraser, pencil, safety pin?
+2. What is the same about every object you think will stick?
+3. Is there a metal here you think will NOT stick?
+
+## Commitment Questions (2 to 4)
+1. Circle your prediction for each object before we test anything.
+2. What rule are you using to decide?
+
+## Hold Questions (2 to 4)
+1. Who circled the coin? Who didn't? What made you decide?
+2. What result would prove your rule wrong?
+
+## Return Questions (3 to 5)
+1. You predicted the coin would stick. It didn't. What was your rule before?
+2. What is your rule now?
+3. Where else would your old rule have failed?
+```
+
+For three more subject worked examples (magnets, fractions, descriptive writing) and the stimulus-and-question library for every move, load [curiosity-by-design.md](./references/curiosity-by-design.md).
 
 ## Quality Check
 

--- a/.agents/skills/workshop-question-framing/references/curiosity-by-design.md
+++ b/.agents/skills/workshop-question-framing/references/curiosity-by-design.md
@@ -1,0 +1,103 @@
+# Curiosity by Design — Source Examples
+
+Grounding examples for the eight curiosity moves, drawn from *Curiosity by Design: Eight Moves to Start Thinking Before You Teach* by Vicky Brooks (Give Spark, 2026), part of the SEEDS Framework.
+
+Load this file when the user wants concrete stimulus-and-question phrasings, a fully worked end-to-end frame, or facilitator language for protecting wrong answers.
+
+SOURCE: Vicky Brooks, *Curiosity by Design: Eight Moves to Start Thinking Before You Teach* (Introduction), Give Spark, 2026, [give-spark.com](https://give-spark.com) — [source PDF](https://www.dropbox.com/scl/fi/1dmyi8e3n2bbj5zpsppe1/Curiosity-by-Design-Introduction.pdf?rlkey=pe1nuxdxpb1q2qnj61xa389ft) (accessed 2026-06-01). Examples below are quoted or condensed from pages 3, 8-9, 14, 17-20.
+
+## The method in one example
+
+The same fact, delivered two ways:
+
+- Flat: "The human stomach replaces its lining every three to four days." — information lands flat; the brain has nowhere to put it.
+- Curiosity-first: "The acid in your stomach is strong enough to dissolve metal. So why doesn't it dissolve you?" — now the brain has a question and needs the answer. Then teach: the stomach replaces its lining every three to four days, faster than the acid can damage it.
+
+Same explanation. Different cognitive state. The fix is sequencing: create the gap first, then explain into a brain already working.
+
+## The six beats (what each does)
+
+| Beat | Job | Facilitator stance |
+|------|-----|--------------------|
+| Spark | Open the gap | Provoke with a question, artifact, image, or moment that gives thinking somewhere to go |
+| Think | Give time to think | Wait longer than feels comfortable; do not fill the silence |
+| Commit | Put something on the line | Have learners commit a prediction, theory, position, or possibility (public or private) |
+| Hold | Resist resolving too soon | Do not explain, confirm, or correct yet; let the uncertainty sit |
+| Teach | Teach into a thinking room | Deliver the explanation now — it resolves something learners already feel |
+| Return | Bring learners back to their first thinking | "What did you predict? What changed? What do you understand now?" Close the loop in the learner's voice |
+
+## Stimulus + question library for the eight moves
+
+Each move pairs a concrete stimulus (something to see, touch, hear, or do) with a question that asks the brain to commit. The stimulus opens the felt experience; the question asks for commitment.
+
+| Move | Stimulus | Question |
+|------|----------|----------|
+| Prediction | Place a paperclip, a coin, an eraser, and a safety pin on each table. Let learners handle them. | "Which of these will the magnet pick up? Write your prediction." |
+| Mystery | Show a sealed cardboard box. Let learners shake it, weigh it, smell it. Do not open it. | "What do you think is inside? What is your reasoning?" |
+| Contradiction | Drop a heavy log into water — it floats. Drop a small coin — it sinks. | "Most people think heavy things sink. Why might that be wrong?" |
+| Close Observation | Project a black-and-white photograph of an empty room. Stay silent for thirty seconds. | "Who do you think lived here? What in the photo makes you say that?" |
+| Dilemma & Decision | Read a one-paragraph scenario: a child finds a wallet on the way to school. They are already late. | "What would you do? Pick one. Defend it." |
+| Puzzle | Write a number sequence on the board: 2, 4, 8, 16. | "What comes next? What rule are you following?" |
+| Real-Life Connection | Play a recording of a heartbeat for ten seconds. | "Your heart is doing this right now. How is it doing it without you thinking about it?" |
+| Cause and Effect | Have learners run on the spot for sixty seconds, then sit down. | "List everything that has changed in your body. Why?" |
+
+## Move selection: choose the thinking first
+
+Do not choose the move first. Decide what thinking learners need, then pick the doorway.
+
+| If learners need to… | Use this move | It creates |
+|----------------------|---------------|------------|
+| Commit to an idea before they know | Prediction | Ownership |
+| Explain something incomplete | Mystery | A gap |
+| Reconsider what they believe is true | Contradiction | Conflict |
+| Look closely before being told what it is | Close Observation | Attention |
+| Weigh two meaningful options | Dilemma and Decision | Reasoning |
+| Work out a pattern or rule | Puzzle | Search |
+| Notice something already happening in their own life | Real-Life Connection | Relevance |
+| Reason backward from an outcome | Cause and Effect | Causality |
+
+If unsure, start with Real-Life Connection. It works across subjects and ages and begins inside something already true.
+
+## Same lesson, opened differently
+
+Three subject examples showing the shift — same content, opened to start thinking first.
+
+- Science / Magnets (Prediction). Instead of "Today we're going to learn about magnets and which materials they attract," try: place a pile of objects on each table (paperclip, coin, eraser, pencil, safety pin) and ask "Which of these will the magnet pick up? Circle your predictions." Every child commits. Test it together. The explanation arrives into a room full of children checking their own answers.
+- Math / Fractions (Contradiction). Instead of "A fraction is equal parts of a whole," try: hold up a picture of a round cake and ask "I want to share this fairly between 4 people, making one straight cut at a time. How many cuts will I need?" Most say 4. The answer is 2. Teach fractions into a room already arguing about cuts versus pieces.
+- English / Descriptive Writing (Close Observation). Instead of "Good descriptive writing uses adjectives and adverbs," try: show a photograph of an abandoned house with no title or context and ask "Look at this for 30 seconds. What do you think is happening here? What makes you say that?" Students are already writing, and they already have something to say.
+
+## Full worked example — Prediction, end to end
+
+Topic: which materials a magnet attracts (primary science). Carried through all six beats and the output frame.
+
+- Core concept: magnets attract some metals (iron, steel) but not all materials, and not all metals.
+- Learners may currently think: a magnet picks up anything metal, or anything shiny/heavy.
+- The workshop needs them to understand: magnetism is a property of specific materials, not "metalness" in general.
+- The explanation should land after they have wondered: why the coin (metal) was not picked up but the paperclip and safety pin were.
+
+Opening spark: "Which of these will the magnet pick up — the paperclip, the coin, the eraser, the pencil, or the safety pin?"
+
+Commitment: "Circle your prediction for each object before we test anything."
+
+Hold: "Who circled the coin? Who didn't? What made you decide?" (Do not reveal yet.)
+
+Teach (bridge in): "We're about to test it. What would the result have to be for your rule to be right?" — then test, then explain magnetic materials.
+
+Return: "You predicted the coin would stick. It didn't. What was your rule before? What is your rule now? Where else would your old rule have failed?"
+
+## Facilitator language — protecting the moment of being wrong
+
+The moment after a wrong answer is the most important moment for safety. What you say next decides whether learners conclude that being wrong is survivable.
+
+| Moment | What to say |
+|--------|-------------|
+| A learner answers incorrectly | "That makes complete sense with what we knew before. Let's see what changes it." |
+| Before revealing the answer | "There's no wrong answer at this point. We're all guessing. That's the point." |
+| When many learners are wrong | "Most of us had that, and that's exactly why this lesson matters." |
+| After an incorrect prediction | "Good, that's what I was hoping for. Now we actually need the explanation." |
+
+## The decoration test
+
+If you can remove the opening without changing the lesson, it was not a cognitive-tension move — it was decoration. A real move is structurally tied to the concept: the gap it opens must be filled by the lesson, and the contradiction it creates must be resolved by the explanation.
+
+Every move works from early years to upper secondary and beyond. What changes is the concreteness of the gap, the length of the hold, and the complexity of the thinking learners generate.

--- a/.agents/skills/workshop-question-framing/references/curiosity-by-design.md
+++ b/.agents/skills/workshop-question-framing/references/curiosity-by-design.md
@@ -1,49 +1,49 @@
-# Curiosity by Design — Source Examples
+# Curiosity by Design — Worked Patterns
 
-Grounding examples for the eight curiosity moves, drawn from *Curiosity by Design: Eight Moves to Start Thinking Before You Teach* by Vicky Brooks (Give Spark, 2026), part of the SEEDS Framework.
+Grounding patterns for the eight curiosity moves. The framework and method — the six-beat sequence and the eight curiosity "moves" — originate with Vicky Brooks' *Curiosity by Design* and the SEEDS Framework.
 
-Load this file when the user wants concrete stimulus-and-question phrasings, a fully worked end-to-end frame, or facilitator language for protecting wrong answers.
+SOURCE: Vicky Brooks, *Curiosity by Design* / SEEDS Framework, Give Spark — [give-spark.com](https://give-spark.com). The phrasings, stimulus ideas, and facilitator language below are original wording written for this skill, not reproductions of the source text.
 
-SOURCE: Vicky Brooks, *Curiosity by Design: Eight Moves to Start Thinking Before You Teach* (Introduction), Give Spark, 2026, [give-spark.com](https://give-spark.com) — [source PDF](https://www.dropbox.com/scl/fi/1dmyi8e3n2bbj5zpsppe1/Curiosity-by-Design-Introduction.pdf?rlkey=pe1nuxdxpb1q2qnj61xa389ft) (accessed 2026-06-01). Examples below are quoted or condensed from pages 3, 8-9, 14, 17-20.
+Load this file when the user wants a concrete stimulus-and-question pattern for each move, a fully worked end-to-end frame, or facilitator language for protecting wrong answers.
 
 ## The method in one example
 
-The same fact, delivered two ways:
+Take any striking fact and notice how it lands two ways.
 
-- Flat: "The human stomach replaces its lining every three to four days." — information lands flat; the brain has nowhere to put it.
-- Curiosity-first: "The acid in your stomach is strong enough to dissolve metal. So why doesn't it dissolve you?" — now the brain has a question and needs the answer. Then teach: the stomach replaces its lining every three to four days, faster than the acid can damage it.
+- Stated flat, as information: a fact is delivered, the brain files it, nothing happens. There is no question to attach it to.
+- Reframed as a gap: pose the puzzle first — set up a tension the fact resolves — and only then deliver the fact. Now the explanation answers something the listener was already chewing on.
 
-Same explanation. Different cognitive state. The fix is sequencing: create the gap first, then explain into a brain already working.
+Same fact, same explanation, different cognitive state. The lever is sequencing: open the gap first, then teach into a brain that is already working.
 
 ## The six beats (what each does)
 
 | Beat | Job | Facilitator stance |
 |------|-----|--------------------|
-| Spark | Open the gap | Provoke with a question, artifact, image, or moment that gives thinking somewhere to go |
+| Spark | Open the gap | Provoke with a question, object, image, or moment that gives thinking somewhere to go |
 | Think | Give time to think | Wait longer than feels comfortable; do not fill the silence |
-| Commit | Put something on the line | Have learners commit a prediction, theory, position, or possibility (public or private) |
+| Commit | Put something on the line | Have learners commit a prediction, theory, position, or possibility (out loud or on paper) |
 | Hold | Resist resolving too soon | Do not explain, confirm, or correct yet; let the uncertainty sit |
 | Teach | Teach into a thinking room | Deliver the explanation now — it resolves something learners already feel |
-| Return | Bring learners back to their first thinking | "What did you predict? What changed? What do you understand now?" Close the loop in the learner's voice |
+| Return | Bring learners back to their first thinking | Ask what they predicted, what changed, what they understand now; close the loop in the learner's voice |
 
-## Stimulus + question library for the eight moves
+## Stimulus + question pattern for the eight moves
 
-Each move pairs a concrete stimulus (something to see, touch, hear, or do) with a question that asks the brain to commit. The stimulus opens the felt experience; the question asks for commitment.
+Each move pairs a concrete stimulus (something to see, touch, hear, or do) with a question that asks the brain to commit. The stimulus opens the felt experience; the question asks for commitment. The examples below are illustrative patterns — swap in any subject.
 
-| Move | Stimulus | Question |
-|------|----------|----------|
-| Prediction | Place a paperclip, a coin, an eraser, and a safety pin on each table. Let learners handle them. | "Which of these will the magnet pick up? Write your prediction." |
-| Mystery | Show a sealed cardboard box. Let learners shake it, weigh it, smell it. Do not open it. | "What do you think is inside? What is your reasoning?" |
-| Contradiction | Drop a heavy log into water — it floats. Drop a small coin — it sinks. | "Most people think heavy things sink. Why might that be wrong?" |
-| Close Observation | Project a black-and-white photograph of an empty room. Stay silent for thirty seconds. | "Who do you think lived here? What in the photo makes you say that?" |
-| Dilemma & Decision | Read a one-paragraph scenario: a child finds a wallet on the way to school. They are already late. | "What would you do? Pick one. Defend it." |
-| Puzzle | Write a number sequence on the board: 2, 4, 8, 16. | "What comes next? What rule are you following?" |
-| Real-Life Connection | Play a recording of a heartbeat for ten seconds. | "Your heart is doing this right now. How is it doing it without you thinking about it?" |
-| Cause and Effect | Have learners run on the spot for sixty seconds, then sit down. | "List everything that has changed in your body. Why?" |
+| Move | Stimulus pattern | Question pattern |
+|------|------------------|------------------|
+| Prediction | Lay out a small set of objects, some that fit the rule and some that don't; let learners handle them. | "Which of these will behave the way we're about to test? Write your prediction first." |
+| Mystery | Present something partly hidden — a closed container, a cropped image, a result with the cause removed. | "What do you think is going on here, and what's your reasoning?" |
+| Contradiction | Stage two outcomes that violate the obvious rule (a heavy thing that floats next to a light thing that sinks). | "Most people expect the opposite. Why might the obvious rule be wrong?" |
+| Close Observation | Show one rich image or artifact and hold silence for thirty seconds before any talk. | "What do you actually notice, and what does it make you think happened?" |
+| Dilemma & Decision | Read a short scenario with two defensible but costly options. | "You have to pick one. Which, and why?" |
+| Puzzle | Show a short pattern or sequence with the rule left implicit. | "What comes next, and what rule are you following?" |
+| Real-Life Connection | Surface something the concept is already doing in the learner's own body or day. | "This is happening to you right now — how is it working?" |
+| Cause and Effect | Produce a visible change, then strip away the explanation of it. | "List what changed. What must have caused it?" |
 
 ## Move selection: choose the thinking first
 
-Do not choose the move first. Decide what thinking learners need, then pick the doorway.
+Decide what thinking learners need, then pick the doorway — not the other way around.
 
 | If learners need to… | Use this move | It creates |
 |----------------------|---------------|------------|
@@ -56,45 +56,45 @@ Do not choose the move first. Decide what thinking learners need, then pick the 
 | Notice something already happening in their own life | Real-Life Connection | Relevance |
 | Reason backward from an outcome | Cause and Effect | Causality |
 
-If unsure, start with Real-Life Connection. It works across subjects and ages and begins inside something already true.
+If unsure, start with Real-Life Connection. It works across subjects and ages and begins inside something already true for the learner.
 
 ## Same lesson, opened differently
 
-Three subject examples showing the shift — same content, opened to start thinking first.
+Three patterns showing the shift — same content, opened to start thinking first instead of explaining first.
 
-- Science / Magnets (Prediction). Instead of "Today we're going to learn about magnets and which materials they attract," try: place a pile of objects on each table (paperclip, coin, eraser, pencil, safety pin) and ask "Which of these will the magnet pick up? Circle your predictions." Every child commits. Test it together. The explanation arrives into a room full of children checking their own answers.
-- Math / Fractions (Contradiction). Instead of "A fraction is equal parts of a whole," try: hold up a picture of a round cake and ask "I want to share this fairly between 4 people, making one straight cut at a time. How many cuts will I need?" Most say 4. The answer is 2. Teach fractions into a room already arguing about cuts versus pieces.
-- English / Descriptive Writing (Close Observation). Instead of "Good descriptive writing uses adjectives and adverbs," try: show a photograph of an abandoned house with no title or context and ask "Look at this for 30 seconds. What do you think is happening here? What makes you say that?" Students are already writing, and they already have something to say.
+- Science / magnetism (Prediction). Rather than announcing the topic and listing which materials are magnetic, put a mix of objects on each table and ask learners to predict which the magnet will lift before anyone tests. The explanation then arrives into a room of people checking their own predictions.
+- Math / fractions (Contradiction). Rather than defining a fraction up front, pose a sharing problem whose obvious answer is wrong — how many straight cuts it takes to split a round cake among four — and let the surprise drive the need for the idea of equal parts.
+- English / descriptive writing (Close Observation). Rather than listing the features of good description, show an evocative, context-free photograph and ask what is happening and what makes them say so. Learners are already generating description before any rule is named.
 
 ## Full worked example — Prediction, end to end
 
-Topic: which materials a magnet attracts (primary science). Carried through all six beats and the output frame.
+Topic: which materials a magnet attracts (primary science). Carried through all six beats.
 
 - Core concept: magnets attract some metals (iron, steel) but not all materials, and not all metals.
-- Learners may currently think: a magnet picks up anything metal, or anything shiny/heavy.
+- Learners may currently think: a magnet picks up anything metal, or anything shiny or heavy.
 - The workshop needs them to understand: magnetism is a property of specific materials, not "metalness" in general.
-- The explanation should land after they have wondered: why the coin (metal) was not picked up but the paperclip and safety pin were.
+- The explanation should land after they have wondered: why a coin (a metal) is not picked up while a paperclip and safety pin are.
 
-Opening spark: "Which of these will the magnet pick up — the paperclip, the coin, the eraser, the pencil, or the safety pin?"
+Spark: ask which of a handful of objects the magnet will lift.
 
-Commitment: "Circle your prediction for each object before we test anything."
+Commit: have each learner record a prediction for every object before any testing.
 
-Hold: "Who circled the coin? Who didn't? What made you decide?" (Do not reveal yet.)
+Hold: surface the split in the room — who predicted the coin would stick, who didn't, and what rule each was using — without revealing the result.
 
-Teach (bridge in): "We're about to test it. What would the result have to be for your rule to be right?" — then test, then explain magnetic materials.
+Teach: test the objects, then explain magnetic materials into the gap the failed coin prediction opened.
 
-Return: "You predicted the coin would stick. It didn't. What was your rule before? What is your rule now? Where else would your old rule have failed?"
+Return: point back to the original prediction — what rule did they hold before, what is their rule now, and where else would the old rule have failed?
 
 ## Facilitator language — protecting the moment of being wrong
 
-The moment after a wrong answer is the most important moment for safety. What you say next decides whether learners conclude that being wrong is survivable.
+The moment after a wrong answer is the most important moment for safety. What you say next decides whether learners conclude that being wrong is survivable. Original phrasings you can adapt:
 
 | Moment | What to say |
 |--------|-------------|
-| A learner answers incorrectly | "That makes complete sense with what we knew before. Let's see what changes it." |
-| Before revealing the answer | "There's no wrong answer at this point. We're all guessing. That's the point." |
-| When many learners are wrong | "Most of us had that, and that's exactly why this lesson matters." |
-| After an incorrect prediction | "Good, that's what I was hoping for. Now we actually need the explanation." |
+| A learner answers incorrectly | "That fits what we knew a minute ago. Let's find out what changes it." |
+| Before revealing the answer | "Nobody can be wrong yet — we're all predicting. That's the whole point." |
+| When many learners are wrong | "Almost everyone landed there, which is exactly why this is worth a lesson." |
+| After an incorrect prediction | "Perfect — now the explanation actually has a job to do." |
 
 ## The decoration test
 

--- a/.agents/skills/workshop-question-framing/references/curiosity-by-design.md
+++ b/.agents/skills/workshop-question-framing/references/curiosity-by-design.md
@@ -60,16 +60,17 @@ If unsure, start with Real-Life Connection. It works across subjects and ages an
 
 ## Same lesson, opened differently
 
-Three patterns showing the shift — same content, opened to start thinking first instead of explaining first.
+Three patterns showing the shift — same content, opened to start thinking first instead of explaining first. Each names an assumed audience and the explanation the opening is setting up, so the question set has something to land into.
 
-- Science / magnetism (Prediction). Rather than announcing the topic and listing which materials are magnetic, put a mix of objects on each table and ask learners to predict which the magnet will lift before anyone tests. The explanation then arrives into a room of people checking their own predictions.
-- Math / fractions (Contradiction). Rather than defining a fraction up front, pose a sharing problem whose obvious answer is wrong — how many straight cuts it takes to split a round cake among four — and let the surprise drive the need for the idea of equal parts.
-- English / descriptive writing (Close Observation). Rather than listing the features of good description, show an evocative, context-free photograph and ask what is happening and what makes them say so. Learners are already generating description before any rule is named.
+- Science / magnetism (Prediction). Audience (assumed): primary, ages 7 to 9. Explanation it lands: only some metals (iron, steel) are magnetic — "metal," "shiny," and "heavy" are not the rule. Rather than announcing the topic and listing which materials are magnetic, put a mix of objects on each table and ask learners to predict which the magnet will lift before anyone tests. The explanation then arrives into a room of people checking their own predictions.
+- Math / fractions (Contradiction). Audience (assumed): upper-primary maths, ages 9 to 11. Explanation it lands: a fraction is equal parts of a whole, and the number of pieces is not the number of cuts. Rather than defining a fraction up front, pose a sharing problem whose obvious answer is wrong — how many straight cuts it takes to split a round cake among four — and let the surprise drive the need for the idea of equal parts.
+- English / descriptive writing (Close Observation). Audience (assumed): lower-secondary English, ages 11 to 13. Explanation it lands: concrete sensory detail and inference (show, don't tell) are what make description vivid. Rather than listing the features of good description, show an evocative, context-free photograph and ask what is happening and what makes them say so. Learners are already generating description before any rule is named.
 
 ## Full worked example — Prediction, end to end
 
 Topic: which materials a magnet attracts (primary science). Carried through all six beats.
 
+- Audience (assumed): primary-science class, ages 7 to 9.
 - Core concept: magnets attract some metals (iron, steel) but not all materials, and not all metals.
 - Learners may currently think: a magnet picks up anything metal, or anything shiny or heavy.
 - The workshop needs them to understand: magnetism is a property of specific materials, not "metalness" in general.

--- a/.claude/skills/workshop-question-framing
+++ b/.claude/skills/workshop-question-framing
@@ -1,0 +1,1 @@
+../../.agents/skills/workshop-question-framing


### PR DESCRIPTION
## Summary

Adds a new skill at `.agents/skills/workshop-question-framing/SKILL.md`.

The skill turns a workshop topic and explanation into curiosity-first question sets — questions that make participants think *before* they are taught, rather than generic discussion prompts. It encodes the reusable method: do not begin with explanation; first create a meaningful gap that makes participants want the explanation.

## Method encoded

- **Stable sequence:** Spark → Think → Commit → Hold → Teach → Return
- **Eight Spark doorways:** Prediction, Mystery, Contradiction, Close Observation, Dilemma and Decision, Puzzle, Real-Life Connection, Cause and Effect
- A six-step workflow (extract teaching core → choose the thinking → generate five question sets → offer move options → recommend the strongest frame → safety/facilitation rules)
- A fixed output format and a final quality check

## Triggering

The `description` activates the skill when a user is reviewing, designing, or improving a workshop, lesson, training session, facilitation plan, talk, or educational explanation and wants framing questions, curiosity hooks, opening prompts, discussion questions, or learner reflection prompts.

## Validation

- `uvx skilllint@latest check .agents/skills/workshop-question-framing` → exit 0, no findings.

https://claude.ai/code/session_01Ft2sfJo1RvHaosQ4BSZUEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft2sfJo1RvHaosQ4BSZUEX)_