### PR TITLE
docs(skill-creator): add anti-rationalization table pattern to authoring guidance

### DIFF
--- a/plugins/development-harness/skills/backlog/references/mcp-connection-check.md
+++ b/plugins/development-harness/skills/backlog/references/mcp-connection-check.md
@@ -69,11 +69,25 @@ installed and the plugin cache is current (see CLAUDE.md — Testing MCP Servers
 
 ## SAM CLI Fallback
 
-If the SAM server is unavailable and the task cannot wait, use the `uv run sam` CLI for
-SAM-only operations. For backlog operations there is no CLI equivalent — the MCP server
-must be available.
+If the SAM server is unavailable and the task cannot wait, use the `sam` CLI for SAM-only
+operations. It is registered as a console script in the `plugins/development-harness`
+sub-project (`pyproject.toml` — `sam = "sam_schema.cli:app"`), which is a separate uv
+project from the repo root. Running `uv run sam ...` from the repo root fails with
+`error: Failed to spawn: 'sam'` because the root project has no such script. For backlog
+operations there is no CLI equivalent — the MCP server must be available.
+
+From the repo root, use `--project`:
 
 ```bash
+uv run --project plugins/development-harness sam list
+uv run --project plugins/development-harness sam status P{N}
+uv run --project plugins/development-harness sam ready P{N}
+```
+
+Or `cd plugins/development-harness` first and drop `--project`:
+
+```bash
+cd plugins/development-harness
 uv run sam list
 uv run sam status P{N}
 uv run sam ready P{N}

--- a/plugins/plugin-creator/skills/skill-creator/SKILL.md
+++ b/plugins/plugin-creator/skills/skill-creator/SKILL.md
@@ -122,7 +122,7 @@ Every SKILL.md consists of:
 - **Frontmatter** (YAML): Metadata fields like `name`, `description`, `argument-hint`, `allowed-tools`, `model`, `context`, `user-invocable`, `disable-model-invocation`, and `hooks`. The `description` field (or first paragraph if omitted) is what Claude reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is and when it should be used.
 - **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
 
-#### Bundled Resources (optional)
+#### Bundled Resources and Content Patterns (optional)
 
 ##### Scripts (`scripts/`)
 
@@ -528,6 +528,8 @@ For advanced body features (string substitutions, dynamic context injection, ext
 
 ### After Step 5: Quality Review
 
+Before delegating the draft, run it against [references/authoring-checklist.md](./references/authoring-checklist.md) — the pre-publish checklist covering Structure, Core Quality, Code and Scripts, and Testing.
+
 After completing the SKILL.md and all bundled resources, delegate the draft to the `ai-doc-optimizer` agent before packaging or evaluation. This agent pre-loads `prompt-optimization`, `audit-skill-completeness`, and the official Claude Code skill guidelines — it verifies the draft against best practices and produces an optimized version with evidence-backed changes.
 
 Task is SKILL.md quality review with subagent_type="plugin-creator:ai-doc-optimizer"
@@ -583,7 +585,7 @@ Load [schemas.md](./references/schemas.md) for evals.json and grading.json forma
 | `@plugin-creator:grader` | Assertion grading — evaluates eval outputs against expectations |
 | `@plugin-creator:comparator` | Blind A/B comparison — evaluates two skill versions without knowing which is which |
 | `@plugin-creator:analyzer` | Post-hoc analysis — explains why the winning version won and generates improvement suggestions |
-| `references/` | `references/schemas.md` (JSON schemas), `references/evaluation-and-optimization.md` (Steps 7-10), `references/claude-code-skills-official.md` (spec), `references/workflows.md` (patterns) |
+| `references/` | `references/schemas.md` (JSON schemas), `references/evaluation-and-optimization.md` (Steps 7-10), `references/claude-code-skills-official.md` (spec), `references/workflows.md` (patterns), [`references/authoring-checklist.md`](./references/authoring-checklist.md) (pre-publish checklist) |
 | `eval-viewer/` | `viewer.html` (interactive eval viewer), `generate_review.py` (HTML generator) |
 | `assets/` | `eval_review.html` (trigger eval review template) |
 | `scripts/` | `init_skill.py`, `package_skill.py`, `quick_validate.py`, `run_eval.py`, `run_loop.py`, `improve_description.py`, `generate_report.py`, `aggregate_benchmark.py` |

--- a/plugins/plugin-creator/skills/skill-creator/SKILL.md
+++ b/plugins/plugin-creator/skills/skill-creator/SKILL.md
@@ -153,6 +153,10 @@ Files not intended to be loaded into context, but rather used within the output 
 - **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
 - **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
 
+##### Anti-Rationalization Component (optional)
+
+For skills that enforce a multi-step discipline with skippable quality gates, add a two-column table pairing common agent excuses with counter-responses, plus an optional Red Flags list, to defend against agents rationalizing their way past required steps. See [anti-rationalization-pattern.md](./references/anti-rationalization-pattern.md) for the pattern, table shape, and worked examples.
+
 #### What to Not Include in a Skill
 
 A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:

--- a/plugins/plugin-creator/skills/skill-creator/references/anti-rationalization-pattern.md
+++ b/plugins/plugin-creator/skills/skill-creator/references/anti-rationalization-pattern.md
@@ -15,11 +15,13 @@ Include this component when the skill enforces a multi-step discipline containin
 
 Header row is exactly:
 
+```markdown
 | Rationalization | Response |
 |---|---|
 | "I'll add tests later" | Add the test in this same turn — a task marked complete without tests is not complete |
 | "This should be fine, I'm confident" | Confidence is not verification; run the check and cite its output |
 | "The step doesn't apply this time" | Confirm the exemption against the skill's stated conditions before skipping; do not assume |
+```
 
 Each row pairs a first-person quoted excuse with a direct imperative counter-response. Source rows from rationalizations actually observed in agent output where possible, rather than inventing hypothetical ones. A table needs a minimum of one row; there is no fixed maximum — see the verify-done precedent below for a larger worked example.
 
@@ -27,9 +29,11 @@ Each row pairs a first-person quoted excuse with a direct imperative counter-res
 
 Red Flags are an optional bullet list (not a table) of self-checkable warning signs an author includes alongside the table. Optional means the skill author decides, per skill, whether to add it — the authoring-checklist item covers the decision, not a mandate to always include it.
 
+```markdown
 - Language in your own output like "should work", "probably fine", or "seems correct" appearing before the verification step ran
 - A completion claim ("Done!") followed immediately by a commit or push with no fresh command output in the same turn
 - A verification step that exists in the skill's process but is treated as optional in practice
+```
 
 ## Distinguishing This From Similar Tables
 

--- a/plugins/plugin-creator/skills/skill-creator/references/anti-rationalization-pattern.md
+++ b/plugins/plugin-creator/skills/skill-creator/references/anti-rationalization-pattern.md
@@ -1,0 +1,48 @@
+# Anti-Rationalization Pattern
+
+The anti-rationalization component is an optional two-column table pairing a first-person excuse an agent might use to skip a required step with a direct imperative counter-response, plus an optional Red Flags list of self-checkable warning signs. It defends workflow-enforcing skills against an agent declaring a multi-step process "complete" after silently skipping an intermediate verification or quality-gate step.
+
+## When to Include This Component
+
+Include this component when the skill enforces a multi-step discipline containing at least one skippable quality gate — a sequence an agent could plausibly report as complete after skipping one or more intermediate steps. Do not include it for pure reference lookups, single-action tools, or workflows that contain no gate an agent could skip.
+
+| Skill shape | Needs the component? |
+|---|---|
+| `dh:verify-done`, `dh:validation-protocol` — multi-step workflows with skippable verification gates | Yes |
+| A skill that only documents a CLI flag reference — single lookup, no sequence to skip | No |
+
+## Table Shape
+
+Header row is exactly:
+
+| Rationalization | Response |
+|---|---|
+| "I'll add tests later" | Add the test in this same turn — a task marked complete without tests is not complete |
+| "This should be fine, I'm confident" | Confidence is not verification; run the check and cite its output |
+| "The step doesn't apply this time" | Confirm the exemption against the skill's stated conditions before skipping; do not assume |
+
+Each row pairs a first-person quoted excuse with a direct imperative counter-response. Source rows from rationalizations actually observed in agent output where possible, rather than inventing hypothetical ones. A table needs a minimum of one row; there is no fixed maximum — see the verify-done precedent below for a larger worked example.
+
+## Red Flags (Optional)
+
+Red Flags are an optional bullet list (not a table) of self-checkable warning signs an author includes alongside the table. Optional means the skill author decides, per skill, whether to add it — the authoring-checklist item covers the decision, not a mandate to always include it.
+
+- Language in your own output like "should work", "probably fine", or "seems correct" appearing before the verification step ran
+- A completion claim ("Done!") followed immediately by a commit or push with no fresh command output in the same turn
+- A verification step that exists in the skill's process but is treated as optional in practice
+
+## Distinguishing This From Similar Tables
+
+Three tables in this repository share a similar two- or three-column shape but serve different purposes — do not merge them:
+
+- The verify-done `Rationalization | Response` table is the shipped precedent this pattern generalizes from, not a duplicate to fold into this file.
+- The agentskills `best-practices.md` Anti-Patterns table (`| Anti-pattern | Problem | Instead |`) documents mistakes an author makes while constructing a skill. It operates at authoring time. The Rationalization | Response table operates at execution time, documenting excuses an agent uses while running a skill's workflow. Keep the two separate.
+- This file is the reusable authoring template: it is what a skill author consults to build their own Rationalization | Response table for a new workflow-enforcing skill.
+
+## Source
+
+SOURCE: [research/skill-generation-tools/agent-skills.md](../../../../../research/skill-generation-tools/agent-skills.md) lines 116-131 — quote: "Anti-rationalization. Every skill includes a table of common excuses agents use to skip steps (e.g., 'I'll add tests later') with documented counter-arguments." (accessed 2026-07-10)
+
+SOURCE: <https://github.com/addyosmani/agent-skills/blob/main/README.md> (accessed 2026-07-10) — primary URL for the upstream Consistent Skill Anatomy pattern.
+
+SOURCE: [plugins/development-harness/skills/verify-done/SKILL.md](../../../../../plugins/development-harness/skills/verify-done/SKILL.md) lines 169-182 — precedent for the `Rationalization | Response` column vocabulary.

--- a/plugins/plugin-creator/skills/skill-creator/references/authoring-checklist.md
+++ b/plugins/plugin-creator/skills/skill-creator/references/authoring-checklist.md
@@ -19,6 +19,7 @@ SOURCE: Anthropic skill-authoring best practices (docs.anthropic.com, accessed 2
 - [ ] File references are one level deep — ``references/file.md`` not ``references/subdir/file.md``
 - [ ] Progressive disclosure used appropriately — overview in SKILL.md, detail in references
 - [ ] Workflows have clear, numbered steps
+- [ ] For skills enforcing a multi-step discipline with skippable quality gates, a `Rationalization | Response` table (plus optional Red Flags) is present or explicitly deemed not applicable — see [anti-rationalization-pattern.md](./anti-rationalization-pattern.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds an optional "anti-rationalization" component to `skill-creator` authoring guidance for workflow-enforcing skills — a `Rationalization | Response` table pairing agent excuses with counter-responses, plus an optional Red Flags list, modeled on the existing precedent in `dh:verify-done`.
- New reference file `plugins/plugin-creator/skills/skill-creator/references/anti-rationalization-pattern.md`: pattern definition, when-to-include rule, table shape with worked examples, Red Flags list, and reconciliation against two adjacent tables (`verify-done`'s `Rationalization | Response` table and `agentskills`' Anti-Patterns table) so they aren't conflated.
- `SKILL.md`: short pointer added to "Anatomy of a Skill" linking to the new reference file; "Bundled Resources" heading retitled to "Bundled Resources and Content Patterns" so its scope covers the new non-directory content pattern; added inbound links from SKILL.md to the pre-publish checklist (previously unreferenced from the skill's primary workflow).
- `authoring-checklist.md`: one new Core Quality item prompting authors to add the table (or explicitly mark not applicable) for workflow-enforcing skills.
- Unrelated fix: `mcp-connection-check.md`'s documented SAM CLI fallback (`uv run sam ...`) fails from the repo root because the `sam` console script is registered in the `plugins/development-harness` sub-project, a separate uv project — corrected to use `uv run --project plugins/development-harness sam ...` or `cd` first.

## Test plan

- [x] `uvx skilllint@latest check plugins/plugin-creator/skills/skill-creator` — exit 0, no SK006/SK007 token-threshold violations
- [x] `uv run prek run --files` on all changed files — all hooks pass
- [x] `grep -ri rationalization plugins/plugin-creator/skills/skill-creator/` — matches in both the new reference file and the checklist
- [x] Column vocabulary verified uniform (`Rationalization | Response`) — no `Reality` or `Counter-argument` variants anywhere in the diff
- [x] `verify-done/SKILL.md` and `agentskills/references/best-practices.md` confirmed untouched (anti-goal)
- [x] Reproduced the SAM CLI fallback failure (`uv run sam status ...` → `Failed to spawn: 'sam'`) and confirmed the corrected invocation works

Closes #2722
