### PR TITLE
refactor(test): remove unnecessary Task as _Task alias

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.10",
+  "version": "9.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/tests/test_server_sam_taskbackend.py
+++ b/plugins/development-harness/tests/test_server_sam_taskbackend.py
@@ -664,7 +664,7 @@ def test_update_task_round_trips_list_fields_without_coercion(tmp_path: Path) ->
     from ruamel.yaml import YAML
     from sam_schema.core.action_models import CreatePlanConfig, TaskDefinition
     from sam_schema.core.backends.local_yaml import LocalYamlTaskProvider
-    from sam_schema.core.models import Complexity, CreatePlanResult, Priority, Task as _Task, TaskStatus
+    from sam_schema.core.models import Complexity, CreatePlanResult, Priority, Task, TaskStatus
     from sam_schema.core.task_config import TaskConfig, reset_task_config, set_task_config
 
     # Arrange: create plan via LocalYamlTaskProvider so the file is real YAML
@@ -688,7 +688,7 @@ def test_update_task_round_trips_list_fields_without_coercion(tmp_path: Path) ->
 
         # Act: update task with a Task model that has non-empty dependencies
         task_data = backend.read_task(plan_id, "T01")
-        updated_task = _Task.model_validate({**task_data, "dependencies": ["T01", "T02"]})
+        updated_task = Task.model_validate({**task_data, "dependencies": ["T01", "T02"]})
         backend.update_task(plan_id, updated_task)
 
         # Assert: read the raw YAML file — dependencies must be a sequence, not a string


### PR DESCRIPTION
Drop the defensive `_Task` alias — no name collision exists with `TaskConfig` or `TaskDefinition` in scope.