### PR TITLE
fix(tests): repair test_set_manifest_skips_edit — broken mock chain hit live GitHub API

### DIFF
--- a/.claude/hooks/run-commands-try-all.cjs
+++ b/.claude/hooks/run-commands-try-all.cjs
@@ -29,7 +29,7 @@ function getCommands() {
   }
   try {
     const stdin = fs.readFileSync(0, 'utf8');
-    if (!stdin || !stdin.trim()) return [];
+    if (!stdin?.trim()) return [];
     const data = JSON.parse(stdin);
     const cmds = data.commands ?? data.command ?? [];
     return Array.isArray(cmds) ? cmds : [String(cmds)];

--- a/.claude/hooks/validate-delegation.cjs
+++ b/.claude/hooks/validate-delegation.cjs
@@ -119,7 +119,7 @@ function readStdin() {
 
 function main() {
   const raw = readStdin();
-  if (!raw || !raw.trim()) {
+  if (!raw?.trim()) {
     // No input — nothing to validate
     process.exit(0);
   }

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "8.8.25",
+  "version": "8.8.26",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/tests_backlog/test_artifact_provider.py
+++ b/plugins/development-harness/tests_backlog/test_artifact_provider.py
@@ -436,72 +436,67 @@ class TestGitHubArtifactProviderSetManifest:
         assert "<!-- artifact-gist:" in mutation_variables["body"]
 
     def test_set_manifest_skips_edit_when_body_unchanged(
-        self, provider: GitHubArtifactProvider, mock_issue: MagicMock, mock_repo: MagicMock, registry: ArtifactRegistry
+        self, provider: GitHubArtifactProvider, mock_repo: MagicMock
     ) -> None:
-        """set_manifest skips the mutation when the rendered body equals the current body.
+        """set_manifest calls gist.edit() but skips updateIssue when sentinel is already in body.
 
-        Tests: No-op optimisation when body content is identical
-        How: Use a stateful graphql_query side_effect that records the body written by
-             the first call and returns it on the second fetch. Verify the mutation is
-             NOT called on the second set_manifest invocation.
-        Why: Avoids unnecessary GitHub API writes that consume GitHub rate limit quota.
+        Tests: When the issue body already carries the gist sentinel, set_manifest updates
+               the Gist content via gist.edit() but does NOT issue a GraphQL updateIssue
+               mutation (the issue body does not need to change).
+        How: Pre-populate provider._gist_cache with a mock Gist and configure graphql_query
+             to return a body containing the sentinel. Call set_manifest once. Assert
+             gist.edit() is called but no updateIssue mutation is issued.
+        Why: _get_gist() checks _gist_cache first (before calling _make_github_client).
+             Pre-seeding the cache and body avoids all live API calls while exercising the
+             correct code path. The previous implementation called _make_github_client()
+             (which uses GITHUB_TOKEN) when the sentinel was absent, hitting the real API
+             under CI conditions with a live token.
         """
-        from backlog_core.artifact_registry import parse_manifest_section
+        # Arrange — a hex gist_id matching _GIST_SENTINEL_RE: r"<!-- artifact-gist:(?P<gist_id>[0-9a-f]+) -->"
+        gist_id = "abc123def456abcd"
+        sentinel_body = f"Issue description.\n<!-- artifact-gist:{gist_id} -->"
 
-        # Arrange — stateful mock: tracks the most recently written body
-        written_body: list[str] = [""]  # mutable container to allow mutation inside side_effect
+        mock_gist = MagicMock()
+        # Pre-seed the cache: _get_gist checks this before calling _make_github_client
+        provider._gist_cache[965] = mock_gist
 
-        def _graphql_query_side_effect(query: str, variables: dict[str, Any]) -> tuple[dict, dict]:
-            # Mutation queries contain 'updateIssue' — capture the written body
-            if "updateIssue" in query:
-                written_body[0] = variables.get("body", written_body[0])
-                return ({}, {"data": {"updateIssue": {}}})
-            # Query: return the most recently written body
-            return (
-                {},
-                {
-                    "data": {
-                        "repository": {
-                            "issue": {
-                                "id": "I_test_node_id",
-                                "number": 965,
-                                "title": "",
-                                "state": "OPEN",
-                                "body": written_body[0],
-                                "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-01T00:00:00Z",
-                                "labels": {"nodes": []},
-                                "milestone": None,
-                                "assignees": {"nodes": []},
-                            }
+        mock_repo.requester.graphql_query.return_value = (
+            {},
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "id": "I_test_node_id",
+                            "number": 965,
+                            "title": "",
+                            "state": "OPEN",
+                            "body": sentinel_body,
+                            "createdAt": "2026-01-01T00:00:00Z",
+                            "updatedAt": "2026-01-01T00:00:00Z",
+                            "labels": {"nodes": []},
+                            "milestone": None,
+                            "assignees": {"nodes": []},
                         }
                     }
-                },
-            )
-
-        mock_repo.requester.graphql_query.side_effect = _graphql_query_side_effect
+                }
+            },
+        )
 
         manifest = ArtifactManifest(issue_number=965)
 
-        # First call: body is empty → mutation is issued
+        # Act
         provider.set_manifest(965, manifest)
-        assert mock_repo.requester.graphql_query.call_count == 2  # fetch + mutation
 
-        # Capture what was written and reconstruct the same manifest
-        updated_body = written_body[0]
-        same_manifest = parse_manifest_section(updated_body, 965)
-        mock_repo.requester.graphql_query.reset_mock()
+        # Assert — gist.edit() was called with the serialised manifest JSON
+        mock_gist.edit.assert_called_once()
+        call_files: dict[str, Any] = mock_gist.edit.call_args.kwargs["files"]
+        assert "manifest.json" in call_files
 
-        # Act — second call: graphql_query now returns updated_body → new_body == current_body
-        # set_manifest stamps last_updated; however, same_manifest carries no last_updated
-        # from the re-parse, so rendered output will differ in the timestamp.
-        # The test verifies the conditional path is exercised — mutation call count reflects
-        # whether body changed. With a freshly stamped last_updated on the same base manifest,
-        # the body WILL differ from updated_body → mutation IS called again.
-        provider.set_manifest(965, same_manifest)
-
-        # Assert — at least one graphql_query call was made (the second fetch)
-        assert mock_repo.requester.graphql_query.call_count >= 1
+        # The issue body did not change (sentinel was already present) — no updateIssue mutation
+        mutation_calls = [
+            call for call in mock_repo.requester.graphql_query.call_args_list if "updateIssue" in call[0][0]
+        ]
+        assert mutation_calls == [], "updateIssue mutation must not fire when sentinel is already in body"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/frustration-analyzer/.claude-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs the triggering assistant output, and renders a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/frustration-analyzer/.codex-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.codex-plugin/plugin.json
@@ -6,13 +6,6 @@
     "name": "Jamie-BitFlight"
   },
   "license": "MIT",
-  "keywords": [
-    "transcripts",
-    "frustration",
-    "rage-receipt",
-    "duckdb",
-    "session-analysis",
-    "png"
-  ],
+  "keywords": ["transcripts", "frustration", "rage-receipt", "duckdb", "session-analysis", "png"],
   "skills": "./skills/"
 }

--- a/plugins/orchestrator-discipline/.claude-plugin/plugin.json
+++ b/plugins/orchestrator-discipline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrator-discipline",
   "description": "Enforces orchestrator context window discipline via PreToolUse hooks and rules. Prevents the orchestrator from reading source files it will not edit, running diagnostic commands that should be delegated, and bypassing delegation with 'small change' rationalizations. Install to structurally prevent investigation escalation anti-patterns.",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/orchestrator-discipline/hooks/pre-tool-block-explore-for-analysis.cjs
+++ b/plugins/orchestrator-discipline/hooks/pre-tool-block-explore-for-analysis.cjs
@@ -124,7 +124,7 @@ function readStdin() {
 
 function main() {
   const raw = readStdin();
-  if (!raw || !raw.trim()) {
+  if (!raw?.trim()) {
     process.exit(0);
   }
 

--- a/plugins/orchestrator-discipline/hooks/prevent-bash-tool-misuse.cjs
+++ b/plugins/orchestrator-discipline/hooks/prevent-bash-tool-misuse.cjs
@@ -111,7 +111,7 @@ const LEGITIMATE_PATTERNS = [
 
 function main() {
   const raw = readStdin();
-  if (!raw || !raw.trim()) {
+  if (!raw?.trim()) {
     process.exit(0);
   }
 

--- a/plugins/process-siren/.claude-plugin/plugin.json
+++ b/plugins/process-siren/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "process-siren",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Converts bullet steps, ASCII art, markdown tables, and prose workflows into Mermaid diagrams for AI-facing documents. Includes process quality methodology for improving ambiguous or incomplete processes before conversion.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/process-siren/.codex-plugin/plugin.json
+++ b/plugins/process-siren/.codex-plugin/plugin.json
@@ -6,12 +6,6 @@
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"
   },
-  "keywords": [
-    "mermaid",
-    "process",
-    "workflow",
-    "diagram",
-    "flowchart"
-  ],
+  "keywords": ["mermaid", "process", "workflow", "diagram", "flowchart"],
   "skills": "./skills/"
 }

--- a/plugins/rtfp/.claude-plugin/plugin.json
+++ b/plugins/rtfp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rtfp",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Read The Fucking Prompt \u2014 mines Claude Code session transcripts to surface the strongest user reactions to assistant instruction-following failures and renders the exchange as a terminal-style PNG",
   "author": {
     "name": "Jamie-BitFlight",

--- a/plugins/rtfp/.codex-plugin/plugin.json
+++ b/plugins/rtfp/.codex-plugin/plugin.json
@@ -8,11 +8,6 @@
   },
   "repository": "https://github.com/Jamie-BitFlight/claude_skills",
   "license": "MIT",
-  "keywords": [
-    "session-analysis",
-    "emotional-reaction",
-    "instruction-following",
-    "png-artifact"
-  ],
+  "keywords": ["session-analysis", "emotional-reaction", "instruction-following", "png-artifact"],
   "skills": "./skills/"
 }

--- a/plugins/scientific-method/.claude-plugin/plugin.json
+++ b/plugins/scientific-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scientific-method",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/scientific-method/hooks/notify-investigation-complete.cjs
+++ b/plugins/scientific-method/hooks/notify-investigation-complete.cjs
@@ -52,7 +52,7 @@ function extractLastAssistantText(transcriptPath) {
 
     if (record.type !== 'assistant') continue;
     const message = record.message;
-    if (!message || message.role !== 'assistant') continue;
+    if (message?.role !== 'assistant') continue;
     const content = Array.isArray(message.content) ? message.content : [];
     const textParts = content
       .filter((c) => c && c.type === 'text' && typeof c.text === 'string')

--- a/plugins/summarizer/.claude-plugin/plugin.json
+++ b/plugins/summarizer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "summarizer",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "Faithful information summarization with fidelity preservation, structured output, and anti-hallucination methodology. Provides skills for file, URL, and image summarization; agents for autonomous summarization tasks; and hooks for validating agent output structure.",
   "author": {
     "name": "jamie-bitflight-skills",

--- a/plugins/summarizer/.codex-plugin/plugin.json
+++ b/plugins/summarizer/.codex-plugin/plugin.json
@@ -7,12 +7,6 @@
     "url": "https://github.com/bitflight-devops/claude-skills"
   },
   "license": "MIT",
-  "keywords": [
-    "summarization",
-    "fidelity",
-    "anti-hallucination",
-    "synthesis",
-    "extractive"
-  ],
+  "keywords": ["summarization", "fidelity", "anti-hallucination", "synthesis", "extractive"],
   "skills": "./skills/"
 }

--- a/plugins/summarizer/hooks/validate-summarizer-output.cjs
+++ b/plugins/summarizer/hooks/validate-summarizer-output.cjs
@@ -48,7 +48,7 @@ function extractLastAssistantText(transcriptPath) {
 
     if (record.type !== 'assistant') continue;
     const message = record.message;
-    if (!message || message.role !== 'assistant') continue;
+    if (message?.role !== 'assistant') continue;
     const content = Array.isArray(message.content) ? message.content : [];
     const textParts = content
       .filter((c) => c && c.type === 'text' && typeof c.text === 'string')

--- a/plugins/the-rewrite-room/.claude-plugin/plugin.json
+++ b/plugins/the-rewrite-room/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rwr",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "description": "Documentation and authoring workflow router: audit docs vs code drift, sync docs after changes, optimize prompts and SKILL.md files, validate GLFM and Markdown formatting, summarize files/URLs/images with fidelity enforcement. Use when: docs are out of date, CLAUDE.md needs improving, SKILL.md needs optimizing, checking if documentation matches code, summarizing files or URLs.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/the-rewrite-room/hooks/validate-status-block.cjs
+++ b/plugins/the-rewrite-room/hooks/validate-status-block.cjs
@@ -49,7 +49,7 @@ function extractLastAssistantText(transcriptPath) {
     if (record.type !== 'assistant') continue;
 
     const message = record.message;
-    if (!message || message.role !== 'assistant') continue;
+    if (message?.role !== 'assistant') continue;
 
     const content = Array.isArray(message.content) ? message.content : [];
     const textParts = content

--- a/plugins/the-rewrite-room/hooks/validate-status-block.cjs
+++ b/plugins/the-rewrite-room/hooks/validate-status-block.cjs
@@ -86,19 +86,19 @@ function validateStatusBlock(text) {
 
   // SUMMARY: non-empty
   const summaryMatch = text.match(/^\s*SUMMARY:\s*(.+)/m);
-  if (!summaryMatch || !summaryMatch[1].trim()) {
+  if (!summaryMatch?.[1].trim()) {
     missingFields.push('SUMMARY');
   }
 
   // ARTIFACTS: non-empty (value may be "none" — that is acceptable)
   const artifactsMatch = text.match(/^\s*ARTIFACTS:\s*(.+)/m);
-  if (!artifactsMatch || !artifactsMatch[1].trim()) {
+  if (!artifactsMatch?.[1].trim()) {
     missingFields.push('ARTIFACTS');
   }
 
   // VALIDATION: non-empty
   const validationMatch = text.match(/^\s*VALIDATION:\s*(.+)/m);
-  if (!validationMatch || !validationMatch[1].trim()) {
+  if (!validationMatch?.[1].trim()) {
     missingFields.push('VALIDATION');
   }
 


### PR DESCRIPTION
## Summary

- `test_set_manifest_skips_edit_when_body_unchanged` had a broken mock chain: `_make_github_client()` was not mocked, so the test hit the real GitHub Gist API (creating a real gist) when `GITHUB_TOKEN` was present — triggering 403 secondary rate-limit errors under CI conditions
- The two-call approach never exercised the intended "skip mutation" path because `last_updated` differed on each timestamp stamp, making the body always change and always issuing the `updateIssue` mutation
- The assertion `call_count >= 1` was too weak to catch this

## Root cause (design, not symptom)

`_get_gist()` checks `_gist_cache` first; it only calls `_make_github_client()` when the cache misses. The test left the cache empty and the issue body empty — so `_get_gist()` returned `None` and execution fell through to `_create_and_link_gist()`, which calls `_make_github_client()` unconditionally.

## Fix

Replace the broken two-call stateful approach with a single focused test:

1. Pre-populate `provider._gist_cache[965]` with a `MagicMock` gist — `_get_gist()` hits the cache and never calls `_make_github_client()`
2. Configure `graphql_query` to return an issue body containing the gist sentinel `<!-- artifact-gist:{hex_id} -->`
3. Assert `mock_gist.edit()` was called once with `"manifest.json"` in the files dict
4. Assert zero `updateIssue` mutation calls — the issue body is unchanged, the mutation must be skipped

## Test plan

- [x] `TestGitHubArtifactProviderSetManifest::test_set_manifest_skips_edit_when_body_unchanged` — passes, no live API calls
- [x] `TestGitHubArtifactProviderSetManifest::test_set_manifest_calls_issue_edit_when_body_changes` — unchanged, still passes
- [x] Full `tests_backlog/test_artifact_provider.py` — 41/41 passed
- [x] `prek` pre-commit hooks — ruff, ty, conventional-commit all green

Resolves #2589

https://claude.ai/code/session_016nj9obGD6MZQQXDttfNhPt

---
_Generated by [Claude Code](https://claude.ai/code/session_016nj9obGD6MZQQXDttfNhPt)_