### PR TITLE
fix(add-new-feature): reframe Phase 4 plan link without "orchestrator" — reader-anchored + post-condition

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.8.19",
+  "version": "8.8.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/add-new-feature/SKILL.md
+++ b/plugins/development-harness/skills/add-new-feature/SKILL.md
@@ -462,13 +462,25 @@ into each implementation agent's prompt. Omitting it means implementation agents
 without domain schema context.
 ```
 
-After the agent completes, write the plan path back to the backlog item:
+Linking the plan to the backlog item is a step of `add-new-feature` itself, run in the same
+context that read this file — not part of the `swarm-task-planner` delegation above. Everything
+sent to that subagent lives inside the fenced delegation prompt block above; this step sits
+outside it. The `swarm-task-planner` never reads this file, so it cannot perform this step — a
+self-report such as "linked to issue #N" is not evidence the link exists. Confirm the link by
+reading state, not by trusting a report:
 
 ```text
+# 1. Read current state — plan_path is null until the link is written
+mcp__plugin_dh_backlog__backlog_view(selector="#{issue}", summary=True)
+
+# 2. If plan_path is null, write the link
 mcp__plugin_dh_backlog__backlog_update(
     selector="{title}",
     plan="P{id}"
 )
+
+# 3. Re-read and confirm plan_path is non-null before proceeding to Phase 5
+mcp__plugin_dh_backlog__backlog_view(selector="#{issue}", summary=True)
 ```
 
 Note: `sam_plan(action='create', issue={issue})` already auto-registers the `task-plan`
@@ -476,9 +488,10 @@ artifact. Do NOT call `artifact_register` for the `task-plan` type — it is red
 would create a duplicate entry.
 
 The `backlog_update(plan=...)` call writes the plan address into the backlog item's `metadata.plan`
-field. This is a backend signal — it records that a plan exists and its address, not a filesystem
-path. `work-backlog-item` uses this to route directly to `implement-feature` on subsequent
-invocations. The SAM MCP resolves `P{id}` to the full plan without filesystem access.
+field, surfaced by `backlog_view(summary=True)` as `plan_path`. This is a backend signal — it
+records that a plan exists and its address, not a filesystem path. `work-backlog-item` reads
+`plan_path` to route directly to `implement-feature` on subsequent invocations. The SAM MCP
+resolves `P{id}` to the full plan without filesystem access.
 
 ---
 


### PR DESCRIPTION
## Summary

An alternative to #2536 for the same defect (#2510), built on a critique of the word **"orchestrator"**.

"Orchestrator" is a *relative* role, not an identity: any agent that spawns another reasons it is the orchestrator from its own frame. So the `ORCHESTRATOR-ONLY` label in #2536 has no fixed referent — the `swarm-task-planner` subagent could read the same label as applying to itself. The label also addresses only **one** of the three defects in #2510.

## The defect (#2510), de-jargoned

After Phase 4 of `add-new-feature`, the `backlog_update(plan=...)` link must be written so `work-backlog-item` can later route to `implement-feature` via the item's `plan_path`. Three things go wrong:

1. **Actor ambiguity** — the call sits as prose next to the delegation block and gets folded into the subagent prompt.
2. **Self-report trust** — the subagent reports "linked to issue #N" and that narrative is taken as proof.
3. **Missing verification** — nothing confirms `plan_path` actually landed.

`ORCHESTRATOR-ONLY` targets #1 by naming a role. #2 and #3 remain.

## This approach

Drops "orchestrator" entirely and replaces it with two grounded anchors:

- **Reading boundary** (not role) — the step belongs to `add-new-feature`, the context that *reads this file*. The `swarm-task-planner` only ever sees the fenced delegation prompt block and never reads this file, so it cannot perform the step. A self-report is explicitly stated to not be evidence.
- **Observable post-condition** (not actor) — read `plan_path`, write the link if null, re-read to confirm non-null. Idempotent and self-correcting regardless of who ran it or what was reported. This targets defects #2 and #3, which a label cannot.

Also corrects the documented field name to `plan_path` (verified against `backlog_core/server.py:1869,1881`).

## Verification performed (static)

- `backlog_view(summary=True)` returns a field named `plan_path` — `backlog_core/server.py:1869,1881`.
- The item's plan field is written only by `backlog_update(plan=...)` (`backlog_core/operations.py:719`); `sam_plan create` registers the task-plan artifact but does not set it (`sam_schema/core/gist_task_layer.py`).
- `prek` passes on the edited file.

## Not included (open design fork)

A deeper option — fold the plan link into `sam_plan create` so no separate step exists — is a cross-module change coupling the SAM server's write path to `backlog_core`. Left out of this prose-only change; can be filed as a follow-up if preferred over the verification-step approach.

Relates to #2510. Alternative to #2536.

https://claude.ai/code/session_01693mGoMFnA6KvtxbanT5gS

---
_Generated by [Claude Code](https://claude.ai/code/session_01693mGoMFnA6KvtxbanT5gS)_