### PR TITLE
fix(tests): replace raw int/str literals with typed Priority/Complexity enum values

### DIFF
--- a/plugins/development-harness/backlog_core/tests/unit/test_disclosure_handler.py
+++ b/plugins/development-harness/backlog_core/tests/unit/test_disclosure_handler.py
@@ -68,7 +68,7 @@ from backlog_core.disclosure_types import (
     NavigateResponse,
     OrdinalNotFoundError,
 )
-from backlog_core.models import SectionEntryDict, SectionEntryMetadata, ViewItemResult
+from backlog_core.models import GroomedSectionMetadata, SectionEntryDict, SectionEntryMetadata, ViewItemResult
 from backlog_core.ordinal_mapper import OrdinalEntry, OrdinalPathMapper
 
 if TYPE_CHECKING:
@@ -202,7 +202,7 @@ def multi_entry_view_result() -> ViewItemResult:
     level-2 lines so the buggy all-entries sum diverges from the correct
     level-1-only sum.
     """
-    sections = {
+    sections: dict[str, SectionEntryMetadata | GroomedSectionMetadata] = {
         "AlphaSection": _section([
             "First entry for alpha. This sentence provides a meaningful token count.",
             "Second entry for alpha. Another distinct sentence with its own tokens.",

--- a/plugins/development-harness/tests_backlog/test_beads_artifact_provider.py
+++ b/plugins/development-harness/tests_backlog/test_beads_artifact_provider.py
@@ -572,7 +572,7 @@ class TestBdShowListWrapping:
 
     def test_round_trip_register_list_read(self, provider: BeadsArtifactProvider, mock_runner: MagicMock) -> None:
         """Round-trip: store then read returns the original content with list-wrapped show output."""
-        notes_before: list[str] = [None]  # type: ignore[list-item]
+        notes_before: list[str | None] = [None]
 
         def capture_notes_update(argv: list[str]) -> None:
             if "--notes" in argv:

--- a/plugins/development-harness/tests_sam/test_backward_compat_local_plans.py
+++ b/plugins/development-harness/tests_sam/test_backward_compat_local_plans.py
@@ -21,7 +21,7 @@ from sam_schema.core.artifact_registry_client import ArtifactRegistryClient
 from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
 from sam_schema.core.exceptions import PlanNotFoundError
 from sam_schema.core.gist_task_layer import GistTaskLayer
-from sam_schema.core.models import Task, TaskStatus
+from sam_schema.core.models import Complexity, Priority, Task, TaskStatus
 from sam_schema.core.plan_id_index import PlanIdIndex
 
 if TYPE_CHECKING:
@@ -150,8 +150,8 @@ def test_local_plan_full_content_equality(tmp_path: Path) -> None:
             status=TaskStatus.NOT_STARTED,
             agent="python-cli-architect",
             dependencies=[],
-            priority=1,
-            complexity="low",
+            priority=Priority.CRITICAL,
+            complexity=Complexity.LOW,
         ),
         Task(
             id="T2",
@@ -159,8 +159,8 @@ def test_local_plan_full_content_equality(tmp_path: Path) -> None:
             status=TaskStatus.NOT_STARTED,
             agent="python-cli-architect",
             dependencies=["T1"],
-            priority=2,
-            complexity="medium",
+            priority=Priority.HIGH,
+            complexity=Complexity.MEDIUM,
         ),
     ]
     plan_id = _create_local_only_plan(plan_dir, "pre-fix-full-equality", tasks)
@@ -210,10 +210,29 @@ def test_local_plan_with_many_tasks(tmp_path: Path) -> None:
     plan_dir.mkdir()
 
     tasks = [
-        Task(id="T1", title="Task one", status=TaskStatus.NOT_STARTED, agent="agent", dependencies=[], priority=1),
-        Task(id="T2", title="Task two", status=TaskStatus.NOT_STARTED, agent="agent", dependencies=["T1"], priority=2),
         Task(
-            id="T3", title="Task three", status=TaskStatus.NOT_STARTED, agent="agent", dependencies=["T1"], priority=3
+            id="T1",
+            title="Task one",
+            status=TaskStatus.NOT_STARTED,
+            agent="agent",
+            dependencies=[],
+            priority=Priority.CRITICAL,
+        ),
+        Task(
+            id="T2",
+            title="Task two",
+            status=TaskStatus.NOT_STARTED,
+            agent="agent",
+            dependencies=["T1"],
+            priority=Priority.HIGH,
+        ),
+        Task(
+            id="T3",
+            title="Task three",
+            status=TaskStatus.NOT_STARTED,
+            agent="agent",
+            dependencies=["T1"],
+            priority=Priority.MEDIUM,
         ),
         Task(
             id="T4",
@@ -221,9 +240,16 @@ def test_local_plan_with_many_tasks(tmp_path: Path) -> None:
             status=TaskStatus.NOT_STARTED,
             agent="agent",
             dependencies=["T2", "T3"],
-            priority=4,
+            priority=Priority.LOW,
         ),
-        Task(id="T5", title="Task five", status=TaskStatus.NOT_STARTED, agent="agent", dependencies=["T4"], priority=5),
+        Task(
+            id="T5",
+            title="Task five",
+            status=TaskStatus.NOT_STARTED,
+            agent="agent",
+            dependencies=["T4"],
+            priority=Priority.LOWEST,
+        ),
     ]
     plan_id = _create_local_only_plan(plan_dir, "pre-fix-many-tasks", tasks)
 

--- a/plugins/development-harness/tests_sam/test_gist_write_through.py
+++ b/plugins/development-harness/tests_sam/test_gist_write_through.py
@@ -27,7 +27,7 @@ from sam_schema.core.artifact_registry_client import ArtifactRegistryClient
 from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
 from sam_schema.core.exceptions import ArtifactWriteError, ConcurrentClaimUnsupportedError
 from sam_schema.core.gist_task_layer import GistTaskLayer
-from sam_schema.core.models import Task, TaskStatus
+from sam_schema.core.models import Complexity, Priority, Task, TaskStatus
 from sam_schema.core.plan_id_index import PlanIdIndex, PlanIndexEntry, _serialize_index_yaml
 
 if TYPE_CHECKING:
@@ -111,8 +111,8 @@ def _two_tasks() -> list[Task]:
             status=TaskStatus.NOT_STARTED,
             agent="test-agent",
             dependencies=[],
-            priority=1,
-            complexity="low",
+            priority=Priority.CRITICAL,
+            complexity=Complexity.LOW,
         ),
         Task(
             id="T2",
@@ -120,8 +120,8 @@ def _two_tasks() -> list[Task]:
             status=TaskStatus.NOT_STARTED,
             agent="test-agent",
             dependencies=["T1"],
-            priority=2,
-            complexity="medium",
+            priority=Priority.HIGH,
+            complexity=Complexity.MEDIUM,
         ),
     ]
 
@@ -423,8 +423,8 @@ def test_full_content_equality_roundtrip(gist_layer: GistTaskLayer, store: _InMe
             status=TaskStatus.NOT_STARTED,
             agent="python-cli-architect",
             dependencies=[],
-            priority=1,
-            complexity="low",
+            priority=Priority.CRITICAL,
+            complexity=Complexity.LOW,
         ),
         Task(
             id="T2",
@@ -432,8 +432,8 @@ def test_full_content_equality_roundtrip(gist_layer: GistTaskLayer, store: _InMe
             status=TaskStatus.NOT_STARTED,
             agent="python-cli-architect",
             dependencies=["T1"],
-            priority=2,
-            complexity="high",
+            priority=Priority.HIGH,
+            complexity=Complexity.HIGH,
         ),
         Task(
             id="T3",
@@ -441,8 +441,8 @@ def test_full_content_equality_roundtrip(gist_layer: GistTaskLayer, store: _InMe
             status=TaskStatus.NOT_STARTED,
             agent="python-pytest-architect",
             dependencies=["T1", "T2"],
-            priority=3,
-            complexity="medium",
+            priority=Priority.MEDIUM,
+            complexity=Complexity.MEDIUM,
         ),
     ]
     slug = "roundtrip-equality"
@@ -891,8 +891,8 @@ def test_append_task_persists_to_gist(gist_layer: GistTaskLayer, store: _InMemor
         status=TaskStatus.NOT_STARTED,
         agent="test-agent",
         dependencies=[],
-        priority=3,
-        complexity="low",
+        priority=Priority.MEDIUM,
+        complexity=Complexity.LOW,
     )
 
     # Act: append the task — must write through to Gist.
@@ -934,8 +934,8 @@ def test_finalize_plan_persists_to_gist(gist_layer: GistTaskLayer, store: _InMem
         status=TaskStatus.NOT_STARTED,
         agent="test-agent",
         dependencies=[],
-        priority=1,
-        complexity="low",
+        priority=Priority.CRITICAL,
+        complexity=Complexity.LOW,
     )
     t2 = Task(
         id="T2",
@@ -943,8 +943,8 @@ def test_finalize_plan_persists_to_gist(gist_layer: GistTaskLayer, store: _InMem
         status=TaskStatus.NOT_STARTED,
         agent="test-agent",
         dependencies=["T1"],
-        priority=2,
-        complexity="medium",
+        priority=Priority.HIGH,
+        complexity=Complexity.MEDIUM,
     )
     gist_layer.append_task(plan_id, t1)
     gist_layer.append_task(plan_id, t2)
@@ -996,8 +996,8 @@ def test_append_task_raises_on_gist_write_failure(gist_layer: GistTaskLayer, sto
         status=TaskStatus.NOT_STARTED,
         agent="test-agent",
         dependencies=[],
-        priority=3,
-        complexity="low",
+        priority=Priority.MEDIUM,
+        complexity=Complexity.LOW,
     )
 
     # Act + Assert: ArtifactWriteError must propagate (no silent swallow).


### PR DESCRIPTION
## Summary

- **Root cause**: Tests constructed `Task` objects using bare `int`/`str` literals (`priority=1`, `complexity="low"`). Pydantic coerces these at runtime, so tests passed — but `ty` correctly rejected them as type violations because `Literal[1]` is not assignable to `Priority(IntEnum)` and `"low"` is not assignable to `Complexity(StrEnum)`. The design flaw is that the enum contract was invisible to the static type checker.

- **29 `ty` diagnostics eliminated** across 4 test files:
  - `tests_sam/test_gist_write_through.py` — 18 occurrences of `priority=int`, `complexity=str` replaced with `Priority.*` / `Complexity.*` enum members
  - `tests_sam/test_backward_compat_local_plans.py` — 9 occurrences replaced
  - `backlog_core/tests/unit/test_disclosure_handler.py` — dict invariance fix: `dict[str, SectionEntryMetadata]` → `dict[str, SectionEntryMetadata | GroomedSectionMetadata]` + import added
  - `tests_backlog/test_beads_artifact_provider.py` — `list[str] = [None]  # type: ignore[list-item]` → `list[str | None] = [None]` (forbidden `# type: ignore` removed)

## Test plan

- [x] `uv run ty check plugins/development-harness/` → `All checks passed!`
- [x] `uv run prek run --files <4 changed files>` → all hooks pass
- [x] `uv run pytest tests_sam/test_gist_write_through.py tests_sam/test_backward_compat_local_plans.py tests_backlog/test_beads_artifact_provider.py` → 77 passed

https://claude.ai/code/session_01ULGizNMk2EUQJuVDHjMbPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULGizNMk2EUQJuVDHjMbPJ)_