### PR TITLE
fix(development-harness): replace issue_number=0 sentinel with beads ID in BeadsArtifactProvider

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/beads_artifact_provider.py
+++ b/plugins/development-harness/backlog_core/backends/beads_artifact_provider.py
@@ -385,8 +385,8 @@ class BeadsArtifactProvider:
             issue_id: Beads issue ID string (e.g. ``"bd-a3f8"``).
 
         Returns:
-            ``ArtifactManifest``.  ``issue_number`` is ``0`` for manifests
-            returned from the beads backend (no integer ID applies).
+            ``ArtifactManifest``.  ``issue_number`` is always *issue_id*
+            (the beads nanoid string, e.g. ``"bd-a3f8"``).
 
         Raises:
             bd_runner.BdNotInstalledError: When ``bd`` is not on ``PATH``.
@@ -565,9 +565,10 @@ class BeadsArtifactProvider:
             issue_id: Beads issue ID string (e.g. ``"bd-a3f8"``).
 
         Returns:
-            Tuple of ``(ArtifactManifest, BeadsIssueRaw)``.  The manifest is
-            an empty ``ArtifactManifest(issue_number=0)`` when no manifest
-            data is stored on the issue.
+            Tuple of ``(ArtifactManifest, BeadsIssueRaw)``.  When no manifest
+            data is stored on the issue the manifest is an empty
+            ``ArtifactManifest(issue_number=issue_id)`` so callers always
+            receive the actual beads ID in ``manifest.issue_number``.
 
         Raises:
             bd_runner.BdNotInstalledError: When ``bd`` is not on ``PATH``.
@@ -577,9 +578,9 @@ class BeadsArtifactProvider:
         raw = self._runner.run_json(["show", issue_id])
         issue = parse_show_issue(raw)
         if issue.metadata is None:
-            return ArtifactManifest(issue_number=0), issue
+            return ArtifactManifest(issue_number=issue_id), issue
         if (manifest := _extract_manifest_from_metadata(issue.metadata)) is None:
-            return ArtifactManifest(issue_number=0), issue
+            return ArtifactManifest(issue_number=issue_id), issue
         return manifest, issue
 
     @property

--- a/plugins/development-harness/backlog_core/tests/test_beads_artifact_provider_manifest.py
+++ b/plugins/development-harness/backlog_core/tests/test_beads_artifact_provider_manifest.py
@@ -37,12 +37,9 @@ _BD_SHOW_METADATA_NO_DH_ARTIFACTS: list[dict] = [
 
 def _provider_with_mock_runner(raw_json: object) -> BeadsArtifactProvider:
     """Return a BeadsArtifactProvider whose runner returns *raw_json* from run_json."""
-    provider = BeadsArtifactProvider.__new__(BeadsArtifactProvider)
-    provider._root_worktree = None  # type: ignore[attr-defined]
     runner_mock = MagicMock()
     runner_mock.run_json.return_value = raw_json
-    provider._runner_instance = runner_mock  # type: ignore[attr-defined]
-    return provider
+    return BeadsArtifactProvider(runner=runner_mock)
 
 
 class TestGetManifestBdIssueNumberPreservation:

--- a/plugins/development-harness/backlog_core/tests/test_beads_artifact_provider_manifest.py
+++ b/plugins/development-harness/backlog_core/tests/test_beads_artifact_provider_manifest.py
@@ -1,0 +1,78 @@
+"""Regression tests for BeadsArtifactProvider.get_manifest_bd issue_number field.
+
+Background: ``_fetch_issue_and_manifest`` used ``ArtifactManifest(issue_number=0)``
+as a sentinel when a beads issue had no stored manifest data.  ``0`` is not a valid
+beads ID and caused cross-issue manifest confusion when multiple beads-backed issues
+were active simultaneously.
+
+Fix (issue #2442): Both empty-manifest return paths now pass ``issue_id`` to
+``ArtifactManifest(issue_number=issue_id)`` so the actual beads nanoid is always
+preserved in the returned manifest.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from backlog_core.backends.beads_artifact_provider import BeadsArtifactProvider
+
+# Minimal valid bd-show JSON (single-element list as returned by ``bd show``)
+_ISSUE_ID = "bd-a3f8"
+
+_BD_SHOW_NO_METADATA: list[dict] = [
+    {"id": _ISSUE_ID, "title": "Test issue", "status": "open", "issue_type": "task", "priority": 2}
+]
+
+_BD_SHOW_METADATA_NO_DH_ARTIFACTS: list[dict] = [
+    {
+        "id": _ISSUE_ID,
+        "title": "Test issue",
+        "status": "open",
+        "issue_type": "task",
+        "priority": 2,
+        "metadata": {"other_key": "some_value"},
+    }
+]
+
+
+def _provider_with_mock_runner(raw_json: object) -> BeadsArtifactProvider:
+    """Return a BeadsArtifactProvider whose runner returns *raw_json* from run_json."""
+    provider = BeadsArtifactProvider.__new__(BeadsArtifactProvider)
+    provider._root_worktree = None  # type: ignore[attr-defined]
+    runner_mock = MagicMock()
+    runner_mock.run_json.return_value = raw_json
+    provider._runner_instance = runner_mock  # type: ignore[attr-defined]
+    return provider
+
+
+class TestGetManifestBdIssueNumberPreservation:
+    """get_manifest_bd always returns manifest.issue_number == issue_id."""
+
+    def test_no_metadata_returns_issue_id_not_zero(self) -> None:
+        """When bd show returns no metadata, issue_number must be the beads ID string.
+
+        Regression for #2442: previously returned ArtifactManifest(issue_number=0).
+        """
+        provider = _provider_with_mock_runner(_BD_SHOW_NO_METADATA)
+
+        manifest = provider.get_manifest_bd(_ISSUE_ID)
+
+        assert manifest.issue_number == _ISSUE_ID
+
+    def test_metadata_without_dh_artifacts_returns_issue_id_not_zero(self) -> None:
+        """When metadata has no dh.artifacts key, issue_number must be the beads ID string.
+
+        Regression for #2442: previously returned ArtifactManifest(issue_number=0).
+        """
+        provider = _provider_with_mock_runner(_BD_SHOW_METADATA_NO_DH_ARTIFACTS)
+
+        manifest = provider.get_manifest_bd(_ISSUE_ID)
+
+        assert manifest.issue_number == _ISSUE_ID
+
+    def test_zero_is_never_returned_as_issue_number(self) -> None:
+        """Confirm the sentinel 0 value is gone from both empty-manifest paths."""
+        for raw in (_BD_SHOW_NO_METADATA, _BD_SHOW_METADATA_NO_DH_ARTIFACTS):
+            provider = _provider_with_mock_runner(raw)
+            manifest = provider.get_manifest_bd(_ISSUE_ID)
+            assert manifest.issue_number != 0, f"issue_number must not be sentinel 0; got {manifest.issue_number!r}"


### PR DESCRIPTION
## Summary

- **Root design flaw (#2442):** `_fetch_issue_and_manifest` used integer `0` as a sentinel for "no stored manifest" when the issue is beads-backed. `ArtifactManifest.issue_number` is already typed `str | int` to support beads nanoid strings — the sentinel pattern contradicted that design intent and caused all beads issues to return `issue_number=0`, making cross-issue manifest lookup ambiguous.
- **Fix:** Both empty-manifest return paths now pass `issue_id` (the actual beads nanoid, e.g. `"bd-a3f8"`) to `ArtifactManifest(issue_number=issue_id)` so the manifest always carries the real identifier.
- **Docstrings updated** in `_fetch_issue_and_manifest` and `get_manifest_bd` to reflect the corrected behaviour (removed the stale `issue_number is 0` claim).
- **3 regression tests added** in `test_beads_artifact_provider_manifest.py` covering the no-metadata path, the metadata-with-no-dh.artifacts path, and a guard against sentinel `0` on either path.

## Design intent

`ArtifactManifest.issue_number: str | int` was explicitly widened to `str | int` (models.py line 1386) to accommodate non-integer backends (beads nanoids, Linear UUIDs). The sentinel `0` pattern broke that contract by silently discarding the beads ID before returning. The fix threads the actual `issue_id` string through to the Pydantic constructor — no model change required, the model was already correct.

## Test plan

- [x] `uv run pytest plugins/development-harness/backlog_core/tests/test_beads_artifact_provider_manifest.py` — 3 new tests pass
- [x] `uv run pytest plugins/development-harness/backlog_core/tests/` — 500 tests pass, 0 regressions
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — clean
- [x] `grep "issue_number=0" beads_artifact_provider.py` — no matches (sentinel gone)

Closes #2442

https://claude.ai/code/session_01LLHvkVrytiSeanCNpyARsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLHvkVrytiSeanCNpyARsK)_