### PR TITLE
fix(dh): enforce str narrowing after ast.Constant check in test_server_descriptions

### DIFF
--- a/plugins/development-harness/tests/test_server_descriptions.py
+++ b/plugins/development-harness/tests/test_server_descriptions.py
@@ -92,6 +92,10 @@ def _extract_selector_descriptions(source: str) -> dict[str, str]:
                         f"{node.name}: selector Field description is not a string constant "
                         f"(got {type(kw.value).__name__})"
                     )
+                    assert isinstance(kw.value.value, str), (
+                        f"{node.name}: selector Field description must be a string literal "
+                        f"(got {type(kw.value.value).__name__})"
+                    )
                     selector_desc = kw.value.value
                     break
             assert selector_desc is not None, f"{node.name}: selector Field has no description= keyword"


### PR DESCRIPTION
## Summary

- `test_server_descriptions.py:95` had a type error: `kw.value.value` (typed `str | bytes | int | float | complex | bool | None`) was assigned to `selector_desc: str | None` without type narrowing
- The existing `isinstance(kw.value, ast.Constant)` check only proved the node is a literal — not that its value is a `str`
- Added `isinstance(kw.value.value, str)` assertion to narrow the type and enforce the design contract that `Field(description=...)` must be a string literal

## Root cause (design level)

The bug is not the type error — the bug is that the validation checked the AST node kind (`Constant`) but not the Python value kind (`str`). These are orthogonal: `Field(description=42)` passes the Constant check but violates the string-literal contract. The missing `isinstance(kw.value.value, str)` left the contract implicit and the type unsound.

## Test plan

- `uv run ty check` → `All checks passed!` (was 1 diagnostic before)
- `uv run pytest plugins/development-harness/tests/test_server_descriptions.py -v` → 10/10 passed
- `uv run pytest plugins/development-harness/tests/ -x -q` → 2368 passed, 0 failures
- `uv run prek run --files plugins/development-harness/tests/test_server_descriptions.py` → all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bCea4wXVBd8ksFRgbE8EQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015bCea4wXVBd8ksFRgbE8EQ)_