### PR TITLE
fix(add-new-feature): enforce ORCHESTRATOR-ONLY on backlog_update(plan=) after task decomposition

### DIFF
--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -462,7 +462,7 @@ into each implementation agent's prompt. Omitting it means implementation agents
 without domain schema context.
 ```
 
-After the agent completes, write the plan path back to the backlog item:
+**ORCHESTRATOR-ONLY** — After the agent completes, the orchestrator MUST call this unconditionally. Do NOT include this in the subagent delegation prompt. Do NOT skip it based on the subagent's self-report:
 
 ```text
 mcp__plugin_dh_backlog__backlog_update(


### PR DESCRIPTION
## Summary

- The `backlog_update(plan=...)` call in Phase 4 of `add-new-feature/SKILL.md` (lines 465-472) lacked an explicit actor annotation, allowing orchestrators to misread it as delegatable to the `swarm-task-planner` subagent
- When the orchestrator accepted the subagent's self-report as proof of execution, `plan_path` was left null on the backlog item
- This silently broke the `work-backlog-item` shortcut in `locate.md` (lines 41-45) that routes directly to `implement-feature` when a plan already exists

## Root Cause

The instruction used passive imperative voice ("write the plan path back") without identifying the actor. An LLM orchestrator reading the subagent's self-report ("plan linked to issue #N") could reasonably infer the call had already been made and skip it.

## Fix

Added `**ORCHESTRATOR-ONLY**` annotation with three explicit constraints:
1. The orchestrator MUST call this unconditionally
2. Do NOT include in the subagent delegation prompt
3. Do NOT skip based on subagent self-report

## Test plan

- [ ] After `dh:add-new-feature` Phase 4 completes, verify `backlog_view(selector="#N", summary=True)` returns non-null `plan_path`
- [ ] Confirm the `swarm-task-planner` delegation prompt (lines 435-463) contains no `backlog_update` call
- [ ] Verify `work-backlog-item` plan shortcut fires on next invocation without manual `backlog_update` call

Closes #2510

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHpGt8FGNsRCxV62ks1C1n)_