### PR TITLE
fix(tests): narrow ast.Constant.value to str before assignment

### DIFF
--- a/plugins/development-harness/tests/test_server_descriptions.py
+++ b/plugins/development-harness/tests/test_server_descriptions.py
@@ -92,6 +92,10 @@ def _extract_selector_descriptions(source: str) -> dict[str, str]:
                         f"{node.name}: selector Field description is not a string constant "
                         f"(got {type(kw.value).__name__})"
                     )
+                    assert isinstance(kw.value.value, str), (
+                        f"{node.name}: selector Field description= must be a str literal "
+                        f"(got {type(kw.value.value).__name__!r})"
+                    )
                     selector_desc = kw.value.value
                     break
             assert selector_desc is not None, f"{node.name}: selector Field has no description= keyword"


### PR DESCRIPTION
## Summary

- `ast.Constant.value` is typed `str | bytes | int | float | complex | bool | None` — `isinstance(node, ast.Constant)` narrows the *node* type but not the `.value` attribute
- Added `assert isinstance(kw.value.value, str)` in `_extract_selector_descriptions()` after the existing `ast.Constant` assertion, providing proper runtime type narrowing without `cast` or `# type: ignore`
- `uv run ty check plugins/development-harness/` now passes clean; the assertion also serves as a runtime guardrail that fails loudly with the tool name if a non-string description literal is ever introduced

## Root cause

The design bug was incomplete type narrowing: checking the node type (`ast.Constant`) is not the same as checking the value type (`str`). The type checker correctly flagged `selector_desc = kw.value.value` because `str | bytes | int | ...` is not assignable to `str | None`.

## Test plan

- [x] `uv run ty check plugins/development-harness/` → All checks passed
- [x] Pre-commit hooks (ruff lint, ruff format, ty check) all pass on commit
- [x] No `cast`, no `# type: ignore`, no `object`/`Any` — typing is strictly stronger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkFnrZANkSGbXXNsKgLJLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkFnrZANkSGbXXNsKgLJLa)_