### PR TITLE
fix(backlog_core): remove cast() by strengthening type conformance

### DIFF
--- a/plugins/development-harness/backlog_core/tests/conftest.py
+++ b/plugins/development-harness/backlog_core/tests/conftest.py
@@ -19,20 +19,37 @@ pre-populates that cache *before any test imports ``server``*:
 
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, Literal
 
 import tiktoken
 import tiktoken.registry
 
+if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence, Set as AbstractSet
 
-class _StubEncoder:
-    """Deterministic ~4-chars-per-token stand-in for cl100k_base (offline only)."""
 
-    def encode(self, text: str, *_args: object, **_kwargs: object) -> list[int]:
+class _StubEncoder(tiktoken.Encoding):
+    """Deterministic ~4-chars-per-token stand-in for cl100k_base (offline only).
+
+    Inherits from tiktoken.Encoding so it satisfies the ENCODINGS registry type
+    (dict[str, Encoding]) without a cast().  __init__ bypasses the BPE
+    initialisation — the stub only needs encode() and decode().
+    """
+
+    def __init__(self) -> None:
+        object.__init__(self)  # skip BPE init — no encoding data is needed
+
+    def encode(
+        self,
+        text: str,
+        *,
+        allowed_special: Literal["all"] | AbstractSet[str] = frozenset(),
+        disallowed_special: Literal["all"] | Collection[str] = "all",
+    ) -> list[int]:
         """Return a token list whose length tracks the input length monotonically."""
         return [0] * ((len(text) + 3) // 4)
 
-    def decode(self, tokens: list[int], *_args: object, **_kwargs: object) -> str:
+    def decode(self, tokens: Sequence[int], errors: str = "replace") -> str:
         """Return a placeholder string proportional to the token count."""
         return " " * (len(tokens) * 4)
 
@@ -52,7 +69,7 @@ def _ensure_cl100k_cached() -> bool:
     try:
         tiktoken.get_encoding("cl100k_base")  # populates ENCODINGS from cache/network
     except Exception:  # noqa: BLE001 - tiktoken raises undeclared download/network errors when its cache is empty and the network is unreachable; the concrete class is not part of its public API, so seed a deterministic stub to keep server importable offline.
-        tiktoken.registry.ENCODINGS["cl100k_base"] = cast("tiktoken.Encoding", _StubEncoder())
+        tiktoken.registry.ENCODINGS["cl100k_base"] = _StubEncoder()
         return False
     else:
         return True

--- a/plugins/development-harness/backlog_core/tests/test_rendering.py
+++ b/plugins/development-harness/backlog_core/tests/test_rendering.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -45,12 +45,12 @@ def backend_instance(request: pytest.FixtureRequest) -> BacklogBackend:
     """
     name: str = request.param
     if name == "github":
-        return cast("BacklogBackend", GitHubBackend())
+        return GitHubBackend()
     if name == "sqlite":
-        return cast("BacklogBackend", SQLiteBackend(db_path=":memory:"))
+        return SQLiteBackend(db_path=":memory:")
     if name == "beads":
-        return cast("BacklogBackend", BeadsBackend())
-    return cast("BacklogBackend", InMemoryBackend())
+        return BeadsBackend()
+    return InMemoryBackend()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`test_rendering.py`**: Removed 4 unnecessary `cast("BacklogBackend", ...)` calls. `BacklogBackend` is a `@runtime_checkable` Protocol and all four concrete backends (`GitHubBackend`, `SQLiteBackend`, `BeadsBackend`, `InMemoryBackend`) structurally conform — verified by `ty check` without cast. The casts were bypassing the type checker's Protocol conformance check instead of letting it verify each backend's contract. Future Protocol drift will now be caught immediately.

- **`conftest.py`**: `_StubEncoder` now inherits from `tiktoken.Encoding` directly, eliminating the `cast("tiktoken.Encoding", _StubEncoder())` call. The subclass matches the public method signatures exactly (`encode` with `allowed_special`/`disallowed_special`, `decode` with `Sequence[int]` + `errors`). `__init__` calls `object.__init__()` to bypass BPE initialisation — the stub only needs `encode()` and `decode()` for offline token-count tests.

## Root Cause

The design that made these `cast()` calls possible was treating them as a way to _assert_ types at return boundaries rather than ensuring those types were actually correct. `cast()` tells the type checker "trust me" — which silences it instead of using it as a correctness tool.

## Test Plan

- [x] `uv run ruff check` → 0 errors (5 auto-fixed by ruff during this session)
- [x] `uv run ty check` → All checks passed (both files, full module)
- [x] `uv run pytest plugins/development-harness/backlog_core/tests/` → 497 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x4D84fhbErDfWjowM8GLx

---
_Generated by [Claude Code](https://claude.ai/code/session_013x4D84fhbErDfWjowM8GLx)_