### PR TITLE
fix(backlog_core): remove isdigit() coercion from _require_int_item_id (#2438)

### DIFF
--- a/.claude/hooks/run-commands-try-all.cjs
+++ b/.claude/hooks/run-commands-try-all.cjs
@@ -29,7 +29,7 @@ function getCommands() {
   }
   try {
     const stdin = fs.readFileSync(0, 'utf8');
-    if (!stdin || !stdin.trim()) return [];
+    if (!stdin?.trim()) return [];
     const data = JSON.parse(stdin);
     const cmds = data.commands ?? data.command ?? [];
     return Array.isArray(cmds) ? cmds : [String(cmds)];

--- a/.claude/hooks/validate-delegation.cjs
+++ b/.claude/hooks/validate-delegation.cjs
@@ -119,7 +119,7 @@ function readStdin() {
 
 function main() {
   const raw = readStdin();
-  if (!raw || !raw.trim()) {
+  if (!raw?.trim()) {
     // No input — nothing to validate
     process.exit(0);
   }

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.8.25",
+  "version": "8.8.26",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/artifact_provider.py
+++ b/plugins/development-harness/backlog_core/artifact_provider.py
@@ -143,11 +143,17 @@ def _make_github_client() -> Github:
 def _require_int_item_id(cls_name: str, item_id: ItemId) -> int:
     """Raise ``TypeError`` when *item_id* is a string.
 
-    GitHub and GitLab providers require a positive integer item ID.  String
+    GitHub and GitLab providers require an integer item ID.  String
     identifiers (beads nanoid ``"bd-a3f8"``) are only valid for
     ``BeadsArtifactProvider``.  Linear UUID strings must NOT pass through
     this helper — ``LinearArtifactProvider`` accepts strings natively and
     does not call this function.
+
+    The MCP tool boundary uses ``int | str`` (integer-first) annotations so
+    Pydantic delivers ``int`` for numeric inputs at the boundary.  String
+    coercion via ``isdigit()`` was removed — any string that reaches this
+    guard is a provider-routing error and must raise immediately rather than
+    silently coerce.
 
     Args:
         cls_name: Name of the calling provider class, used in the error message.
@@ -160,15 +166,6 @@ def _require_int_item_id(cls_name: str, item_id: ItemId) -> int:
         TypeError: When *item_id* is a ``str`` instance.
     """
     if isinstance(item_id, str):
-        if item_id.isdigit():
-            coerced = int(item_id)
-            if coerced <= 0:
-                msg = (
-                    f"{cls_name} requires an integer item ID, got {item_id!r}. "
-                    "Use BeadsArtifactProvider for string (beads) item identifiers."
-                )
-                raise TypeError(msg)
-            return coerced
         msg = (
             f"{cls_name} requires an integer item ID, got {item_id!r}. "
             "Use BeadsArtifactProvider for string (beads) item identifiers."

--- a/plugins/development-harness/backlog_core/tests/test_artifact_provider_item_id_coercion.py
+++ b/plugins/development-harness/backlog_core/tests/test_artifact_provider_item_id_coercion.py
@@ -1,22 +1,21 @@
-"""Regression tests for numeric-string item_id coercion in artifact_provider.
+"""Regression tests for item_id type contract in artifact_provider.
 
-Bug: ``artifact_read`` and ``artifact_list`` fail with
+Background: ``artifact_read`` and ``artifact_list`` raised
 ``GitHubGistArtifactProvider requires an integer item ID, got '2459'``
-when a numeric string is passed instead of an integer.
+when a numeric string was passed instead of an integer.
 
-The MCP tool schema declares ``item_id: Union[str, int]`` to handle both
-GitHub integer IDs and beads nanoid strings (e.g. ``'bd-a3f8'``).  But
-``_require_int_item_id`` currently raises on ANY string — including strings
-that are valid integer representations like ``'2459'``.
+Fix approach (implemented): The MCP tool schema uses ``item_id: int | str``
+(integer-first union) so Pydantic coerces numeric inputs to ``int`` at the
+MCP boundary before they reach ``_require_int_item_id``.  The previous
+``isdigit()`` coercion branch in ``_require_int_item_id`` was removed — any
+string that arrives at the guard is a provider-routing error.
 
-The expected post-fix behaviour:
-- A numeric-only string such as ``'2459'`` is coerced to ``int(2459)`` and
-  returned without raising.
-- A non-numeric beads string such as ``'bd-a3f8'`` still raises ``TypeError``
-  because it cannot route to a GitHub/GitLab provider.
-- A plain integer ``2459`` is returned unchanged.
-
-These tests are RED (failing) before the fix is applied.
+Post-fix contract:
+- A plain integer ``2459`` passes through unchanged.
+- A numeric string ``'2459'`` raises ``TypeError`` — Pydantic delivers int at
+  the MCP boundary, so a string here means the caller bypassed the boundary.
+- A beads nanoid string ``'bd-a3f8'`` raises ``TypeError`` — must route via
+  ``BeadsArtifactProvider``, not GitHub/GitLab providers.
 """
 
 from __future__ import annotations
@@ -27,24 +26,21 @@ from backlog_core.artifact_provider import _require_int_item_id
 
 
 class TestRequireIntItemIdCoercion:
-    """_require_int_item_id coerces numeric strings and rejects beads strings."""
+    """_require_int_item_id rejects all strings; ints pass through unchanged."""
 
-    def test_numeric_string_is_coerced_to_int(self) -> None:
-        """A numeric string like '2459' must be coerced to int(2459), not raise.
+    def test_numeric_string_raises_type_error(self) -> None:
+        """A numeric string like '2459' must raise TypeError, not coerce.
 
-        This is the root-cause reproduction of the reported bug.  Agents pass
-        item_id as a string when the MCP tool schema allows str|int; the helper
-        must accept numeric strings instead of raising TypeError.
+        The MCP boundary (int | str annotation) coerces numeric inputs to int
+        before reaching this guard.  A string here means the caller bypassed
+        the MCP boundary — that is a routing error and must raise immediately.
         """
         # Arrange
         item_id_string = "2459"
 
-        # Act
-        result = _require_int_item_id("GitHubGistArtifactProvider", item_id_string)
-
-        # Assert
-        assert result == 2459
-        assert isinstance(result, int)
+        # Act / Assert
+        with pytest.raises(TypeError, match="requires an integer item ID"):
+            _require_int_item_id("GitHubGistArtifactProvider", item_id_string)
 
     def test_beads_string_still_raises_type_error(self) -> None:
         """A beads nanoid string like 'bd-a3f8' must still raise TypeError.
@@ -83,11 +79,11 @@ class TestRequireIntItemIdCoercion:
             _require_int_item_id("GitLabArtifactProvider", "bd-a3f8")
 
     def test_zero_string_raises_type_error(self) -> None:
-        """item_id='0' must raise TypeError because GitHub issue IDs start at 1.
+        """item_id='0' must raise TypeError — all strings are rejected.
 
-        '0'.isdigit() returns True, so int('0') = 0 would silently pass the
-        isdigit() guard without this check. Zero is not a valid GitHub issue ID
-        and is likely an unsubstituted template placeholder.
+        With the isdigit() coercion removed, '0' raises the same way as any
+        other string.  Business-level zero validation (GitHub IDs start at 1)
+        is the caller's responsibility; the guard only enforces the type contract.
         """
         # Arrange / Act / Assert
         with pytest.raises(TypeError, match="requires an integer item ID"):

--- a/plugins/development-harness/tests/test_require_int_item_id.py
+++ b/plugins/development-harness/tests/test_require_int_item_id.py
@@ -1,0 +1,57 @@
+"""Unit tests for the _require_int_item_id guard function.
+
+Covers the post-fix contract: any string input raises TypeError immediately;
+integer inputs pass through unchanged.  The isdigit() coercion branch was
+removed in #2438 — numeric strings are no longer silently coerced.
+"""
+
+from __future__ import annotations
+
+import pytest
+from backlog_core.artifact_provider import _require_int_item_id
+
+
+class TestRequireIntItemIdIntInputs:
+    def test_positive_int_passes_through(self) -> None:
+        assert _require_int_item_id("GitHubGistArtifactProvider", 2438) == 2438
+
+    def test_one_passes_through(self) -> None:
+        assert _require_int_item_id("GitHubGistArtifactProvider", 1) == 1
+
+    def test_large_int_passes_through(self) -> None:
+        assert _require_int_item_id("GitHubGistArtifactProvider", 999999) == 999999
+
+    def test_zero_passes_through(self) -> None:
+        # Zero is technically valid at this layer; callers validate business rules
+        assert _require_int_item_id("GitHubGistArtifactProvider", 0) == 0
+
+    def test_negative_int_passes_through(self) -> None:
+        # Sign validation is not this function's responsibility
+        assert _require_int_item_id("GitHubGistArtifactProvider", -1) == -1
+
+
+class TestRequireIntItemIdStringInputs:
+    def test_beads_nanoid_raises(self) -> None:
+        with pytest.raises(TypeError, match="bd-a3f8"):
+            _require_int_item_id("GitHubGistArtifactProvider", "bd-a3f8")
+
+    def test_numeric_string_raises(self) -> None:
+        """Numeric strings are no longer coerced — isdigit() branch was removed."""
+        with pytest.raises(TypeError, match="2438"):
+            _require_int_item_id("GitHubGistArtifactProvider", "2438")
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(TypeError, match="''"):
+            _require_int_item_id("GitHubGistArtifactProvider", "")
+
+    def test_zero_string_raises(self) -> None:
+        with pytest.raises(TypeError, match="'0'"):
+            _require_int_item_id("GitHubGistArtifactProvider", "0")
+
+    def test_error_message_includes_cls_name(self) -> None:
+        with pytest.raises(TypeError, match="GitLabArtifactProvider"):
+            _require_int_item_id("GitLabArtifactProvider", "bd-a3f8")
+
+    def test_error_message_mentions_beads_provider(self) -> None:
+        with pytest.raises(TypeError, match="BeadsArtifactProvider"):
+            _require_int_item_id("GitHubGistArtifactProvider", "bd-a3f8")

--- a/plugins/frustration-analyzer/.claude-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs the triggering assistant output, and renders a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/frustration-analyzer/.codex-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.codex-plugin/plugin.json
@@ -6,13 +6,6 @@
     "name": "Jamie-BitFlight"
   },
   "license": "MIT",
-  "keywords": [
-    "transcripts",
-    "frustration",
-    "rage-receipt",
-    "duckdb",
-    "session-analysis",
-    "png"
-  ],
+  "keywords": ["transcripts", "frustration", "rage-receipt", "duckdb", "session-analysis", "png"],
   "skills": "./skills/"
 }

--- a/plugins/orchestrator-discipline/.claude-plugin/plugin.json
+++ b/plugins/orchestrator-discipline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrator-discipline",
   "description": "Enforces orchestrator context window discipline via PreToolUse hooks and rules. Prevents the orchestrator from reading source files it will not edit, running diagnostic commands that should be delegated, and bypassing delegation with 'small change' rationalizations. Install to structurally prevent investigation escalation anti-patterns.",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/orchestrator-discipline/hooks/pre-tool-block-explore-for-analysis.cjs
+++ b/plugins/orchestrator-discipline/hooks/pre-tool-block-explore-for-analysis.cjs
@@ -124,7 +124,7 @@ function readStdin() {
 
 function main() {
   const raw = readStdin();
-  if (!raw || !raw.trim()) {
+  if (!raw?.trim()) {
     process.exit(0);
   }
 

--- a/plugins/orchestrator-discipline/hooks/prevent-bash-tool-misuse.cjs
+++ b/plugins/orchestrator-discipline/hooks/prevent-bash-tool-misuse.cjs
@@ -111,7 +111,7 @@ const LEGITIMATE_PATTERNS = [
 
 function main() {
   const raw = readStdin();
-  if (!raw || !raw.trim()) {
+  if (!raw?.trim()) {
     process.exit(0);
   }
 

--- a/plugins/process-siren/.claude-plugin/plugin.json
+++ b/plugins/process-siren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "process-siren",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Converts bullet steps, ASCII art, markdown tables, and prose workflows into Mermaid diagrams for AI-facing documents. Includes process quality methodology for improving ambiguous or incomplete processes before conversion.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/process-siren/.codex-plugin/plugin.json
+++ b/plugins/process-siren/.codex-plugin/plugin.json
@@ -6,12 +6,6 @@
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"
   },
-  "keywords": [
-    "mermaid",
-    "process",
-    "workflow",
-    "diagram",
-    "flowchart"
-  ],
+  "keywords": ["mermaid", "process", "workflow", "diagram", "flowchart"],
   "skills": "./skills/"
 }

--- a/plugins/rtfp/.claude-plugin/plugin.json
+++ b/plugins/rtfp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rtfp",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Read The Fucking Prompt \u2014 mines Claude Code session transcripts to surface the strongest user reactions to assistant instruction-following failures and renders the exchange as a terminal-style PNG",
   "author": {
     "name": "Jamie-BitFlight",

--- a/plugins/rtfp/.codex-plugin/plugin.json
+++ b/plugins/rtfp/.codex-plugin/plugin.json
@@ -8,11 +8,6 @@
   },
   "repository": "https://github.com/Jamie-BitFlight/claude_skills",
   "license": "MIT",
-  "keywords": [
-    "session-analysis",
-    "emotional-reaction",
-    "instruction-following",
-    "png-artifact"
-  ],
+  "keywords": ["session-analysis", "emotional-reaction", "instruction-following", "png-artifact"],
   "skills": "./skills/"
 }

--- a/plugins/scientific-method/.claude-plugin/plugin.json
+++ b/plugins/scientific-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scientific-method",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/scientific-method/hooks/notify-investigation-complete.cjs
+++ b/plugins/scientific-method/hooks/notify-investigation-complete.cjs
@@ -52,7 +52,7 @@ function extractLastAssistantText(transcriptPath) {
 
     if (record.type !== 'assistant') continue;
     const message = record.message;
-    if (!message || message.role !== 'assistant') continue;
+    if (message?.role !== 'assistant') continue;
     const content = Array.isArray(message.content) ? message.content : [];
     const textParts = content
       .filter((c) => c && c.type === 'text' && typeof c.text === 'string')

--- a/plugins/summarizer/.claude-plugin/plugin.json
+++ b/plugins/summarizer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "summarizer",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "Faithful information summarization with fidelity preservation, structured output, and anti-hallucination methodology. Provides skills for file, URL, and image summarization; agents for autonomous summarization tasks; and hooks for validating agent output structure.",
   "author": {
     "name": "jamie-bitflight-skills",

--- a/plugins/summarizer/.codex-plugin/plugin.json
+++ b/plugins/summarizer/.codex-plugin/plugin.json
@@ -7,12 +7,6 @@
     "url": "https://github.com/bitflight-devops/claude-skills"
   },
   "license": "MIT",
-  "keywords": [
-    "summarization",
-    "fidelity",
-    "anti-hallucination",
-    "synthesis",
-    "extractive"
-  ],
+  "keywords": ["summarization", "fidelity", "anti-hallucination", "synthesis", "extractive"],
   "skills": "./skills/"
 }

--- a/plugins/summarizer/hooks/validate-summarizer-output.cjs
+++ b/plugins/summarizer/hooks/validate-summarizer-output.cjs
@@ -48,7 +48,7 @@ function extractLastAssistantText(transcriptPath) {
 
     if (record.type !== 'assistant') continue;
     const message = record.message;
-    if (!message || message.role !== 'assistant') continue;
+    if (message?.role !== 'assistant') continue;
     const content = Array.isArray(message.content) ? message.content : [];
     const textParts = content
       .filter((c) => c && c.type === 'text' && typeof c.text === 'string')

--- a/plugins/the-rewrite-room/.claude-plugin/plugin.json
+++ b/plugins/the-rewrite-room/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rwr",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "description": "Documentation and authoring workflow router: audit docs vs code drift, sync docs after changes, optimize prompts and SKILL.md files, validate GLFM and Markdown formatting, summarize files/URLs/images with fidelity enforcement. Use when: docs are out of date, CLAUDE.md needs improving, SKILL.md needs optimizing, checking if documentation matches code, summarizing files or URLs.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/the-rewrite-room/hooks/validate-status-block.cjs
+++ b/plugins/the-rewrite-room/hooks/validate-status-block.cjs
@@ -49,7 +49,7 @@ function extractLastAssistantText(transcriptPath) {
     if (record.type !== 'assistant') continue;
 
     const message = record.message;
-    if (!message || message.role !== 'assistant') continue;
+    if (message?.role !== 'assistant') continue;
 
     const content = Array.isArray(message.content) ? message.content : [];
     const textParts = content

--- a/plugins/the-rewrite-room/hooks/validate-status-block.cjs
+++ b/plugins/the-rewrite-room/hooks/validate-status-block.cjs
@@ -86,19 +86,19 @@ function validateStatusBlock(text) {
 
   // SUMMARY: non-empty
   const summaryMatch = text.match(/^\s*SUMMARY:\s*(.+)/m);
-  if (!summaryMatch || !summaryMatch[1].trim()) {
+  if (!summaryMatch?.[1].trim()) {
     missingFields.push('SUMMARY');
   }
 
   // ARTIFACTS: non-empty (value may be "none" — that is acceptable)
   const artifactsMatch = text.match(/^\s*ARTIFACTS:\s*(.+)/m);
-  if (!artifactsMatch || !artifactsMatch[1].trim()) {
+  if (!artifactsMatch?.[1].trim()) {
     missingFields.push('ARTIFACTS');
   }
 
   // VALIDATION: non-empty
   const validationMatch = text.match(/^\s*VALIDATION:\s*(.+)/m);
-  if (!validationMatch || !validationMatch[1].trim()) {
+  if (!validationMatch?.[1].trim()) {
     missingFields.push('VALIDATION');
   }
 


### PR DESCRIPTION
## Summary

- Removes the `isdigit()` coercion branch from `_require_int_item_id` in `artifact_provider.py`
- Any string reaching this guard is now a hard routing error (raises `TypeError` immediately)
- Adds 11 unit tests covering all int passthrough cases and all string-rejection cases, including the previously-coerced numeric string path

## Root cause (#2438)

The `isdigit()` branch was added as a defensive workaround for MCP tool parameters annotated `str | int` (string-first). With string-first union order, Pydantic could deliver numeric inputs as `str`, so the coercion papered over a routing failure silently.

The MCP tool parameters (`artifact_register`, `artifact_list`, `artifact_get`, `artifact_read`) were already fixed to `int | str` (integer-first). With that in place, Pydantic delivers numeric inputs as `int` at the MCP boundary. The `isdigit()` branch is now dead code — and keeping it weakens the type contract by accepting strings that should never reach a GitHub/GitLab provider.

## What changed

**`backlog_core/artifact_provider.py`** — `_require_int_item_id`:
- Before: string input with `isdigit()=True` was silently coerced to `int`
- After: any `str` input raises `TypeError` — no coercion, no exceptions for numeric strings

**`tests/test_require_int_item_id.py`** (new):
- `TestRequireIntItemIdIntInputs`: 5 cases — positive, one, large, zero, negative all pass through
- `TestRequireIntItemIdStringInputs`: 6 cases — beads nanoid, numeric string, empty string, zero string, class name in message, BeadsArtifactProvider mention in message

## Test plan

- [x] `uv run pytest tests/test_require_int_item_id.py` — 11 passed
- [x] `uv run pytest tests/test_artifact_provider_local.py tests/test_artifact_provider_fallback.py tests/test_artifact_content_storage.py` — 67 passed, no regressions
- [x] `uv run prek run --files ...` — all hooks pass including `ty check`

https://claude.ai/code/session_019Qy9HfAU22VhRqoERC4Uhy

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qy9HfAU22VhRqoERC4Uhy)_