### PR TITLE
fix(development-harness): normalize stale issue_number on stored beads manifests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,7 +100,11 @@ repos:
         additional_dependencies: ["@biomejs/biome@2.4.16"]
         types_or: [javascript, jsx, ts, tsx, json, css]
         pass_filenames: true
-        exclude: graphify-out/
+        # Mirror biome.json's own `files.includes` excludes — pre-commit's
+        # types_or filter is unaware of biome's internal ignore list, so an
+        # excluded file passed explicitly makes the biome CLI report "no
+        # files processed" and exit non-zero instead of a benign no-op.
+        exclude: (graphify-out/|.*/\.claude-plugin/plugin\.json$|\.claude-plugin/marketplace\.json$)
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.22.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,11 @@ repos:
         # types_or filter is unaware of biome's internal ignore list, so an
         # excluded file passed explicitly makes the biome CLI report "no
         # files processed" and exit non-zero instead of a benign no-op.
-        exclude: (graphify-out/|.*/\.claude-plugin/plugin\.json$|\.claude-plugin/marketplace\.json$)
+        # biome.json excludes **/.claude-plugin/plugin.json (root or nested,
+        # hence the optional leading path group) but only the ROOT
+        # .claude-plugin/marketplace.json (hence the ^ anchor with no
+        # optional path group) — a nested marketplace.json is not excluded.
+        exclude: (graphify-out/|^(.*/)?\.claude-plugin/plugin\.json$|^\.claude-plugin/marketplace\.json$)
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.22.0

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/beads_artifact_provider.py
+++ b/plugins/development-harness/backlog_core/backends/beads_artifact_provider.py
@@ -565,10 +565,13 @@ class BeadsArtifactProvider:
             issue_id: Beads issue ID string (e.g. ``"bd-a3f8"``).
 
         Returns:
-            Tuple of ``(ArtifactManifest, BeadsIssueRaw)``.  When no manifest
-            data is stored on the issue the manifest is an empty
-            ``ArtifactManifest(issue_number=issue_id)`` so callers always
-            receive the actual beads ID in ``manifest.issue_number``.
+            Tuple of ``(ArtifactManifest, BeadsIssueRaw)``.  The manifest
+            always carries ``issue_number == issue_id`` — when no manifest
+            data is stored, an empty ``ArtifactManifest(issue_number=issue_id)``
+            is returned; when a manifest is stored but was persisted by a
+            pre-fix version with a stale ``issue_number`` (e.g. the old ``0``
+            sentinel), it is normalized to *issue_id* before being returned so
+            callers never observe the stale value.
 
         Raises:
             bd_runner.BdNotInstalledError: When ``bd`` is not on ``PATH``.
@@ -581,6 +584,8 @@ class BeadsArtifactProvider:
             return ArtifactManifest(issue_number=issue_id), issue
         if (manifest := _extract_manifest_from_metadata(issue.metadata)) is None:
             return ArtifactManifest(issue_number=issue_id), issue
+        if manifest.issue_number != issue_id:
+            manifest = manifest.model_copy(update={"issue_number": issue_id})
         return manifest, issue
 
     @property

--- a/plugins/development-harness/backlog_core/tests/test_beads_artifact_provider_manifest.py
+++ b/plugins/development-harness/backlog_core/tests/test_beads_artifact_provider_manifest.py
@@ -8,10 +8,20 @@ were active simultaneously.
 Fix (issue #2442): Both empty-manifest return paths now pass ``issue_id`` to
 ``ArtifactManifest(issue_number=issue_id)`` so the actual beads nanoid is always
 preserved in the returned manifest.
+
+Follow-up fix (Codex review on #2645): the two empty-manifest paths were the only
+paths corrected. An issue with a manifest already persisted by pre-fix code — with
+``issue_number: 0`` baked into the stored JSON — was returned unchanged by
+``_extract_manifest_from_metadata``, and ``ArtifactRegistry.register()`` preserves
+whatever ``issue_number`` the input manifest carries via ``model_copy``. So a stale
+``0`` written before the fix would survive indefinitely across read/register/persist
+cycles. ``_fetch_issue_and_manifest`` now normalizes ``manifest.issue_number`` to
+*issue_id* whenever a stored manifest is successfully parsed and its value differs.
 """
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 from backlog_core.backends.beads_artifact_provider import BeadsArtifactProvider
@@ -31,6 +41,34 @@ _BD_SHOW_METADATA_NO_DH_ARTIFACTS: list[dict] = [
         "issue_type": "task",
         "priority": 2,
         "metadata": {"other_key": "some_value"},
+    }
+]
+
+# A manifest persisted by pre-fix code: issue_number is the stale sentinel 0,
+# but one real artifact entry is present — normalization must preserve it.
+_STALE_MANIFEST_JSON: str = json.dumps({
+    "issue_number": 0,
+    "artifacts": [
+        {
+            "artifact-type": "architect",
+            "artifact_id": "plan/architect-foo.md",
+            "status": "current",
+            "created-at": "2026-01-01T00:00:00Z",
+            "agent": "swarm-task-planner",
+            "storage-tier": "remote",
+        }
+    ],
+    "last-updated": "2026-01-01T00:00:00Z",
+})
+
+_BD_SHOW_STALE_ISSUE_NUMBER: list[dict] = [
+    {
+        "id": _ISSUE_ID,
+        "title": "Test issue",
+        "status": "open",
+        "issue_type": "task",
+        "priority": 2,
+        "metadata": {"dh.artifacts": _STALE_MANIFEST_JSON},
     }
 ]
 
@@ -73,3 +111,27 @@ class TestGetManifestBdIssueNumberPreservation:
             provider = _provider_with_mock_runner(raw)
             manifest = provider.get_manifest_bd(_ISSUE_ID)
             assert manifest.issue_number != 0, f"issue_number must not be sentinel 0; got {manifest.issue_number!r}"
+
+    def test_stale_stored_manifest_issue_number_normalized(self) -> None:
+        """A manifest persisted by pre-fix code with issue_number=0 is normalized on read.
+
+        Regression for the Codex review finding on #2645: _extract_manifest_from_metadata
+        returns a successfully-parsed manifest unchanged, and ArtifactRegistry.register()
+        preserves whatever issue_number the input manifest carries via model_copy — so a
+        stale 0 written before the #2442 fix would survive indefinitely across
+        read/register/persist cycles without this normalization.
+        """
+        provider = _provider_with_mock_runner(_BD_SHOW_STALE_ISSUE_NUMBER)
+
+        manifest = provider.get_manifest_bd(_ISSUE_ID)
+
+        assert manifest.issue_number == _ISSUE_ID
+
+    def test_stale_manifest_normalization_preserves_artifacts(self) -> None:
+        """Normalizing issue_number must not drop or alter the existing artifacts list."""
+        provider = _provider_with_mock_runner(_BD_SHOW_STALE_ISSUE_NUMBER)
+
+        manifest = provider.get_manifest_bd(_ISSUE_ID)
+
+        assert len(manifest.artifacts) == 1
+        assert manifest.artifacts[0].artifact_id == "plan/architect-foo.md"


### PR DESCRIPTION
## Summary

Follow-up to #2645. Codex's automated review on that PR flagged a residual gap that the merged fix didn't cover — see [review comment](https://github.com/Jamie-BitFlight/claude_skills/pull/2645#discussion_r3542155059)-adjacent finding on `beads_artifact_provider.py:584`.

**Root design flaw:** `_fetch_issue_and_manifest` in #2645 only corrected the two *empty-manifest* fallback paths (no metadata / no `dh.artifacts` key). It did not touch the third return path, where `_extract_manifest_from_metadata` successfully parses an *already-stored* manifest. For any beads issue that had `dh.artifacts` metadata persisted by the pre-#2442 code — with `issue_number: 0` baked into the stored JSON — that stale value is returned unchanged on every read. Traced the write path to confirm the bug is self-perpetuating:

1. `provider.get_manifest(item_id)` → `_fetch_issue_and_manifest` → returns the stored manifest with `issue_number=0` (unchanged)
2. `ArtifactRegistry.register(manifest, entry)` (`artifact_registry.py:270`) → `manifest.model_copy(update={"artifacts": updated})` — copies the input manifest, touching only the `artifacts` list; `issue_number` passes through untouched
3. `provider.set_manifest(item_id, updated_manifest)` → persists the same stale `0` back to `bd` metadata

So any beads issue touched before #2442's fix keeps re-persisting the `0` sentinel forever, even after that fix landed.

**Fix:** `_fetch_issue_and_manifest` now normalizes `manifest.issue_number` to `issue_id` whenever a stored manifest is successfully parsed and its value differs — self-healing on the next read/write cycle, no separate migration script needed.

**Second, unrelated fix bundled in:** while committing the above, `biome-check` blocked the commit — `biome.json`'s own `files.includes` explicitly excludes `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (lines 18–19), but the pre-commit hook's `types_or: [json]` filter doesn't know about that exclusion, so it passes those paths straight to `biome check --write` whenever the auto-version-bump hook touches them alongside other staged files. Biome then reports "no files were processed" and exits non-zero, blocking the commit. Fixed by mirroring `biome.json`'s own excludes in the pre-commit hook's `exclude:` pattern. Verified the regex against the real paths that should/shouldn't match before applying.

## Test plan

- [x] `uv run pytest plugins/development-harness/backlog_core/tests/test_beads_artifact_provider_manifest.py` — 5 tests pass (3 existing + 2 new)
- [x] `uv run pytest plugins/development-harness/backlog_core/tests/` — 502 tests pass, 0 regressions
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — clean
- [x] Verified the biome-check exclude regex against real repo paths (`.claude-plugin/plugin.json` under a plugin dir, root `.claude-plugin/marketplace.json`, `graphify-out/` — all excluded; unrelated `.json` files still included)
- [x] Both commits passed the full local pre-commit hook suite on this machine

https://claude.ai/code/session_01LLHvkVrytiSeanCNpyARsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLHvkVrytiSeanCNpyARsK)_