### PR TITLE
feat(python-engineering): grant context-mode MCP tools to python-cli-architect

### DIFF
--- a/plugins/python-engineering/.claude-plugin/plugin.json
+++ b/plugins/python-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python-engineering",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
-  "version": "9.26.7",
+  "version": "9.26.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python-engineering/agents/python-cli-architect.md
+++ b/plugins/python-engineering/agents/python-cli-architect.md
@@ -4,7 +4,7 @@ description: Creates, enhances, and reviews Python CLI code using Typer and Rich
 color: pink
 model: sonnet
 memory: project
-tools: Read, Write, Glob, Grep, Skill, Bash, WebSearch, WebFetch
+tools: Read, Write, Glob, Grep, Skill, Bash, WebSearch, WebFetch, mcp__plugin_context-mode_context-mode__ctx_batch_execute, mcp__plugin_context-mode_context-mode__ctx_search, mcp__plugin_context-mode_context-mode__ctx_execute, mcp__plugin_context-mode_context-mode__ctx_execute_file, mcp__plugin_context-mode_context-mode__ctx_fetch_and_index, mcp__plugin_context-mode_context-mode__ctx_index, mcp__plugin_context-mode_context-mode__ctx_insight, mcp__plugin_context-mode_context-mode__ctx_stats, mcp__plugin_context-mode_context-mode__ctx_doctor, mcp__plugin_context-mode_context-mode__ctx_upgrade, mcp__plugin_context-mode_context-mode__ctx_purge
 skills:
   - python-engineering:python3-core
   - python-engineering:python3-cli


### PR DESCRIPTION
## Summary

Grants the full context-mode MCP tool set to `@python-engineering:python-cli-architect` via its `tools:` frontmatter allowlist.

## Why

The global `context_window_protection` system prompt instructs every spawned agent to use `ctx_batch_execute` (context-mode) as its primary research tool. But `python-cli-architect`'s `tools:` allowlist listed only `Read, Write, Glob, Grep, Skill, Bash, WebSearch, WebFetch` — so every context-mode call failed with `No such tool available: mcp__plugin_context-mode_context-mode__ctx_batch_execute`, and agents stalled mid-task (observed repeatedly: 0-edit early exits during the #2546 work).

Evidence: parsed stalled sub-agent transcripts — the error appears in each; the agents ended on a tool_result with no following turn and no `stop_reason`.

## Change

Append the 11 `ctx_*` context-mode tools to the agent's `tools:` line. No behavior change to the agent's logic; it can now actually call the tools the global prompt tells it to use.

## Note

A duplicate `python-cli-architect.md` exists under `plugins/python3-development/agents/` — not changed here. The other python-engineering specialist agents (`python-pytest-architect`, `python-cli-design-spec`, `code-reviewer`, `adversarial-solution-design`) have the same gap; can be addressed in a follow-up if desired.

Takes effect after a plugin version bump + session restart (plugin reload).

https://claude.ai/code/session_01693mGoMFnA6KvtxbanT5gS

---
_Generated by [Claude Code](https://claude.ai/code/session_01693mGoMFnA6KvtxbanT5gS)_