### PR TITLE
fix(sam): graceful degradation for GitHub secondary rate limit in GistTaskLayer

### DIFF
--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -71,9 +71,9 @@ fi
 # gitConfigInjection — manual insteadOf entries conflict and break git.
 echo ""
 log "Checking for stale git insteadOf entries in ~/.gitconfig..."
-stale=$(git config --global --get-regexp 'url\..*\.insteadOf' 2>/dev/null || true)
+stale=$(git config --global --get-regexp 'url\..*\.insteadOf' 2>/dev/null | grep -Ei '127\.0\.0\.1|local_proxy' || true)
 if [[ -n "${stale}" ]]; then
-    warn "Found stale insteadOf entries from a previous session:"
+    warn "Found stale insteadOf entries from a previous session (filtered to local-proxy rewrites only):"
     while IFS=' ' read -r key _value; do
         echo "  removing: ${key}"
         git config --global --unset-all "${key}" 2>/dev/null || true
@@ -95,8 +95,19 @@ raw_url=$(git -C "${REPO_ROOT}" config --local remote.origin.url 2>/dev/null) ||
 # or plain http://127.0.0.1:... URLs from previous proxy injection
 if [[ "${raw_url}" =~ 127\.0\.0\.1 ]] || [[ "${raw_url}" =~ local_proxy ]]; then
     warn "remote.origin.url is a stale local proxy URL: ${raw_url}"
-    # Extract owner/repo from the end of the URL (last two path segments)
-    repo_path="${raw_url##*/git/}" # strip everything up to /git/
+    # Extract owner/repo from the end of the URL (last two path segments).
+    # The /git/ prefix form (http://user@127.0.0.1:PORT/git/owner/repo) is stripped
+    # directly. The plain form (http://127.0.0.1:PORT/owner/repo) has no /git/
+    # segment, so ##*/git/ would be a no-op and leave the whole URL in repo_path —
+    # strip scheme, credentials, and host:port instead to isolate owner/repo.
+    if [[ "${raw_url}" == */git/* ]]; then
+        repo_path="${raw_url##*/git/}"
+    else
+        repo_path="${raw_url#*://}" # strip scheme
+        repo_path="${repo_path#*@}" # strip user@ credentials, if present
+        repo_path="${repo_path#*/}" # strip host:port
+    fi
+    repo_path="${repo_path%.git}" # strip trailing .git suffix, if present
     if [[ -n "${repo_path}" && "${repo_path}" == */* ]]; then
         if [[ -n "${GITHUB_TOKEN:-}" ]]; then
             new_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${repo_path}"

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -48,7 +48,8 @@ fi
 
 # ─── 3. Proxy connectivity check ─────────────────────────────────────────────
 # Extract port from HTTPS_PROXY=http://127.0.0.1:<port>  using greedy strip to last colon.
-PROXY_PORT="${HTTPS_PROXY##*:}"
+# Use :+ so the expansion is empty (not an unbound-variable abort) when HTTPS_PROXY is unset.
+PROXY_PORT="${HTTPS_PROXY:+${HTTPS_PROXY##*:}}"
 if [[ -n "${PROXY_PORT}" ]] &&
     curl -sS --max-time 2 "http://127.0.0.1:${PROXY_PORT}/__agentproxy/status" >/dev/null 2>&1; then
     ok "Proxy reachable at port ${PROXY_PORT}"
@@ -182,7 +183,7 @@ else
     warn "shellcheck not in PATH"
     warn "  Pre-commit hook 'shellcheck-py' will fail: pip downloads a ~2.5MB binary"
     warn "  from GitHub releases and the proxy drops large streaming downloads."
-    warn "  Use --no-verify for commits that trigger shellcheck until fixed."
+    warn "  Commits touching shell files will be blocked until shellcheck is available."
     warn "  Permanent fix: see infrastructure requirements below."
 fi
 

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -20,9 +20,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-log()  { echo "[session-init] $*"; }
+log() { echo "[session-init] $*"; }
 warn() { echo "[session-init] WARNING: $*" >&2; }
-ok()   { echo "[session-init] OK: $*"; }
+ok() { echo "[session-init] OK: $*"; }
 
 echo "━━━ session-init: Claude Code sandbox environment setup ━━━"
 echo ""
@@ -49,8 +49,8 @@ fi
 # ─── 3. Proxy connectivity check ─────────────────────────────────────────────
 # Extract port from HTTPS_PROXY=http://127.0.0.1:<port>  using greedy strip to last colon.
 PROXY_PORT="${HTTPS_PROXY##*:}"
-if [[ -n "${PROXY_PORT}" ]] && \
-   curl -sS --max-time 2 "http://127.0.0.1:${PROXY_PORT}/__agentproxy/status" >/dev/null 2>&1; then
+if [[ -n "${PROXY_PORT}" ]] &&
+    curl -sS --max-time 2 "http://127.0.0.1:${PROXY_PORT}/__agentproxy/status" >/dev/null 2>&1; then
     ok "Proxy reachable at port ${PROXY_PORT}"
 else
     warn "Proxy not reachable at port ${PROXY_PORT:-unknown} — all outbound HTTPS will fail"
@@ -69,7 +69,7 @@ if [[ -n "${stale}" ]]; then
     while IFS=' ' read -r key _value; do
         echo "  removing: ${key}"
         git config --global --unset-all "${key}" 2>/dev/null || true
-    done <<< "${stale}"
+    done <<<"${stale}"
     ok "Stale insteadOf entries removed"
 else
     ok "git insteadOf: clean"
@@ -88,7 +88,7 @@ raw_url=$(git -C "${REPO_ROOT}" config --local remote.origin.url 2>/dev/null) ||
 if [[ "${raw_url}" =~ 127\.0\.0\.1 ]] || [[ "${raw_url}" =~ local_proxy ]]; then
     warn "remote.origin.url is a stale local proxy URL: ${raw_url}"
     # Extract owner/repo from the end of the URL (last two path segments)
-    repo_path="${raw_url##*/git/}"     # strip everything up to /git/
+    repo_path="${raw_url##*/git/}" # strip everything up to /git/
     if [[ -n "${repo_path}" && "${repo_path}" == */* ]]; then
         if [[ -n "${GITHUB_TOKEN:-}" ]]; then
             new_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${repo_path}"
@@ -135,7 +135,7 @@ uv self update 2>&1 | tail -1 | sed 's/^/[session-init] /' || true
 echo ""
 log "Installing git hooks via prek..."
 if (cd "${REPO_ROOT}" && uv run prek install \
-        -t pre-commit -t commit-msg -t pre-rebase -t post-merge 2>&1); then
+    -t pre-commit -t commit-msg -t pre-rebase -t post-merge 2>&1); then
     ok "prek: git hook scripts installed"
 else
     warn "prek install failed — hooks may not run on commit"
@@ -167,8 +167,8 @@ fi
 
 # Test 3: PyPI HTTPS via curl (exercises proxy + sandbox cert bundle for pip/uv downloads)
 if curl -sS --max-time 5 \
-        --cacert "${SSL_CERT_FILE:-/root/.ccr/ca-bundle.crt}" \
-        "https://pypi.org/simple/pip/" 2>/dev/null | grep -q 'pip'; then
+    --cacert "${SSL_CERT_FILE:-/root/.ccr/ca-bundle.crt}" \
+    "https://pypi.org/simple/pip/" 2>/dev/null | grep -q 'pip'; then
     ok "PyPI HTTPS:     proxy + SSL ✓"
 else
     warn "PyPI HTTPS FAILED — pip/uv downloads will fail; check SSL_CERT_FILE and proxy"

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -81,7 +81,7 @@ fi
 # This must be replaced with the real github.com URL for fetch and push to work.
 echo ""
 log "Checking remote.origin.url..."
-raw_url=$(cd "${REPO_ROOT}" && git config --local remote.origin.url 2>/dev/null || true)
+raw_url=$(git -C "${REPO_ROOT}" config --local remote.origin.url 2>/dev/null) || raw_url=""
 
 # Detect stale local proxy URLs (pattern: http(s)://...@127.0.0.1:.../git/<owner>/<repo>)
 # or plain http://127.0.0.1:... URLs from previous proxy injection
@@ -103,8 +103,12 @@ if [[ "${raw_url}" =~ 127\.0\.0\.1 ]] || [[ "${raw_url}" =~ local_proxy ]]; then
     fi
 elif [[ "${raw_url}" == https://github.com/* ]] || [[ "${raw_url}" =~ ^https://[^@]+@github\.com/ ]]; then
     # URL points to github.com (with or without embedded credentials) — refresh token
-    bare_url=$(echo "${raw_url}" | sed 's|https://[^@]*@github\.com/|https://github.com/|')
-    repo_path="${bare_url#https://github.com/}"
+    # Extract owner/repo using parameter expansion (avoids SC2001 sed warning)
+    if [[ "${raw_url}" == *"@github.com/"* ]]; then
+        repo_path="${raw_url##*@github.com/}"
+    else
+        repo_path="${raw_url#https://github.com/}"
+    fi
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
         new_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${repo_path}"
         if [[ "${raw_url}" != "${new_url}" ]]; then

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -15,6 +15,13 @@
 # All outbound HTTPS in this sandbox is routed through HTTPS_PROXY — the goal is
 # correct configuration through the proxy, not bypassing it.
 
+# When sourced, save the caller's shell options and restore them on exit so that
+# enabling strict mode here does not permanently alter the caller's session.
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    _session_init_saved_opts="$(set +o)"
+    trap 'eval "${_session_init_saved_opts}"; unset _session_init_saved_opts; trap - RETURN' RETURN
+fi
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# .claude/scripts/session-init.sh
+#
+# Initializes a Claude Code remote sandbox session.
+# Fixes known environment issues, cleans stale git config, and installs git hooks.
+#
+# Usage:
+#   bash .claude/scripts/session-init.sh        — apply fixes (env vars NOT exported to caller shell)
+#   source .claude/scripts/session-init.sh      — apply fixes AND export env vars to current shell
+#
+# To add to CLAUDE.md session-start instructions:
+#   !`source .claude/scripts/session-init.sh`
+#
+# Validation: the script tests that each critical tool works THROUGH the proxy.
+# All outbound HTTPS in this sandbox is routed through HTTPS_PROXY — the goal is
+# correct configuration through the proxy, not bypassing it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+log()  { echo "[session-init] $*"; }
+warn() { echo "[session-init] WARNING: $*" >&2; }
+ok()   { echo "[session-init] OK: $*"; }
+
+echo "━━━ session-init: Claude Code sandbox environment setup ━━━"
+echo ""
+
+# ─── 1. UV certificate environment ───────────────────────────────────────────
+# UV_NATIVE_TLS is deprecated since uv 0.6.x; UV_SYSTEM_CERTS=true is the replacement.
+# This export works when sourced; when run as a subshell it affects child processes only.
+if [[ "${UV_NATIVE_TLS:-}" == "true" ]]; then
+    export UV_SYSTEM_CERTS=true
+    log "Exported UV_SYSTEM_CERTS=true (replaces deprecated UV_NATIVE_TLS)"
+    log "Infrastructure fix needed: replace UV_NATIVE_TLS=true with UV_SYSTEM_CERTS=true"
+else
+    ok "UV cert env already correct"
+fi
+
+# ─── 2. Verify CA bundle ─────────────────────────────────────────────────────
+CA_BUNDLE="${SSL_CERT_FILE:-}"
+if [[ -f "${CA_BUNDLE}" ]]; then
+    ok "CA bundle: ${CA_BUNDLE}"
+else
+    warn "SSL_CERT_FILE not set or file missing — proxy TLS will fail"
+fi
+
+# ─── 3. Proxy connectivity check ─────────────────────────────────────────────
+# Extract port from HTTPS_PROXY=http://127.0.0.1:<port>  using greedy strip to last colon.
+PROXY_PORT="${HTTPS_PROXY##*:}"
+if [[ -n "${PROXY_PORT}" ]] && \
+   curl -sS --max-time 2 "http://127.0.0.1:${PROXY_PORT}/__agentproxy/status" >/dev/null 2>&1; then
+    ok "Proxy reachable at port ${PROXY_PORT}"
+else
+    warn "Proxy not reachable at port ${PROXY_PORT:-unknown} — all outbound HTTPS will fail"
+    warn "HTTPS_PROXY=${HTTPS_PROXY:-unset}"
+fi
+
+# ─── 4. Stale git insteadOf cleanup in ~/.gitconfig ──────────────────────────
+# Previous sessions may leave insteadOf URL rewrites pointing to wrong proxy ports
+# or plain-HTTP proxy URLs. The current proxy handles SSH→HTTPS rewrites via
+# gitConfigInjection — manual insteadOf entries conflict and break git.
+echo ""
+log "Checking for stale git insteadOf entries in ~/.gitconfig..."
+stale=$(git config --global --get-regexp 'url\..*\.insteadOf' 2>/dev/null || true)
+if [[ -n "${stale}" ]]; then
+    warn "Found stale insteadOf entries from a previous session:"
+    while IFS=' ' read -r key _value; do
+        echo "  removing: ${key}"
+        git config --global --unset-all "${key}" 2>/dev/null || true
+    done <<< "${stale}"
+    ok "Stale insteadOf entries removed"
+else
+    ok "git insteadOf: clean"
+fi
+
+# ─── 5. Fix stale remote.origin.url in .git/config ───────────────────────────
+# Each container may be cloned through a different proxy port, leaving the remote
+# URL pointing to a local proxy address like http://local_proxy@127.0.0.1:<old-port>/git/...
+# This must be replaced with the real github.com URL for fetch and push to work.
+echo ""
+log "Checking remote.origin.url..."
+raw_url=$(cd "${REPO_ROOT}" && git config --local remote.origin.url 2>/dev/null || true)
+
+# Detect stale local proxy URLs (pattern: http(s)://...@127.0.0.1:.../git/<owner>/<repo>)
+# or plain http://127.0.0.1:... URLs from previous proxy injection
+if [[ "${raw_url}" =~ 127\.0\.0\.1 ]] || [[ "${raw_url}" =~ local_proxy ]]; then
+    warn "remote.origin.url is a stale local proxy URL: ${raw_url}"
+    # Extract owner/repo from the end of the URL (last two path segments)
+    repo_path="${raw_url##*/git/}"     # strip everything up to /git/
+    if [[ -n "${repo_path}" && "${repo_path}" == */* ]]; then
+        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+            new_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${repo_path}"
+        else
+            new_url="https://github.com/${repo_path}"
+        fi
+        (cd "${REPO_ROOT}" && git remote set-url origin "${new_url}")
+        ok "remote.origin.url fixed: https://github.com/${repo_path}"
+    else
+        warn "Could not parse owner/repo from: ${raw_url}"
+        warn "Set remote URL manually: git remote set-url origin https://github.com/<owner>/<repo>"
+    fi
+elif [[ "${raw_url}" == https://github.com/* ]] || [[ "${raw_url}" =~ ^https://[^@]+@github\.com/ ]]; then
+    # URL points to github.com (with or without embedded credentials) — refresh token
+    bare_url=$(echo "${raw_url}" | sed 's|https://[^@]*@github\.com/|https://github.com/|')
+    repo_path="${bare_url#https://github.com/}"
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        new_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${repo_path}"
+        if [[ "${raw_url}" != "${new_url}" ]]; then
+            (cd "${REPO_ROOT}" && git remote set-url origin "${new_url}")
+            ok "remote.origin.url: refreshed GITHUB_TOKEN for github.com/${repo_path}"
+        else
+            ok "remote.origin.url: already has current GITHUB_TOKEN"
+        fi
+    else
+        ok "remote.origin.url: github.com URL (no GITHUB_TOKEN — push will require credentials)"
+    fi
+else
+    warn "remote.origin.url is unrecognized: ${raw_url}"
+fi
+
+# ─── 6. uv update ────────────────────────────────────────────────────────────
+echo ""
+log "Updating uv..."
+uv self update 2>&1 | tail -1 | sed 's/^/[session-init] /' || true
+
+# ─── 7. prek hook installation ───────────────────────────────────────────────
+# Installs git hook scripts into .git/hooks/ (fast, no network required).
+# Hook venvs are created lazily on first hook run.
+echo ""
+log "Installing git hooks via prek..."
+if (cd "${REPO_ROOT}" && uv run prek install \
+        -t pre-commit -t commit-msg -t pre-rebase -t post-merge 2>&1); then
+    ok "prek: git hook scripts installed"
+else
+    warn "prek install failed — hooks may not run on commit"
+fi
+
+# ─── 8. Validation: test that tooling works correctly through the proxy ───────
+# All outbound HTTPS goes through HTTPS_PROXY. These tests confirm each tool
+# can reach the internet correctly with the current proxy and cert configuration.
+echo ""
+log "Validating tool connectivity through proxy..."
+
+# Test 1: git fetch (exercises GIT_SSL_CAINFO + proxy HTTPS CONNECT)
+if (cd "${REPO_ROOT}" && git fetch --dry-run origin 2>/dev/null); then
+    ok "git fetch:      proxy + SSL ✓"
+else
+    warn "git fetch FAILED — check GIT_SSL_CAINFO (${GIT_SSL_CAINFO:-unset}) and proxy"
+fi
+
+# Test 2: Python HTTPS (exercises SSL_CERT_FILE + HTTPS_PROXY env)
+if uv run python -c "
+import urllib.request, ssl, os
+ctx = ssl.create_default_context(cafile=os.environ.get('SSL_CERT_FILE'))
+urllib.request.urlopen('https://pypi.org/simple/', context=ctx, timeout=5)
+" 2>/dev/null; then
+    ok "Python HTTPS:   proxy + SSL ✓"
+else
+    warn "Python HTTPS FAILED — check SSL_CERT_FILE (${SSL_CERT_FILE:-unset}) and HTTPS_PROXY"
+fi
+
+# Test 3: PyPI HTTPS via curl (exercises proxy + sandbox cert bundle for pip/uv downloads)
+if curl -sS --max-time 5 \
+        --cacert "${SSL_CERT_FILE:-/root/.ccr/ca-bundle.crt}" \
+        "https://pypi.org/simple/pip/" 2>/dev/null | grep -q 'pip'; then
+    ok "PyPI HTTPS:     proxy + SSL ✓"
+else
+    warn "PyPI HTTPS FAILED — pip/uv downloads will fail; check SSL_CERT_FILE and proxy"
+fi
+
+# ─── 9. shellcheck availability ──────────────────────────────────────────────
+echo ""
+if command -v shellcheck >/dev/null 2>&1; then
+    ok "shellcheck: $(command -v shellcheck) ($(shellcheck --version | head -2 | tail -1))"
+else
+    warn "shellcheck not in PATH"
+    warn "  Pre-commit hook 'shellcheck-py' will fail: pip downloads a ~2.5MB binary"
+    warn "  from GitHub releases and the proxy drops large streaming downloads."
+    warn "  Use --no-verify for commits that trigger shellcheck until fixed."
+    warn "  Permanent fix: see infrastructure requirements below."
+fi
+
+# ─── 10. Infrastructure requirements ─────────────────────────────────────────
+echo ""
+echo "━━━ Infrastructure requirements (must be fixed at sandbox provisioning) ━━━"
+echo ""
+echo "  Environment variables (set at sandbox creation):"
+echo ""
+echo "    CHANGE: UV_NATIVE_TLS=true  →  UV_SYSTEM_CERTS=true  (deprecated since uv 0.6)"
+echo "    OK:     SSL_CERT_FILE=/root/.ccr/ca-bundle.crt"
+echo "    OK:     REQUESTS_CA_BUNDLE=/root/.ccr/ca-bundle.crt"
+echo "    OK:     GIT_SSL_CAINFO=/root/.ccr/ca-bundle.crt"
+echo "    OK:     NODE_EXTRA_CA_CERTS=/root/.ccr/ca-bundle.crt"
+echo "    OK:     PIP_CERT=/root/.ccr/ca-bundle.crt"
+echo "    OK:     CARGO_HTTP_CAINFO=/root/.ccr/ca-bundle.crt"
+echo ""
+echo "  Base image packages (proxy cannot stream large binary downloads):"
+echo ""
+if command -v shellcheck >/dev/null 2>&1; then
+    echo "    OK: shellcheck already in base image: $(command -v shellcheck)"
+    echo "        Replace shellcheck-py hook in .pre-commit-config.yaml with a local hook"
+    echo "        that calls the system binary — eliminates the binary download on pip install:"
+    echo ""
+    echo "          - repo: local"
+    echo "            hooks:"
+    echo "              - id: shellcheck"
+    echo "                name: shellcheck"
+    echo "                language: system"
+    echo "                entry: shellcheck"
+    echo "                types: [shell]"
+else
+    echo "    MISSING: shellcheck — apt-get install -y shellcheck"
+    echo ""
+    echo "    Root cause: shellcheck-py downloads a ~2.5MB tar.xz from GitHub releases"
+    echo "    during 'pip install'. The proxy drops the connection mid-stream"
+    echo "    (IncompleteRead after ~200KB). This is NOT a certificate issue."
+    echo ""
+    echo "    After adding shellcheck to the base image, replace the pre-commit hook:"
+    echo ""
+    echo "      - repo: local"
+    echo "        hooks:"
+    echo "          - id: shellcheck"
+    echo "            name: shellcheck"
+    echo "            language: system"
+    echo "            entry: shellcheck"
+    echo "            types: [shell]"
+fi
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+log "session-init complete"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,13 +124,10 @@ repos:
           - "4"
           - -ci
 
-  - repo: local
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
-        name: shellcheck
-        language: system
-        entry: shellcheck
-        types: [shell]
 
   # Local hooks for type checking
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,10 +124,13 @@ repos:
           - "4"
           - -ci
 
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+  - repo: local
     hooks:
       - id: shellcheck
+        name: shellcheck
+        language: system
+        entry: shellcheck
+        types: [shell]
 
   # Local hooks for type checking
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,10 +124,22 @@ repos:
           - "4"
           - -ci
 
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+  # Installs shellcheck-py from its published PyPI wheel (which bundles the
+  # prebuilt binary) instead of the upstream git-repo hook, which clones the
+  # repo and does a source install. The source install's setup.py downloads
+  # the binary via stdlib urllib.request, which truncates large GitHub
+  # release downloads through some HTTPS proxies (IncompleteRead). PyPI
+  # ships wheels for linux (manylinux), macOS (both arches), and Windows
+  # (win_amd64), so this works cross-platform without assuming a
+  # pre-installed system shellcheck binary.
+  - repo: local
     hooks:
       - id: shellcheck
+        name: shellcheck
+        entry: shellcheck
+        language: python
+        additional_dependencies: ["shellcheck-py==0.11.0.1"]
+        types: [shell]
 
   # Local hooks for type checking
   - repo: local

--- a/plugins/development-harness/backlog_core/artifact_provider.py
+++ b/plugins/development-harness/backlog_core/artifact_provider.py
@@ -583,19 +583,29 @@ class GitHubGistArtifactProvider:
                 Not used in the Gist filename — *path* is the unique key.
             path: Repo-relative artifact path, e.g. ``plan/architect-foo.md``.
             content: Full artifact content to store.
+
+        Raises:
+            backlog_core.models.GitHubUnavailableError: When ``GITHUB_TOKEN``
+                is not set.
+            backlog_core.models.BacklogError: On GraphQL API or gist-scope
+                failures.
         """
         item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
-        repo = get_github(self._repo)
-        owner, repo_name = self._repo.split("/", 1)
-        issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
-        body = issue.get("body") or ""
+        try:
+            repo = get_github(self._repo)
+            owner, repo_name = self._repo.split("/", 1)
+            issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
+            body = issue.get("body") or ""
 
-        gist = self._get_gist(item_id, body)
-        if gist is None:
-            gist = self._create_and_link_gist(item_id, issue["id"], body, {"manifest.json": InputFileContent("{}")})
+            gist = self._get_gist(item_id, body)
+            if gist is None:
+                gist = self._create_and_link_gist(item_id, issue["id"], body, {"manifest.json": InputFileContent("{}")})
 
-        filename = _sanitize_gist_filename(path)
-        gist.edit(files={filename: InputFileContent(content)})
+            filename = _sanitize_gist_filename(path)
+            gist.edit(files={filename: InputFileContent(content)})
+        except GithubException as exc:
+            msg = f"GitHub API error storing artifact content for item #{item_id}: {exc}"
+            raise BacklogError(msg) from exc
 
     def read_artifact_content_from_remote(self, item_id: ItemId, artifact_type: str, path: str) -> str | None:
         """Read artifact content from the linked Gist.

--- a/plugins/development-harness/sam_schema/core/gist_task_layer.py
+++ b/plugins/development-harness/sam_schema/core/gist_task_layer.py
@@ -611,6 +611,91 @@ class GistTaskLayer:
             raise ArtifactWriteError(plan_id=plan_id, issue=None, reason=msg) from exc
         return self._read_local_yaml(plan_id, local_path)
 
+    def _resolve_write_through_sidecars(self, plan_id: str) -> tuple[Path | None, Path | None]:
+        """Resolve the ``.sha256`` and ``.stale`` sidecar paths for a plan, best-effort.
+
+        ``hash_sidecar`` — content-hash dedup to skip unchanged Gist PATCHes.
+        ``stale_sidecar`` — durable marker that local YAML is ahead of Gist after
+        a rate-limited write-through skip.  Persists across ``GistTaskLayer``
+        instances (a fresh instance is created per MCP call) so ``read_plan``
+        bypasses Gist-first in subsequent calls even though the in-memory
+        ``_local_authoritative_plans`` set resets to empty.
+
+        Returns:
+            A ``(hash_sidecar, stale_sidecar)`` tuple, or ``(None, None)`` when the
+            local path cannot be resolved — sidecar handling is best-effort and
+            callers must tolerate both being absent.
+        """
+        try:
+            local_path = self._local._resolve_path(plan_id)  # noqa: SLF001
+        except PlanNotFoundError:
+            _log.debug(
+                "GistTaskLayer._write_through: path resolution failed for plan %s — skipping hash dedup", plan_id
+            )
+            return None, None
+        return local_path.with_suffix(".sha256"), local_path.with_suffix(".stale")
+
+    def _write_through_content_unchanged(
+        self, hash_sidecar: Path | None, content_hash: str, plan_id: str, issue: int
+    ) -> bool:
+        """Return ``True`` when ``content_hash`` matches the last uploaded hash sidecar."""
+        if hash_sidecar is None:
+            return False
+        try:
+            if hash_sidecar.read_text().strip() == content_hash:
+                _log.debug(
+                    "GistTaskLayer._write_through: content unchanged for plan %s (issue #%d), skipping Gist PATCH",
+                    plan_id,
+                    issue,
+                )
+                return True
+        except OSError:
+            _log.debug(
+                "GistTaskLayer._write_through: sidecar read failed for plan %s — uploading as normal",
+                plan_id,
+                exc_info=True,
+            )
+        return False
+
+    def _clear_stale_sidecar(self, stale_sidecar: Path | None, plan_id: str) -> None:
+        """Best-effort removal of the ``.stale`` sidecar after a successful upload."""
+        if stale_sidecar is None:
+            return
+        try:
+            stale_sidecar.unlink(missing_ok=True)
+        except OSError:
+            _log.debug(
+                "GistTaskLayer._write_through: failed to clear stale sidecar for plan %s — "
+                "read_plan will re-check on next call",
+                plan_id,
+            )
+
+    def _mark_stale_sidecar(self, stale_sidecar: Path | None, plan_id: str) -> None:
+        """Best-effort write of the ``.stale`` sidecar after a rate-limited upload skip."""
+        if stale_sidecar is None:
+            return
+        try:
+            stale_sidecar.touch()
+        except OSError:
+            _log.debug(
+                "GistTaskLayer._write_through: failed to write stale sidecar for plan %s — "
+                "local-authoritative bypass will not persist across MCP calls",
+                plan_id,
+            )
+
+    def _write_hash_sidecar(self, hash_sidecar: Path | None, content_hash: str, plan_id: str) -> None:
+        """Best-effort write of the ``.sha256`` sidecar after a successful upload."""
+        if hash_sidecar is None:
+            return
+        try:
+            hash_sidecar.write_text(content_hash)
+        except OSError:
+            _log.debug(
+                "GistTaskLayer._write_through: sidecar write failed for plan %s — dedup skipped next call",
+                plan_id,
+                exc_info=True,
+            )
+
     def _write_through(self, plan_id: str, issue: int) -> None:
         """Read the current local YAML and upload it to Gist.
 
@@ -640,41 +725,10 @@ class GistTaskLayer:
         yaml_content = self._read_local_yaml_for_plan(plan_id)
         content_hash = hashlib.sha256(yaml_content.encode()).hexdigest()
 
-        # Resolve sidecar paths best-effort — _resolve_path should not fail here
-        # since _read_local_yaml_for_plan just succeeded, but guard against races.
-        # hash_sidecar (.sha256) — content-hash dedup to skip unchanged Gist PATCHes.
-        # stale_sidecar (.stale) — durable marker that local YAML is ahead of Gist after
-        #   a rate-limited write-through skip.  Persists across GistTaskLayer instances
-        #   (a fresh instance is created per MCP call) so read_plan bypasses Gist-first
-        #   in subsequent calls even though the in-memory _local_authoritative_plans set
-        #   resets to empty.
-        hash_sidecar: Path | None = None
-        stale_sidecar: Path | None = None
-        try:
-            local_path = self._local._resolve_path(plan_id)  # noqa: SLF001
-            hash_sidecar = local_path.with_suffix(".sha256")
-            stale_sidecar = local_path.with_suffix(".stale")
-        except PlanNotFoundError:
-            _log.debug(
-                "GistTaskLayer._write_through: path resolution failed for plan %s — skipping hash dedup", plan_id
-            )
+        hash_sidecar, stale_sidecar = self._resolve_write_through_sidecars(plan_id)
 
-        # Skip the Gist PATCH when the content is unchanged since last upload.
-        if hash_sidecar is not None:
-            try:
-                if hash_sidecar.read_text().strip() == content_hash:
-                    _log.debug(
-                        "GistTaskLayer._write_through: content unchanged for plan %s (issue #%d), skipping Gist PATCH",
-                        plan_id,
-                        issue,
-                    )
-                    return
-            except OSError:
-                _log.debug(
-                    "GistTaskLayer._write_through: sidecar read failed for plan %s — uploading as normal",
-                    plan_id,
-                    exc_info=True,
-                )
+        if self._write_through_content_unchanged(hash_sidecar, content_hash, plan_id, issue):
+            return
 
         RATE_LIMIT_SIGNALS = ("secondary rate limit", "abuse detection")
 
@@ -682,15 +736,7 @@ class GistTaskLayer:
             self._artifact_client.store(issue=issue, content=yaml_content)
             _log.info("GistTaskLayer._write_through: uploaded plan %s YAML to Gist (issue #%d)", plan_id, issue)
             self._local_authoritative_plans.discard(plan_id)
-            if stale_sidecar is not None:
-                try:
-                    stale_sidecar.unlink(missing_ok=True)
-                except OSError:
-                    _log.debug(
-                        "GistTaskLayer._write_through: failed to clear stale sidecar for plan %s — "
-                        "read_plan will re-check on next call",
-                        plan_id,
-                    )
+            self._clear_stale_sidecar(stale_sidecar, plan_id)
         except ArtifactWriteError as exc:
             reason_lower = exc.reason.lower()
             if any(signal in reason_lower for signal in RATE_LIMIT_SIGNALS):
@@ -702,30 +748,14 @@ class GistTaskLayer:
                     exc.reason,
                 )
                 self._local_authoritative_plans.add(plan_id)
-                if stale_sidecar is not None:
-                    try:
-                        stale_sidecar.touch()
-                    except OSError:
-                        _log.debug(
-                            "GistTaskLayer._write_through: failed to write stale sidecar for plan %s — "
-                            "local-authoritative bypass will not persist across MCP calls",
-                            plan_id,
-                        )
+                self._mark_stale_sidecar(stale_sidecar, plan_id)
                 return
             _log.error(
                 "GistTaskLayer._write_through: Gist upload failed for plan %s (issue #%d) — raising", plan_id, issue
             )
             raise
 
-        if hash_sidecar is not None:
-            try:
-                hash_sidecar.write_text(content_hash)
-            except OSError:
-                _log.debug(
-                    "GistTaskLayer._write_through: sidecar write failed for plan %s — dedup skipped next call",
-                    plan_id,
-                    exc_info=True,
-                )
+        self._write_hash_sidecar(hash_sidecar, content_hash, plan_id)
 
     def update_plan_fields(
         self, plan_id: str, *, context: str | None = None, set_fields: dict[str, str | int | list[str]] | None = None

--- a/plugins/development-harness/sam_schema/core/gist_task_layer.py
+++ b/plugins/development-harness/sam_schema/core/gist_task_layer.py
@@ -159,6 +159,12 @@ class GistTaskLayer:
         #: when served from the local filesystem cache.  ``None`` before the
         #: first read.  The MCP handler surfaces a warning when this is ``"local"``.
         self.last_read_source: str | None = None
+        #: Plan IDs whose local YAML is known to be ahead of Gist because a
+        #: rate-limited ``_write_through`` skipped the upload.  ``read_plan``
+        #: bypasses the Gist-first read for these plans to prevent stale Gist
+        #: content from overwriting the in-flight local mutation.  Entries are
+        #: cleared when a subsequent successful write-through syncs the plan.
+        self._local_authoritative_plans: set[str] = set()
 
     # ------------------------------------------------------------------
     # Plan lifecycle — create_plan has write-through logic; others delegate
@@ -332,6 +338,18 @@ class GistTaskLayer:
         """
         # Always reset source annotation at the start of each read.
         self.last_read_source = None
+
+        # Skip Gist-first read when local YAML is known to be ahead of Gist because a
+        # rate-limited _write_through skipped the upload.  Fetching stale Gist content
+        # here would overwrite the in-flight local mutation via _write_local_cache.
+        if plan_id in self._local_authoritative_plans:
+            _log.debug(
+                "GistTaskLayer.read_plan: %s is local-authoritative (pending Gist sync), serving from local",
+                plan_id,
+            )
+            plan_data = self._local.read_plan(plan_id)
+            self.last_read_source = "local"
+            return plan_data
 
         # Step 1: resolve plan_id → issue via PlanIdIndex.
         issue: int | None = None
@@ -628,6 +646,7 @@ class GistTaskLayer:
         try:
             self._artifact_client.store(issue=issue, content=yaml_content)
             _log.info("GistTaskLayer._write_through: uploaded plan %s YAML to Gist (issue #%d)", plan_id, issue)
+            self._local_authoritative_plans.discard(plan_id)
         except ArtifactWriteError as exc:
             reason_lower = exc.reason.lower()
             if any(signal in reason_lower for signal in RATE_LIMIT_SIGNALS):
@@ -638,6 +657,7 @@ class GistTaskLayer:
                     issue,
                     exc.reason,
                 )
+                self._local_authoritative_plans.add(plan_id)
                 return
             _log.error(
                 "GistTaskLayer._write_through: Gist upload failed for plan %s (issue #%d) — raising", plan_id, issue

--- a/plugins/development-harness/sam_schema/core/gist_task_layer.py
+++ b/plugins/development-harness/sam_schema/core/gist_task_layer.py
@@ -344,8 +344,7 @@ class GistTaskLayer:
         # here would overwrite the in-flight local mutation via _write_local_cache.
         if plan_id in self._local_authoritative_plans:
             _log.debug(
-                "GistTaskLayer.read_plan: %s is local-authoritative (pending Gist sync), serving from local",
-                plan_id,
+                "GistTaskLayer.read_plan: %s is local-authoritative (pending Gist sync), serving from local", plan_id
             )
             plan_data = self._local.read_plan(plan_id)
             self.last_read_source = "local"

--- a/plugins/development-harness/sam_schema/core/gist_task_layer.py
+++ b/plugins/development-harness/sam_schema/core/gist_task_layer.py
@@ -167,6 +167,31 @@ class GistTaskLayer:
         self._local_authoritative_plans: set[str] = set()
 
     # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _is_local_authoritative(self, plan_id: str) -> bool:
+        """Return ``True`` when local YAML is known to be ahead of the Gist copy.
+
+        Checks the in-memory set first (fast path), then falls back to the
+        ``.stale`` sidecar file on disk.  The sidecar check is necessary
+        because ``_get_backend()`` in ``server.py`` constructs a fresh
+        ``GistTaskLayer`` per MCP tool call — the in-memory set resets to
+        empty each time, so the sidecar is the only durable signal that
+        survives across calls.
+        """
+        if plan_id in self._local_authoritative_plans:
+            return True
+        try:
+            local_path = self._local._resolve_path(plan_id)  # noqa: SLF001
+            if local_path.with_suffix(".stale").exists():
+                self._local_authoritative_plans.add(plan_id)
+                return True
+        except (PlanNotFoundError, OSError):
+            pass
+        return False
+
+    # ------------------------------------------------------------------
     # Plan lifecycle — create_plan has write-through logic; others delegate
     # ------------------------------------------------------------------
 
@@ -342,7 +367,10 @@ class GistTaskLayer:
         # Skip Gist-first read when local YAML is known to be ahead of Gist because a
         # rate-limited _write_through skipped the upload.  Fetching stale Gist content
         # here would overwrite the in-flight local mutation via _write_local_cache.
-        if plan_id in self._local_authoritative_plans:
+        # _is_local_authoritative checks both the in-memory set (same-call fast path)
+        # and a .stale sidecar file (cross-call persistence — _get_backend constructs
+        # a fresh GistTaskLayer per MCP call, so the in-memory set alone is not enough).
+        if self._is_local_authoritative(plan_id):
             _log.debug(
                 "GistTaskLayer.read_plan: %s is local-authoritative (pending Gist sync), serving from local", plan_id
             )
@@ -612,12 +640,20 @@ class GistTaskLayer:
         yaml_content = self._read_local_yaml_for_plan(plan_id)
         content_hash = hashlib.sha256(yaml_content.encode()).hexdigest()
 
-        # Resolve sidecar path best-effort — _resolve_path should not fail here
+        # Resolve sidecar paths best-effort — _resolve_path should not fail here
         # since _read_local_yaml_for_plan just succeeded, but guard against races.
+        # hash_sidecar (.sha256) — content-hash dedup to skip unchanged Gist PATCHes.
+        # stale_sidecar (.stale) — durable marker that local YAML is ahead of Gist after
+        #   a rate-limited write-through skip.  Persists across GistTaskLayer instances
+        #   (a fresh instance is created per MCP call) so read_plan bypasses Gist-first
+        #   in subsequent calls even though the in-memory _local_authoritative_plans set
+        #   resets to empty.
         hash_sidecar: Path | None = None
+        stale_sidecar: Path | None = None
         try:
             local_path = self._local._resolve_path(plan_id)  # noqa: SLF001
             hash_sidecar = local_path.with_suffix(".sha256")
+            stale_sidecar = local_path.with_suffix(".stale")
         except PlanNotFoundError:
             _log.debug(
                 "GistTaskLayer._write_through: path resolution failed for plan %s — skipping hash dedup", plan_id
@@ -646,6 +682,15 @@ class GistTaskLayer:
             self._artifact_client.store(issue=issue, content=yaml_content)
             _log.info("GistTaskLayer._write_through: uploaded plan %s YAML to Gist (issue #%d)", plan_id, issue)
             self._local_authoritative_plans.discard(plan_id)
+            if stale_sidecar is not None:
+                try:
+                    stale_sidecar.unlink(missing_ok=True)
+                except OSError:
+                    _log.debug(
+                        "GistTaskLayer._write_through: failed to clear stale sidecar for plan %s — "
+                        "read_plan will re-check on next call",
+                        plan_id,
+                    )
         except ArtifactWriteError as exc:
             reason_lower = exc.reason.lower()
             if any(signal in reason_lower for signal in RATE_LIMIT_SIGNALS):
@@ -657,6 +702,15 @@ class GistTaskLayer:
                     exc.reason,
                 )
                 self._local_authoritative_plans.add(plan_id)
+                if stale_sidecar is not None:
+                    try:
+                        stale_sidecar.touch()
+                    except OSError:
+                        _log.debug(
+                            "GistTaskLayer._write_through: failed to write stale sidecar for plan %s — "
+                            "local-authoritative bypass will not persist across MCP calls",
+                            plan_id,
+                        )
                 return
             _log.error(
                 "GistTaskLayer._write_through: Gist upload failed for plan %s (issue #%d) — raising", plan_id, issue

--- a/plugins/development-harness/sam_schema/core/gist_task_layer.py
+++ b/plugins/development-harness/sam_schema/core/gist_task_layer.py
@@ -586,7 +586,11 @@ class GistTaskLayer:
 
         Raises:
             ArtifactWriteError: When the local YAML cannot be read, or when
-                the Gist upload fails.
+                the Gist upload fails due to a genuine error (e.g. wrong token
+                scope).  Rate-limit responses (secondary rate limit, abuse
+                detection) are handled by logging a WARNING and returning
+                without raising — local YAML state is preserved and the MCP
+                call succeeds.
         """
         yaml_content = self._read_local_yaml_for_plan(plan_id)
         content_hash = hashlib.sha256(yaml_content.encode()).hexdigest()
@@ -619,10 +623,22 @@ class GistTaskLayer:
                     exc_info=True,
                 )
 
+        RATE_LIMIT_SIGNALS = ("secondary rate limit", "abuse detection")
+
         try:
             self._artifact_client.store(issue=issue, content=yaml_content)
             _log.info("GistTaskLayer._write_through: uploaded plan %s YAML to Gist (issue #%d)", plan_id, issue)
-        except ArtifactWriteError:
+        except ArtifactWriteError as exc:
+            reason_lower = exc.reason.lower()
+            if any(signal in reason_lower for signal in RATE_LIMIT_SIGNALS):
+                _log.warning(
+                    "GistTaskLayer._write_through: Gist upload skipped for plan %s (issue #%d) due to rate limit"
+                    " — local YAML is preserved; remote may be stale. Reason: %s",
+                    plan_id,
+                    issue,
+                    exc.reason,
+                )
+                return
             _log.error(
                 "GistTaskLayer._write_through: Gist upload failed for plan %s (issue #%d) — raising", plan_id, issue
             )

--- a/plugins/development-harness/tests_sam/test_gist_write_through.py
+++ b/plugins/development-harness/tests_sam/test_gist_write_through.py
@@ -1066,9 +1066,7 @@ class _RateLimitArtifactStore(_InMemoryArtifactStore):
         super().store(issue, content, artifact_type=artifact_type)
 
 
-def _make_rate_limit_layer(
-    tmp_path: Path,
-) -> tuple[GistTaskLayer, _RateLimitArtifactStore]:
+def _make_rate_limit_layer(tmp_path: Path) -> tuple[GistTaskLayer, _RateLimitArtifactStore]:
     """Construct a GistTaskLayer backed by a _RateLimitArtifactStore.
 
     Returns a (layer, store) pair so tests can toggle ``force_rate_limit``
@@ -1105,7 +1103,10 @@ def test_update_task_status_succeeds_on_rate_limit(tmp_path: Path) -> None:
     layer, rate_store = _make_rate_limit_layer(tmp_path)
     tasks = _two_tasks()
     plan_data = layer.create_plan(
-        slug="rate-limit-mutation", goal="Verify rate-limit degrade on update_task_status", tasks=tasks, issue=_PLAN_ISSUE
+        slug="rate-limit-mutation",
+        goal="Verify rate-limit degrade on update_task_status",
+        tasks=tasks,
+        issue=_PLAN_ISSUE,
     )
     plan_id = plan_data["plan_id"]
 

--- a/plugins/development-harness/tests_sam/test_gist_write_through.py
+++ b/plugins/development-harness/tests_sam/test_gist_write_through.py
@@ -1179,6 +1179,104 @@ def test_rate_limit_local_authoritative_prevents_stale_gist_overwrite(tmp_path: 
     )
 
 
+def test_rate_limit_stale_sidecar_persists_across_layer_instances(tmp_path: Path) -> None:
+    """Rate-limit P1 (cross-call): local-authoritative bypass survives GistTaskLayer re-instantiation.
+
+    ``_get_backend()`` in ``server.py`` constructs a fresh ``GistTaskLayer`` per
+    MCP tool call.  The in-memory ``_local_authoritative_plans`` set resets to empty
+    each time, so the bypass from the P1 fix would not survive across calls without
+    the persistent ``.stale`` sidecar file.
+
+    This test simulates a second MCP call by constructing a new ``GistTaskLayer``
+    over the same plan directory after a rate-limited write-through on the first
+    layer.  The second layer must still bypass Gist-first and serve the mutated
+    local state.
+    """
+    # Call 1: create plan and perform a rate-limited mutation.
+    layer1, rate_store = _make_rate_limit_layer(tmp_path)
+    tasks = _two_tasks()
+    plan_data = layer1.create_plan(
+        slug="cross-call-stale-sidecar",
+        goal="Verify .stale sidecar persists local-authoritative bypass across layer instances",
+        tasks=tasks,
+        issue=_PLAN_ISSUE,
+    )
+    plan_id = plan_data["plan_id"]
+
+    rate_store.force_rate_limit = True
+    layer1.update_task_status(plan_id, "T1", "in-progress")  # write-through skipped, .stale written
+
+    # Verify the .stale sidecar exists on disk.
+    from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider  # noqa: PLC0415
+
+    plan_dir = tmp_path / "plan"
+    local = LocalYamlTaskProvider(plan_dir)
+    local_path = local._resolve_path(plan_id)  # noqa: SLF001
+    stale_sidecar = local_path.with_suffix(".stale")
+    assert stale_sidecar.exists(), ".stale sidecar must be written when rate-limited write-through skips Gist upload"
+
+    # Call 2: construct a fresh GistTaskLayer (simulating a new MCP call).
+    # The in-memory _local_authoritative_plans set starts empty in this new instance.
+    from sam_schema.core.artifact_registry_client import ArtifactRegistryClient  # noqa: PLC0415
+    from sam_schema.core.gist_task_layer import GistTaskLayer  # noqa: PLC0415
+    from sam_schema.core.plan_id_index import PlanIdIndex  # noqa: PLC0415
+
+    client2 = _make_fake_client(rate_store)
+    plan_index2 = PlanIdIndex(artifact_client=client2, sentinel_issue=_SENTINEL_ISSUE)
+    layer2 = GistTaskLayer(local_backend=local, artifact_client=client2, plan_index=plan_index2)
+
+    assert plan_id not in layer2._local_authoritative_plans, (  # noqa: SLF001
+        "Fresh GistTaskLayer must start with empty _local_authoritative_plans"
+    )
+
+    # Act: read_plan on the new layer must bypass Gist-first (via .stale sidecar).
+    # Gist still holds pre-mutation content (rate_store not cleared).
+    retrieved = layer2.read_plan(plan_id)
+
+    task_t1 = next(t for t in retrieved["tasks"] if t["id"] == "T1")
+    assert task_t1["status"] == "in-progress", (
+        "Fresh GistTaskLayer must serve mutated local state via .stale sidecar, not stale Gist content"
+    )
+    assert layer2.last_read_source == "local", (
+        "Fresh GistTaskLayer must annotate source='local' when .stale sidecar triggers the bypass"
+    )
+
+
+def test_rate_limit_stale_sidecar_cleared_on_successful_upload(tmp_path: Path) -> None:
+    """Rate-limit: .stale sidecar is removed when a subsequent write-through succeeds.
+
+    After a rate-limited skip writes the .stale sidecar, the next mutation that
+    succeeds must delete it so future read_plan calls resume normal Gist-first
+    behaviour (the local YAML and Gist are in sync after the successful upload).
+    """
+    layer, rate_store = _make_rate_limit_layer(tmp_path)
+    tasks = _two_tasks()
+    plan_data = layer.create_plan(
+        slug="stale-sidecar-cleared",
+        goal="Verify .stale sidecar is removed on successful write-through",
+        tasks=tasks,
+        issue=_PLAN_ISSUE,
+    )
+    plan_id = plan_data["plan_id"]
+
+    # Step 1: rate-limited mutation — .stale sidecar is written.
+    rate_store.force_rate_limit = True
+    layer.update_task_status(plan_id, "T1", "in-progress")
+
+    from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider  # noqa: PLC0415
+
+    plan_dir = tmp_path / "plan"
+    local_path = LocalYamlTaskProvider(plan_dir)._resolve_path(plan_id)  # noqa: SLF001
+    stale_sidecar = local_path.with_suffix(".stale")
+    assert stale_sidecar.exists(), ".stale sidecar must exist after rate-limited skip"
+
+    # Step 2: successful mutation — .stale sidecar must be removed.
+    rate_store.force_rate_limit = False
+    layer.update_task_status(plan_id, "T2", "in-progress")
+
+    assert not stale_sidecar.exists(), ".stale sidecar must be deleted after successful Gist upload"
+
+
 def test_rate_limit_emits_warning_log(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     """Rate-limit degrade: a WARNING log is emitted when _write_through absorbs a rate limit.
 

--- a/plugins/development-harness/tests_sam/test_gist_write_through.py
+++ b/plugins/development-harness/tests_sam/test_gist_write_through.py
@@ -73,6 +73,15 @@ class _InMemoryArtifactStore:
         """Retrieve plan-index YAML for sentinel issue."""
         return self._index_store.get(sentinel_issue)
 
+    def clear_content_store(self) -> None:
+        """Evict all stored artifact content, leaving the index intact.
+
+        Useful in tests that need to force a local-fallback read after a
+        rate-limited write-through: clearing stale Gist content from the
+        in-memory store ensures read_plan falls back to the local YAML file.
+        """
+        self._store.clear()
+
 
 def _make_fake_client(store: _InMemoryArtifactStore) -> ArtifactRegistryClient:
     """Return an ArtifactRegistryClient backed by the given in-memory store.
@@ -1003,3 +1012,229 @@ def test_append_task_raises_on_gist_write_failure(gist_layer: GistTaskLayer, sto
     # Act + Assert: ArtifactWriteError must propagate (no silent swallow).
     with pytest.raises(ArtifactWriteError):
         gist_layer.append_task(plan_id, new_task)
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit graceful degradation: _write_through absorbs secondary rate limits
+# ---------------------------------------------------------------------------
+
+
+class _RateLimitArtifactStore(_InMemoryArtifactStore):
+    """_InMemoryArtifactStore subclass that simulates a GitHub secondary rate-limit response.
+
+    When ``force_rate_limit`` is ``True``, ``store()`` raises
+    :exc:`ArtifactWriteError` with ``"secondary rate limit"`` in the reason
+    string, matching the signal strings checked by
+    ``GistTaskLayer._write_through``.
+
+    Inheriting from ``_InMemoryArtifactStore`` gives access to the same
+    ``read``, ``store_index``, and ``read_index`` methods so fake clients
+    can be constructed with :func:`_make_fake_client` unchanged.
+    """
+
+    def __init__(self) -> None:
+        """Initialise with rate-limit simulation disabled."""
+        super().__init__()
+        #: When True, store() raises ArtifactWriteError simulating a GitHub
+        #: secondary rate-limit response rather than storing content.
+        self.force_rate_limit: bool = False
+
+    def store(self, issue: int, content: str, *, artifact_type: str = "task-plan") -> None:
+        """Raise ArtifactWriteError with secondary rate limit reason when force_rate_limit is set.
+
+        When ``force_rate_limit`` is ``False``, delegates to the parent class,
+        which respects the ``force_store_failure`` flag from
+        :class:`_InMemoryArtifactStore`.
+
+        Args:
+            issue: GitHub issue number keying the artifact.
+            content: YAML content to store.
+            artifact_type: Artifact type key (default ``"task-plan"``).
+
+        Raises:
+            ArtifactWriteError: When ``force_rate_limit`` is ``True``, with a
+                reason containing ``"secondary rate limit"``.
+            ArtifactWriteError: When ``force_store_failure`` is ``True``
+                (inherited behaviour, genuine error path).
+        """
+        if self.force_rate_limit:
+            raise ArtifactWriteError(
+                plan_id="<unknown>",
+                issue=issue,
+                reason="You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+            )
+        super().store(issue, content, artifact_type=artifact_type)
+
+
+def _make_rate_limit_layer(
+    tmp_path: Path,
+) -> tuple[GistTaskLayer, _RateLimitArtifactStore]:
+    """Construct a GistTaskLayer backed by a _RateLimitArtifactStore.
+
+    Returns a (layer, store) pair so tests can toggle ``force_rate_limit``
+    between the create (successful) and mutation (rate-limited) steps.
+
+    Args:
+        tmp_path: pytest ``tmp_path`` fixture providing an isolated plan directory.
+
+    Returns:
+        Tuple of (GistTaskLayer, _RateLimitArtifactStore).
+    """
+    plan_dir = tmp_path / "plan"
+    plan_dir.mkdir()
+    local_backend = LocalYamlTaskProvider(plan_dir)
+    rate_store = _RateLimitArtifactStore()
+    client = _make_fake_client(rate_store)
+    plan_index = _make_fake_plan_index(client, sentinel_issue=_SENTINEL_ISSUE)
+    layer = GistTaskLayer(local_backend=local_backend, artifact_client=client, plan_index=plan_index)
+    return layer, rate_store
+
+
+def test_update_task_status_succeeds_on_rate_limit(tmp_path: Path) -> None:
+    """Rate-limit degrade: update_task_status succeeds (no exception) when Gist is rate-limited.
+
+    Verifies that when ``artifact_client.store()`` raises
+    :exc:`ArtifactWriteError` with ``"secondary rate limit"`` in the reason,
+    ``GistTaskLayer._write_through`` absorbs the error and
+    ``update_task_status`` returns without raising.
+
+    The local YAML state must still reflect the mutation — the task status is
+    committed locally even though the Gist write-back is skipped.
+    """
+    # Arrange: create plan while the store is healthy.
+    layer, rate_store = _make_rate_limit_layer(tmp_path)
+    tasks = _two_tasks()
+    plan_data = layer.create_plan(
+        slug="rate-limit-mutation", goal="Verify rate-limit degrade on update_task_status", tasks=tasks, issue=_PLAN_ISSUE
+    )
+    plan_id = plan_data["plan_id"]
+
+    # Enable rate-limit simulation before the mutation attempt.
+    rate_store.force_rate_limit = True
+
+    # Act: update_task_status must not raise, even though Gist is rate-limited.
+    layer.update_task_status(plan_id, "T1", "in-progress")  # must not raise
+
+    # Assert: local YAML state reflects the mutation.
+    # Disable rate-limit and clear the stale Gist content so read_plan falls
+    # back to the local file that was just mutated — this verifies the local
+    # write committed even though the Gist upload was skipped.
+    rate_store.force_rate_limit = False
+    rate_store.clear_content_store()  # remove stale pre-mutation content; forces local-fallback read
+
+    retrieved = layer.read_plan(plan_id)
+    task_t1 = next(t for t in retrieved["tasks"] if t["id"] == "T1")
+    assert task_t1["status"] == "in-progress", (
+        "Task status must be committed locally even when Gist write-back is rate-limited"
+    )
+
+
+def test_rate_limit_emits_warning_log(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Rate-limit degrade: a WARNING log is emitted when _write_through absorbs a rate limit.
+
+    Verifies that ``GistTaskLayer._write_through`` logs at WARNING level
+    (not ERROR or DEBUG) when the ``"secondary rate limit"`` signal is detected
+    in the :exc:`ArtifactWriteError` reason, so operators can observe the event
+    without it being surfaced as an error to the MCP caller.
+
+    The log record must be from the ``"sam_schema.core.gist_task_layer"`` logger.
+    """
+    import logging
+
+    layer, rate_store = _make_rate_limit_layer(tmp_path)
+    tasks = _two_tasks()
+    plan_data = layer.create_plan(
+        slug="rate-limit-warn", goal="Verify WARNING log emission on rate-limit degrade", tasks=tasks, issue=_PLAN_ISSUE
+    )
+    plan_id = plan_data["plan_id"]
+
+    # Enable rate-limit simulation and trigger a write-through mutation.
+    rate_store.force_rate_limit = True
+
+    with caplog.at_level(logging.WARNING, logger="sam_schema.core.gist_task_layer"):
+        layer.update_task_status(plan_id, "T1", "in-progress")
+
+    # Assert: at least one WARNING record from the gist_task_layer logger that
+    # references the rate-limit event.
+    rate_limit_warnings = [
+        r
+        for r in caplog.records
+        if r.name == "sam_schema.core.gist_task_layer"
+        and r.levelno == logging.WARNING
+        and "rate limit" in r.getMessage().lower()
+    ]
+    assert rate_limit_warnings, (
+        "Expected at least one WARNING log from 'sam_schema.core.gist_task_layer' "
+        f"mentioning 'rate limit'; got records: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_create_plan_raises_on_rate_limit(tmp_path: Path) -> None:
+    """Rate-limit hard-fail: create_plan raises ArtifactWriteError when Gist is rate-limited.
+
+    Verifies that create_plan does NOT absorb rate-limit errors — the
+    ``_write_through`` degradation path applies only to mutations routed
+    through ``_write_through``.  ``create_plan`` calls ``artifact_client.store()``
+    directly and must propagate any :exc:`ArtifactWriteError`, including
+    rate-limit variants, as a hard error.
+
+    This preserves the AC7 contract: a plan that fails to upload to Gist must
+    not appear to succeed.
+    """
+    # Arrange: enable rate-limit simulation before create so the first upload fails.
+    layer, rate_store = _make_rate_limit_layer(tmp_path)
+    rate_store.force_rate_limit = True
+
+    tasks = _two_tasks()
+
+    # Act + Assert: ArtifactWriteError must propagate (no graceful degrade for create).
+    with pytest.raises(ArtifactWriteError) as exc_info:
+        layer.create_plan(
+            slug="rate-limit-create-fail",
+            goal="Verify create_plan hard-fails on rate limit",
+            tasks=tasks,
+            issue=_PLAN_ISSUE,
+        )
+
+    assert exc_info.value.issue == _PLAN_ISSUE, "ArtifactWriteError must reference the target issue"
+    assert "rate limit" in exc_info.value.reason.lower(), (
+        "ArtifactWriteError reason must carry the rate-limit message from the store"
+    )
+
+
+def test_genuine_error_propagates_from_update_task_status(
+    gist_layer: GistTaskLayer, store: _InMemoryArtifactStore
+) -> None:
+    """Genuine-error path: ArtifactWriteError propagates from update_task_status when force_store_failure=True.
+
+    Verifies that the rate-limit degrade path does not accidentally swallow
+    genuine write errors (i.e. errors whose reason does NOT contain the
+    ``"secondary rate limit"`` or ``"abuse detection"`` signal strings).
+
+    The existing ``force_store_failure=True`` path raises with reason
+    ``"forced failure for testing"``, which is NOT a rate-limit signal.
+    ``update_task_status`` must re-raise such errors as :exc:`ArtifactWriteError`.
+
+    This test ensures the pre-existing genuine-error contract (AC7 analog for
+    mutations) is unchanged by the rate-limit degrade feature.
+    """
+    # Arrange: create plan while the store is healthy.
+    tasks = _two_tasks()
+    plan_data = gist_layer.create_plan(
+        slug="genuine-error-mutation",
+        goal="Verify genuine-error propagation from update_task_status",
+        tasks=tasks,
+        issue=_PLAN_ISSUE,
+    )
+    plan_id = plan_data["plan_id"]
+
+    # Enable genuine store failure (reason does NOT contain "secondary rate limit").
+    store.force_store_failure = True
+
+    # Act + Assert: ArtifactWriteError must propagate (not absorbed as rate-limit).
+    with pytest.raises(ArtifactWriteError) as exc_info:
+        gist_layer.update_task_status(plan_id, "T1", "in-progress")
+
+    assert "forced failure" in exc_info.value.reason.lower(), (
+        "The genuine-error reason must be carried through ArtifactWriteError unchanged"
+    )

--- a/plugins/development-harness/tests_sam/test_gist_write_through.py
+++ b/plugins/development-harness/tests_sam/test_gist_write_through.py
@@ -1130,6 +1130,55 @@ def test_update_task_status_succeeds_on_rate_limit(tmp_path: Path) -> None:
     )
 
 
+def test_rate_limit_local_authoritative_prevents_stale_gist_overwrite(tmp_path: Path) -> None:
+    """Rate-limit P1: read_plan after skipped write-through must NOT return stale Gist content.
+
+    Verifies that when ``_write_through`` skips due to secondary rate limit, a
+    subsequent ``read_plan()`` serves from local (which has the mutation) rather
+    than fetching stale pre-mutation Gist content and overwriting local state.
+
+    This is the production-realistic scenario: the Gist store is NOT cleared
+    between the skipped write and the read — contrast with
+    ``test_update_task_status_succeeds_on_rate_limit`` which calls
+    ``clear_content_store()`` to force the local fallback.  Without the
+    ``_local_authoritative_plans`` guard added by the Codex P1 fix, this test
+    would regress: ``read_plan`` would fetch the stale pre-mutation Gist YAML,
+    write it to local cache (overwriting the mutation), and return stale state.
+    """
+    # Arrange: create plan while the store is healthy.
+    layer, rate_store = _make_rate_limit_layer(tmp_path)
+    tasks = _two_tasks()
+    plan_data = layer.create_plan(
+        slug="stale-gist-regression",
+        goal="Verify local-authoritative bypass on rate-limited write-through",
+        tasks=tasks,
+        issue=_PLAN_ISSUE,
+    )
+    plan_id = plan_data["plan_id"]
+
+    # Enable rate-limit so the next write-through is skipped.
+    rate_store.force_rate_limit = True
+    layer.update_task_status(plan_id, "T1", "in-progress")  # write-through skipped
+
+    # Production scenario: Gist store still holds the pre-mutation content.
+    # Do NOT call rate_store.clear_content_store() — that would mask the bug.
+    assert rate_store.read(_PLAN_ISSUE, "task-plan") is not None, (
+        "Gist store must still hold pre-mutation content for the regression scenario to be valid"
+    )
+
+    # Act: read_plan must serve from local (mutation present), not Gist (stale).
+    retrieved = layer.read_plan(plan_id)
+
+    # Assert: mutation is visible in the returned data.
+    task_t1 = next(t for t in retrieved["tasks"] if t["id"] == "T1")
+    assert task_t1["status"] == "in-progress", (
+        "read_plan after rate-limited write-through must serve local state, not stale Gist content"
+    )
+    assert layer.last_read_source == "local", (
+        "read_plan must annotate source='local' when serving a local-authoritative plan"
+    )
+
+
 def test_rate_limit_emits_warning_log(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     """Rate-limit degrade: a WARNING log is emitted when _write_through absorbs a rate limit.
 

--- a/plugins/development-harness/tests_sam/test_gist_write_through.py
+++ b/plugins/development-harness/tests_sam/test_gist_write_through.py
@@ -1207,25 +1207,24 @@ def test_rate_limit_stale_sidecar_persists_across_layer_instances(tmp_path: Path
     layer1.update_task_status(plan_id, "T1", "in-progress")  # write-through skipped, .stale written
 
     # Verify the .stale sidecar exists on disk.
-    from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider  # noqa: PLC0415
+    from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
 
     plan_dir = tmp_path / "plan"
     local = LocalYamlTaskProvider(plan_dir)
-    local_path = local._resolve_path(plan_id)  # noqa: SLF001
+    local_path = local._resolve_path(plan_id)
     stale_sidecar = local_path.with_suffix(".stale")
     assert stale_sidecar.exists(), ".stale sidecar must be written when rate-limited write-through skips Gist upload"
 
     # Call 2: construct a fresh GistTaskLayer (simulating a new MCP call).
     # The in-memory _local_authoritative_plans set starts empty in this new instance.
-    from sam_schema.core.artifact_registry_client import ArtifactRegistryClient  # noqa: PLC0415
-    from sam_schema.core.gist_task_layer import GistTaskLayer  # noqa: PLC0415
-    from sam_schema.core.plan_id_index import PlanIdIndex  # noqa: PLC0415
+    from sam_schema.core.gist_task_layer import GistTaskLayer
+    from sam_schema.core.plan_id_index import PlanIdIndex
 
     client2 = _make_fake_client(rate_store)
     plan_index2 = PlanIdIndex(artifact_client=client2, sentinel_issue=_SENTINEL_ISSUE)
     layer2 = GistTaskLayer(local_backend=local, artifact_client=client2, plan_index=plan_index2)
 
-    assert plan_id not in layer2._local_authoritative_plans, (  # noqa: SLF001
+    assert plan_id not in layer2._local_authoritative_plans, (
         "Fresh GistTaskLayer must start with empty _local_authoritative_plans"
     )
 
@@ -1263,10 +1262,10 @@ def test_rate_limit_stale_sidecar_cleared_on_successful_upload(tmp_path: Path) -
     rate_store.force_rate_limit = True
     layer.update_task_status(plan_id, "T1", "in-progress")
 
-    from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider  # noqa: PLC0415
+    from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
 
     plan_dir = tmp_path / "plan"
-    local_path = LocalYamlTaskProvider(plan_dir)._resolve_path(plan_id)  # noqa: SLF001
+    local_path = LocalYamlTaskProvider(plan_dir)._resolve_path(plan_id)
     stale_sidecar = local_path.with_suffix(".stale")
     assert stale_sidecar.exists(), ".stale sidecar must exist after rate-limited skip"
 


### PR DESCRIPTION
## Summary

### `gist_task_layer.py` — secondary rate-limit graceful degradation (backlog #2590)

- **Root cause**: `store_artifact_content()` in `artifact_provider.py` called `gist.edit()` with no exception handling — a `GithubException(403)` from GitHub's secondary rate limiter escaped `ArtifactRegistryClient.store()`'s catch clause `(BacklogError, OSError, ValueError)` unhandled, crashing any `sam_task` mutation mid-session.
- **Fix (T1)**: Wrap `gist.edit()` in `store_artifact_content()` with `try/except GithubException` and re-raise as `BacklogError`, matching the pattern already used in `set_manifest()`.
- **Fix (T2)**: Add graceful degradation in `GistTaskLayer._write_through()` — inspect `ArtifactWriteError.reason` for the secondary rate-limit signal; log a WARNING and return on match; re-raise on non-rate-limit errors. `create_plan()` retains hard-fail behaviour per ADR-2509-5.
- **Fix (T4 — Codex P1)**: After a rate-limited `_write_through` skip, a subsequent `read_plan()` fetched stale pre-mutation Gist content and overwrote the local mutation via `_write_local_cache`. Fixed by adding `_local_authoritative_plans: set[str]` to `GistTaskLayer`: `_write_through` marks a plan local-authoritative on rate-limit skip and clears it on successful upload; `read_plan` bypasses Gist-first fetch for local-authoritative plans.
- **Tests (T3)**: New `force_rate_limit=True` variant of `_InMemoryArtifactStore` in `test_gist_write_through.py` covers the degrade path. New `test_rate_limit_local_authoritative_prevents_stale_gist_overwrite` tests the production-realistic scenario (Gist store not cleared between skipped write and read).

### `.claude/scripts/session-init.sh` — review comment fixes

- **PROXY_PORT expansion under `set -u`** (Copilot): Changed `PROXY_PORT="${HTTPS_PROXY##*:}"` to `PROXY_PORT="${HTTPS_PROXY:+${HTTPS_PROXY##*:}}"` — the `:+` form expands to empty string when `HTTPS_PROXY` is unset rather than aborting with an unbound variable error.
- **`--no-verify` guidance removed** (Copilot/Codex): Removed the suggestion to use `--no-verify` when shellcheck is unavailable; replaced with accurate guidance that commits touching shell files will be blocked until shellcheck is available.

## Test plan

- [x] `uv run pytest plugins/development-harness/tests_sam/test_gist_write_through.py` — 26 passed
- [x] `uv run ruff check` — no violations
- [x] `uv run ty check` — no violations
- [x] Existing write-failure tests unchanged and passing
- [x] New regression test `test_rate_limit_local_authoritative_prevents_stale_gist_overwrite` passes without `clear_content_store()` workaround

Closes #2590

---
_Generated by [Claude Code](https://claude.ai/code/session_01EheWBG5icDfgkuj2naeaHi)_