### PR TITLE
fix(dispatch): remove banned --validate flag, add dependency validation tests

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.8",
+  "version": "9.0.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/sam_schema/dispatch.py
+++ b/plugins/development-harness/sam_schema/dispatch.py
@@ -243,7 +243,6 @@ def create_plan(
     pre_merge: Annotated[list[str] | None, typer.Option("--pre-merge")] = None,
     post_merge: Annotated[list[str] | None, typer.Option("--post-merge")] = None,
     overwrite: Annotated[bool, typer.Option("--overwrite")] = False,
-    validate_after_write: Annotated[bool, typer.Option("--validate/--no-validate")] = True,
     issue: Annotated[
         int | None, typer.Option("--issue", help="Backlog issue to register the dispatch-plan artifact against")
     ] = None,
@@ -271,16 +270,14 @@ def create_plan(
         )
     except (ValidationError, ValueError) as exc:
         err(f"Invalid dispatch plan input: {exc}")
-    if validate_after_write:
-        integrity = validate_plan_integrity(plan)
-        if integrity.errors:
-            err(f"Dispatch plan integrity errors: {'; '.join(integrity.errors)}")
+    integrity = validate_plan_integrity(plan)
+    if integrity.errors:
+        err(f"Dispatch plan integrity errors: {'; '.join(integrity.errors)}")
     emit_result(
         operations.dispatch_create_plan(
             milestone_number=milestone_number,
             plan=plan.model_dump(mode="json", by_alias=True),
             overwrite=overwrite,
-            validate=validate_after_write,
             issue=issue,
         )
     )

--- a/plugins/development-harness/sam_schema/tests/test_dispatch_validation.py
+++ b/plugins/development-harness/sam_schema/tests/test_dispatch_validation.py
@@ -81,8 +81,9 @@ def test_create_plan_forwards_all_supported_dispatch_plan_fields(monkeypatch: py
             "Milestone",
             "--integration-branch",
             "main",
+            "--no-validate",
             "--wave-item",
-            "wave=1;issue=101;title=Feature;priority=P1;conflict_group=3;depends_on=7;status=complete;parallel=false",
+            "wave=1;issue=101;title=Feature;priority=P1;conflict_group=3;status=complete;parallel=false",
             "--conflict-group",
             "group_id=3;reason=shared files;items=101,102",
             "--pre-merge",
@@ -108,7 +109,7 @@ def test_create_plan_forwards_all_supported_dispatch_plan_fields(monkeypatch: py
                             "issue": 101,
                             "priority": "P1",
                             "conflict_group": 3,
-                            "depends_on": [7],
+                            "depends_on": [],
                             "status": "complete",
                         }
                     ],
@@ -117,7 +118,7 @@ def test_create_plan_forwards_all_supported_dispatch_plan_fields(monkeypatch: py
             "quality_gates": {"pre_merge": ["uv run ruff check"], "post_merge": ["uv run pytest"]},
         },
         overwrite=False,
-        validate=True,
+        validate=False,
         issue=None,
     )
 

--- a/plugins/development-harness/sam_schema/tests/test_dispatch_validation.py
+++ b/plugins/development-harness/sam_schema/tests/test_dispatch_validation.py
@@ -82,7 +82,6 @@ def test_create_plan_forwards_all_supported_dispatch_plan_fields(monkeypatch: py
             "Milestone",
             "--integration-branch",
             "main",
-            "--no-validate",
             "--wave-item",
             "wave=1;issue=101;title=Feature;priority=P1;conflict_group=3;status=complete;parallel=false",
             "--conflict-group",
@@ -119,7 +118,6 @@ def test_create_plan_forwards_all_supported_dispatch_plan_fields(monkeypatch: py
             "quality_gates": {"pre_merge": ["uv run ruff check"], "post_merge": ["uv run pytest"]},
         },
         overwrite=False,
-        validate=False,
         issue=None,
     )
 

--- a/plugins/development-harness/sam_schema/tests/test_dispatch_validation.py
+++ b/plugins/development-harness/sam_schema/tests/test_dispatch_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import Mock
 
 import pytest
@@ -130,3 +131,81 @@ def test_conflict_group_rejects_empty_branch_and_missing_items() -> None:
         dispatch._parse_conflict_group("group_id=1;reason=shared;items=101")
     with pytest.raises(ValueError, match="unknown conflict-group field"):
         dispatch._parse_conflict_group("group_id=1;reason=shared;items=101,102;unexpected=x")
+
+
+class TestDependencyValidation:
+    """The ``create-plan`` command validates the dependency graph pre-write."""
+
+    _BASE_ARGS: ClassVar[tuple[str, ...]] = (
+        "create-plan",
+        "--milestone-number",
+        "1",
+        "--milestone-title",
+        "Milestone",
+        "--integration-branch",
+        "main",
+    )
+
+    def test_valid_dep_in_earlier_wave_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        operation = Mock(return_value={"created": True})
+        monkeypatch.setattr(dispatch.operations, "dispatch_create_plan", operation)
+
+        result = runner.invoke(
+            dispatch.app,
+            [
+                *self._BASE_ARGS,
+                "--wave-item",
+                "wave=1;issue=7;title=Dep",
+                "--wave-item",
+                "wave=2;issue=101;title=Feature;depends_on=7",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stderr
+
+    def test_missing_dep_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        operation = Mock(return_value={"created": True})
+        monkeypatch.setattr(dispatch.operations, "dispatch_create_plan", operation)
+
+        result = runner.invoke(
+            dispatch.app, [*self._BASE_ARGS, "--wave-item", "wave=1;issue=101;title=Feature;depends_on=7"]
+        )
+
+        assert result.exit_code == 1
+        assert "does not appear in any wave" in result.stderr
+
+    def test_same_wave_dep_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        operation = Mock(return_value={"created": True})
+        monkeypatch.setattr(dispatch.operations, "dispatch_create_plan", operation)
+
+        result = runner.invoke(
+            dispatch.app,
+            [
+                *self._BASE_ARGS,
+                "--wave-item",
+                "wave=1;issue=7;title=Dep",
+                "--wave-item",
+                "wave=1;issue=101;title=Feature;depends_on=7",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "same wave" in result.stderr
+
+    def test_later_wave_dep_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        operation = Mock(return_value={"created": True})
+        monkeypatch.setattr(dispatch.operations, "dispatch_create_plan", operation)
+
+        result = runner.invoke(
+            dispatch.app,
+            [
+                *self._BASE_ARGS,
+                "--wave-item",
+                "wave=1;issue=101;title=Feature;depends_on=7",
+                "--wave-item",
+                "wave=2;issue=7;title=Dep",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "later wave" in result.stderr


### PR DESCRIPTION
Follow-up to #2781. Removes the banned `--validate/--no-validate` dual-mode flag (validation always runs). Adds 4 dependency-graph validation tests.