### PR TITLE
fix(e2e): filter live backlog list by created item

### DIFF
--- a/plugins/development-harness/tests/test_live_validation.py
+++ b/plugins/development-harness/tests/test_live_validation.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
 import uuid
 
 import backlog_core.models as _bc_models
@@ -150,42 +151,17 @@ def live_items(tmp_path_factory, monkeypatch_class):
     # Restore backend_protocol singleton so later tests don't inherit the test config.
     _bp_reset_config()
 
-    # Teardown: close all created issues — log failures instead of swallowing silently
-    token = os.environ.get("GITHUB_TOKEN", "")
-    if token and ctx["issues"]:
-        try:
-            from github import Auth, Github, GithubException
-        except ImportError:
-            logger.warning(
-                "PyGithub not available — cannot clean up %d test issues: %s", len(ctx["issues"]), ctx["issues"]
+    repo_slug = os.environ.get("GITHUB_REPO", existing.default_repo if existing is not None else "")
+    if repo_slug:
+        for issue_num in ctx["issues"]:
+            result = subprocess.run(
+                ["gh", "issue", "close", str(issue_num), "--repo", repo_slug, "--reason", "not planned"],
+                capture_output=True,
+                text=True,
+                check=False,
             )
-        else:
-            try:
-                from backlog_core.models import RepoDiscoveryError, discover_repo
-
-                try:
-                    repo_slug = discover_repo()
-                except RepoDiscoveryError:
-                    # repo_root is a temp non-git dir and GITHUB_REPO is unset;
-                    # fall back to the pre-patched default_repo if available
-                    repo_slug = existing.default_repo if existing is not None else ""
-                if not repo_slug:
-                    logger.warning("Cannot determine repo slug for teardown cleanup of issues: %s", ctx["issues"])
-                else:
-                    g = Github(auth=Auth.Token(token))
-                    repo = g.get_repo(repo_slug)
-                    for issue_num in ctx["issues"]:
-                        try:
-                            issue = repo.get_issue(issue_num)
-                            issue.edit(state="closed")
-                        except GithubException:
-                            logger.warning(
-                                "Failed to close test issue #%d — will remain open as orphan", issue_num, exc_info=True
-                            )
-            except GithubException:
-                logger.warning(
-                    "Failed to connect to GitHub for teardown cleanup of issues: %s", ctx["issues"], exc_info=True
-                )
+            if result.returncode:
+                logger.warning("Failed to close test issue #%d: %s", issue_num, result.stderr)
 
 
 @pytest.fixture(scope="class")
@@ -245,7 +221,7 @@ class TestLiveLifecycle:
         """L2: backlog_list returns the item created in L1."""
         if not live_items["l1_ok"]:
             pytest.skip("L1 (test_l1_add_with_real_issue) did not complete — skipping dependent test")
-        result = await _call("backlog_list", {})
+        result = await _call("backlog_list", {"title": live_items["title_prefix"]})
 
         assert isinstance(result["items"], list)
         assert result["count"] >= 1


### PR DESCRIPTION
Fixes the live E2E lifecycle list visibility failure and cleanup path.\n\nValidation: `uv run pytest -m e2e -v plugins/development-harness/tests/test_live_validation.py -k "l1 or l2"` (2 passed); `uv run prek run --files plugins/development-harness/tests/test_live_validation.py`.