### PR TITLE
fix(session-init): wire as SessionStart hook, fix pipefail race and stale advice

### DIFF
--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 # .claude/scripts/session-init.sh
 #
-# Initializes a Claude Code remote sandbox session.
-# Fixes known environment issues, cleans stale git config, and installs git hooks.
+# Corrects stale sandbox state left over from a previous Claude Code session,
+# before the agent starts: deprecated uv cert env var, stale proxy-pinned git
+# config, out-of-date uv/prek. Purely corrective, no diagnostics — nothing
+# here observes and reports without also fixing what it found. Produces no
+# output: SessionStart hook stdout is added to Claude's context on every
+# session, forever (https://code.claude.com/docs/en/hooks.md), so nothing is
+# printed. Failures are swallowed (|| true) — this is best-effort background
+# cleanup, not something worth interrupting the session over.
 #
 # Usage:
-#   Wired as a SessionStart hook in .claude/settings.json — runs automatically,
-#   every session, via CLAUDE_ENV_FILE for env var persistence (see §1 below).
+#   Wired as a SessionStart hook in .claude/settings.json.
 #   Can also be run manually: bash .claude/scripts/session-init.sh
 #   or sourced in an interactive shell to export vars directly: source .claude/scripts/session-init.sh
-#
-# Validation: the script tests that each critical tool works THROUGH the proxy.
-# All outbound HTTPS in this sandbox is routed through HTTPS_PROXY — the goal is
-# correct configuration through the proxy, not bypassing it.
 
 # When sourced, save the caller's shell options and restore them on exit so that
 # enabling strict mode here does not permanently alter the caller's session.
@@ -26,109 +27,69 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-log() { echo "[session-init] $*"; }
-warn() { echo "[session-init] WARNING: $*" >&2; }
-ok() { echo "[session-init] OK: $*"; }
-
-echo "━━━ session-init: Claude Code sandbox environment setup ━━━"
-echo ""
-
 # ─── 1. UV certificate environment ───────────────────────────────────────────
-# UV_NATIVE_TLS is deprecated since uv 0.6.x; UV_SYSTEM_CERTS=true is the replacement.
-# uv itself warns on ANY set value (true/false/1/0/yes — anything boolish), not just
-# the literal string "true", so match on "is it set" rather than "is it == true".
-# `export` only affects this script's own process and its children — it does not
-# reach the session's later Bash tool calls, whether run standalone, sourced, or
-# as a SessionStart hook. CLAUDE_ENV_FILE is the actual persistence mechanism:
-# Claude Code sources it before every subsequent Bash command in the session.
+# UV_NATIVE_TLS is deprecated since uv 0.6.x; UV_SYSTEM_CERTS=true is the
+# replacement. uv warns on ANY set value (true/false/1/0/yes), not just the
+# literal string "true", so match on "is it set". `export` only affects this
+# script's own process — CLAUDE_ENV_FILE is what actually persists into the
+# session's later Bash calls. Also unset UV_NATIVE_TLS there so uv stops
+# warning going forward; guard both appends against duplicates across
+# repeated SessionStart firings (startup/resume/clear/compact all match
+# matcher "" in settings.json).
 if [[ -n "${UV_NATIVE_TLS:-}" ]]; then
     export UV_SYSTEM_CERTS=true
+    unset UV_NATIVE_TLS
     if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
-        echo 'export UV_SYSTEM_CERTS=true' >>"${CLAUDE_ENV_FILE}"
+        grep -q 'UV_SYSTEM_CERTS' "${CLAUDE_ENV_FILE}" 2>/dev/null || echo 'export UV_SYSTEM_CERTS=true' >>"${CLAUDE_ENV_FILE}"
+        grep -q 'unset UV_NATIVE_TLS' "${CLAUDE_ENV_FILE}" 2>/dev/null || echo 'unset UV_NATIVE_TLS' >>"${CLAUDE_ENV_FILE}"
     fi
-    log "Exported UV_SYSTEM_CERTS=true (replaces deprecated UV_NATIVE_TLS)"
-else
-    ok "UV cert env already correct"
 fi
 
-# ─── 2. Verify CA bundle ─────────────────────────────────────────────────────
-CA_BUNDLE="${SSL_CERT_FILE:-}"
-if [[ -f "${CA_BUNDLE}" ]]; then
-    ok "CA bundle: ${CA_BUNDLE}"
-else
-    warn "SSL_CERT_FILE not set or file missing — proxy TLS will fail"
-fi
-
-# ─── 3. Proxy connectivity check ─────────────────────────────────────────────
-# Extract port from HTTPS_PROXY=http://127.0.0.1:<port>  using greedy strip to last colon.
-# Use :+ so the expansion is empty (not an unbound-variable abort) when HTTPS_PROXY is unset.
-PROXY_PORT="${HTTPS_PROXY:+${HTTPS_PROXY##*:}}"
-if [[ -n "${PROXY_PORT}" ]] &&
-    curl -sS --max-time 2 "http://127.0.0.1:${PROXY_PORT}/__agentproxy/status" >/dev/null 2>&1; then
-    ok "Proxy reachable at port ${PROXY_PORT}"
-else
-    warn "Proxy not reachable at port ${PROXY_PORT:-unknown} — all outbound HTTPS will fail"
-    warn "HTTPS_PROXY=${HTTPS_PROXY:-unset}"
-fi
-
-# ─── 4. Stale git insteadOf cleanup in ~/.gitconfig ──────────────────────────
-# Previous sessions may leave insteadOf URL rewrites pointing to wrong proxy ports
-# or plain-HTTP proxy URLs. The current proxy handles SSH→HTTPS rewrites via
-# gitConfigInjection — manual insteadOf entries conflict and break git.
-echo ""
-log "Checking for stale git insteadOf entries in ~/.gitconfig..."
+# ─── 2. Stale git insteadOf cleanup in ~/.gitconfig ──────────────────────────
+# Previous sessions may leave insteadOf URL rewrites pointing to wrong proxy
+# ports or plain-HTTP proxy URLs. The current proxy handles SSH→HTTPS
+# rewrites via gitConfigInjection — manual insteadOf entries conflict and
+# break git. Filtered to local-proxy rewrites only — never touch unrelated
+# insteadOf entries (e.g. corporate mirrors) a user may have configured.
 stale=$(git config --global --get-regexp 'url\..*\.insteadOf' 2>/dev/null | grep -Ei '127\.0\.0\.1|local_proxy' || true)
 if [[ -n "${stale}" ]]; then
-    warn "Found stale insteadOf entries from a previous session (filtered to local-proxy rewrites only):"
     while IFS=' ' read -r key _value; do
-        echo "  removing: ${key}"
         git config --global --unset-all "${key}" 2>/dev/null || true
     done <<<"${stale}"
-    ok "Stale insteadOf entries removed"
-else
-    ok "git insteadOf: clean"
 fi
 
-# ─── 5. Fix stale remote.origin.url in .git/config ───────────────────────────
-# Each container may be cloned through a different proxy port, leaving the remote
-# URL pointing to a local proxy address like http://local_proxy@127.0.0.1:<old-port>/git/...
-# This must be replaced with the real github.com URL for fetch and push to work.
-echo ""
-log "Checking remote.origin.url..."
+# ─── 3. Fix stale remote.origin.url in .git/config ───────────────────────────
+# Each container may be cloned through a different proxy port, leaving the
+# remote URL pointing to a local proxy address like
+# http://local_proxy@127.0.0.1:<old-port>/git/... — replace with the real
+# github.com URL for fetch and push to work.
 raw_url=$(git -C "${REPO_ROOT}" config --local remote.origin.url 2>/dev/null) || raw_url=""
 
-# Detect stale local proxy URLs (pattern: http(s)://...@127.0.0.1:.../git/<owner>/<repo>)
-# or plain http://127.0.0.1:... URLs from previous proxy injection
 if [[ "${raw_url}" =~ 127\.0\.0\.1 ]] || [[ "${raw_url}" =~ local_proxy ]]; then
-    warn "remote.origin.url is a stale local proxy URL: ${raw_url}"
     # Extract owner/repo from the end of the URL (last two path segments).
-    # The /git/ prefix form (http://user@127.0.0.1:PORT/git/owner/repo) is stripped
-    # directly. The plain form (http://127.0.0.1:PORT/owner/repo) has no /git/
-    # segment, so ##*/git/ would be a no-op and leave the whole URL in repo_path —
-    # strip scheme, credentials, and host:port instead to isolate owner/repo.
+    # The /git/ prefix form (http://user@127.0.0.1:PORT/git/owner/repo) is
+    # stripped directly. The plain form (http://127.0.0.1:PORT/owner/repo)
+    # has no /git/ segment, so ##*/git/ would be a no-op and leave the whole
+    # URL in repo_path — strip scheme, credentials, and host:port instead.
     if [[ "${raw_url}" == */git/* ]]; then
         repo_path="${raw_url##*/git/}"
     else
-        repo_path="${raw_url#*://}" # strip scheme
-        repo_path="${repo_path#*@}" # strip user@ credentials, if present
-        repo_path="${repo_path#*/}" # strip host:port
+        repo_path="${raw_url#*://}"
+        repo_path="${repo_path#*@}"
+        repo_path="${repo_path#*/}"
     fi
-    repo_path="${repo_path%.git}" # strip trailing .git suffix, if present
+    repo_path="${repo_path%.git}"
     if [[ -n "${repo_path}" && "${repo_path}" == */* ]]; then
         if [[ -n "${GITHUB_TOKEN:-}" ]]; then
             new_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${repo_path}"
         else
             new_url="https://github.com/${repo_path}"
         fi
-        (cd "${REPO_ROOT}" && git remote set-url origin "${new_url}")
-        ok "remote.origin.url fixed: https://github.com/${repo_path}"
-    else
-        warn "Could not parse owner/repo from: ${raw_url}"
-        warn "Set remote URL manually: git remote set-url origin https://github.com/<owner>/<repo>"
+        (cd "${REPO_ROOT}" && git remote set-url origin "${new_url}") 2>/dev/null || true
     fi
 elif [[ "${raw_url}" == https://github.com/* ]] || [[ "${raw_url}" =~ ^https://[^@]+@github\.com/ ]]; then
-    # URL points to github.com (with or without embedded credentials) — refresh token
-    # Extract owner/repo using parameter expansion (avoids SC2001 sed warning)
+    # URL already points to github.com (with or without embedded
+    # credentials) — refresh the token if one is available and differs.
     if [[ "${raw_url}" == *"@github.com/"* ]]; then
         repo_path="${raw_url##*@github.com/}"
     else
@@ -137,93 +98,12 @@ elif [[ "${raw_url}" == https://github.com/* ]] || [[ "${raw_url}" =~ ^https://[
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
         new_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${repo_path}"
         if [[ "${raw_url}" != "${new_url}" ]]; then
-            (cd "${REPO_ROOT}" && git remote set-url origin "${new_url}")
-            ok "remote.origin.url: refreshed GITHUB_TOKEN for github.com/${repo_path}"
-        else
-            ok "remote.origin.url: already has current GITHUB_TOKEN"
+            (cd "${REPO_ROOT}" && git remote set-url origin "${new_url}") 2>/dev/null || true
         fi
-    else
-        ok "remote.origin.url: github.com URL (no GITHUB_TOKEN — push will require credentials)"
     fi
-else
-    warn "remote.origin.url is unrecognized: ${raw_url}"
 fi
 
-# ─── 6. uv update ────────────────────────────────────────────────────────────
-echo ""
-log "Updating uv..."
-uv self update 2>&1 | tail -1 | sed 's/^/[session-init] /' || true
-
-# ─── 7. prek hook installation ───────────────────────────────────────────────
-# Installs git hook scripts into .git/hooks/ (fast, no network required).
-# Hook venvs are created lazily on first hook run.
-echo ""
-log "Installing git hooks via prek..."
-if (cd "${REPO_ROOT}" && uv run prek install \
-    -t pre-commit -t commit-msg -t pre-rebase -t post-merge 2>&1); then
-    ok "prek: git hook scripts installed"
-else
-    warn "prek install failed — hooks may not run on commit"
-fi
-
-# ─── 8. Validation: test that tooling works correctly through the proxy ───────
-# All outbound HTTPS goes through HTTPS_PROXY. These tests confirm each tool
-# can reach the internet correctly with the current proxy and cert configuration.
-# Each check retries before reporting failure — a single network blip is not
-# a real proxy/cert problem, and the script (not the reader) is responsible
-# for telling the two apart.
-echo ""
-log "Validating tool connectivity through proxy..."
-
-retry() {
-    local attempts="$1"
-    shift
-    local i
-    for ((i = 1; i <= attempts; i++)); do
-        if "$@" >/dev/null 2>&1; then
-            return 0
-        fi
-        ((i < attempts)) && sleep 1
-    done
-    return 1
-}
-
-check_git_fetch() { (cd "${REPO_ROOT}" && git fetch --dry-run origin); }
-check_python_https() {
-    uv run python -c "
-import urllib.request, ssl, os
-ctx = ssl.create_default_context(cafile=os.environ.get('SSL_CERT_FILE'))
-urllib.request.urlopen('https://pypi.org/simple/', context=ctx, timeout=5)
-"
-}
-check_pypi_https() {
-    # No pipe to grep: curl | grep -q races under `set -o pipefail` — grep exits the
-    # instant it finds a match, closing its end of the pipe, and curl (still writing
-    # remaining body data) gets a write error that poisons the pipeline's exit status
-    # even though grep already found what it was looking for. Checking the HTTP status
-    # code directly avoids the pipe entirely.
-    local code
-    code=$(curl -sS --max-time 5 --cacert "${SSL_CERT_FILE:-/root/.ccr/ca-bundle.crt}" \
-        -o /dev/null -w '%{http_code}' "https://pypi.org/simple/pip/")
-    [[ "${code}" == "200" ]]
-}
-
-if retry 3 check_git_fetch; then
-    ok "git fetch:      proxy + SSL ✓"
-else
-    warn "git fetch FAILED (3 attempts) — check GIT_SSL_CAINFO (${GIT_SSL_CAINFO:-unset}) and proxy"
-fi
-
-if retry 3 check_python_https; then
-    ok "Python HTTPS:   proxy + SSL ✓"
-else
-    warn "Python HTTPS FAILED (3 attempts) — check SSL_CERT_FILE (${SSL_CERT_FILE:-unset}) and HTTPS_PROXY"
-fi
-
-if retry 3 check_pypi_https; then
-    ok "PyPI HTTPS:     proxy + SSL ✓"
-else
-    warn "PyPI HTTPS FAILED (3 attempts) — pip/uv downloads will fail; check SSL_CERT_FILE and proxy"
-fi
-
-log "session-init complete"
+# ─── 4. uv + prek maintenance ─────────────────────────────────────────────────
+uv self update >/dev/null 2>&1 || true
+(cd "${REPO_ROOT}" && uv run prek install \
+    -t pre-commit -t commit-msg -t pre-rebase -t post-merge) >/dev/null 2>&1 || true

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -36,11 +36,12 @@ echo ""
 
 # ─── 1. UV certificate environment ───────────────────────────────────────────
 # UV_NATIVE_TLS is deprecated since uv 0.6.x; UV_SYSTEM_CERTS=true is the replacement.
+# uv itself warns on ANY set value (true/false/1/0/yes — anything boolish), not just
+# the literal string "true", so match on "is it set" rather than "is it == true".
 # This export works when sourced; when run as a subshell it affects child processes only.
-if [[ "${UV_NATIVE_TLS:-}" == "true" ]]; then
+if [[ -n "${UV_NATIVE_TLS:-}" ]]; then
     export UV_SYSTEM_CERTS=true
     log "Exported UV_SYSTEM_CERTS=true (replaces deprecated UV_NATIVE_TLS)"
-    log "Infrastructure fix needed: replace UV_NATIVE_TLS=true with UV_SYSTEM_CERTS=true"
 else
     ok "UV cert env already correct"
 fi

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -5,11 +5,10 @@
 # Fixes known environment issues, cleans stale git config, and installs git hooks.
 #
 # Usage:
-#   bash .claude/scripts/session-init.sh        — apply fixes (env vars NOT exported to caller shell)
-#   source .claude/scripts/session-init.sh      — apply fixes AND export env vars to current shell
-#
-# To add to CLAUDE.md session-start instructions:
-#   !`source .claude/scripts/session-init.sh`
+#   Wired as a SessionStart hook in .claude/settings.json — runs automatically,
+#   every session, via CLAUDE_ENV_FILE for env var persistence (see §1 below).
+#   Can also be run manually: bash .claude/scripts/session-init.sh
+#   or sourced in an interactive shell to export vars directly: source .claude/scripts/session-init.sh
 #
 # Validation: the script tests that each critical tool works THROUGH the proxy.
 # All outbound HTTPS in this sandbox is routed through HTTPS_PROXY — the goal is
@@ -38,9 +37,15 @@ echo ""
 # UV_NATIVE_TLS is deprecated since uv 0.6.x; UV_SYSTEM_CERTS=true is the replacement.
 # uv itself warns on ANY set value (true/false/1/0/yes — anything boolish), not just
 # the literal string "true", so match on "is it set" rather than "is it == true".
-# This export works when sourced; when run as a subshell it affects child processes only.
+# `export` only affects this script's own process and its children — it does not
+# reach the session's later Bash tool calls, whether run standalone, sourced, or
+# as a SessionStart hook. CLAUDE_ENV_FILE is the actual persistence mechanism:
+# Claude Code sources it before every subsequent Bash command in the session.
 if [[ -n "${UV_NATIVE_TLS:-}" ]]; then
     export UV_SYSTEM_CERTS=true
+    if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+        echo 'export UV_SYSTEM_CERTS=true' >>"${CLAUDE_ENV_FILE}"
+    fi
     log "Exported UV_SYSTEM_CERTS=true (replaces deprecated UV_NATIVE_TLS)"
 else
     ok "UV cert env already correct"
@@ -164,34 +169,61 @@ fi
 # ─── 8. Validation: test that tooling works correctly through the proxy ───────
 # All outbound HTTPS goes through HTTPS_PROXY. These tests confirm each tool
 # can reach the internet correctly with the current proxy and cert configuration.
+# Each check retries before reporting failure — a single network blip is not
+# a real proxy/cert problem, and the script (not the reader) is responsible
+# for telling the two apart.
 echo ""
 log "Validating tool connectivity through proxy..."
 
-# Test 1: git fetch (exercises GIT_SSL_CAINFO + proxy HTTPS CONNECT)
-if (cd "${REPO_ROOT}" && git fetch --dry-run origin 2>/dev/null); then
-    ok "git fetch:      proxy + SSL ✓"
-else
-    warn "git fetch FAILED — check GIT_SSL_CAINFO (${GIT_SSL_CAINFO:-unset}) and proxy"
-fi
+retry() {
+    local attempts="$1"
+    shift
+    local i
+    for ((i = 1; i <= attempts; i++)); do
+        if "$@" >/dev/null 2>&1; then
+            return 0
+        fi
+        ((i < attempts)) && sleep 1
+    done
+    return 1
+}
 
-# Test 2: Python HTTPS (exercises SSL_CERT_FILE + HTTPS_PROXY env)
-if uv run python -c "
+check_git_fetch() { (cd "${REPO_ROOT}" && git fetch --dry-run origin); }
+check_python_https() {
+    uv run python -c "
 import urllib.request, ssl, os
 ctx = ssl.create_default_context(cafile=os.environ.get('SSL_CERT_FILE'))
 urllib.request.urlopen('https://pypi.org/simple/', context=ctx, timeout=5)
-" 2>/dev/null; then
-    ok "Python HTTPS:   proxy + SSL ✓"
+"
+}
+check_pypi_https() {
+    # No pipe to grep: curl | grep -q races under `set -o pipefail` — grep exits the
+    # instant it finds a match, closing its end of the pipe, and curl (still writing
+    # remaining body data) gets a write error that poisons the pipeline's exit status
+    # even though grep already found what it was looking for. Checking the HTTP status
+    # code directly avoids the pipe entirely.
+    local code
+    code=$(curl -sS --max-time 5 --cacert "${SSL_CERT_FILE:-/root/.ccr/ca-bundle.crt}" \
+        -o /dev/null -w '%{http_code}' "https://pypi.org/simple/pip/")
+    [[ "${code}" == "200" ]]
+}
+
+if retry 3 check_git_fetch; then
+    ok "git fetch:      proxy + SSL ✓"
 else
-    warn "Python HTTPS FAILED — check SSL_CERT_FILE (${SSL_CERT_FILE:-unset}) and HTTPS_PROXY"
+    warn "git fetch FAILED (3 attempts) — check GIT_SSL_CAINFO (${GIT_SSL_CAINFO:-unset}) and proxy"
 fi
 
-# Test 3: PyPI HTTPS via curl (exercises proxy + sandbox cert bundle for pip/uv downloads)
-if curl -sS --max-time 5 \
-    --cacert "${SSL_CERT_FILE:-/root/.ccr/ca-bundle.crt}" \
-    "https://pypi.org/simple/pip/" 2>/dev/null | grep -q 'pip'; then
+if retry 3 check_python_https; then
+    ok "Python HTTPS:   proxy + SSL ✓"
+else
+    warn "Python HTTPS FAILED (3 attempts) — check SSL_CERT_FILE (${SSL_CERT_FILE:-unset}) and HTTPS_PROXY"
+fi
+
+if retry 3 check_pypi_https; then
     ok "PyPI HTTPS:     proxy + SSL ✓"
 else
-    warn "PyPI HTTPS FAILED — pip/uv downloads will fail; check SSL_CERT_FILE and proxy"
+    warn "PyPI HTTPS FAILED (3 attempts) — pip/uv downloads will fail; check SSL_CERT_FILE and proxy"
 fi
 
 log "session-init complete"

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -193,46 +193,4 @@ else
     warn "PyPI HTTPS FAILED — pip/uv downloads will fail; check SSL_CERT_FILE and proxy"
 fi
 
-# ─── 9. shellcheck availability ──────────────────────────────────────────────
-# Informational only. The pre-commit shellcheck hook installs shellcheck-py from
-# its PyPI wheel (language: python, see .pre-commit-config.yaml) — the wheel
-# bundles the binary, so this does NOT depend on a system shellcheck being
-# present in PATH. A system install is neither required nor used by the hook.
-echo ""
-if command -v shellcheck >/dev/null 2>&1; then
-    ok "shellcheck (system, informational only): $(command -v shellcheck) ($(shellcheck --version | head -2 | tail -1))"
-else
-    ok "shellcheck: no system install — not required, pre-commit hook installs its own from the PyPI wheel"
-fi
-
-# ─── 10. Infrastructure requirements ─────────────────────────────────────────
-echo ""
-echo "━━━ Infrastructure requirements (must be fixed at sandbox provisioning) ━━━"
-echo ""
-echo "  Environment variables (set at sandbox creation):"
-echo ""
-echo "    CHANGE: UV_NATIVE_TLS=true  →  UV_SYSTEM_CERTS=true  (deprecated since uv 0.6)"
-echo "    OK:     SSL_CERT_FILE=/root/.ccr/ca-bundle.crt"
-echo "    OK:     REQUESTS_CA_BUNDLE=/root/.ccr/ca-bundle.crt"
-echo "    OK:     GIT_SSL_CAINFO=/root/.ccr/ca-bundle.crt"
-echo "    OK:     NODE_EXTRA_CA_CERTS=/root/.ccr/ca-bundle.crt"
-echo "    OK:     PIP_CERT=/root/.ccr/ca-bundle.crt"
-echo "    OK:     CARGO_HTTP_CAINFO=/root/.ccr/ca-bundle.crt"
-echo ""
-echo "  Known proxy quirk (repo-level fix already applied, no action needed here):"
-echo ""
-echo "    Python's stdlib urllib.request/http.client truncates large HTTPS"
-echo "    responses through this proxy's MITM re-termination (IncompleteRead,"
-echo "    at a different byte offset each attempt) — curl and requests/urllib3"
-echo "    are unaffected on the identical URL. This broke the shellcheck-py"
-echo "    pre-commit hook, which cloned the shellcheck-py git repo and ran its"
-echo "    setup.py's urllib.request-based binary download. Fixed in"
-echo "    .pre-commit-config.yaml by installing shellcheck-py from its PyPI"
-echo "    wheel instead (language: python + additional_dependencies) — the"
-echo "    wheel bundles the binary, so no build-time download occurs. If a"
-echo "    similar IncompleteRead surfaces in something else, this proxy quirk"
-echo "    is the first thing to check."
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo ""
 log "session-init complete"

--- a/.claude/scripts/session-init.sh
+++ b/.claude/scripts/session-init.sh
@@ -194,15 +194,15 @@ else
 fi
 
 # ─── 9. shellcheck availability ──────────────────────────────────────────────
+# Informational only. The pre-commit shellcheck hook installs shellcheck-py from
+# its PyPI wheel (language: python, see .pre-commit-config.yaml) — the wheel
+# bundles the binary, so this does NOT depend on a system shellcheck being
+# present in PATH. A system install is neither required nor used by the hook.
 echo ""
 if command -v shellcheck >/dev/null 2>&1; then
-    ok "shellcheck: $(command -v shellcheck) ($(shellcheck --version | head -2 | tail -1))"
+    ok "shellcheck (system, informational only): $(command -v shellcheck) ($(shellcheck --version | head -2 | tail -1))"
 else
-    warn "shellcheck not in PATH"
-    warn "  Pre-commit hook 'shellcheck-py' will fail: pip downloads a ~2.5MB binary"
-    warn "  from GitHub releases and the proxy drops large streaming downloads."
-    warn "  Commits touching shell files will be blocked until shellcheck is available."
-    warn "  Permanent fix: see infrastructure requirements below."
+    ok "shellcheck: no system install — not required, pre-commit hook installs its own from the PyPI wheel"
 fi
 
 # ─── 10. Infrastructure requirements ─────────────────────────────────────────
@@ -219,37 +219,19 @@ echo "    OK:     NODE_EXTRA_CA_CERTS=/root/.ccr/ca-bundle.crt"
 echo "    OK:     PIP_CERT=/root/.ccr/ca-bundle.crt"
 echo "    OK:     CARGO_HTTP_CAINFO=/root/.ccr/ca-bundle.crt"
 echo ""
-echo "  Base image packages (proxy cannot stream large binary downloads):"
+echo "  Known proxy quirk (repo-level fix already applied, no action needed here):"
 echo ""
-if command -v shellcheck >/dev/null 2>&1; then
-    echo "    OK: shellcheck already in base image: $(command -v shellcheck)"
-    echo "        Replace shellcheck-py hook in .pre-commit-config.yaml with a local hook"
-    echo "        that calls the system binary — eliminates the binary download on pip install:"
-    echo ""
-    echo "          - repo: local"
-    echo "            hooks:"
-    echo "              - id: shellcheck"
-    echo "                name: shellcheck"
-    echo "                language: system"
-    echo "                entry: shellcheck"
-    echo "                types: [shell]"
-else
-    echo "    MISSING: shellcheck — apt-get install -y shellcheck"
-    echo ""
-    echo "    Root cause: shellcheck-py downloads a ~2.5MB tar.xz from GitHub releases"
-    echo "    during 'pip install'. The proxy drops the connection mid-stream"
-    echo "    (IncompleteRead after ~200KB). This is NOT a certificate issue."
-    echo ""
-    echo "    After adding shellcheck to the base image, replace the pre-commit hook:"
-    echo ""
-    echo "      - repo: local"
-    echo "        hooks:"
-    echo "          - id: shellcheck"
-    echo "            name: shellcheck"
-    echo "            language: system"
-    echo "            entry: shellcheck"
-    echo "            types: [shell]"
-fi
+echo "    Python's stdlib urllib.request/http.client truncates large HTTPS"
+echo "    responses through this proxy's MITM re-termination (IncompleteRead,"
+echo "    at a different byte offset each attempt) — curl and requests/urllib3"
+echo "    are unaffected on the identical URL. This broke the shellcheck-py"
+echo "    pre-commit hook, which cloned the shellcheck-py git repo and ran its"
+echo "    setup.py's urllib.request-based binary download. Fixed in"
+echo "    .pre-commit-config.yaml by installing shellcheck-py from its PyPI"
+echo "    wheel instead (language: python + additional_dependencies) — the"
+echo "    wheel bundles the binary, so no build-time download occurs. If a"
+echo "    similar IncompleteRead surfaces in something else, this proxy quirk"
+echo "    is the first thing to check."
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,10 @@
           {
             "command": "bd prime",
             "type": "command"
+          },
+          {
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/session-init.sh\"",
+            "type": "command"
           }
         ],
         "matcher": ""


### PR DESCRIPTION
## Summary

Follow-up to #2684 (merged), which added `.claude/scripts/session-init.sh` but never wired it into the session-start flow its own header comment described. This PR fixes issues found while auditing that script for actual correctness and finally wires it in.

- **Wires `session-init.sh` into `SessionStart`** (matcher `""`, alongside the existing `bd prime` hook) in `.claude/settings.json` — it now runs automatically every session instead of only when manually invoked.
- **Silences all output.** `SessionStart` hook stdout is added directly to Claude's context on every session, forever (confirmed against the primary docs: "Any text your hook script prints to stdout is added as context for Claude"). Since none of the diagnostic-only checks (CA bundle presence, proxy reachability, git/Python/curl connectivity probes) could self-heal anything — they only ever produced things to print — they're removed entirely. What remains is corrective-only: detect a known stale-state problem and fix it, or do nothing. Verified: 0 bytes on both stdout and stderr on a real run.
- **Fixes `UV_NATIVE_TLS` detection scope and persistence**: the check only matched the literal string `"true"`, but `uv` itself warns on any set boolish value (`1`, `TRUE`, `yes`, `false`, `0`) — verified against all six values that trigger `uv`'s own deprecation warning. Also now `unset UV_NATIVE_TLS` (not just export `UV_SYSTEM_CERTS=true`), since leaving it set meant uv kept warning regardless. Both changes persist via `$CLAUDE_ENV_FILE` (the actual mechanism `SessionStart` hooks use — a hook's own `export` doesn't reach the session's later `Bash` calls), guarded with `grep -q` against duplicate lines across repeated `SessionStart` firings (startup/resume/clear/compact all match matcher `""`).
- **Fixed and then removed** a real intermittent failure in the (now-deleted) connectivity checks: `curl | grep -q 'pip'` raced under `set -o pipefail` — `grep -q` exits the instant it matches, closing its end of the pipe while `curl` is still writing, producing a spurious pipeline failure. Reproduced directly (2/5 failures under load) before the whole check was removed as part of the output-silencing pass.

## Test plan

- [x] `shellcheck` and `bash -n` clean on `session-init.sh`
- [x] `python3 -c "import json; json.load(...)"` — `settings.json` is valid JSON
- [x] Verified the `UV_NATIVE_TLS` fix against `true`/`1`/`TRUE`/`yes`/`false`/`0` (all trigger `uv`'s own warning and are now all detected) and the unset case
- [x] Simulated two consecutive `SessionStart` firings against the same `$CLAUDE_ENV_FILE` — confirmed `export UV_SYSTEM_CERTS=true` and `unset UV_NATIVE_TLS` each appear exactly once, no duplication
- [x] Verified the silent insteadOf cleanup and remote-URL repair against real injected stale state
- [x] Confirmed 0 bytes on stdout and 0 bytes on stderr on a real script run
- [x] Full `prek run --all-files` passes (all hooks, no `--no-verify`)
- [x] Live end-to-end run of the script in this sandbox at each stage of development