### PR TITLE
fix(dh-tests): narrow ast.Constant.value to str before assignment

### DIFF
--- a/plugins/development-harness/tests/test_server_descriptions.py
+++ b/plugins/development-harness/tests/test_server_descriptions.py
@@ -92,6 +92,10 @@ def _extract_selector_descriptions(source: str) -> dict[str, str]:
                         f"{node.name}: selector Field description is not a string constant "
                         f"(got {type(kw.value).__name__})"
                     )
+                    assert isinstance(kw.value.value, str), (
+                        f"{node.name}: selector Field description value is not a str "
+                        f"(got {type(kw.value.value).__name__})"
+                    )
                     selector_desc = kw.value.value
                     break
             assert selector_desc is not None, f"{node.name}: selector Field has no description= keyword"


### PR DESCRIPTION
## Summary

- `_extract_selector_descriptions` in `test_server_descriptions.py` narrowed `kw.value` to `ast.Constant` but never narrowed `kw.value.value` to `str`
- This left a type hole: `ast.Constant.value` is `str | bytes | int | float | complex | bool | None | ellipsis`, so assigning it to `selector_desc: str | None` and returning `dict[str, str]` was unsound
- A non-str constant (e.g. `description=42`) would silently pass the existing `isinstance(kw.value, ast.Constant)` check

## Root cause (design-level)

The assertion pattern trusted that any `description=` keyword in a `Field(...)` call would always carry a `str` value, but did not make this machine-verifiable. The type system could not prove the `dict[str, str]` return type was correct.

## Fix

Added `assert isinstance(kw.value.value, str)` immediately after the existing `ast.Constant` check. This:
1. Makes the narrowing explicit and machine-verifiable (`ty check` now passes clean)
2. Strengthens the test — a non-str description now produces a clear assertion error with a diagnostic message instead of a silent type confusion downstream

## Test plan

- [x] `uv run ty check plugins/development-harness/tests/test_server_descriptions.py` → `All checks passed!`
- [x] `uv run pytest plugins/development-harness/tests/test_server_descriptions.py` → 10/10 passed
- [x] Single-file change, no behaviour change under correct inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W77p9i55QgowiNaUeFDjdg

---
_Generated by [Claude Code](https://claude.ai/code/session_01W77p9i55QgowiNaUeFDjdg)_