### PR TITLE
fix(dasel): migrate -f flag to stdin pattern for dasel v3 compatibility

### DIFF
--- a/plugins/dasel/.claude-plugin/plugin.json
+++ b/plugins/dasel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dasel",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Query, transform, and convert structured data files (JSON, YAML, TOML, XML, CSV, HCL, INI) using dasel v3. Provides reference syntax, exploration workflows, transformation patterns, and cross-platform installation.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/dasel/README.md
+++ b/plugins/dasel/README.md
@@ -125,7 +125,7 @@ cat config.yaml | dasel -i yaml 'server.port'
 cat data.json | dasel -i json 'users.[0].name'
 
 # Update a value (safe: writes to temp file then renames)
-dasel put -f config.yaml -o config.yaml -t string 'server.host' 'newhost'
+cat config.yaml | dasel -i yaml --root 'server.host = "newhost"' > config_tmp.yaml && mv config_tmp.yaml config.yaml
 
 # Convert YAML to JSON
 cat config.yaml | dasel -i yaml -o json > config.json
@@ -168,7 +168,7 @@ Claude: The database host is "db.example.com".
 
 ```
 You: Update the server port to 9090 in config.yaml
-Claude: [dasel put -f config.yaml -t int 'server.port' 9090]
+Claude: [cat config.yaml | dasel -i yaml --root 'server.port = 9090' > config_tmp.yaml && mv config_tmp.yaml config.yaml]
 Claude: Done. server.port is now 9090.
 ```
 

--- a/plugins/dasel/README.md
+++ b/plugins/dasel/README.md
@@ -119,10 +119,10 @@ Available options:
 
 ```bash
 # Read a value
-dasel -f config.yaml 'server.port'
+cat config.yaml | dasel -i yaml 'server.port'
 
 # Read from JSON
-dasel -f data.json -i json 'users.[0].name'
+cat data.json | dasel -i json 'users.[0].name'
 
 # Update a value (safe: writes to temp file then renames)
 dasel put -f config.yaml -o config.yaml -t string 'server.host' 'newhost'
@@ -134,13 +134,13 @@ cat config.yaml | dasel -i yaml -o json > config.json
 cat data.json | dasel -i json -o toml > data.toml
 
 # List all top-level keys
-dasel -f config.yaml 'all()'
+cat config.yaml | dasel -i yaml 'all()'
 
 # Count array elements
-dasel -f data.json 'len(items)'
+cat data.json | dasel -i json 'len(items)'
 
 # Filter array by condition
-dasel -f data.json 'items.filter(type = "admin").map(name)'
+cat data.json | dasel -i json 'items.filter(type = "admin").map(name)'
 ```
 
 ## Example
@@ -162,7 +162,7 @@ Claude: [reads config.yaml into context, writes Python to parse and rewrite YAML
 
 ```
 You: What database host is configured in config.yaml?
-Claude: [runs: dasel -f config.yaml 'database.host']
+Claude: [runs: cat config.yaml | dasel -i yaml 'database.host']
 Claude: The database host is "db.example.com".
 ```
 
@@ -174,7 +174,7 @@ Claude: Done. server.port is now 9090.
 
 ```
 You: How many beans are in chaosrouter_beans.xml?
-Claude: [dasel -f chaosrouter_beans.xml -i xml 'len(beans.bean)']
+Claude: [cat chaosrouter_beans.xml | dasel -i xml 'len(beans.bean)']
 Claude: chaosrouter_beans.xml contains 47 beans.
 ```
 

--- a/plugins/dasel/agents/dasel-guide.md
+++ b/plugins/dasel/agents/dasel-guide.md
@@ -32,13 +32,13 @@ Always give complete commands. Never describe an approach without a concrete com
 
 ```bash
 # Top-level keys
-dasel -f data.json 'keys($this)'
+cat data.json | dasel -i json 'keys($this)'
 
 # Children of a specific node
-dasel -f config.yaml 'root.keys($this)'
+cat config.yaml | dasel -i yaml 'root.keys($this)'
 
 # Keys at any node including XML element attributes
-dasel -f file.xml -i xml 'root.element[0].keys($this)'
+cat file.xml | dasel -i xml 'root.element[0].keys($this)'
 ```
 
 `keys($this)` returns all child element names and attribute names at the current node.
@@ -49,10 +49,10 @@ Recursive descent finds at any depth without knowing the full path:
 
 ```bash
 # Find all elements named "item" at any depth
-dasel -f data.json '..item'
+cat data.json | dasel -i json '..item'
 
 # Find any node where a field exists
-dasel -f file.xml -i xml 'search(has("-name"))'
+cat file.xml | dasel -i xml 'search(has("-name"))'
 ```
 
 `..elementName` descends recursively through all levels. `search(predicate)` finds any node where the predicate matches.
@@ -61,10 +61,10 @@ dasel -f file.xml -i xml 'search(has("-name"))'
 
 ```bash
 # Extract "name" from every element in a collection
-dasel -f data.json 'items.map(name)'
+cat data.json | dasel -i json 'items.map(name)'
 
 # Extract an XML attribute from every matching element
-dasel -f file.xml -i xml '..element.map("-id")'
+cat file.xml | dasel -i xml '..element.map("-id")'
 ```
 
 XML attributes are accessed with a `-` prefix in friendly mode. The `id` attribute is `-id`.
@@ -73,13 +73,13 @@ XML attributes are accessed with a `-` prefix in friendly mode. The `id` attribu
 
 ```bash
 # Filter by exact value
-dasel -f data.json 'items.filter(status == "active").map(name)'
+cat data.json | dasel -i json 'items.filter(status == "active").map(name)'
 
 # Filter by pattern match
-dasel -f file.xml -i xml 'root.items.filter(-class ~ ".*Service.*").map("-id")'
+cat file.xml | dasel -i xml 'root.items.filter(-class ~ ".*Service.*").map("-id")'
 
 # Filter where a child element exists matching a condition
-dasel -f file.xml -i xml 'root.items.filter(child.filter(-name == "key").len($this) > 0).map("-id")'
+cat file.xml | dasel -i xml 'root.items.filter(child.filter(-name == "key").len($this) > 0).map("-id")'
 ```
 
 Pattern for child-existence filter: `parentCollection.filter(childElement.filter(condition).len($this) > 0)`.
@@ -88,10 +88,10 @@ Pattern for child-existence filter: `parentCollection.filter(childElement.filter
 
 ```bash
 # Count all elements at any depth
-dasel -f file.xml -i xml 'len(..elementName)'
+cat file.xml | dasel -i xml 'len(..elementName)'
 
 # Count after filtering
-dasel -f data.json 'len(items.filter(active == true))'
+cat data.json | dasel -i json 'len(items.filter(active == true))'
 ```
 
 ### "How do I diff two files to find what changed?"
@@ -100,8 +100,8 @@ Dasel extracts the data; shell tooling handles the diff:
 
 ```bash
 # Extract a field from both files, sort, then diff
-dasel -f file1.json 'items.map(name)' | sort > /tmp/file1_names.txt
-dasel -f file2.json 'items.map(name)' | sort > /tmp/file2_names.txt
+cat file1.json | dasel -i json 'items.map(name)' | sort > /tmp/file1_names.txt
+cat file2.json | dasel -i json 'items.map(name)' | sort > /tmp/file2_names.txt
 diff /tmp/file1_names.txt /tmp/file2_names.txt
 ```
 
@@ -109,8 +109,8 @@ diff /tmp/file1_names.txt /tmp/file2_names.txt
 
 ```bash
 # <element id="foo">some text</element>
-dasel -f file.xml -i xml 'root.element[0].-id'     # → foo
-dasel -f file.xml -i xml 'root.element[0].#text'   # → some text
+cat file.xml | dasel -i xml 'root.element[0].-id'     # → foo
+cat file.xml | dasel -i xml 'root.element[0].#text'   # → some text
 ```
 
 Attributes use `-` prefix. Text content uses `#text`.
@@ -120,41 +120,41 @@ Attributes use `-` prefix. Text content uses `#text`.
 Dasel friendly mode strips namespace prefixes from element names. If namespace prefixes cause selector failures, use structured mode:
 
 ```bash
-dasel -f file.xml -i xml --read-flag xml-mode=structured 'root.element[0]'
+cat file.xml | dasel -i xml --read-flag xml-mode=structured 'root.element[0]'
 ```
 
 ## XML Selector Reference
 
 ```bash
 # Navigate to element
-dasel -f file.xml -i xml 'root.child.grandchild'
+cat file.xml | dasel -i xml 'root.child.grandchild'
 
 # Attribute access (- prefix)
-dasel -f file.xml -i xml 'root.element.-id'
+cat file.xml | dasel -i xml 'root.element.-id'
 
 # Text content
-dasel -f file.xml -i xml 'root.element.#text'
+cat file.xml | dasel -i xml 'root.element.#text'
 
 # Array indexing (zero-based)
-dasel -f file.xml -i xml 'root.element[0]'
+cat file.xml | dasel -i xml 'root.element[0]'
 
 # Recursive descent
-dasel -f file.xml -i xml '..elementName'
+cat file.xml | dasel -i xml '..elementName'
 
 # Filter by attribute value
-dasel -f file.xml -i xml 'root.element.filter(-id == "target")'
+cat file.xml | dasel -i xml 'root.element.filter(-id == "target")'
 
 # Filter by attribute pattern
-dasel -f file.xml -i xml 'root.element.filter(-class ~ ".*Pattern.*")'
+cat file.xml | dasel -i xml 'root.element.filter(-class ~ ".*Pattern.*")'
 
 # Map field across all matching elements
-dasel -f file.xml -i xml 'root.element.map("-name")'
+cat file.xml | dasel -i xml 'root.element.map("-name")'
 
 # Count matching elements
-dasel -f file.xml -i xml 'len(..elementName)'
+cat file.xml | dasel -i xml 'len(..elementName)'
 
 # Check attribute existence
-dasel -f file.xml -i xml 'root.element.filter(has("-id"))'
+cat file.xml | dasel -i xml 'root.element.filter(has("-id"))'
 ```
 
 ## v3 vs v2 Differences

--- a/plugins/dasel/agents/data-analyst.md
+++ b/plugins/dasel/agents/data-analyst.md
@@ -33,21 +33,21 @@ State the full plan before executing the first step.
 
 ```bash
 # Top-level keys
-dasel -f data.json 'keys($this)'
+cat data.json | dasel -i json 'keys($this)'
 
 # Enumerate all elements of a type
-dasel -f config.yaml 'root.items.map(name)'
+cat config.yaml | dasel -i yaml 'root.items.map(name)'
 
 # Count occurrences
-dasel -f file.xml -i xml 'len(..elementName)'
+cat file.xml | dasel -i xml 'len(..elementName)'
 ```
 
 ### Cross-File Comparison
 
 ```bash
 # Extract a field from two files, sort, diff
-dasel -f file1.json 'items.map(name)' | sort > /tmp/file1_names.txt
-dasel -f file2.json 'items.map(name)' | sort > /tmp/file2_names.txt
+cat file1.json | dasel -i json 'items.map(name)' | sort > /tmp/file1_names.txt
+cat file2.json | dasel -i json 'items.map(name)' | sort > /tmp/file2_names.txt
 diff /tmp/file1_names.txt /tmp/file2_names.txt > /tmp/comparison.txt
 cat /tmp/comparison.txt
 ```
@@ -58,7 +58,7 @@ cat /tmp/comparison.txt
 # Run the same query across all matching files
 for f in $(fdfind -e xml .); do
   echo "=== $f ===" >> /tmp/all_results.txt
-  dasel -f "$f" -i xml '<selector>' >> /tmp/all_results.txt 2>/dev/null
+  cat "$f" | dasel -i xml '<selector>' >> /tmp/all_results.txt 2>/dev/null
 done
 ```
 
@@ -66,23 +66,23 @@ done
 
 ```bash
 # Filter by field value
-dasel -f data.json 'items.filter(status == "active").map(name)'
+cat data.json | dasel -i json 'items.filter(status == "active").map(name)'
 
 # Filter by pattern
-dasel -f file.xml -i xml 'root.items.filter(-class ~ ".*Service.*").map("-id")'
+cat file.xml | dasel -i xml 'root.items.filter(-class ~ ".*Service.*").map("-id")'
 
 # Filter where child matches condition
-dasel -f file.xml -i xml 'root.items.filter(child.filter(-name == "key").len($this) > 0).map("-id")'
+cat file.xml | dasel -i xml 'root.items.filter(child.filter(-name == "key").len($this) > 0).map("-id")'
 ```
 
 ### Recursive Search
 
 ```bash
 # Find all elements of a type at any depth
-dasel -f file.xml -i xml '..elementName.map("-name")'
+cat file.xml | dasel -i xml '..elementName.map("-name")'
 
 # Find all nodes where a field exists
-dasel -f file.xml -i xml 'search(has("-platform")).map("-platform")'
+cat file.xml | dasel -i xml 'search(has("-platform")).map("-platform")'
 ```
 
 ## Cross-File Analysis Protocol
@@ -96,8 +96,8 @@ When analysis spans multiple files:
 
 ```bash
 # Pattern for reproducible cross-file analysis
-dasel -f file1.xml -i xml '<selector>' > /tmp/file1_result.txt
-dasel -f file2.xml -i xml '<selector>' > /tmp/file2_result.txt
+cat file1.xml | dasel -i xml '<selector>' > /tmp/file1_result.txt
+cat file2.xml | dasel -i xml '<selector>' > /tmp/file2_result.txt
 diff /tmp/file1_result.txt /tmp/file2_result.txt > /tmp/comparison.txt
 cat /tmp/comparison.txt
 ```

--- a/plugins/dasel/agents/data-explorer.md
+++ b/plugins/dasel/agents/data-explorer.md
@@ -22,7 +22,7 @@ You are a fast read-only exploration agent for querying structured data files us
 
 1. Receive file path + question (or exploration request)
 2. Construct a dasel v3 selector targeting the requested data
-3. Execute via `dasel -f <file> [-i <format>] '<selector>'`
+3. Execute via `cat <file> | dasel -i <format> '<selector>'`
 4. Return the exact dasel command used and its output
 
 Always show the exact command before showing output. For XML files, always pass `-i xml` explicitly.
@@ -31,35 +31,35 @@ Always show the exact command before showing output. For XML files, always pass 
 
 ```bash
 # Top-level keys
-dasel -f data.json 'keys($this)'
+cat data.json | dasel -i json 'keys($this)'
 
 # Children of a specific element
-dasel -f config.yaml 'root.keys($this)'
+cat config.yaml | dasel -i yaml 'root.keys($this)'
 
 # Keys at any node
-dasel -f file.xml -i xml 'root.element[0].keys($this)'
+cat file.xml | dasel -i xml 'root.element[0].keys($this)'
 ```
 
 ## Common Query Patterns
 
 ```bash
 # Navigate a path
-dasel -f config.yaml 'server.host'
+cat config.yaml | dasel -i yaml 'server.host'
 
 # Array element by index
-dasel -f data.json 'items[0]'
+cat data.json | dasel -i json 'items[0]'
 
 # Recursive search for element name at any depth
-dasel -f file.xml -i xml '..elementName'
+cat file.xml | dasel -i xml '..elementName'
 
 # Filter by attribute or field value
-dasel -f file.xml -i xml 'root.items.filter(-id == "target")'
+cat file.xml | dasel -i xml 'root.items.filter(-id == "target")'
 
 # Map a field across all elements in a collection
-dasel -f data.json 'items.map(name)'
+cat data.json | dasel -i json 'items.map(name)'
 
 # Count elements
-dasel -f file.xml -i xml 'len(..elementName)'
+cat file.xml | dasel -i xml 'len(..elementName)'
 ```
 
 ## XML Mode Notes
@@ -70,8 +70,8 @@ dasel -f file.xml -i xml 'len(..elementName)'
 
 ```bash
 # Element with both attribute and text content
-dasel -f file.xml -i xml 'root.element[0].-id'
-dasel -f file.xml -i xml 'root.element[0].#text'
+cat file.xml | dasel -i xml 'root.element[0].-id'
+cat file.xml | dasel -i xml 'root.element[0].#text'
 ```
 
 ## Error Handling
@@ -94,19 +94,19 @@ Common errors:
 
 <example>
 User: What top-level keys does this JSON file have?
-Action: `dasel -f data.json 'keys($this)'`
+Action: `cat data.json | dasel -i json 'keys($this)'`
 Return: The command and its output listing all top-level keys.
 </example>
 
 <example>
 User: Find all name values in config.yaml
-Action: `dasel -f config.yaml '..name'`
+Action: `cat config.yaml | dasel -i yaml '..name'`
 Return: The command and the list of matching values.
 </example>
 
 <example>
 User: List all elements at the root of this XML file
-Action: `dasel -f file.xml -i xml 'keys($this)'`
+Action: `cat file.xml | dasel -i xml 'keys($this)'`
 Return: The command and all root element names.
 </example>
 

--- a/plugins/dasel/skills/data-exploration/SKILL.md
+++ b/plugins/dasel/skills/data-exploration/SKILL.md
@@ -38,7 +38,7 @@ cat mystery_file | dasel -i json 'keys($this)'
 ### Step 2 — Top-Level Keys
 
 ```bash
-dasel -f config.yaml 'keys($this)'
+cat config.yaml | dasel -i yaml 'keys($this)'
 ```
 
 Output: array of top-level key names. This is always the first exploration command.
@@ -48,7 +48,7 @@ Output: array of top-level key names. This is always the first exploration comma
 For small files (configs, manifests), dump the full document:
 
 ```bash
-dasel -f config.yaml
+cat config.yaml | dasel -i yaml
 ```
 
 For large files, skip to Step 4.
@@ -58,15 +58,15 @@ For large files, skip to Step 4.
 Navigate level by level:
 
 ```bash
-dasel -f config.yaml 'server'
-dasel -f config.yaml 'keys(server)'
-dasel -f config.yaml 'keys(server.logging)'
+cat config.yaml | dasel -i yaml 'server'
+cat config.yaml | dasel -i yaml 'keys(server)'
+cat config.yaml | dasel -i yaml 'keys(server.logging)'
 ```
 
 Recursive key discovery across all depths:
 
 ```bash
-dasel -f config.yaml '..keys($this)'
+cat config.yaml | dasel -i yaml '..keys($this)'
 ```
 
 ### Step 5 — Array Sampling
@@ -74,13 +74,13 @@ dasel -f config.yaml '..keys($this)'
 Preview first few elements without loading entire array:
 
 ```bash
-dasel -f data.json 'items[0:3]'
+cat data.json | dasel -i json 'items[0:3]'
 ```
 
 Single element inspection:
 
 ```bash
-dasel -f data.json 'items[0]'
+cat data.json | dasel -i json 'items[0]'
 ```
 
 ### Step 6 — Type Inspection
@@ -88,8 +88,8 @@ dasel -f data.json 'items[0]'
 Determine the type of any node:
 
 ```bash
-dasel -f data.json 'typeOf(settings)'
-dasel -f data.json 'typeOf(items[0].count)'
+cat data.json | dasel -i json 'typeOf(settings)'
+cat data.json | dasel -i json 'typeOf(items[0].count)'
 ```
 
 Return values: `"string"`, `"array"`, `"bool"`, `"null"`, `"int"`, `"float"`
@@ -99,8 +99,8 @@ Return values: `"string"`, `"array"`, `"bool"`, `"null"`, `"int"`, `"float"`
 Once path is known, extract specific values:
 
 ```bash
-dasel -f config.yaml 'database.connection.host'
-dasel -f data.json 'users[0].email'
+cat config.yaml | dasel -i yaml 'database.connection.host'
+cat data.json | dasel -i json 'users[0].email'
 ```
 
 ## Exploration Patterns
@@ -110,9 +110,9 @@ dasel -f data.json 'users[0].email'
 Start at root, enumerate keys at each level before going deeper:
 
 ```bash
-dasel -f file.json 'keys($this)'           # Level 0
-dasel -f file.json 'keys(metadata)'         # Level 1
-dasel -f file.json 'keys(metadata.labels)'  # Level 2
+cat file.json | dasel -i json 'keys($this)'           # Level 0
+cat file.json | dasel -i json 'keys(metadata)'         # Level 1
+cat file.json | dasel -i json 'keys(metadata.labels)'  # Level 2
 ```
 
 ### Search-Based Exploration (Large Files)
@@ -121,20 +121,20 @@ When the file is too large for manual traversal, use `search()` with predicates:
 
 ```bash
 # Find all objects containing a specific key
-dasel -f data.json 'search(has("email"))'
+cat data.json | dasel -i json 'search(has("email"))'
 
 # Find all objects with both "id" and "name" keys
-dasel -f data.json 'search(has("id") && has("name"))'
+cat data.json | dasel -i json 'search(has("id") && has("name"))'
 
 # Find nodes where a value matches
-dasel -f data.json 'search($this == 42)'
+cat data.json | dasel -i json 'search($this == 42)'
 ```
 
 ### Count Elements
 
 ```bash
-dasel -f data.json 'len(items)'
-dasel -f data.json 'len(keys($this))'
+cat data.json | dasel -i json 'len(items)'
+cat data.json | dasel -i json 'len(keys($this))'
 ```
 
 ### Unique Value Discovery
@@ -142,7 +142,7 @@ dasel -f data.json 'len(keys($this))'
 Extract a field from all array elements, then deduplicate in shell:
 
 ```bash
-dasel -f data.json 'items.map(category)' | dasel -i json '$this...' | sort -u
+cat data.json | dasel -i json 'items.map(category)' | dasel -i json '$this...' | sort -u
 ```
 
 ### Recursive Descent
@@ -150,13 +150,13 @@ dasel -f data.json 'items.map(category)' | dasel -i json '$this...' | sort -u
 Find all values for a key name at any depth:
 
 ```bash
-dasel -f data.json '..name'
+cat data.json | dasel -i json '..name'
 ```
 
 Get first element of every nested array:
 
 ```bash
-dasel -f data.json '..[0]'
+cat data.json | dasel -i json '..[0]'
 ```
 
 ## Format-Specific Recipes

--- a/plugins/dasel/skills/data-exploration/references/format-recipes.md
+++ b/plugins/dasel/skills/data-exploration/references/format-recipes.md
@@ -22,60 +22,60 @@ JSON is dasel's native format. All operations work without caveats.
 
 ```bash
 # Top-level keys
-dasel -f data.json 'keys($this)'
+cat data.json | dasel -i json 'keys($this)'
 
 # Nested object keys
-dasel -f data.json 'keys(config.database)'
+cat data.json | dasel -i json 'keys(config.database)'
 ```
 
 ### Inspect Arrays of Objects
 
 ```bash
 # Preview first element to understand object shape
-dasel -f data.json 'users[0]'
+cat data.json | dasel -i json 'users[0]'
 
 # Keys of first element (reveals schema of array items)
-dasel -f data.json 'keys(users[0])'
+cat data.json | dasel -i json 'keys(users[0])'
 
 # Count elements
-dasel -f data.json 'len(users)'
+cat data.json | dasel -i json 'len(users)'
 
 # Sample first 3 elements
-dasel -f data.json 'users[0:3]'
+cat data.json | dasel -i json 'users[0:3]'
 ```
 
 ### Search Nested Objects
 
 ```bash
 # Find all objects containing "email" at any depth
-dasel -f data.json 'search(has("email"))'
+cat data.json | dasel -i json 'search(has("email"))'
 
 # Find objects where "status" equals "active"
-dasel -f data.json 'search(status == "active")'
+cat data.json | dasel -i json 'search(status == "active")'
 
 # Combined predicate
-dasel -f data.json 'search(has("id") && has("name"))'
+cat data.json | dasel -i json 'search(has("id") && has("name"))'
 ```
 
 ### Extract Specific Fields from Arrays
 
 ```bash
 # Get all names from users array
-dasel -f data.json 'users.map(name)'
+cat data.json | dasel -i json 'users.map(name)'
 
 # Get all unique roles
-dasel -f data.json 'users.map(role)' | dasel -i json '$this...' | sort -u
+cat data.json | dasel -i json 'users.map(role)' | dasel -i json '$this...' | sort -u
 ```
 
 ### Mixed-Type Detection
 
 ```bash
 # Check type of ambiguous field
-dasel -f data.json 'typeOf(config.port)'
+cat data.json | dasel -i json 'typeOf(config.port)'
 # Returns: "int", "string", "float", etc.
 
 # Check if field is array or object
-dasel -f data.json 'typeOf(metadata)'
+cat data.json | dasel -i json 'typeOf(metadata)'
 ```
 
 ---
@@ -88,46 +88,46 @@ YAML supports anchors, multi-document files, and deep nesting common in Kubernet
 
 ```bash
 # Top-level keys
-dasel -f config.yaml 'keys($this)'
+cat config.yaml | dasel -i yaml 'keys($this)'
 
 # Deeply nested config (common in Kubernetes)
-dasel -f deployment.yaml 'keys(spec.template.spec)'
+cat deployment.yaml | dasel -i yaml 'keys(spec.template.spec)'
 ```
 
 ### Deep Nesting Navigation
 
 ```bash
 # Step through Kubernetes manifest
-dasel -f deployment.yaml 'keys($this)'
+cat deployment.yaml | dasel -i yaml 'keys($this)'
 # -> ["apiVersion", "kind", "metadata", "spec"]
 
-dasel -f deployment.yaml 'keys(spec)'
+cat deployment.yaml | dasel -i yaml 'keys(spec)'
 # -> ["replicas", "selector", "template"]
 
-dasel -f deployment.yaml 'spec.template.spec.containers[0].image'
+cat deployment.yaml | dasel -i yaml 'spec.template.spec.containers[0].image'
 ```
 
 ### Inspect Nested Arrays
 
 ```bash
 # List container names in a pod spec
-dasel -f deployment.yaml 'spec.template.spec.containers.map(name)'
+cat deployment.yaml | dasel -i yaml 'spec.template.spec.containers.map(name)'
 
 # Count containers
-dasel -f deployment.yaml 'len(spec.template.spec.containers)'
+cat deployment.yaml | dasel -i yaml 'len(spec.template.spec.containers)'
 
 # Get all environment variable names from first container
-dasel -f deployment.yaml 'spec.template.spec.containers[0].env.map(name)'
+cat deployment.yaml | dasel -i yaml 'spec.template.spec.containers[0].env.map(name)'
 ```
 
 ### Recursive Key Search
 
 ```bash
 # Find all keys named "image" at any depth
-dasel -f deployment.yaml '..image'
+cat deployment.yaml | dasel -i yaml '..image'
 
 # Find all objects with a "name" field
-dasel -f deployment.yaml 'search(has("name"))'
+cat deployment.yaml | dasel -i yaml 'search(has("name"))'
 ```
 
 ---
@@ -140,38 +140,38 @@ TOML uses tables (sections) and arrays of tables. Common in Rust (Cargo.toml), P
 
 ```bash
 # Top-level tables and keys
-dasel -f pyproject.toml 'keys($this)'
+cat pyproject.toml | dasel -i toml 'keys($this)'
 
 # Nested tables
-dasel -f Cargo.toml 'keys(dependencies)'
-dasel -f pyproject.toml 'keys(tool.ruff)'
+cat Cargo.toml | dasel -i toml 'keys(dependencies)'
+cat pyproject.toml | dasel -i toml 'keys(tool.ruff)'
 ```
 
 ### Inspect Arrays of Tables
 
 ```bash
 # pyproject.toml optional-dependencies or similar array sections
-dasel -f Cargo.toml 'keys(bin[0])'
-dasel -f Cargo.toml 'len(bin)'
+cat Cargo.toml | dasel -i toml 'keys(bin[0])'
+cat Cargo.toml | dasel -i toml 'len(bin)'
 ```
 
 ### Value Extraction
 
 ```bash
 # Package metadata
-dasel -f pyproject.toml 'project.name'
-dasel -f pyproject.toml 'project.version'
+cat pyproject.toml | dasel -i toml 'project.name'
+cat pyproject.toml | dasel -i toml 'project.version'
 
 # Dependency list
-dasel -f pyproject.toml 'keys(project.dependencies)'
+cat pyproject.toml | dasel -i toml 'keys(project.dependencies)'
 ```
 
 ### Type Checking
 
 ```bash
 # Verify field types (TOML distinguishes int, float, string, bool, datetime)
-dasel -f config.toml 'typeOf(server.port)'
-dasel -f config.toml 'typeOf(server.debug)'
+cat config.toml | dasel -i toml 'typeOf(server.port)'
+cat config.toml | dasel -i toml 'typeOf(server.debug)'
 ```
 
 ---
@@ -184,21 +184,21 @@ XML has elements, attributes, and text content. Dasel represents these as nested
 
 ```bash
 # Top-level element (XML has single root)
-dasel -f data.xml 'keys($this)'
+cat data.xml | dasel -i xml 'keys($this)'
 
 # Child elements
-dasel -f pom.xml 'keys(project)'
-dasel -f pom.xml 'keys(project.dependencies)'
+cat pom.xml | dasel -i xml 'keys(project)'
+cat pom.xml | dasel -i xml 'keys(project.dependencies)'
 ```
 
 ### Inspect Repeated Elements
 
 ```bash
 # Count dependency entries in Maven POM
-dasel -f pom.xml 'len(project.dependencies.dependency)'
+cat pom.xml | dasel -i xml 'len(project.dependencies.dependency)'
 
 # First dependency
-dasel -f pom.xml 'project.dependencies.dependency[0]'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency[0]'
 ```
 
 ### Attribute Access
@@ -207,14 +207,14 @@ XML attributes are accessible as properties on the element. The exact representa
 
 ```bash
 # View full element to see attribute representation
-dasel -f data.xml 'root.element[0]'
+cat data.xml | dasel -i xml 'root.element[0]'
 ```
 
 ### Recursive Search
 
 ```bash
 # Find all elements with a specific child
-dasel -f data.xml 'search(has("version"))'
+cat data.xml | dasel -i xml 'search(has("version"))'
 ```
 
 ---
@@ -227,33 +227,33 @@ CSV files are represented as arrays of objects (header row becomes keys).
 
 ```bash
 # Get column names from first row
-dasel -f data.csv 'keys($this[0])'
+cat data.csv | dasel -i csv 'keys($this[0])'
 ```
 
 ### Row Count
 
 ```bash
-dasel -f data.csv 'len($this)'
+cat data.csv | dasel -i csv 'len($this)'
 ```
 
 ### Sample Rows
 
 ```bash
 # First row (as object with column keys)
-dasel -f data.csv '$this[0]'
+cat data.csv | dasel -i csv '$this[0]'
 
 # First 3 rows
-dasel -f data.csv '$this[0:3]'
+cat data.csv | dasel -i csv '$this[0:3]'
 ```
 
 ### Column Sampling
 
 ```bash
 # Extract single column values
-dasel -f data.csv '$this.map(name)'
+cat data.csv | dasel -i csv '$this.map(name)'
 
 # Unique values in a column
-dasel -f data.csv '$this.map(category)' | dasel -i json '$this...' | sort -u
+cat data.csv | dasel -i csv '$this.map(category)' | dasel -i json '$this...' | sort -u
 ```
 
 ### Type Inspection
@@ -261,7 +261,7 @@ dasel -f data.csv '$this.map(category)' | dasel -i json '$this...' | sort -u
 CSV values are typically strings. Check with:
 
 ```bash
-dasel -f data.csv 'typeOf($this[0].age)'
+cat data.csv | dasel -i csv 'typeOf($this[0].age)'
 ```
 
 ---
@@ -274,7 +274,7 @@ HCL (HashiCorp Configuration Language) uses blocks with labels. Common in Terraf
 
 ```bash
 # Top-level block types
-dasel -f main.tf 'keys($this)'
+cat main.tf | dasel -i hcl 'keys($this)'
 # -> ["resource", "variable", "output", "provider"]
 ```
 
@@ -282,29 +282,29 @@ dasel -f main.tf 'keys($this)'
 
 ```bash
 # Resource types
-dasel -f main.tf 'keys(resource)'
+cat main.tf | dasel -i hcl 'keys(resource)'
 
 # Specific resource
-dasel -f main.tf 'resource.aws_instance'
-dasel -f main.tf 'keys(resource.aws_instance)'
+cat main.tf | dasel -i hcl 'resource.aws_instance'
+cat main.tf | dasel -i hcl 'keys(resource.aws_instance)'
 ```
 
 ### Nested Block Inspection
 
 ```bash
 # Terraform resource attributes
-dasel -f main.tf 'resource.aws_instance.web'
-dasel -f main.tf 'keys(resource.aws_instance.web)'
+cat main.tf | dasel -i hcl 'resource.aws_instance.web'
+cat main.tf | dasel -i hcl 'keys(resource.aws_instance.web)'
 ```
 
 ### Variable Discovery
 
 ```bash
 # List all variable names
-dasel -f variables.tf 'keys(variable)'
+cat variables.tf | dasel -i hcl 'keys(variable)'
 
 # Get variable default value
-dasel -f variables.tf 'variable.region.default'
+cat variables.tf | dasel -i hcl 'variable.region.default'
 ```
 
 ---
@@ -317,29 +317,29 @@ INI files have sections and key-value pairs. Common in systemd, PHP, Git config.
 
 ```bash
 # List all sections
-dasel -f config.ini 'keys($this)'
+cat config.ini | dasel -i ini 'keys($this)'
 ```
 
 ### Key Listing Within Section
 
 ```bash
 # Keys in a specific section
-dasel -f config.ini 'keys(database)'
-dasel -f config.ini 'keys(server)'
+cat config.ini | dasel -i ini 'keys(database)'
+cat config.ini | dasel -i ini 'keys(server)'
 ```
 
 ### Value Extraction
 
 ```bash
-dasel -f config.ini 'database.host'
-dasel -f config.ini 'server.port'
+cat config.ini | dasel -i ini 'database.host'
+cat config.ini | dasel -i ini 'server.port'
 ```
 
 ### Full Section Dump
 
 ```bash
 # View all keys and values in a section
-dasel -f config.ini 'database'
+cat config.ini | dasel -i ini 'database'
 ```
 
 ---

--- a/plugins/dasel/skills/data-transformation/SKILL.md
+++ b/plugins/dasel/skills/data-transformation/SKILL.md
@@ -25,19 +25,19 @@ Activate this skill when:
 
 ```bash
 # WRONG — destroys input
-dasel -f config.yaml --root 'port = 9090' > config.yaml
+cat config.yaml | dasel -i yaml --root 'port = 9090' > config.yaml
 
 # CORRECT — write to temp, then rename
-dasel -f config.yaml --root 'port = 9090' > config_tmp.yaml && mv config_tmp.yaml config.yaml
+cat config.yaml | dasel -i yaml --root 'port = 9090' > config_tmp.yaml && mv config_tmp.yaml config.yaml
 ```
 
 **Always verify before overwriting.** Preview the transformation output first, then redirect:
 
 ```bash
 # Preview
-dasel -f config.yaml --root 'server.port = 9090'
+cat config.yaml | dasel -i yaml --root 'server.port = 9090'
 # Apply
-dasel -f config.yaml --root 'server.port = 9090' > config_tmp.yaml && mv config_tmp.yaml config.yaml
+cat config.yaml | dasel -i yaml --root 'server.port = 9090' > config_tmp.yaml && mv config_tmp.yaml config.yaml
 ```
 
 </constraints>
@@ -50,7 +50,7 @@ In dasel v3, `put` and `delete` subcommands do not exist. All modifications use 
 
 ```bash
 # Output full document with one field changed
-dasel -f config.yaml --root 'server.port = 9090'
+cat config.yaml | dasel -i yaml --root 'server.port = 9090'
 
 # Numeric, boolean, and string assignments
 echo '{"count": 1}' | dasel -i json --root 'count = 42'
@@ -61,18 +61,18 @@ echo '{"name": "old"}' | dasel -i json --root 'name = "new"'
 ### Set Nested Values
 
 ```bash
-dasel -f config.yaml --root 'database.connection.host = "db.example.com"'
-dasel -f config.yaml --root 'database.connection.port = 5432'
+cat config.yaml | dasel -i yaml --root 'database.connection.host = "db.example.com"'
+cat config.yaml | dasel -i yaml --root 'database.connection.port = 5432'
 ```
 
 ## In-Place Modification (Safe Pattern)
 
 ```bash
 # Single field update
-dasel -f config.yaml --root 'server.port = 9090' > config_tmp.yaml && mv config_tmp.yaml config.yaml
+cat config.yaml | dasel -i yaml --root 'server.port = 9090' > config_tmp.yaml && mv config_tmp.yaml config.yaml
 
 # Multiple fields — chain with semicolons
-dasel -f config.yaml --root 'server.port = 9090; server.host = "0.0.0.0"' > config_tmp.yaml && mv config_tmp.yaml config.yaml
+cat config.yaml | dasel -i yaml --root 'server.port = 9090; server.host = "0.0.0.0"' > config_tmp.yaml && mv config_tmp.yaml config.yaml
 ```
 
 ## Format Conversion
@@ -106,17 +106,17 @@ echo '[1,2,3]' | dasel -i json --root '[$this..., 4]'
 # Output: [1, 2, 3, 4]
 
 # Append object to array
-dasel -f data.json --root 'items = [$root.items..., {"name": "new", "value": 42}]'
+cat data.json | dasel -i json --root 'items = [$root.items..., {"name": "new", "value": 42}]'
 ```
 
 ### Batch Update with each
 
 ```bash
 # Multiply all prices by 1.1 (10% increase)
-dasel -f data.json --root 'items.each(price = price * 1.1)'
+cat data.json | dasel -i json --root 'items.each(price = price * 1.1)'
 
 # Set a flag on all elements
-dasel -f data.json --root 'users.each(active = true)'
+cat data.json | dasel -i json --root 'users.each(active = true)'
 
 # Increment all values
 echo '[1,2,3]' | dasel -i json --root 'each($this = $this + 1)'
@@ -126,7 +126,7 @@ echo '[1,2,3]' | dasel -i json --root 'each($this = $this + 1)'
 
 ```bash
 # Get only active users, then extract names
-dasel -f data.json 'users.filter(active == true).map(name)'
+cat data.json | dasel -i json 'users.filter(active == true).map(name)'
 ```
 
 ## Object Operations
@@ -135,10 +135,10 @@ dasel -f data.json 'users.filter(active == true).map(name)'
 
 ```bash
 # Add new key to existing object
-dasel -f base.json --root '{ $root..., "newKey": "value" }'
+cat base.json | dasel -i json --root '{ $root..., "newKey": "value" }'
 
 # Merge two objects
-dasel -f base.json --root '{ $root..., "extra": true, "version": 2 }'
+cat base.json | dasel -i json --root '{ $root..., "extra": true, "version": 2 }'
 ```
 
 ### Field Deletion via Reconstruction
@@ -162,17 +162,17 @@ Use variable assignment and semicolons for complex operations:
 
 ```bash
 # Store intermediate result in variable, then transform
-dasel -f data.json '$active = users.filter(active == true); $active.map(name)'
+cat data.json | dasel -i json '$active = users.filter(active == true); $active.map(name)'
 
 # Multiple variables
-dasel -f data.json '$a = items.filter(price > 100); $b = $a.map(name); $b'
+cat data.json | dasel -i json '$a = items.filter(price > 100); $b = $a.map(name); $b'
 ```
 
 ## Conditional Transformation
 
 ```bash
 # Set value based on condition
-dasel -f data.json --root 'if(count > 5) { status = "many" } else { status = "few" }'
+cat data.json | dasel -i json --root 'if(count > 5) { status = "many" } else { status = "few" }'
 ```
 
 ## Transformation Patterns

--- a/plugins/dasel/skills/data-transformation/references/transformation-patterns.md
+++ b/plugins/dasel/skills/data-transformation/references/transformation-patterns.md
@@ -20,7 +20,7 @@ Detailed dasel v3 patterns organized by use case. Each pattern follows the struc
 **Problem**: Update a database host in a multi-level YAML config.
 
 ```bash
-dasel -f config.yaml --root 'database.connection.host = "db-prod.example.com"' > tmp.yaml && mv tmp.yaml config.yaml
+cat config.yaml | dasel -i yaml --root 'database.connection.host = "db-prod.example.com"' > tmp.yaml && mv tmp.yaml config.yaml
 ```
 
 **Expected**: Full document output with only the target field changed.
@@ -30,7 +30,7 @@ dasel -f config.yaml --root 'database.connection.host = "db-prod.example.com"' >
 **Problem**: Add an entirely new top-level section.
 
 ```bash
-dasel -f config.yaml --root '{ $root..., "monitoring": {"enabled": true, "port": 9090} }' > tmp.yaml && mv tmp.yaml config.yaml
+cat config.yaml | dasel -i yaml --root '{ $root..., "monitoring": {"enabled": true, "port": 9090} }' > tmp.yaml && mv tmp.yaml config.yaml
 ```
 
 **Expected**: Original document preserved with new `monitoring` section appended.
@@ -40,7 +40,7 @@ dasel -f config.yaml --root '{ $root..., "monitoring": {"enabled": true, "port":
 **Problem**: Update version in pyproject.toml.
 
 ```bash
-dasel -f pyproject.toml --root 'project.version = "2.0.0"' > tmp.toml && mv tmp.toml pyproject.toml
+cat pyproject.toml | dasel -i toml --root 'project.version = "2.0.0"' > tmp.toml && mv tmp.toml pyproject.toml
 ```
 
 ### TOML Settings — Add Array-of-Tables Entry
@@ -48,7 +48,7 @@ dasel -f pyproject.toml --root 'project.version = "2.0.0"' > tmp.toml && mv tmp.
 **Problem**: Add a new `[[tool.ruff.per-file-ignores]]` entry or similar array-of-tables.
 
 ```bash
-dasel -f pyproject.toml --root 'tool.ruff.per-file-ignores = [$root.tool.ruff.per-file-ignores..., {"pattern": "tests/**", "ignore": ["S101"]}]' > tmp.toml && mv tmp.toml pyproject.toml
+cat pyproject.toml | dasel -i toml --root 'tool.ruff.per-file-ignores = [$root.tool.ruff.per-file-ignores..., {"pattern": "tests/**", "ignore": ["S101"]}]' > tmp.toml && mv tmp.toml pyproject.toml
 ```
 
 **Caveat**: TOML array-of-tables have specific serialization rules. Verify output format matches TOML spec expectations.
@@ -58,7 +58,7 @@ dasel -f pyproject.toml --root 'tool.ruff.per-file-ignores = [$root.tool.ruff.pe
 **Problem**: Bump version in package.json.
 
 ```bash
-dasel -f package.json --root 'version = "3.1.0"' > tmp.json && mv tmp.json package.json
+cat package.json | dasel -i json --root 'version = "3.1.0"' > tmp.json && mv tmp.json package.json
 ```
 
 ### JSON Package Files — Add Dependency
@@ -66,7 +66,7 @@ dasel -f package.json --root 'version = "3.1.0"' > tmp.json && mv tmp.json packa
 **Problem**: Add a new dependency to package.json.
 
 ```bash
-dasel -f package.json --root '{ $root..., "dependencies": { $root.dependencies..., "lodash": "^4.17.21" } }' > tmp.json && mv tmp.json package.json
+cat package.json | dasel -i json --root '{ $root..., "dependencies": { $root.dependencies..., "lodash": "^4.17.21" } }' > tmp.json && mv tmp.json package.json
 ```
 
 ---
@@ -79,7 +79,7 @@ dasel -f package.json --root '{ $root..., "dependencies": { $root.dependencies..
 
 ```bash
 # Get full names from objects with firstName and lastName
-dasel -f users.json 'users.map({ "full": firstName })'
+cat users.json | dasel -i json 'users.map({ "full": firstName })'
 ```
 
 ### Filter Then Transform
@@ -88,7 +88,7 @@ dasel -f users.json 'users.map({ "full": firstName })'
 
 ```bash
 # Chain filter + each
-dasel -f products.json --root '$expensive = products.filter(price > 100); $expensive.each(price = price * 0.9)'
+cat products.json | dasel -i json --root '$expensive = products.filter(price > 100); $expensive.each(price = price * 0.9)'
 ```
 
 **Caveat**: The `each` mutates in the query context. Use `--root` to get the full document with changes applied.
@@ -98,7 +98,7 @@ dasel -f products.json --root '$expensive = products.filter(price > 100); $expen
 **Problem**: Set all users to inactive.
 
 ```bash
-dasel -f data.json --root 'users.each(active = false)'
+cat data.json | dasel -i json --root 'users.each(active = false)'
 ```
 
 **Expected**: Every element in the `users` array has `active` set to `false`.
@@ -108,7 +108,7 @@ dasel -f data.json --root 'users.each(active = false)'
 **Problem**: Increase all prices by 15%.
 
 ```bash
-dasel -f catalog.json --root 'items.each(price = price * 1.15)'
+cat catalog.json | dasel -i json --root 'items.each(price = price * 1.15)'
 ```
 
 ### Conditional Batch Update
@@ -116,7 +116,7 @@ dasel -f catalog.json --root 'items.each(price = price * 1.15)'
 **Problem**: Set status based on a threshold.
 
 ```bash
-dasel -f data.json --root 'items.each(status = if(score > 80) { "pass" } else { "fail" })'
+cat data.json | dasel -i json --root 'items.each(status = if(score > 80) { "pass" } else { "fail" })'
 ```
 
 ---
@@ -216,7 +216,7 @@ echo '{"db_host":"localhost","db_port":5432}' | \
 **Problem**: Pull out only specific fields from a large document.
 
 ```bash
-dasel -f large.json '{ name, version, description }'
+cat large.json | dasel -i json '{ name, version, description }'
 ```
 
 ### Array to Object Mapping
@@ -225,7 +225,7 @@ dasel -f large.json '{ name, version, description }'
 
 ```bash
 # Use map to extract, then reconstruct
-dasel -f data.json 'settings.map({ key, value })'
+cat data.json | dasel -i json 'settings.map({ key, value })'
 ```
 
 ---
@@ -238,7 +238,7 @@ dasel -f data.json 'settings.map({ key, value })'
 
 ```bash
 for f in configs/*.yaml; do
-  dasel -f "$f" --root 'metadata.version = "2.0"' > "${f}.tmp" && mv "${f}.tmp" "$f"
+  cat "$f" | dasel -i yaml --root 'metadata.version = "2.0"' > "${f}.tmp" && mv "${f}.tmp" "$f"
 done
 ```
 
@@ -254,7 +254,7 @@ done
 
 ```bash
 for f in services/*/config.yaml; do
-  echo "$f: $(dasel -f "$f" 'service.port')"
+  echo "$f: $(cat "$f" | dasel -i yaml 'service.port')"
 done
 ```
 
@@ -271,8 +271,8 @@ done
 **Fix**: Verify path with exploration commands first:
 
 ```bash
-dasel -f data.json 'keys($this)'
-dasel -f data.json 'has("fieldname")'
+cat data.json | dasel -i json 'keys($this)'
+cat data.json | dasel -i json 'has("fieldname")'
 ```
 
 **Error**: `cannot use X as type Y`
@@ -282,7 +282,7 @@ dasel -f data.json 'has("fieldname")'
 **Fix**: Use type casting functions:
 
 ```bash
-dasel -f data.json --root 'port = toInt("9090")'
+cat data.json | dasel -i json --root 'port = toInt("9090")'
 ```
 
 **Error**: `expected array, got object` (or vice versa)
@@ -292,7 +292,7 @@ dasel -f data.json --root 'port = toInt("9090")'
 **Fix**: Check type before operating:
 
 ```bash
-dasel -f data.json 'typeOf(items)'
+cat data.json | dasel -i json 'typeOf(items)'
 ```
 
 **Error**: Truncated/empty output file
@@ -302,7 +302,7 @@ dasel -f data.json 'typeOf(items)'
 **Fix**: Always use temp file + rename pattern:
 
 ```bash
-dasel -f input.json --root '...' > tmp.json && mv tmp.json input.json
+cat input.json | dasel -i json --root '...' > tmp.json && mv tmp.json input.json
 ```
 
 ### Defensive Transformation Pattern
@@ -311,10 +311,10 @@ For critical files, validate before overwriting:
 
 ```bash
 # 1. Transform to temp
-dasel -f config.yaml --root 'server.port = 9090' > config_new.yaml
+cat config.yaml | dasel -i yaml --root 'server.port = 9090' > config_new.yaml
 
 # 2. Verify temp is valid (non-empty, parseable)
-dasel -f config_new.yaml 'keys($this)' > /dev/null && mv config_new.yaml config.yaml || echo "Transformation produced invalid output"
+cat config_new.yaml | dasel -i yaml 'keys($this)' > /dev/null && mv config_new.yaml config.yaml || echo "Transformation produced invalid output"
 ```
 
 ### Dry Run Pattern
@@ -323,7 +323,7 @@ Preview transformation without writing:
 
 ```bash
 # Just print — do not redirect
-dasel -f config.yaml --root 'server.port = 9090'
+cat config.yaml | dasel -i yaml --root 'server.port = 9090'
 ```
 
 Inspect the output. If correct, re-run with redirect.
@@ -336,7 +336,7 @@ Inspect the output. If correct, re-run with redirect.
 
 ```bash
 # Store filtered subset, then transform
-dasel -f data.json '$active = users.filter(active == true); $names = $active.map(name); $names'
+cat data.json | dasel -i json '$active = users.filter(active == true); $names = $active.map(name); $names'
 ```
 
 ### Passing External Variables
@@ -345,7 +345,7 @@ Use `--var` to inject values from the shell:
 
 ```bash
 VERSION="3.0.0"
-dasel -f package.json --var "v=$VERSION" --root 'version = $v' > tmp.json && mv tmp.json package.json
+cat package.json | dasel -i json --var "v=$VERSION" --root 'version = $v' > tmp.json && mv tmp.json package.json
 ```
 
 ### Chaining with Shell Pipes

--- a/plugins/dasel/skills/enterprise-hibernate-hbm/SKILL.md
+++ b/plugins/dasel/skills/enterprise-hibernate-hbm/SKILL.md
@@ -21,20 +21,20 @@ Domain skill for dasel v3 queries against Hibernate `.hbm.xml` mapping files.
 
 ```bash
 # Fully qualified Java entity class name
-dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.-name'
+cat User.hbm.xml | dasel -i xml 'hibernate-mapping.class.-name'
 
 # Database table the entity maps to
-dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.-table'
+cat User.hbm.xml | dasel -i xml 'hibernate-mapping.class.-table'
 ```
 
 ## Property Column Mapping
 
 ```bash
 # All mapped Java property names in the entity
-dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.property.map(-name)'
+cat User.hbm.xml | dasel -i xml 'hibernate-mapping.class.property.map(-name)'
 
 # All database column names for mapped properties
-dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.property.map(-column)'
+cat User.hbm.xml | dasel -i xml 'hibernate-mapping.class.property.map(-column)'
 ```
 
 ## Collection Relationships
@@ -43,10 +43,10 @@ dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.property.map(-column)'
 
 ```bash
 # All set collection names (one-to-many)
-dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.set.map(-name)'
+cat User.hbm.xml | dasel -i xml 'hibernate-mapping.class.set.map(-name)'
 
 # All list collection names
-dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.list.map(-name)'
+cat User.hbm.xml | dasel -i xml 'hibernate-mapping.class.list.map(-name)'
 ```
 
 ## Foreign Key Discovery
@@ -55,10 +55,10 @@ dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.list.map(-name)'
 
 ```bash
 # All foreign key column names
-dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.many-to-one.map(-column)'
+cat User.hbm.xml | dasel -i xml 'hibernate-mapping.class.many-to-one.map(-column)'
 
 # All referenced entity class names (the FK target)
-dasel -f User.hbm.xml -i xml 'hibernate-mapping.class.many-to-one.map(-class)'
+cat User.hbm.xml | dasel -i xml 'hibernate-mapping.class.many-to-one.map(-class)'
 ```
 
 ## Batch Entity-Table Mapping
@@ -67,8 +67,8 @@ Extract entity→table pairs across all `.hbm.xml` files. Write to `/tmp/` — n
 
 ```bash
 for f in $(fdfind -e hbm.xml .); do
-  entity=$(dasel -f "$f" -i xml 'hibernate-mapping.class.-name' 2>/dev/null)
-  table=$(dasel -f "$f" -i xml 'hibernate-mapping.class.-table' 2>/dev/null)
+  entity=$(cat "$f" | dasel -i xml 'hibernate-mapping.class.-name' 2>/dev/null)
+  table=$(cat "$f" | dasel -i xml 'hibernate-mapping.class.-table' 2>/dev/null)
   echo "$entity -> $table"
 done > /tmp/entity_table_map.txt
 ```

--- a/plugins/dasel/skills/enterprise-installanywhere/SKILL.md
+++ b/plugins/dasel/skills/enterprise-installanywhere/SKILL.md
@@ -23,26 +23,26 @@ InstallAnywhere `.iap_xml` files have a fixed root path: `InstallAnywhere.projec
 
 ```bash
 # Top-level element names at the document root
-dasel -f installer.iap_xml -i xml 'keys($this)'
+cat installer.iap_xml | dasel -i xml 'keys($this)'
 
 # Navigate to the install action sequence
-dasel -f installer.iap_xml -i xml 'InstallAnywhere.project.installSequence'
+cat installer.iap_xml | dasel -i xml 'InstallAnywhere.project.installSequence'
 
 # Children of the project node
-dasel -f installer.iap_xml -i xml 'InstallAnywhere.project.keys($this)'
+cat installer.iap_xml | dasel -i xml 'InstallAnywhere.project.keys($this)'
 ```
 
 Recursive descent — finds elements at any depth without knowing the full path:
 
 ```bash
 # All elements named "action" at any depth
-dasel -f installer.iap_xml -i xml '..action'
+cat installer.iap_xml | dasel -i xml '..action'
 
 # All elements named "panel" at any depth
-dasel -f installer.iap_xml -i xml '..panel'
+cat installer.iap_xml | dasel -i xml '..panel'
 
 # Any node at any depth where a specific attribute exists
-dasel -f installer.iap_xml -i xml 'search(has("-name"))'
+cat installer.iap_xml | dasel -i xml 'search(has("-name"))'
 ```
 
 `..elementName` descends recursively. `search(predicate)` matches nodes at any depth.
@@ -51,31 +51,31 @@ dasel -f installer.iap_xml -i xml 'search(has("-name"))'
 
 ```bash
 # All action names in execution order
-dasel -f installer.iap_xml -i xml '..action.map("-name")'
+cat installer.iap_xml | dasel -i xml '..action.map("-name")'
 
 # All action types
-dasel -f installer.iap_xml -i xml '..action.map("-type")'
+cat installer.iap_xml | dasel -i xml '..action.map("-type")'
 
 # Count all action elements
-dasel -f installer.iap_xml -i xml 'len(..action)'
+cat installer.iap_xml | dasel -i xml 'len(..action)'
 
 # Write for analysis
-dasel -f installer.iap_xml -i xml '..action.map("-name")' > /tmp/action_names.txt
-dasel -f installer.iap_xml -i xml '..action.map("-type")' > /tmp/action_types.txt
+cat installer.iap_xml | dasel -i xml '..action.map("-name")' > /tmp/action_names.txt
+cat installer.iap_xml | dasel -i xml '..action.map("-type")' > /tmp/action_types.txt
 ```
 
 ## Variable Discovery
 
 ```bash
 # All variable definitions
-dasel -f installer.iap_xml -i xml '..variable.map("-name")' > /tmp/installer_vars.txt
+cat installer.iap_xml | dasel -i xml '..variable.map("-name")' > /tmp/installer_vars.txt
 ```
 
 ## Platform Conditions
 
 ```bash
 # All platform conditions (Windows vs Linux branches)
-dasel -f installer.iap_xml -i xml 'search(has("-platform")).map("-platform")' > /tmp/platforms.txt
+cat installer.iap_xml | dasel -i xml 'search(has("-platform")).map("-platform")' > /tmp/platforms.txt
 ```
 
 ## Cross-Variant Comparison
@@ -84,13 +84,13 @@ When comparing two builds of the same installer (e.g., RA vs NON_RA, Windows vs 
 
 ```bash
 # Compare action sets between two installer files
-dasel -f installer_a.iap_xml -i xml '..action.map("-name")' | sort > /tmp/actions_a.txt
-dasel -f installer_b.iap_xml -i xml '..action.map("-name")' | sort > /tmp/actions_b.txt
+cat installer_a.iap_xml | dasel -i xml '..action.map("-name")' | sort > /tmp/actions_a.txt
+cat installer_b.iap_xml | dasel -i xml '..action.map("-name")' | sort > /tmp/actions_b.txt
 diff /tmp/actions_a.txt /tmp/actions_b.txt > /tmp/installer_diff.txt
 
 # Compare panel sets
-dasel -f installer_a.iap_xml -i xml '..panel.map("-name")' | sort > /tmp/panels_a.txt
-dasel -f installer_b.iap_xml -i xml '..panel.map("-name")' | sort > /tmp/panels_b.txt
+cat installer_a.iap_xml | dasel -i xml '..panel.map("-name")' | sort > /tmp/panels_a.txt
+cat installer_b.iap_xml | dasel -i xml '..panel.map("-name")' | sort > /tmp/panels_b.txt
 diff /tmp/panels_a.txt /tmp/panels_b.txt
 ```
 
@@ -98,15 +98,15 @@ diff /tmp/panels_a.txt /tmp/panels_b.txt
 
 ```bash
 # All file copy sources
-dasel -f installer.iap_xml -i xml '..installFile.map("-source")' > /tmp/file_copies.txt
+cat installer.iap_xml | dasel -i xml '..installFile.map("-source")' > /tmp/file_copies.txt
 ```
 
 ## Panel Navigation
 
 ```bash
 # Panel names and count
-dasel -f installer.iap_xml -i xml '..panel.map("-name")'
-dasel -f installer.iap_xml -i xml 'len(..panel)'
+cat installer.iap_xml | dasel -i xml '..panel.map("-name")'
+cat installer.iap_xml | dasel -i xml 'len(..panel)'
 ```
 
 ## Attribute Syntax Reference
@@ -115,17 +115,17 @@ XML attributes use `-` prefix in dasel friendly mode:
 
 ```bash
 # Access specific attribute on first match
-dasel -f installer.iap_xml -i xml '..action[0].-name'
+cat installer.iap_xml | dasel -i xml '..action[0].-name'
 
 # Discover attributes and children of a node
-dasel -f installer.iap_xml -i xml '..action[0].keys($this)'
+cat installer.iap_xml | dasel -i xml '..action[0].keys($this)'
 
 # Extract attribute values across all matching nodes
-dasel -f installer.iap_xml -i xml '..elementName.map("-attributeName")'
+cat installer.iap_xml | dasel -i xml '..elementName.map("-attributeName")'
 
 # Count matching elements
-dasel -f installer.iap_xml -i xml 'len(..elementName)'
+cat installer.iap_xml | dasel -i xml 'len(..elementName)'
 
 # Search with attribute predicate at any depth
-dasel -f installer.iap_xml -i xml 'search(has("-attributeName"))'
+cat installer.iap_xml | dasel -i xml 'search(has("-attributeName"))'
 ```

--- a/plugins/dasel/skills/enterprise-maven-pom/SKILL.md
+++ b/plugins/dasel/skills/enterprise-maven-pom/SKILL.md
@@ -17,7 +17,7 @@ Domain skill for querying Maven POM XML files using dasel v3. Always pass `-i xm
 
 ```bash
 # All dependency groupIds from a single POM
-dasel -f pom.xml -i xml 'project.dependencies.dependency.map(groupId)'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency.map(groupId)'
 ```
 
 ## Framework Version Filtering
@@ -26,20 +26,20 @@ Filter dependencies by groupId to isolate framework-specific versions.
 
 ```bash
 # Spring dependency versions
-dasel -f pom.xml -i xml 'project.dependencies.dependency.filter(groupId == "org.springframework").map(version)'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency.filter(groupId == "org.springframework").map(version)'
 
 # Hibernate dependency versions
-dasel -f pom.xml -i xml 'project.dependencies.dependency.filter(groupId == "org.hibernate").map(version)'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency.filter(groupId == "org.hibernate").map(version)'
 ```
 
 ## Scope Filtering
 
 ```bash
 # Test-scoped dependency artifactIds
-dasel -f pom.xml -i xml 'project.dependencies.dependency.filter(scope == "test").map(artifactId)'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency.filter(scope == "test").map(artifactId)'
 
 # Compile-scoped dependencies (no scope element defaults to compile)
-dasel -f pom.xml -i xml 'project.dependencies.dependency.filter(scope == "compile").map(artifactId)'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency.filter(scope == "compile").map(artifactId)'
 ```
 
 ## Module Hierarchy
@@ -48,7 +48,7 @@ Extract module paths from a parent POM to map the project structure.
 
 ```bash
 # Module list from parent POM
-dasel -f pom.xml -i xml 'project.modules.module'
+cat pom.xml | dasel -i xml 'project.modules.module'
 ```
 
 ## Cross-POM Version Conflict Detection
@@ -59,7 +59,7 @@ Batch pattern — iterate all POMs, extract dependencies per file, compare. Writ
 # Collect all dependency groupIds across every POM in the hierarchy
 for pom in $(fdfind -e xml -n pom.xml .); do
   echo "=== $pom ===" >> /tmp/all_deps.txt
-  dasel -f "$pom" -i xml 'project.dependencies.dependency.map(groupId)' >> /tmp/all_deps.txt 2>/dev/null
+  cat "$pom" | dasel -i xml 'project.dependencies.dependency.map(groupId)' >> /tmp/all_deps.txt 2>/dev/null
 done
 ```
 
@@ -71,8 +71,8 @@ Extract groupId and artifactId together for dependency inventory.
 
 ```bash
 # Dependency coordinates (groupId + artifactId) — run as two passes
-dasel -f pom.xml -i xml 'project.dependencies.dependency.map(groupId)'
-dasel -f pom.xml -i xml 'project.dependencies.dependency.map(artifactId)'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency.map(groupId)'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency.map(artifactId)'
 ```
 
 ## DependencyManagement vs Dependencies
@@ -81,8 +81,8 @@ Enterprise POMs use `dependencyManagement` to declare BOM-controlled versions se
 
 ```bash
 # Managed dependency versions (BOM section)
-dasel -f pom.xml -i xml 'project.dependencyManagement.dependencies.dependency.map(version)'
+cat pom.xml | dasel -i xml 'project.dependencyManagement.dependencies.dependency.map(version)'
 
 # Active dependency versions (may be empty if version comes from BOM)
-dasel -f pom.xml -i xml 'project.dependencies.dependency.map(version)'
+cat pom.xml | dasel -i xml 'project.dependencies.dependency.map(version)'
 ```

--- a/plugins/dasel/skills/enterprise-spring-xml/SKILL.md
+++ b/plugins/dasel/skills/enterprise-spring-xml/SKILL.md
@@ -19,13 +19,13 @@ Dasel v3 selector patterns for Spring bean factory XML. Always pass `-i xml` exp
 
 ```bash
 # All bean IDs
-dasel -f chaosrouter_beans.xml -i xml 'beans.bean.filter(has("-id")).map("-id")'
+cat chaosrouter_beans.xml | dasel -i xml 'beans.bean.filter(has("-id")).map("-id")'
 
 # All bean classes
-dasel -f chaosrouter_beans.xml -i xml 'beans.bean.filter(has("-class")).map("-class")'
+cat chaosrouter_beans.xml | dasel -i xml 'beans.bean.filter(has("-class")).map("-class")'
 
 # Map -class across every bean (includes beans without -id)
-dasel -f chaosrouter_beans.xml -i xml 'beans.bean.map("-class")'
+cat chaosrouter_beans.xml | dasel -i xml 'beans.bean.map("-class")'
 ```
 
 ## Class Pattern Matching
@@ -34,10 +34,10 @@ Filter beans by class name via regex on `-class`.
 
 ```bash
 # Beans whose class contains JmsTemplate
-dasel -f chaosrouter_beans.xml -i xml 'beans.bean.filter(-class ~ ".*JmsTemplate.*").map("-id")'
+cat chaosrouter_beans.xml | dasel -i xml 'beans.bean.filter(-class ~ ".*JmsTemplate.*").map("-id")'
 
 # Count beans matching a class pattern
-dasel -f beans.xml -i xml 'len(beans.bean.filter(-class ~ ".*Jms.*"))'
+cat beans.xml | dasel -i xml 'len(beans.bean.filter(-class ~ ".*Jms.*"))'
 ```
 
 ## Dependency Wiring Analysis
@@ -48,7 +48,7 @@ Find beans referencing other beans via the `-ref` attribute on `property` child 
 
 ```bash
 # Beans that reference a specific bean ID via ref attribute
-dasel -f chaosrouter_beans.xml -i xml 'beans.bean.filter(property.filter(-ref == "targetBeanId").len($this) > 0).map("-id")'
+cat chaosrouter_beans.xml | dasel -i xml 'beans.bean.filter(property.filter(-ref == "targetBeanId").len($this) > 0).map("-id")'
 ```
 
 ## JMS Destination Mapping
@@ -57,7 +57,7 @@ Find which beans consume which JMS destinations via `property` child elements.
 
 ```bash
 # Beans wired to a specific destination property
-dasel -f integrationpoint_beans.xml -i xml 'beans.bean.filter(property.filter(-name == "destination").len($this) > 0).map("-id")'
+cat integrationpoint_beans.xml | dasel -i xml 'beans.bean.filter(property.filter(-name == "destination").len($this) > 0).map("-id")'
 ```
 
 ## Property Injection Extraction
@@ -66,19 +66,19 @@ Extract externalized `${...}` placeholder values from bean definitions.
 
 ```bash
 # All property values using ${...} placeholders
-dasel -f storage_beans.xml -i xml 'beans.bean.property.filter(-value ~ ".*\\$\\{.*\\}.*").map("-value")'
+cat storage_beans.xml | dasel -i xml 'beans.bean.property.filter(-value ~ ".*\\$\\{.*\\}.*").map("-value")'
 ```
 
 ## Attribute and Text Content Access
 
 ```bash
 # <bean id="myBean" class="com.example.Foo">some text</bean>
-dasel -f beans.xml -i xml 'beans.bean[0].-id'       # myBean
-dasel -f beans.xml -i xml 'beans.bean[0].-class'    # com.example.Foo
-dasel -f beans.xml -i xml 'beans.bean[0].#text'     # some text
+cat beans.xml | dasel -i xml 'beans.bean[0].-id'       # myBean
+cat beans.xml | dasel -i xml 'beans.bean[0].-class'    # com.example.Foo
+cat beans.xml | dasel -i xml 'beans.bean[0].#text'     # some text
 
 # Discover all keys (attributes + child elements) on first bean
-dasel -f beans.xml -i xml 'beans.bean[0].keys($this)'
+cat beans.xml | dasel -i xml 'beans.bean[0].keys($this)'
 ```
 
 ## Namespace Handling
@@ -88,7 +88,7 @@ Friendly mode strips namespace prefixes from element names — works for most Sp
 When namespace prefixes cause selector failures (element not found despite existing), switch to structured mode:
 
 ```bash
-dasel -f spring-context.xml -i xml --read-flag xml-mode=structured 'beans.bean[0]'
+cat spring-context.xml | dasel -i xml --read-flag xml-mode=structured 'beans.bean[0]'
 ```
 
 ## Cross-File Analysis
@@ -97,7 +97,7 @@ Write intermediate results to `/tmp/` — never to the source tree.
 
 ```bash
 # Extract bean IDs from multiple files, compare
-dasel -f chaosrouter_beans.xml -i xml 'beans.bean.filter(has("-id")).map("-id")' > /tmp/chaosrouter_beans.txt
-dasel -f integrationpoint_beans.xml -i xml 'beans.bean.filter(has("-id")).map("-id")' > /tmp/integration_beans.txt
+cat chaosrouter_beans.xml | dasel -i xml 'beans.bean.filter(has("-id")).map("-id")' > /tmp/chaosrouter_beans.txt
+cat integrationpoint_beans.xml | dasel -i xml 'beans.bean.filter(has("-id")).map("-id")' > /tmp/integration_beans.txt
 diff /tmp/chaosrouter_beans.txt /tmp/integration_beans.txt
 ```

--- a/plugins/dasel/skills/enterprise-tomcat-web/SKILL.md
+++ b/plugins/dasel/skills/enterprise-tomcat-web/SKILL.md
@@ -17,17 +17,17 @@ Domain skill for querying Tomcat web.xml files using dasel v3. Always use `-i xm
 
 ```bash
 # All servlet names
-dasel -f web.xml -i xml 'web-app.servlet.map(servlet-name)'
+cat web.xml | dasel -i xml 'web-app.servlet.map(servlet-name)'
 
 # Count servlet definitions
-dasel -f web.xml -i xml 'len(web-app.servlet)'
+cat web.xml | dasel -i xml 'len(web-app.servlet)'
 ```
 
 ## Filter Chain Analysis
 
 ```bash
 # Find filters by class pattern (e.g., Security filters)
-dasel -f web.xml -i xml 'web-app.filter.filter(filter-class ~ ".*Security.*")'
+cat web.xml | dasel -i xml 'web-app.filter.filter(filter-class ~ ".*Security.*")'
 ```
 
 Replace `Security` with any class name fragment.
@@ -36,23 +36,23 @@ Replace `Security` with any class name fragment.
 
 ```bash
 # Count listener definitions
-dasel -f web.xml -i xml 'len(web-app.listener)'
+cat web.xml | dasel -i xml 'len(web-app.listener)'
 ```
 
 ## Context Parameters
 
 ```bash
 # All context-param names
-dasel -f web.xml -i xml 'web-app.context-param.map(param-name)'
+cat web.xml | dasel -i xml 'web-app.context-param.map(param-name)'
 ```
 
 ## Init Parameter Inspection
 
 ```bash
 # Find servlets with a specific init-param name — filters parent collection by testing child length > 0
-dasel -f web.xml -i xml 'web-app.servlet.filter(init-param.filter(param-name == "debug").len($this) > 0).map(servlet-name)'
+cat web.xml | dasel -i xml 'web-app.servlet.filter(init-param.filter(param-name == "debug").len($this) > 0).map(servlet-name)'
 ```
 
 Replace `"debug"` with the target param-name value.
 
-All selectors require the full command prefix: `dasel -f web.xml -i xml '<selector>'`
+All selectors require the full command prefix: `cat web.xml | dasel -i xml '<selector>'`


### PR DESCRIPTION
## Summary

- Replaces all 257 occurrences of the deprecated `dasel -f <file>` flag across 13 files with the dasel v3 stdin pattern `cat <file> | dasel -i <format>`
- Format flags are derived from file extensions (`.yaml`→`yaml`, `.json`→`json`, `.xml`→`xml`, `.toml`→`toml`, `.hcl`/`.tf`→`hcl`) or preserved from existing explicit `-i` flags
- Shell variable filenames in loops are fixed with format derived from the loop glob pattern context (`configs/*.yaml` → `yaml`)
- `FACT_CHECK_REPORT.md` is explicitly excluded as it documents the wrong syntax as a reference

## Test plan

- [ ] `grep -r "dasel -f " plugins/dasel/ --include="*.md" -l` returns only `FACT_CHECK_REPORT.md`
- [ ] `grep -c "dasel -f " plugins/dasel/skills/dasel-reference/FACT_CHECK_REPORT.md` returns `2` (untouched)
- [ ] `uv run prek run --files plugins/dasel/skills/data-transformation/SKILL.md` passes clean
- [ ] All 13 modified files now use `cat <file> | dasel -i <format>` stdin pattern

## Files changed (13)

1. `plugins/dasel/skills/data-exploration/references/format-recipes.md` — 61 replacements (53 auto + 8 `.tf`→`hcl` manual)
2. `plugins/dasel/skills/data-exploration/SKILL.md` — 23 replacements
3. `plugins/dasel/skills/enterprise-maven-pom/SKILL.md` — 11 replacements
4. `plugins/dasel/skills/enterprise-hibernate-hbm/SKILL.md` — 10 replacements
5. `plugins/dasel/skills/enterprise-spring-xml/SKILL.md` — 15 replacements
6. `plugins/dasel/skills/enterprise-tomcat-web/SKILL.md` — 7 replacements
7. `plugins/dasel/skills/data-transformation/references/transformation-patterns.md` — 25 replacements (23 auto + 2 shell variable loops)
8. `plugins/dasel/skills/data-transformation/SKILL.md` — 18 replacements
9. `plugins/dasel/skills/enterprise-installanywhere/SKILL.md` — 25 replacements
10. `plugins/dasel/agents/data-explorer.md` — 15 replacements (14 auto + 1 documentation placeholder)
11. `plugins/dasel/agents/dasel-guide.md` — 27 replacements
12. `plugins/dasel/agents/data-analyst.md` — 13 replacements
13. `plugins/dasel/README.md` — 7 replacements

**Total: 257 replacements**

Background: `FACT_CHECK_REPORT.md` confirmed this on 2026-02-23. The `dasel-reference/` skill was partially fixed then; this PR completes the migration for all remaining files.

https://claude.ai/code/session_01XPKZwN5FgDJSprfEwEDjQk