### PR TITLE
feat(github): add provider-native CAS storage

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.12",
+  "version": "9.0.13",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/ARCHITECTURE.md
+++ b/plugins/development-harness/backlog_core/ARCHITECTURE.md
@@ -591,6 +591,42 @@ The existing independent `create_artifact_provider()` calls in `operations.py` a
 including the server's `LocalFilesystemArtifactProvider` fallback, are migration debt. They must be
 replaced by artifact capabilities obtained from the configured backend.
 
+### GitHub writable records
+
+GitHub uses two provider-native, lossless write representations because its APIs expose different
+concurrency guarantees:
+
+- Plans, artifact manifests, artifact content, dispatch plans, and work-item heads are deterministic
+  files beneath `.dh/content/v1/` on the repository's resolved default branch. Every GitHub request
+  names that branch. Each file stores a compact versioned envelope containing its complete logical identity,
+  owner metadata, and content. Identity fields use one injective URL-safe encoding; the decoded
+  envelope must match its path. Malformed, duplicate, oversized, or mismatched records fail closed.
+  The GitHub Contents API blob SHA is the opaque revision: updates send the observed SHA and creates
+  omit SHA. On `409` or `422`, the provider re-reads the target. A path that appeared, disappeared,
+  or changed SHA is `ContentConflictError`; an unchanged target permits only a bounded retry for an
+  unrelated branch-head race. `403` and protected-branch failures are unavailable, not conflicts.
+  Discovery resolves one branch tree, rejects truncated results, validates every envelope, sorts by
+  logical identity, then applies `ContentQuery` filtering and bounds. Native records take precedence
+  over read-only Gist/index migration records; a malformed native record never falls back.
+- Work-item issue bodies remain human-owned GitHub content and are never overwritten after a
+  preflight-only revision check. The authoritative agent-managed head is a Contents record bound to
+  the issue identity. Its root revision is the digest of the canonical Issue body plus Issue node
+  identity, so unrelated labels or comments do not move it and a human body change does. Each update
+  names the previous head/root revision and advances the head with Contents SHA compare-and-swap.
+  A tagged Issue comment is an append-only-by-agent-convention audit and human projection record;
+  its metadata names the head revision and content digest. The provider accepts a patch only after
+  one head CAS succeeds and the referenced comment/digest validates. Concurrent writers may leave
+  both audit comments, but exactly one head advances and only that writer is checkpointed. Edited,
+  deleted, malformed, forged, or digest-mismatched projection comments fail closed.
+
+GitHub deployments require repository Contents read/write and Issues read/write permissions. The
+provider rejects an encoded envelope above 1 MiB before network I/O; larger artifacts require a
+future provider representation rather than silently crossing GitHub's normal Contents API mode.
+
+Neither representation uses cooperative locks, Gist read-modify-write, unconditional Issue-body
+updates, or a second caller-selected provider. Offline writes continue through the owning
+`GitHubBackend` FileCache queue and replay against the same remote revision boundary.
+
 ---
 
 ## Module: operations.py

--- a/plugins/development-harness/backlog_core/backends/_github_work_item_versions.py
+++ b/plugins/development-harness/backlog_core/backends/_github_work_item_versions.py
@@ -1,0 +1,133 @@
+"""Authenticated logical heads and audit comments for GitHub work items."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from backlog_core.backend_types import IssueCommentNode
+from backlog_core.models import ContentKind, ContentRef, ContentUnavailableError
+
+_TAG_PREFIX = "<!-- dh-work-item-version "
+_TAG_SUFFIX = " -->"
+
+
+class _CommentMetadata(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    version: Literal[1]
+    parent_revision: str = Field(min_length=1)
+    digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class WorkItemHead(BaseModel):
+    """Contents-CAS authority for one GitHub Issue's rendered work-item body."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    version: Literal[1] = 1
+    issue_reference: str = Field(min_length=2)
+    parent_revision: str = Field(min_length=1)
+    root_revision: str = Field(min_length=1)
+    body: str
+    digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    comment_id: str = Field(min_length=1)
+
+    @classmethod
+    def create(
+        cls, issue_reference: str, parent_revision: str, root_revision: str, body: str, comment_id: str
+    ) -> WorkItemHead:
+        """Create an authenticated logical head for a successful Contents update.
+
+        Returns:
+            Authenticated logical head.
+        """
+        return cls(
+            issue_reference=issue_reference,
+            parent_revision=parent_revision,
+            root_revision=root_revision,
+            body=body,
+            digest=_body_digest(body),
+            comment_id=comment_id,
+        )
+
+    @model_validator(mode="after")
+    def _verify_digest(self) -> WorkItemHead:
+        if self.digest != _body_digest(self.body):
+            raise ValueError("work-item head digest is invalid")
+        return self
+
+
+class WorkItemVersion(BaseModel):
+    """Resolved rendered body with its opaque provider revision."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    revision: str = Field(min_length=1)
+    body: str
+
+
+def root_revision(issue_reference: str, issue_node_id: str, issue_body: str) -> str:
+    """Return the Issue-identity-bound canonical root revision for a human body."""
+    return _body_digest(
+        json.dumps(
+            {"body": issue_body, "issue_node_id": issue_node_id, "issue_reference": issue_reference},
+            separators=(",", ":"),
+        )
+    )
+
+
+def work_item_head_ref(issue_reference: str) -> ContentRef:
+    """Return the provider-private Contents identity for an Issue's authoritative head."""
+    return ContentRef(
+        kind=ContentKind.ARTIFACT_CONTENT, namespace=issue_reference, artifact_type="_dh-work-item-head-v1", name="head"
+    )
+
+
+def render_work_item_comment(parent_revision: str, body: str) -> str:
+    """Return the validated audit comment for a prospective Contents head."""
+    metadata = _CommentMetadata(version=1, parent_revision=parent_revision, digest=_body_digest(body))
+    return (
+        f"{_TAG_PREFIX}{json.dumps(metadata.model_dump(), separators=(',', ':'), sort_keys=True)}{_TAG_SUFFIX}\n{body}"
+    )
+
+
+def parse_work_item_comment(head: WorkItemHead, comment: IssueCommentNode | None) -> str:
+    """Validate that the remote audit comment exactly projects an authoritative head.
+
+    Returns:
+        The audited rendered body.
+    """
+    if comment is None:
+        raise ContentUnavailableError("GitHub work-item audit comment is missing")
+    if comment["id"] != head.comment_id:
+        raise ContentUnavailableError("GitHub work-item audit comment identity is invalid")
+    header, separator, body = comment["body"].partition("\n")
+    if not separator or not header.startswith(_TAG_PREFIX) or not header.endswith(_TAG_SUFFIX):
+        raise ContentUnavailableError("GitHub work-item audit comment is invalid")
+    try:
+        metadata = _CommentMetadata.model_validate_json(header.removeprefix(_TAG_PREFIX).removesuffix(_TAG_SUFFIX))
+    except ValidationError as exc:
+        raise ContentUnavailableError("GitHub work-item audit comment is invalid") from exc
+    if metadata.parent_revision != head.parent_revision or metadata.digest != head.digest or body != head.body:
+        raise ContentUnavailableError("GitHub work-item audit comment is invalid")
+    return body
+
+
+def parse_work_item_head(content: str) -> WorkItemHead:
+    """Parse a Contents-head envelope or fail closed on malformed authority data.
+
+    Returns:
+        Validated logical head.
+    """
+    try:
+        return WorkItemHead.model_validate_json(content)
+    except ValidationError as exc:
+        raise ContentUnavailableError("GitHub work-item head is invalid") from exc
+
+
+def _body_digest(body: str) -> str:
+    return hashlib.sha256(body.encode()).hexdigest()

--- a/plugins/development-harness/backlog_core/backends/_github_work_item_versions.py
+++ b/plugins/development-harness/backlog_core/backends/_github_work_item_versions.py
@@ -87,6 +87,14 @@ def work_item_head_ref(issue_reference: str) -> ContentRef:
     )
 
 
+def is_work_item_head_ref(reference: ContentRef) -> bool:
+    return (
+        reference.kind == ContentKind.ARTIFACT_CONTENT
+        and reference.artifact_type == "_dh-work-item-head-v1"
+        and reference.name == "head"
+    )
+
+
 def render_work_item_comment(parent_revision: str, body: str) -> str:
     """Return the validated audit comment for a prospective Contents head."""
     metadata = _CommentMetadata(version=1, parent_revision=parent_revision, digest=_body_digest(body))

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -572,13 +572,15 @@ class GitHubBackend:
             case ReconcileScope.LINKED | ReconcileScope.TARGETED:
                 issues = []
 
-        items_by_identity: dict[tuple[str, str], ProviderItem] = {}
-        for issue in issues:
-            item = self._provider_item_from_issue(repo, owner, repo_name, issue)
-            items_by_identity[item.reference, item.revision] = item
-        listed_references = {item.reference for item in items_by_identity.values()}
+        listed_references = {f"#{issue['number']}" for issue in issues}
         target_references = [reference for reference in request.references if reference not in listed_references]
         targeted = self._fetch_targeted_issues(repo, owner, repo_name, target_references)
+        existing_issues = [*issues, *(issue for issue in targeted.values() if issue is not None)]
+        heads, comments = self._work_item_contexts(repo, existing_issues)
+        items_by_identity: dict[tuple[str, str], ProviderItem] = {}
+        for issue in issues:
+            item = self._provider_item_from_issue(repo, owner, repo_name, issue, heads, comments)
+            items_by_identity[item.reference, item.revision] = item
         for reference, issue in targeted.items():
             if issue is None:
                 item = ProviderItem(
@@ -592,7 +594,7 @@ class GitHubBackend:
                     exists=False,
                 )
             else:
-                item = self._provider_item_from_issue(repo, owner, repo_name, issue)
+                item = self._provider_item_from_issue(repo, owner, repo_name, issue, heads, comments)
             items_by_identity[item.reference, item.revision] = item
         return ProviderSnapshot(
             items=list(items_by_identity.values()), sync_started_at=sync_started_at, pages_fetched=1
@@ -667,10 +669,10 @@ class GitHubBackend:
                     )
                 )
                 continue
-            comment_id = self._add_comment_graphql(
-                repo, issue["id"], render_work_item_comment(current.revision, patch.body)
-            )
             try:
+                comment_id = self._add_comment_graphql(
+                    repo, issue["id"], render_work_item_comment(current.revision, patch.body)
+                )
                 head = WorkItemHead.create(patch.reference, current.revision, root, patch.body, comment_id)
                 written = self._contents.put(
                     ContentWrite(
@@ -704,8 +706,16 @@ class GitHubBackend:
             )
         return results
 
-    def _provider_item_from_issue(self, repo: Repository, owner: str, repo_name: str, issue: IssueNode) -> ProviderItem:
-        version, _head_record, _root = self._work_item_version(repo, owner, repo_name, issue)
+    def _provider_item_from_issue(
+        self,
+        repo: Repository,
+        owner: str,
+        repo_name: str,
+        issue: IssueNode,
+        heads: dict[str, ContentRecord] | None = None,
+        comments: dict[str, IssueCommentNode] | None = None,
+    ) -> ProviderItem:
+        version, _head_record, _root = self._work_item_version(repo, owner, repo_name, issue, heads, comments)
         return ProviderItem(
             provider_id=issue["id"],
             reference=f"#{issue['number']}",
@@ -717,23 +727,79 @@ class GitHubBackend:
         )
 
     def _work_item_version(
-        self, repo: Repository, owner: str, repo_name: str, issue: IssueNode
+        self,
+        repo: Repository,
+        owner: str,
+        repo_name: str,
+        issue: IssueNode,
+        heads: dict[str, ContentRecord] | None = None,
+        comments: dict[str, IssueCommentNode] | None = None,
     ) -> tuple[WorkItemVersion, ContentRecord | None, str]:
         reference = f"#{issue['number']}"
         root = root_revision(reference, issue["id"], issue["body"])
-        try:
-            head_record = self._contents.get(work_item_head_ref(reference))
-        except ContentNotFoundError:
-            return WorkItemVersion(revision=root, body=issue["body"]), None, root
+        if heads is None:
+            try:
+                head_record = self._contents.get(work_item_head_ref(reference))
+            except ContentNotFoundError:
+                return WorkItemVersion(revision=root, body=issue["body"]), None, root
+        else:
+            head_record = heads.get(reference)
+            if head_record is None:
+                return WorkItemVersion(revision=root, body=issue["body"]), None, root
         head = parse_work_item_head(head_record.content)
         if head.issue_reference != reference or head.root_revision != root:
             return WorkItemVersion(revision=root, body=issue["body"]), head_record, root
-        comment = self._fetch_comment_by_id_graphql(repo, head.comment_id)
+        comment = (
+            comments.get(head.comment_id)
+            if comments is not None
+            else self._fetch_comment_by_id_graphql(repo, head.comment_id)
+        )
         return (
             WorkItemVersion(revision=head_record.revision, body=parse_work_item_comment(head, comment)),
             head_record,
             root,
         )
+
+    def _work_item_contexts(
+        self, repo: Repository, issues: list[IssueNode]
+    ) -> tuple[dict[str, ContentRecord], dict[str, IssueCommentNode]]:
+        namespaces = {f"#{issue['number']}" for issue in issues}
+        records = self._list_all_content(
+            self._contents,
+            ContentQuery(kind=ContentKind.ARTIFACT_CONTENT, search="head", limit=self._CONTENT_PAGE_SIZE),
+        )
+        heads = {
+            record.reference.namespace: record
+            for record in records
+            if record.reference.namespace in namespaces
+            and record.reference.artifact_type == "_dh-work-item-head-v1"
+            and record.reference.name == "head"
+        }
+        issue_by_reference = {f"#{issue['number']}": issue for issue in issues}
+        comment_ids = [
+            head.comment_id
+            for reference, record in heads.items()
+            if (head := parse_work_item_head(record.content)).root_revision
+            == root_revision(reference, issue_by_reference[reference]["id"], issue_by_reference[reference]["body"])
+        ]
+        comments: dict[str, IssueCommentNode] = {}
+        for offset in range(0, len(comment_ids), self._TARGET_BATCH_SIZE):
+            ids = comment_ids[offset : offset + self._TARGET_BATCH_SIZE]
+            response = self._graphql_request(
+                repo,
+                "query AuditComments($ids: [ID!]!) { nodes(ids: $ids) { "
+                "... on IssueComment { id body url author { login } createdAt updatedAt } } }",
+                {"ids": ids},
+            )
+            nodes = response.get("nodes")
+            if not isinstance(nodes, list) or len(nodes) != len(ids):
+                raise ContentUnavailableError("GitHub work-item audit comment response was invalid")
+            for node in nodes:
+                if not isinstance(node, dict):
+                    raise ContentUnavailableError("GitHub work-item audit comment response was invalid")
+                comment = gh_client._parse_comment_node(node)
+                comments[comment["id"]] = comment
+        return heads, comments
 
     def reconcile(self, request: ReconcileRequest) -> ReconcileResult:
         """Reconcile provider state through the pure engine and private cache.

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -26,6 +26,16 @@ from sam_schema.core.plan_id_index import PlanIndexEntry, create_plan_id_index
 
 from backlog_core import gh_client, github_branches, github_sync, rendering as _rendering
 from backlog_core.artifact_provider import ArtifactBackend, GitHubGistArtifactProvider
+from backlog_core.backends._github_work_item_versions import (
+    WorkItemHead,
+    WorkItemVersion,
+    parse_work_item_comment,
+    parse_work_item_head,
+    render_work_item_comment,
+    root_revision,
+    work_item_head_ref,
+)
+from backlog_core.backends.github_contents import _GitHubContentsStore
 from backlog_core.file_cache import FileCache, ReplayAcknowledgement, _ProviderSnapshotCheckpoint
 from backlog_core.models import (
     BacklogError,
@@ -81,6 +91,12 @@ __all__ = ["GitHubBackend"]
 
 
 class _PlanPersistence(Protocol):
+    def list(self, query: ContentQuery) -> Sequence[ContentRecord]: ...
+    def get(self, reference: ContentRef) -> ContentRecord: ...
+    def put(self, request: ContentWrite) -> ContentRecord: ...
+
+
+class _ContentPersistence(Protocol):
     def list(self, query: ContentQuery) -> Sequence[ContentRecord]: ...
     def get(self, reference: ContentRef) -> ContentRecord: ...
     def put(self, request: ContentWrite) -> ContentRecord: ...
@@ -329,6 +345,7 @@ class GitHubBackend:
     supports_branches: bool = True
 
     _TARGET_BATCH_SIZE = 100
+    _CONTENT_PAGE_SIZE = 100
 
     def __init__(
         self,
@@ -337,6 +354,7 @@ class GitHubBackend:
         cache: FileCache | None = None,
         artifact_provider: ArtifactBackend | None = None,
         plan_persistence: _PlanPersistence | None = None,
+        contents: _ContentPersistence | None = None,
     ) -> None:
         """Initialise with an optional default repo string.
 
@@ -345,12 +363,14 @@ class GitHubBackend:
             cache: Provider-private durable cache, injectable for isolated callers.
             artifact_provider: Existing GitHub Gist persistence adapter.
             plan_persistence: Existing GitHub plan-index and Gist composition.
+            contents: GitHub Contents persistence, injectable for isolated callers.
         """
         self._repo = repo
         self._cache = cache or FileCache(_dh_paths.state_root() / "github-cache")
         self._artifact_provider = artifact_provider or GitHubGistArtifactProvider(repo=repo)
         self._plan_persistence = plan_persistence or _GitHubPlanPersistence(self._artifact_provider)
         self._dispatch_persistence = _GitHubDispatchPersistence(self._artifact_provider)
+        self._contents = contents or _GitHubContentsStore(self.get_github)
 
     # ------------------------------------------------------------------
     # Repository access
@@ -532,38 +552,6 @@ class GitHubBackend:
                     raise BacklogError(f"GraphQL targeted issue response was invalid for {reference}")
         return resolved
 
-    def _preflight_patches(
-        self, patches: list[ProviderPatch], current_by_reference: dict[str, IssueNode | None]
-    ) -> dict[str, PatchResult]:
-        results_by_reference: dict[str, PatchResult] = {}
-        for patch in patches:
-            issue = current_by_reference.get(patch.reference)
-            if issue is None:
-                results_by_reference[patch.reference] = PatchResult(
-                    provider_id=patch.provider_id, reference=patch.reference, status="error", message="Issue not found"
-                )
-                continue
-            if issue["updatedAt"] != patch.expected_revision:
-                results_by_reference[patch.reference] = PatchResult(
-                    provider_id=patch.provider_id,
-                    reference=patch.reference,
-                    status="conflict",
-                    revision=issue["updatedAt"],
-                )
-                continue
-            if issue["body"].replace("\r\n", "\n") == patch.body.replace("\r\n", "\n"):
-                results_by_reference[patch.reference] = PatchResult(
-                    provider_id=patch.provider_id,
-                    reference=patch.reference,
-                    status="applied",
-                    revision=issue["updatedAt"],
-                )
-                continue
-            results_by_reference[patch.reference] = PatchResult(
-                provider_id=patch.provider_id, reference=patch.reference, status="conflict", revision=issue["updatedAt"]
-            )
-        return results_by_reference
-
     def _fetch_snapshot(self, request: ReconcileRequest) -> ProviderSnapshot:
         """Fetch one normalized bounded GitHub snapshot for reconciliation.
 
@@ -584,18 +572,10 @@ class GitHubBackend:
             case ReconcileScope.LINKED | ReconcileScope.TARGETED:
                 issues = []
 
-        items_by_identity = {
-            (f"#{issue['number']}", issue["updatedAt"]): ProviderItem(
-                provider_id=issue["id"],
-                reference=f"#{issue['number']}",
-                title=issue["title"],
-                body=issue["body"],
-                state=issue["state"],
-                labels=[label["name"] for label in issue["labels"]],
-                revision=issue["updatedAt"],
-            )
-            for issue in issues
-        }
+        items_by_identity: dict[tuple[str, str], ProviderItem] = {}
+        for issue in issues:
+            item = self._provider_item_from_issue(repo, owner, repo_name, issue)
+            items_by_identity[item.reference, item.revision] = item
         listed_references = {item.reference for item in items_by_identity.values()}
         target_references = [reference for reference in request.references if reference not in listed_references]
         targeted = self._fetch_targeted_issues(repo, owner, repo_name, target_references)
@@ -612,15 +592,7 @@ class GitHubBackend:
                     exists=False,
                 )
             else:
-                item = ProviderItem(
-                    provider_id=issue["id"],
-                    reference=f"#{issue['number']}",
-                    title=issue["title"],
-                    body=issue["body"],
-                    state=issue["state"],
-                    labels=[label["name"] for label in issue["labels"]],
-                    revision=issue["updatedAt"],
-                )
+                item = self._provider_item_from_issue(repo, owner, repo_name, issue)
             items_by_identity[item.reference, item.revision] = item
         return ProviderSnapshot(
             items=list(items_by_identity.values()), sync_started_at=sync_started_at, pages_fetched=1
@@ -646,8 +618,122 @@ class GitHubBackend:
                 for patch in patches
             ]
 
-        results_by_reference = self._preflight_patches(patches, current_by_reference)
-        return [results_by_reference[patch.reference] for patch in patches]
+        results: list[PatchResult] = []
+        for patch in patches:
+            issue = current_by_reference.get(patch.reference)
+            if issue is None:
+                results.append(
+                    PatchResult(
+                        provider_id=patch.provider_id,
+                        reference=patch.reference,
+                        status="error",
+                        message="Issue not found",
+                    )
+                )
+                continue
+            try:
+                current, head_record, root = self._work_item_version(repo, owner, repo_name, issue)
+            except ContentConflictError as exc:
+                results.append(
+                    PatchResult(
+                        provider_id=patch.provider_id, reference=patch.reference, status="conflict", message=str(exc)
+                    )
+                )
+                continue
+            except (BacklogError, ContentUnavailableError) as exc:
+                results.append(
+                    PatchResult(
+                        provider_id=patch.provider_id, reference=patch.reference, status="error", message=str(exc)
+                    )
+                )
+                continue
+            if current.revision != patch.expected_revision:
+                results.append(
+                    PatchResult(
+                        provider_id=patch.provider_id,
+                        reference=patch.reference,
+                        status="conflict",
+                        revision=current.revision,
+                    )
+                )
+                continue
+            if current.body.replace("\r\n", "\n") == patch.body.replace("\r\n", "\n"):
+                results.append(
+                    PatchResult(
+                        provider_id=patch.provider_id,
+                        reference=patch.reference,
+                        status="applied",
+                        revision=current.revision,
+                    )
+                )
+                continue
+            comment_id = self._add_comment_graphql(
+                repo, issue["id"], render_work_item_comment(current.revision, patch.body)
+            )
+            try:
+                head = WorkItemHead.create(patch.reference, current.revision, root, patch.body, comment_id)
+                written = self._contents.put(
+                    ContentWrite(
+                        reference=work_item_head_ref(patch.reference),
+                        content=head.model_dump_json(),
+                        expected_revision=head_record.revision if head_record is not None else "",
+                        create_only=head_record is None,
+                    )
+                )
+            except ContentConflictError as exc:
+                results.append(
+                    PatchResult(
+                        provider_id=patch.provider_id, reference=patch.reference, status="conflict", message=str(exc)
+                    )
+                )
+                continue
+            except (BacklogError, ContentUnavailableError) as exc:
+                results.append(
+                    PatchResult(
+                        provider_id=patch.provider_id, reference=patch.reference, status="error", message=str(exc)
+                    )
+                )
+                continue
+            results.append(
+                PatchResult(
+                    provider_id=patch.provider_id,
+                    reference=patch.reference,
+                    status="applied",
+                    revision=written.revision,
+                )
+            )
+        return results
+
+    def _provider_item_from_issue(self, repo: Repository, owner: str, repo_name: str, issue: IssueNode) -> ProviderItem:
+        version, _head_record, _root = self._work_item_version(repo, owner, repo_name, issue)
+        return ProviderItem(
+            provider_id=issue["id"],
+            reference=f"#{issue['number']}",
+            title=issue["title"],
+            body=version.body,
+            state=issue["state"],
+            labels=[label["name"] for label in issue["labels"]],
+            revision=version.revision,
+        )
+
+    def _work_item_version(
+        self, repo: Repository, owner: str, repo_name: str, issue: IssueNode
+    ) -> tuple[WorkItemVersion, ContentRecord | None, str]:
+        reference = f"#{issue['number']}"
+        root = root_revision(reference, issue["id"], issue["body"])
+        try:
+            head_record = self._contents.get(work_item_head_ref(reference))
+        except ContentNotFoundError:
+            return WorkItemVersion(revision=root, body=issue["body"]), None, root
+        head = parse_work_item_head(head_record.content)
+        if head.issue_reference != reference or head.root_revision != root:
+            return WorkItemVersion(revision=root, body=issue["body"]), head_record, root
+        comment = self._fetch_comment_by_id_graphql(repo, head.comment_id)
+        return (
+            WorkItemVersion(revision=head_record.revision, body=parse_work_item_comment(head, comment)),
+            head_record,
+            root,
+        )
 
     def reconcile(self, request: ReconcileRequest) -> ReconcileResult:
         """Reconcile provider state through the pure engine and private cache.
@@ -750,28 +836,15 @@ class GitHubBackend:
         online = self.try_get_github() is not None
         if online:
             self._replay_pending_content()
-            if query.kind == ContentKind.PLAN:
-                try:
-                    records = list(self._plan_persistence.list(query))
-                except ContentNotFoundError:
-                    raise
-                except (BacklogError, ContentUnavailableError, OSError):
-                    online = False
-                else:
-                    for record in records:
-                        self._cache.cache_content(record)
-                    return records
-            if query.kind == ContentKind.DISPATCH_PLAN:
-                try:
-                    records = list(self._dispatch_persistence.list(query))
-                except ContentNotFoundError:
-                    raise
-                except (BacklogError, ContentUnavailableError, OSError):
-                    online = False
-                else:
-                    for record in records:
-                        self._cache.cache_content(record)
-                    return records
+            try:
+                records = self._list_all_content(self._contents, query)
+                records = self._with_legacy_content(query, records)
+            except (BacklogError, ContentUnavailableError, OSError):
+                online = False
+            else:
+                for record in records:
+                    self._cache.cache_content(record)
+                return records[query.offset : query.offset + query.limit]
         records = [
             record.model_copy(update={"stale": not online})
             for record in self._cache._load_state().records
@@ -848,7 +921,10 @@ class GitHubBackend:
             return None
 
     def _read_online_content(self, reference: ContentRef, cached: ContentRecord | None) -> ContentRecord:
-        owner_reference = reference.namespace
+        try:
+            return self._contents.get(reference)
+        except ContentNotFoundError:
+            pass
         match reference.kind:
             case ContentKind.PLAN:
                 return self._plan_persistence.get(reference)
@@ -867,21 +943,51 @@ class GitHubBackend:
             raise ContentNotFoundError(f"Content was not found: {reference.model_dump_json()}")
         return ContentRecord(
             reference=reference,
-            owner_reference=owner_reference,
+            owner_reference=reference.namespace,
             content=content,
             revision=self._content_revision(content),
         )
 
     def _write_online_content(self, request: ContentWrite, cached: ContentRecord | None) -> ContentRecord:
-        match request.reference.kind:
-            case ContentKind.PLAN:
-                return self._plan_persistence.put(request)
-            case ContentKind.DISPATCH_PLAN:
-                return self._dispatch_persistence.put(request)
-            case ContentKind.ARTIFACT_MANIFEST | ContentKind.ARTIFACT_CONTENT:
-                raise UnsupportedCapabilityError("GitHub artifact writes require compare-and-swap support")
-            case unreachable:
-                assert_never(unreachable)
+        return self._contents.put(request)
+
+    def _with_legacy_content(self, query: ContentQuery, current: list[ContentRecord]) -> list[ContentRecord]:
+        try:
+            match query.kind:
+                case ContentKind.PLAN:
+                    legacy = self._list_all_content(self._plan_persistence, query)
+                case ContentKind.DISPATCH_PLAN:
+                    legacy = self._list_all_content(self._dispatch_persistence, query)
+                case ContentKind.ARTIFACT_MANIFEST | ContentKind.ARTIFACT_CONTENT:
+                    legacy = []
+                case unreachable:
+                    assert_never(unreachable)
+        except (BacklogError, ContentUnavailableError, OSError):
+            if current:
+                return current
+            raise
+        current_references = {record.reference.model_dump_json() for record in current}
+        records = [
+            *current,
+            *(record for record in legacy if record.reference.model_dump_json() not in current_references),
+        ]
+        records.sort(
+            key=lambda record: (record.reference.namespace, record.reference.artifact_type, record.reference.name)
+        )
+        return records
+
+    @staticmethod
+    def _list_all_content(persistence: _ContentPersistence, query: ContentQuery) -> list[ContentRecord]:
+        records: list[ContentRecord] = []
+        offset = 0
+        while True:
+            page = list(
+                persistence.list(query.model_copy(update={"offset": offset, "limit": GitHubBackend._CONTENT_PAGE_SIZE}))
+            )
+            records.extend(page)
+            if len(page) < GitHubBackend._CONTENT_PAGE_SIZE:
+                return records
+            offset += len(page)
 
     def _replay_pending_content(self) -> None:
         acknowledgements: list[ReplayAcknowledgement] = []

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -29,13 +29,14 @@ from backlog_core.artifact_provider import ArtifactBackend, GitHubGistArtifactPr
 from backlog_core.backends._github_work_item_versions import (
     WorkItemHead,
     WorkItemVersion,
+    is_work_item_head_ref,
     parse_work_item_comment,
     parse_work_item_head,
     render_work_item_comment,
     root_revision,
     work_item_head_ref,
 )
-from backlog_core.backends.github_contents import _GitHubContentsStore
+from backlog_core.backends.github_contents import _GitHubContentIntegrityError, _GitHubContentsStore
 from backlog_core.file_cache import FileCache, ReplayAcknowledgement, _ProviderSnapshotCheckpoint
 from backlog_core.models import (
     BacklogError,
@@ -673,6 +674,16 @@ class GitHubBackend:
                 comment_id = self._add_comment_graphql(
                     repo, issue["id"], render_work_item_comment(current.revision, patch.body)
                 )
+                if not comment_id:
+                    results.append(
+                        PatchResult(
+                            provider_id=patch.provider_id,
+                            reference=patch.reference,
+                            status="error",
+                            message="GitHub work-item audit comment response was invalid",
+                        )
+                    )
+                    continue
                 head = WorkItemHead.create(patch.reference, current.revision, root, patch.body, comment_id)
                 written = self._contents.put(
                     ContentWrite(
@@ -771,9 +782,7 @@ class GitHubBackend:
         heads = {
             record.reference.namespace: record
             for record in records
-            if record.reference.namespace in namespaces
-            and record.reference.artifact_type == "_dh-work-item-head-v1"
-            and record.reference.name == "head"
+            if record.reference.namespace in namespaces and is_work_item_head_ref(record.reference)
         }
         issue_by_reference = {f"#{issue['number']}": issue for issue in issues}
         comment_ids = [
@@ -904,7 +913,10 @@ class GitHubBackend:
             self._replay_pending_content()
             try:
                 records = self._list_all_content(self._contents, query)
+                records = [record for record in records if not is_work_item_head_ref(record.reference)]
                 records = self._with_legacy_content(query, records)
+            except _GitHubContentIntegrityError:
+                raise
             except (BacklogError, ContentUnavailableError, OSError):
                 online = False
             else:
@@ -937,6 +949,8 @@ class GitHubBackend:
             record = self._read_online_content(reference, cached)
         except ContentNotFoundError:
             raise
+        except _GitHubContentIntegrityError:
+            raise
         except (BacklogError, ContentUnavailableError, OSError):
             return self._cache.get_content(reference, stale=True)
         self._cache.cache_content(record)
@@ -967,6 +981,8 @@ class GitHubBackend:
         try:
             record = self._write_online_content(request, cached)
         except ContentNotFoundError:
+            raise
+        except _GitHubContentIntegrityError:
             raise
         except (BacklogError, ContentUnavailableError, OSError):
             base = cached or ContentRecord(

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -1044,6 +1044,15 @@ class GitHubBackend:
         )
 
     def _write_online_content(self, request: ContentWrite, cached: ContentRecord | None) -> ContentRecord:
+        if not request.expected_revision:
+            return self._contents.put(request)
+        try:
+            self._contents.get(request.reference)
+        except ContentNotFoundError as exc:
+            legacy = self._read_online_content(request.reference, cached)
+            if legacy.revision != request.expected_revision:
+                raise ContentConflictError("Content revision no longer matches") from exc
+            return self._contents.put(request.model_copy(update={"expected_revision": "", "create_only": True}))
         return self._contents.put(request)
 
     def _with_legacy_content(self, query: ContentQuery, current: list[ContentRecord]) -> list[ContentRecord]:

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -950,6 +950,8 @@ class GitHubBackend:
         Returns:
             The provider or cached logical content record.
         """
+        if is_work_item_head_ref(reference):
+            raise UnsupportedCapabilityError("Content reference is provider-private")
         if self.try_get_github() is None:
             return self._cache.get_content(reference, stale=True)
         self._replay_pending_content()
@@ -971,6 +973,8 @@ class GitHubBackend:
         Returns:
             The applied or pending logical content record.
         """
+        if is_work_item_head_ref(request.reference):
+            raise UnsupportedCapabilityError("Content reference is provider-private")
         cached = self._cached_content(request.reference)
         if self.try_get_github() is None:
             if request.create_only and cached is not None:

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -104,6 +104,11 @@ class _ContentPersistence(Protocol):
 
 
 @runtime_checkable
+class _ReferenceContentPersistence(Protocol):
+    def get_many(self, references: Sequence[ContentRef]) -> list[ContentRecord]: ...
+
+
+@runtime_checkable
 class _RemoteArtifactContentLister(Protocol):
     def list_artifact_content_from_remote(
         self, item_id: int, artifact_type: str, path_prefix: str
@@ -775,10 +780,13 @@ class GitHubBackend:
         self, repo: Repository, issues: list[IssueNode]
     ) -> tuple[dict[str, ContentRecord], dict[str, IssueCommentNode]]:
         namespaces = {f"#{issue['number']}" for issue in issues}
-        records = self._list_all_content(
-            self._contents,
-            ContentQuery(kind=ContentKind.ARTIFACT_CONTENT, search="head", limit=self._CONTENT_PAGE_SIZE),
-        )
+        if isinstance(self._contents, _ReferenceContentPersistence):
+            records = self._contents.get_many([work_item_head_ref(reference) for reference in namespaces])
+        else:
+            records = self._list_all_content(
+                self._contents,
+                ContentQuery(kind=ContentKind.ARTIFACT_CONTENT, search="head", limit=self._CONTENT_PAGE_SIZE),
+            )
         heads = {
             record.reference.namespace: record
             for record in records
@@ -927,6 +935,7 @@ class GitHubBackend:
             record.model_copy(update={"stale": not online})
             for record in self._cache._load_state().records
             if record.reference.kind == query.kind
+            and not is_work_item_head_ref(record.reference)
             and (query.owner_reference is None or record.owner_reference == query.owner_reference)
             and query.search.casefold() in record.reference.name.casefold()
         ]

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -90,6 +90,8 @@ if TYPE_CHECKING:
 
 __all__ = ["GitHubBackend"]
 
+_NativeContentsStore = _GitHubContentsStore
+
 
 class _PlanPersistence(Protocol):
     def list(self, query: ContentQuery) -> Sequence[ContentRecord]: ...
@@ -1020,6 +1022,9 @@ class GitHubBackend:
             return self._contents.get(reference)
         except ContentNotFoundError:
             pass
+        return self._read_legacy_content(reference)
+
+    def _read_legacy_content(self, reference: ContentRef) -> ContentRecord:
         match reference.kind:
             case ContentKind.PLAN:
                 return self._plan_persistence.get(reference)
@@ -1044,12 +1049,17 @@ class GitHubBackend:
         )
 
     def _write_online_content(self, request: ContentWrite, cached: ContentRecord | None) -> ContentRecord:
-        if not request.expected_revision:
+        if not request.expected_revision and not request.create_only:
             return self._contents.put(request)
         try:
             self._contents.get(request.reference)
         except ContentNotFoundError as exc:
-            legacy = self._read_online_content(request.reference, cached)
+            try:
+                legacy = self._read_legacy_content(request.reference)
+            except ContentNotFoundError:
+                return self._contents.put(request)
+            if request.create_only:
+                raise ContentConflictError("Content already exists") from exc
             if legacy.revision != request.expected_revision:
                 raise ContentConflictError("Content revision no longer matches") from exc
             return self._contents.put(request.model_copy(update={"expected_revision": "", "create_only": True}))
@@ -1082,6 +1092,8 @@ class GitHubBackend:
 
     @staticmethod
     def _list_all_content(persistence: _ContentPersistence, query: ContentQuery) -> list[ContentRecord]:
+        if isinstance(persistence, _NativeContentsStore):
+            return persistence.list_all(query)
         records: list[ContentRecord] = []
         offset = 0
         while True:

--- a/plugins/development-harness/backlog_core/backends/github_contents.py
+++ b/plugins/development-harness/backlog_core/backends/github_contents.py
@@ -1,0 +1,227 @@
+"""GitHub Contents API persistence for versioned logical backlog content."""
+
+from __future__ import annotations
+
+import json
+from base64 import b64decode
+from collections.abc import Callable, Mapping, Sequence as SequenceABC, Sequence as SequenceType
+from typing import Protocol, TypeAlias, runtime_checkable
+from urllib.parse import quote
+
+from github import GithubException
+
+from backlog_core.models import (
+    ContentConflictError,
+    ContentNotFoundError,
+    ContentQuery,
+    ContentRecord,
+    ContentRef,
+    ContentUnavailableError,
+    ContentWrite,
+)
+
+_ROOT = ".dh/content/v1"
+_VERSION = 1
+_NOT_FOUND = 404
+_CONFLICT_STATUSES = frozenset({409, 422})
+_MAX_CONTENT_BYTES = 1_000_000
+_WRITE_ATTEMPTS = 3
+ContentRecords: TypeAlias = list[ContentRecord]
+
+
+@runtime_checkable
+class _ContentsFile(Protocol):
+    @property
+    def decoded_content(self) -> bytes: ...
+
+    @property
+    def sha(self) -> str: ...
+
+
+class _GitTreeEntry(Protocol):
+    @property
+    def path(self) -> str: ...
+
+    @property
+    def type(self) -> str: ...
+
+    @property
+    def sha(self) -> str: ...
+
+
+class _GitTree(Protocol):
+    @property
+    def tree(self) -> SequenceType[_GitTreeEntry]: ...
+
+    @property
+    def truncated(self) -> bool: ...
+
+
+class _GitBlob(Protocol):
+    @property
+    def content(self) -> str: ...
+
+
+class _ContentsRepository(Protocol):
+    @property
+    def default_branch(self) -> str: ...
+
+    def get_contents(self, path: str, ref: str) -> _ContentsFile | SequenceType[_ContentsFile]: ...
+    def create_file(self, path: str, message: str, content: str, branch: str) -> Mapping[str, object]: ...
+    def update_file(self, path: str, message: str, content: str, sha: str, branch: str) -> Mapping[str, object]: ...
+    def get_git_tree(self, sha: str, recursive: bool) -> _GitTree: ...
+    def get_git_blob(self, sha: str) -> _GitBlob: ...
+
+
+class _GitHubContentsStore:
+    def __init__(self, repository: Callable[[], _ContentsRepository]) -> None:
+        self._repository = repository
+
+    def list(self, query: ContentQuery) -> SequenceType[ContentRecord]:
+        repository = self._repository()
+        try:
+            tree = repository.get_git_tree(repository.default_branch, recursive=True)
+        except GithubException as exc:
+            raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
+        if tree.truncated:
+            raise ContentUnavailableError("GitHub content discovery tree was truncated")
+        records = [
+            self._from_blob(repository, entry.path, entry.sha)
+            for entry in tree.tree
+            if entry.type == "blob" and entry.path.startswith(self._kind_prefix(query.kind.value))
+        ]
+        filtered = [
+            record
+            for record in records
+            if (query.owner_reference is None or record.owner_reference == query.owner_reference)
+            and query.search.casefold() in record.reference.name.casefold()
+        ]
+        filtered.sort(
+            key=lambda record: (record.reference.namespace, record.reference.artifact_type, record.reference.name)
+        )
+        return filtered[query.offset : query.offset + query.limit]
+
+    def list_content(self, query: ContentQuery) -> ContentRecords:
+        return list(self.list(query))
+
+    def get(self, reference: ContentRef) -> ContentRecord:
+        repository = self._repository()
+        return self._get(repository, self._path(reference), repository.default_branch)
+
+    def get_content(self, reference: ContentRef) -> ContentRecord:
+        return self.get(reference)
+
+    def put(self, request: ContentWrite) -> ContentRecord:
+        repository = self._repository()
+        branch = repository.default_branch
+        path = self._path(request.reference)
+        for _ in range(_WRITE_ATTEMPTS):
+            current = self._existing(repository, path, branch)
+            record = self._record_for_write(request, current)
+            if current == record:
+                return current
+            envelope = self._serialize(record)
+            if len(envelope.encode()) > _MAX_CONTENT_BYTES:
+                raise ContentUnavailableError("GitHub content exceeds the 1 MB Contents API limit")
+            try:
+                if current is None:
+                    response = repository.create_file(path, f"Store {request.reference.kind}", envelope, branch=branch)
+                else:
+                    response = repository.update_file(
+                        path, f"Store {request.reference.kind}", envelope, current.revision, branch=branch
+                    )
+            except GithubException as exc:
+                if exc.status not in _CONFLICT_STATUSES:
+                    raise ContentUnavailableError(f"GitHub content write failed: {exc}") from exc
+                observed = self._existing(repository, path, branch)
+                if current is None:
+                    if observed is not None:
+                        raise ContentConflictError("Content already exists") from exc
+                elif observed is None or observed.revision != current.revision:
+                    raise ContentConflictError("Content revision no longer matches") from exc
+            else:
+                written = response.get("content")
+                if not isinstance(written, _ContentsFile):
+                    raise ContentUnavailableError("GitHub content write response was invalid")
+                return self._parse(path, envelope.encode(), written.sha)
+        raise ContentUnavailableError("GitHub content write could not advance the selected branch")
+
+    def put_content(self, request: ContentWrite) -> ContentRecord:
+        return self.put(request)
+
+    def _existing(self, repository: _ContentsRepository, path: str, branch: str) -> ContentRecord | None:
+        try:
+            return self._get(repository, path, branch)
+        except ContentNotFoundError:
+            return None
+
+    @staticmethod
+    def _record_for_write(request: ContentWrite, current: ContentRecord | None) -> ContentRecord:
+        owner_reference = (
+            request.owner_reference
+            if request.owner_reference is not None
+            else (current.owner_reference if current is not None else request.reference.namespace)
+        )
+        if request.create_only and current is not None:
+            raise ContentConflictError("Content already exists")
+        if request.expected_revision and (current is None or current.revision != request.expected_revision):
+            raise ContentConflictError("Content revision no longer matches")
+        if current is not None and current.content == request.content and current.owner_reference == owner_reference:
+            return current
+        return ContentRecord(reference=request.reference, owner_reference=owner_reference, content=request.content)
+
+    @staticmethod
+    def _kind_prefix(kind: object) -> str:
+        return f"{_ROOT}/{_segment(str(kind))}/"
+
+    @staticmethod
+    def _path(reference: ContentRef) -> str:
+        return "/".join((
+            _ROOT,
+            _segment(reference.kind.value),
+            _segment(reference.namespace),
+            _segment(reference.artifact_type),
+            _segment(reference.name),
+        ))
+
+    def _get(self, repository: _ContentsRepository, path: str, branch: str) -> ContentRecord:
+        try:
+            file = repository.get_contents(path, ref=branch)
+        except GithubException as exc:
+            if exc.status == _NOT_FOUND:
+                raise ContentNotFoundError(f"Content was not found: {path}") from exc
+            raise ContentUnavailableError(f"GitHub content read failed: {exc}") from exc
+        if isinstance(file, SequenceABC):
+            raise ContentUnavailableError(f"GitHub content path is not a file: {path}")
+        return self._parse(path, file.decoded_content, file.sha)
+
+    def _from_blob(self, repository: _ContentsRepository, path: str, sha: str) -> ContentRecord:
+        try:
+            content = b64decode(repository.get_git_blob(sha).content)
+        except (GithubException, ValueError) as exc:
+            raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
+        return self._parse(path, content, sha)
+
+    def _parse(self, path: str, content: bytes, revision: str) -> ContentRecord:
+        try:
+            data = json.loads(content.decode())
+            record = ContentRecord.model_validate(data)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise ContentUnavailableError(f"GitHub content envelope is invalid: {path}") from exc
+        if data.get("version") != _VERSION or self._path(record.reference) != path:
+            raise ContentUnavailableError(f"GitHub content envelope is invalid: {path}")
+        return record.model_copy(update={"revision": revision})
+
+    @staticmethod
+    def _serialize(record: ContentRecord) -> str:
+        return json.dumps(
+            {
+                "version": _VERSION,
+                **record.model_dump(mode="json", include={"reference", "owner_reference", "content"}),
+            },
+            separators=(",", ":"),
+        )
+
+
+def _segment(value: str) -> str:
+    return "~" if not value else f"_{quote(value, safe='')}"

--- a/plugins/development-harness/backlog_core/backends/github_contents.py
+++ b/plugins/development-harness/backlog_core/backends/github_contents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from base64 import b64decode
+from binascii import Error as Base64Error
 from collections.abc import Callable, Mapping, Sequence as SequenceABC, Sequence as SequenceType
 from typing import Protocol, TypeAlias, runtime_checkable
 from urllib.parse import quote
@@ -27,6 +28,10 @@ _CONFLICT_STATUSES = frozenset({409, 422})
 _MAX_CONTENT_BYTES = 1_000_000
 _WRITE_ATTEMPTS = 3
 ContentRecords: TypeAlias = list[ContentRecord]
+
+
+class _GitHubContentIntegrityError(ContentUnavailableError):
+    pass
 
 
 @runtime_checkable
@@ -84,7 +89,7 @@ class _GitHubContentsStore:
         except GithubException as exc:
             raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
         if tree.truncated:
-            raise ContentUnavailableError("GitHub content discovery tree was truncated")
+            raise _GitHubContentIntegrityError("GitHub content discovery tree was truncated")
         records = [
             self._from_blob(repository, entry.path, entry.sha)
             for entry in tree.tree
@@ -192,14 +197,18 @@ class _GitHubContentsStore:
                 raise ContentNotFoundError(f"Content was not found: {path}") from exc
             raise ContentUnavailableError(f"GitHub content read failed: {exc}") from exc
         if isinstance(file, SequenceABC):
-            raise ContentUnavailableError(f"GitHub content path is not a file: {path}")
+            raise _GitHubContentIntegrityError(f"GitHub content path is not a file: {path}")
         return self._parse(path, file.decoded_content, file.sha)
 
     def _from_blob(self, repository: _ContentsRepository, path: str, sha: str) -> ContentRecord:
         try:
-            content = b64decode(repository.get_git_blob(sha).content)
-        except (GithubException, ValueError) as exc:
+            encoded = repository.get_git_blob(sha).content
+        except GithubException as exc:
             raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
+        try:
+            content = b64decode(encoded, validate=True)
+        except (Base64Error, ValueError) as exc:
+            raise _GitHubContentIntegrityError(f"GitHub content envelope is invalid: {path}") from exc
         return self._parse(path, content, sha)
 
     def _parse(self, path: str, content: bytes, revision: str) -> ContentRecord:
@@ -207,9 +216,9 @@ class _GitHubContentsStore:
             data = json.loads(content.decode())
             record = ContentRecord.model_validate(data)
         except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
-            raise ContentUnavailableError(f"GitHub content envelope is invalid: {path}") from exc
+            raise _GitHubContentIntegrityError(f"GitHub content envelope is invalid: {path}") from exc
         if data.get("version") != _VERSION or self._path(record.reference) != path:
-            raise ContentUnavailableError(f"GitHub content envelope is invalid: {path}")
+            raise _GitHubContentIntegrityError(f"GitHub content envelope is invalid: {path}")
         return record.model_copy(update={"revision": revision})
 
     @staticmethod

--- a/plugins/development-harness/backlog_core/backends/github_contents.py
+++ b/plugins/development-harness/backlog_core/backends/github_contents.py
@@ -109,6 +109,23 @@ class _GitHubContentsStore:
     def list_content(self, query: ContentQuery) -> ContentRecords:
         return list(self.list(query))
 
+    def get_many(self, references: SequenceType[ContentRef]) -> ContentRecords:
+        if not references:
+            return []
+        repository = self._repository()
+        try:
+            tree = repository.get_git_tree(repository.default_branch, recursive=True)
+        except GithubException as exc:
+            raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
+        if tree.truncated:
+            raise _GitHubContentIntegrityError("GitHub content discovery tree was truncated")
+        paths = {self._path(reference) for reference in references}
+        return [
+            self._from_blob(repository, entry.path, entry.sha)
+            for entry in tree.tree
+            if entry.type == "blob" and entry.path in paths
+        ]
+
     def get(self, reference: ContentRef) -> ContentRecord:
         repository = self._repository()
         return self._get(repository, self._path(reference), repository.default_branch)
@@ -206,7 +223,7 @@ class _GitHubContentsStore:
         except GithubException as exc:
             raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
         try:
-            content = b64decode(encoded, validate=True)
+            content = b64decode(encoded)
         except (Base64Error, ValueError) as exc:
             raise _GitHubContentIntegrityError(f"GitHub content envelope is invalid: {path}") from exc
         return self._parse(path, content, sha)

--- a/plugins/development-harness/backlog_core/backends/github_contents.py
+++ b/plugins/development-harness/backlog_core/backends/github_contents.py
@@ -27,6 +27,7 @@ _NOT_FOUND = 404
 _CONFLICT_STATUSES = frozenset({409, 422})
 _MAX_CONTENT_BYTES = 1_000_000
 _WRITE_ATTEMPTS = 3
+_BASE64_WHITESPACE = str.maketrans("", "", " \t\r\n\v\f")
 ContentRecords: TypeAlias = list[ContentRecord]
 
 
@@ -83,6 +84,10 @@ class _GitHubContentsStore:
         self._repository = repository
 
     def list(self, query: ContentQuery) -> SequenceType[ContentRecord]:
+        records = self.list_all(query)
+        return records[query.offset : query.offset + query.limit]
+
+    def list_all(self, query: ContentQuery) -> ContentRecords:
         repository = self._repository()
         try:
             tree = repository.get_git_tree(repository.default_branch, recursive=True)
@@ -104,7 +109,7 @@ class _GitHubContentsStore:
         filtered.sort(
             key=lambda record: (record.reference.namespace, record.reference.artifact_type, record.reference.name)
         )
-        return filtered[query.offset : query.offset + query.limit]
+        return filtered
 
     def list_content(self, query: ContentQuery) -> ContentRecords:
         return list(self.list(query))
@@ -223,7 +228,7 @@ class _GitHubContentsStore:
         except GithubException as exc:
             raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
         try:
-            content = b64decode(encoded)
+            content = b64decode(encoded.translate(_BASE64_WHITESPACE), validate=True)
         except (Base64Error, ValueError) as exc:
             raise _GitHubContentIntegrityError(f"GitHub content envelope is invalid: {path}") from exc
         return self._parse(path, content, sha)

--- a/plugins/development-harness/tests/test_github_content_safety.py
+++ b/plugins/development-harness/tests/test_github_content_safety.py
@@ -94,34 +94,36 @@ def test_revisionless_plan_update_fails_closed_without_gist_mutation() -> None:
     index.register.assert_not_called()
 
 
-def test_online_artifact_content_update_fails_closed_before_gist_store(tmp_path: Path) -> None:
+def test_online_artifact_content_write_routes_to_contents_before_gist_store(tmp_path: Path) -> None:
     reference = ContentRef(kind=ContentKind.ARTIFACT_CONTENT, namespace="#1", artifact_type="research", name="note")
     provider = MagicMock()
-    provider.read_artifact_content_from_remote.return_value = "before"
-    backend = GitHubBackend(cache=FileCache(tmp_path), artifact_provider=provider)
+    contents = MagicMock()
+    contents.put.return_value = ContentRecord(reference=reference, content="after", revision="sha")
+    backend = GitHubBackend(cache=FileCache(tmp_path), artifact_provider=provider, contents=contents)
     backend.try_get_github = MagicMock(return_value=MagicMock())
 
-    with pytest.raises(UnsupportedCapabilityError, match="compare-and-swap"):
-        backend.put_content(ContentWrite(reference=reference, content="after"))
+    assert backend.put_content(ContentWrite(reference=reference, content="after")).revision == "sha"
 
+    contents.put.assert_called_once()
     provider.store_artifact_content.assert_not_called()
     provider.set_manifest.assert_not_called()
 
 
-def test_online_artifact_manifest_update_fails_closed_before_gist_store(tmp_path: Path) -> None:
+def test_online_artifact_manifest_write_routes_to_contents_before_gist_store(tmp_path: Path) -> None:
     reference = ContentRef(kind=ContentKind.ARTIFACT_MANIFEST, namespace="#1", name="manifest")
     provider = MagicMock()
-    provider.get_manifest.return_value = ArtifactManifest(issue_number=1)
-    backend = GitHubBackend(cache=FileCache(tmp_path), artifact_provider=provider)
+    contents = MagicMock()
+    contents.put.return_value = ContentRecord(reference=reference, content="{}", revision="sha")
+    backend = GitHubBackend(cache=FileCache(tmp_path), artifact_provider=provider, contents=contents)
     backend.try_get_github = MagicMock(return_value=MagicMock())
 
-    with pytest.raises(UnsupportedCapabilityError, match="compare-and-swap"):
-        backend.put_content(
-            ContentWrite(
-                reference=reference, content=ArtifactManifest(issue_number=1, last_updated="new").model_dump_json()
-            )
+    backend.put_content(
+        ContentWrite(
+            reference=reference, content=ArtifactManifest(issue_number=1, last_updated="new").model_dump_json()
         )
+    )
 
+    contents.put.assert_called_once()
     provider.store_artifact_content.assert_not_called()
     provider.set_manifest.assert_not_called()
 
@@ -129,13 +131,15 @@ def test_online_artifact_manifest_update_fails_closed_before_gist_store(tmp_path
 def test_online_artifact_read_remains_available(tmp_path: Path) -> None:
     reference = ContentRef(kind=ContentKind.ARTIFACT_CONTENT, namespace="#1", artifact_type="research", name="note")
     provider = MagicMock()
-    provider.read_artifact_content_from_remote.return_value = "stored"
-    backend = GitHubBackend(cache=FileCache(tmp_path), artifact_provider=provider)
+    contents = MagicMock()
+    contents.get.return_value = ContentRecord(reference=reference, content="stored", revision="sha")
+    backend = GitHubBackend(cache=FileCache(tmp_path), artifact_provider=provider, contents=contents)
     backend.try_get_github = MagicMock(return_value=MagicMock())
 
     record = backend.get_content(reference)
 
     assert (record.content, record.pending, record.stale) == ("stored", False, False)
+    contents.get.assert_called_once_with(reference)
     provider.store_artifact_content.assert_not_called()
 
 
@@ -158,7 +162,9 @@ def _offline_backend(
     cache = FileCache(tmp_path / "github-cache")
     cache.cache_content(cached)
     cache.queue_write(cached, ContentWrite(reference=reference, content="pending", expected_revision="current"))
-    backend = GitHubBackend(cache=cache, plan_persistence=_UnavailablePlanPersistence())
+    backend = GitHubBackend(
+        cache=cache, plan_persistence=_UnavailablePlanPersistence(), contents=_UnavailablePlanPersistence()
+    )
     monkeypatch.setattr(backend, "try_get_github", MagicMock)
     return backend, reference, cached
 

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+from base64 import b64encode
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TypeAlias
+from unittest.mock import MagicMock
+
+import pytest
+from backlog_core.artifact_manifest_store import publish_artifact
+from backlog_core.backends.github_backend import GitHubBackend
+from backlog_core.backends.github_contents import _GitHubContentsStore
+from backlog_core.file_cache import FileCache
+from backlog_core.models import (
+    ArtifactEntry,
+    ArtifactManifest,
+    ArtifactType,
+    ContentConflictError,
+    ContentKind,
+    ContentQuery,
+    ContentRecord,
+    ContentRef,
+    ContentUnavailableError,
+    ContentWrite,
+)
+from github import GithubException
+from pydantic import BaseModel
+
+ContentRecords: TypeAlias = list[ContentRecord]
+
+
+class _File(BaseModel):
+    content: str
+    sha: str
+
+    @property
+    def decoded_content(self) -> bytes:
+        return self.content.encode()
+
+
+class _TreeEntry(BaseModel):
+    path: str
+    sha: str
+    type: str = "blob"
+
+
+class _Tree(BaseModel):
+    tree: list[_TreeEntry]
+    truncated: bool = False
+
+
+class _Repository:
+    def __init__(self) -> None:
+        self.default_branch = "main"
+        self.files: dict[str, _File] = {}
+        self.create_race = False
+        self.conflict_update = False
+        self.branch_contention = 0
+        self.tree_truncated = False
+        self.branches: list[str] = []
+        self.foreign_revision = 0
+        self.mutate_after_tree = False
+        self.advance_after_write = False
+        self._blobs: dict[str, str] = {}
+        self._next_sha = 0
+
+    def get_contents(self, path: str, ref: str) -> _File:
+        self.branches.append(ref)
+        try:
+            return self.files[path]
+        except KeyError as exc:
+            raise GithubException(404, {"message": "Not Found"}, {}) from exc
+
+    def create_file(self, path: str, message: str, content: str, branch: str) -> dict[str, object]:
+        self.branches.append(branch)
+        if self.branch_contention:
+            self.branch_contention -= 1
+            raise GithubException(409, {"message": "branch moved"}, {})
+        if self.create_race:
+            self.create_race = False
+            self.files[path] = _File(
+                content='{"version":1,"reference":{"kind":"plan","namespace":"","artifact_type":"","name":"P1"},"owner_reference":"","content":"foreign"}',
+                sha="sha-other",
+            )
+            raise GithubException(422, {"message": "already exists"}, {})
+        if path in self.files:
+            raise GithubException(422, {"message": "already exists"}, {})
+        written = _File(content=content, sha=self._sha())
+        self.files[path] = written
+        if self.advance_after_write:
+            self.files[path] = _File(content=content.replace("first", "second"), sha=self._sha())
+        return {"content": written}
+
+    def update_file(self, path: str, message: str, content: str, sha: str, branch: str) -> dict[str, object]:
+        self.branches.append(branch)
+        if self.branch_contention:
+            self.branch_contention -= 1
+            raise GithubException(409, {"message": "branch moved"}, {})
+        if self.conflict_update:
+            self.foreign_revision += 1
+            self.files[path] = _File(content=self.files[path].content, sha=f"sha-other-{self.foreign_revision}")
+            raise GithubException(409, {"message": "conflict"}, {})
+        if self.files[path].sha != sha:
+            raise GithubException(409, {"message": "conflict"}, {})
+        written = _File(content=content, sha=self._sha())
+        self.files[path] = written
+        if self.advance_after_write:
+            self.files[path] = _File(content=content.replace("first", "second"), sha=self._sha())
+        return {"content": written}
+
+    def get_git_tree(self, sha: str, recursive: bool) -> _Tree:
+        snapshot = dict(self.files.items())
+        self._blobs = {file.sha: file.content for file in snapshot.values()}
+        if self.mutate_after_tree:
+            path, file = next(iter(self.files.items()))
+            self.files[path] = _File(content=file.content.replace("body", "moved"), sha="sha-moved")
+        return _Tree(
+            tree=[_TreeEntry(path=path, sha=file.sha) for path, file in snapshot.items()], truncated=self.tree_truncated
+        )
+
+    def get_git_blob(self, sha: str) -> SimpleNamespace:
+        return SimpleNamespace(content=b64encode(self._blobs[sha].encode()).decode())
+
+    def _sha(self) -> str:
+        self._next_sha += 1
+        return f"sha-{self._next_sha}"
+
+
+class _PagedContent:
+    def __init__(self, records: ContentRecords) -> None:
+        self.records = records
+
+    def list(self, query: ContentQuery) -> ContentRecords:
+        return self.records[query.offset : query.offset + query.limit]
+
+    def get(self, reference: ContentRef) -> ContentRecord:
+        raise NotImplementedError
+
+    def put(self, request: ContentWrite) -> ContentRecord:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def repository() -> _Repository:
+    return _Repository()
+
+
+@pytest.fixture
+def store(repository: _Repository) -> _GitHubContentsStore:
+    return _GitHubContentsStore(lambda: repository)
+
+
+def test_round_trip_uses_compact_lossless_envelope(store: _GitHubContentsStore, repository: _Repository) -> None:
+    reference = ContentRef(kind=ContentKind.PLAN, name="P/one%two")
+
+    created = store.put(ContentWrite(reference=reference, owner_reference="#7", content="body"))
+
+    assert created.revision == "sha-1"
+    path, stored = next(iter(repository.files.items()))
+    assert path.startswith(".dh/content/v1/")
+    assert (
+        stored.content
+        == '{"version":1,"reference":{"kind":"plan","namespace":"","artifact_type":"","name":"P/one%two"},"owner_reference":"#7","content":"body"}'
+    )
+    assert store.get(reference) == created
+    assert set(repository.branches) == {"main"}
+
+
+def test_stale_update_raises_conflict(store: _GitHubContentsStore, repository: _Repository) -> None:
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    store.put(ContentWrite(reference=reference, content="before"))
+    repository.conflict_update = True
+
+    with pytest.raises(ContentConflictError):
+        store.put(ContentWrite(reference=reference, content="after", expected_revision="sha-1"))
+
+
+def test_create_race_raises_conflict(store: _GitHubContentsStore, repository: _Repository) -> None:
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    repository.create_race = True
+
+    with pytest.raises(ContentConflictError):
+        store.put(ContentWrite(reference=reference, content="body", create_only=True))
+
+
+def test_create_only_conflicts_even_when_content_is_identical(store: _GitHubContentsStore) -> None:
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    store.put(ContentWrite(reference=reference, content="body"))
+
+    with pytest.raises(ContentConflictError):
+        store.put(ContentWrite(reference=reference, content="body", create_only=True))
+
+
+def test_branch_head_contention_retries_when_target_is_unchanged(
+    store: _GitHubContentsStore, repository: _Repository
+) -> None:
+    repository.branch_contention = 1
+
+    record = store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
+
+    assert record.content == "body"
+
+
+def test_success_returns_exact_written_blob_when_path_advances(
+    store: _GitHubContentsStore, repository: _Repository
+) -> None:
+    repository.advance_after_write = True
+
+    written = store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="first"))
+
+    assert (written.content, written.revision) == ("first", "sha-1")
+    assert next(iter(repository.files.values())).sha == "sha-2"
+
+
+def test_paths_remain_distinct_for_ambiguous_characters(store: _GitHubContentsStore, repository: _Repository) -> None:
+    names = ["a/b", "a--b", "%2F", "☃"]
+    for name in names:
+        store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name=name), content=name))
+
+    assert [record.reference.name for record in store.list(ContentQuery(kind=ContentKind.PLAN))] == sorted(names)
+
+
+def test_truncated_tree_fails_closed(store: _GitHubContentsStore, repository: _Repository) -> None:
+    repository.tree_truncated = True
+
+    with pytest.raises(ContentUnavailableError, match="truncated"):
+        store.list(ContentQuery(kind=ContentKind.PLAN))
+
+
+def test_list_reads_one_resolved_tree_snapshot(store: _GitHubContentsStore, repository: _Repository) -> None:
+    store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
+    repository.mutate_after_tree = True
+
+    records = store.list(ContentQuery(kind=ContentKind.PLAN))
+
+    assert [(record.content, record.revision) for record in records] == [("body", "sha-1")]
+
+
+def test_contents_api_size_limit_fails_closed(store: _GitHubContentsStore) -> None:
+    with pytest.raises(ContentUnavailableError, match="1 MB"):
+        store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="x" * 1_000_000))
+
+
+def test_malformed_native_content_does_not_fall_back_to_legacy(
+    tmp_path: Path, store: _GitHubContentsStore, repository: _Repository
+) -> None:
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    repository.files[store._path(reference)] = _File(content="not-json", sha="sha-malformed")
+    legacy = MagicMock()
+    backend = GitHubBackend(
+        cache=FileCache(tmp_path), artifact_provider=MagicMock(), plan_persistence=legacy, contents=store
+    )
+    backend._cache.cache_content = MagicMock()
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+
+    with pytest.raises(ContentUnavailableError, match="envelope"):
+        store.get(reference)
+    with pytest.raises(ContentUnavailableError):
+        backend.get_content(reference)
+    legacy.get.assert_not_called()
+
+
+def test_two_plans_for_one_owner_remain_distinct(store: _GitHubContentsStore) -> None:
+    store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), owner_reference="#1", content="one"))
+    store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P2"), owner_reference="#1", content="two"))
+
+    records = store.list(ContentQuery(kind=ContentKind.PLAN, owner_reference="#1"))
+
+    assert [(record.reference.name, record.content) for record in records] == [("P1", "one"), ("P2", "two")]
+
+
+def test_publish_keeps_body_when_manifest_update_conflicts(
+    store: _GitHubContentsStore, repository: _Repository
+) -> None:
+    manifest = ContentRef(kind=ContentKind.ARTIFACT_MANIFEST, namespace="#1", name="manifest")
+    entry = ArtifactEntry(artifact_type=ArtifactType.RESEARCH, artifact_id="report.md")
+    store.put(ContentWrite(reference=manifest, content=ArtifactManifest(issue_number="#1").model_dump_json()))
+    repository.conflict_update = True
+
+    with pytest.raises(ContentConflictError):
+        publish_artifact(store, manifest, "#1", entry, "body")
+
+    assert any('"content":"body"' in file.content for file in repository.files.values())
+
+
+def test_dispatch_create_update_and_list_preserve_exact_identity(store: _GitHubContentsStore) -> None:
+    reference = ContentRef(kind=ContentKind.DISPATCH_PLAN, name="dispatch/a--b")
+    created = store.put(ContentWrite(reference=reference, owner_reference="#1", content="before"))
+    updated = store.put(
+        ContentWrite(reference=reference, owner_reference="#1", content="after", expected_revision=created.revision)
+    )
+
+    assert updated.revision == "sha-2"
+    assert [
+        (record.reference.name, record.content) for record in store.list(ContentQuery(kind=ContentKind.DISPATCH_PLAN))
+    ] == [("dispatch/a--b", "after")]
+
+
+def test_backend_prefers_v1_content_and_falls_back_to_legacy(tmp_path: Path, store: _GitHubContentsStore) -> None:
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    legacy = MagicMock()
+    legacy_record = store.put(ContentWrite(reference=reference, content="current"))
+    legacy.get.return_value = legacy_record.model_copy(update={"content": "legacy"})
+    backend = GitHubBackend(
+        cache=FileCache(tmp_path), artifact_provider=MagicMock(), plan_persistence=legacy, contents=store
+    )
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+
+    assert backend.get_content(reference).content == "current"
+    legacy.get.assert_not_called()
+
+    missing = ContentRef(kind=ContentKind.PLAN, name="P2")
+    assert backend.get_content(missing).content == "legacy"
+    legacy.get.assert_called_once_with(missing)
+
+
+def test_backend_lists_native_content_when_legacy_migration_is_unavailable(
+    tmp_path: Path, store: _GitHubContentsStore
+) -> None:
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    store.put(ContentWrite(reference=reference, content="current"))
+    legacy = MagicMock()
+    legacy.list.side_effect = OSError("legacy unavailable")
+    backend = GitHubBackend(
+        cache=FileCache(tmp_path), artifact_provider=MagicMock(), plan_persistence=legacy, contents=store
+    )
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+
+    records = backend.list_content(ContentQuery(kind=ContentKind.PLAN))
+
+    assert [(record.reference, record.content, record.stale) for record in records] == [(reference, "current", False)]
+
+
+def _records(start: int, stop: int, content_prefix: str) -> list[ContentRecord]:
+    return [
+        ContentRecord(
+            reference=ContentRef(kind=ContentKind.PLAN, name=f"P{number:03}"), content=f"{content_prefix}{number}"
+        )
+        for number in range(start, stop)
+    ]
+
+
+def _paged_backend(tmp_path: Path, native: list[ContentRecord], legacy: list[ContentRecord]) -> GitHubBackend:
+    backend = GitHubBackend(
+        cache=FileCache(tmp_path),
+        artifact_provider=MagicMock(),
+        plan_persistence=_PagedContent(legacy),
+        contents=_PagedContent(native),
+    )
+    backend._cache.cache_content = MagicMock()
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+    return backend
+
+
+def test_backend_lists_native_records_past_the_first_page(tmp_path: Path) -> None:
+    backend = _paged_backend(tmp_path, _records(0, 101, "native-"), [])
+
+    records = backend.list_content(ContentQuery(kind=ContentKind.PLAN, offset=100, limit=1))
+
+    assert [(record.reference.name, record.content) for record in records] == [("P100", "native-100")]
+
+
+def test_backend_lists_legacy_records_past_the_first_page(tmp_path: Path) -> None:
+    backend = _paged_backend(tmp_path, [], _records(0, 101, "legacy-"))
+
+    records = backend.list_content(ContentQuery(kind=ContentKind.PLAN, offset=100, limit=1))
+
+    assert [(record.reference.name, record.content) for record in records] == [("P100", "legacy-100")]
+
+
+def test_backend_merges_native_first_before_applying_offset(tmp_path: Path) -> None:
+    native = _records(0, 101, "native-")
+    legacy = [*_records(100, 101, "legacy-"), *_records(101, 201, "legacy-")]
+    backend = _paged_backend(tmp_path, native, legacy)
+
+    records = backend.list_content(ContentQuery(kind=ContentKind.PLAN, offset=100, limit=2))
+
+    assert [(record.reference.name, record.content) for record in records] == [
+        ("P100", "native-100"),
+        ("P101", "legacy-101"),
+    ]

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -247,9 +247,9 @@ def test_malformed_native_content_does_not_fall_back_to_legacy(
     reference = ContentRef(kind=ContentKind.PLAN, name="P1")
     repository.files[store._path(reference)] = _File(content="not-json", sha="sha-malformed")
     legacy = MagicMock()
-    backend = GitHubBackend(
-        cache=FileCache(tmp_path), artifact_provider=MagicMock(), plan_persistence=legacy, contents=store
-    )
+    cache = FileCache(tmp_path)
+    cache.cache_content(ContentRecord(reference=reference, content="cached"))
+    backend = GitHubBackend(cache=cache, artifact_provider=MagicMock(), plan_persistence=legacy, contents=store)
     backend._cache.cache_content = MagicMock()
     backend.try_get_github = MagicMock(return_value=MagicMock())
 
@@ -257,7 +257,34 @@ def test_malformed_native_content_does_not_fall_back_to_legacy(
         store.get(reference)
     with pytest.raises(ContentUnavailableError):
         backend.get_content(reference)
+    with pytest.raises(ContentUnavailableError):
+        backend.list_content(ContentQuery(kind=ContentKind.PLAN))
     legacy.get.assert_not_called()
+
+
+def test_malformed_native_blob_fails_closed(store: _GitHubContentsStore, repository: _Repository) -> None:
+    store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
+    repository.get_git_blob = MagicMock(return_value=SimpleNamespace(content="not-base64!"))
+
+    with pytest.raises(ContentUnavailableError, match="envelope"):
+        store.list(ContentQuery(kind=ContentKind.PLAN))
+
+
+def test_backend_hides_private_work_item_heads_from_artifact_listing(
+    tmp_path: Path, store: _GitHubContentsStore
+) -> None:
+    head = ContentRef(
+        kind=ContentKind.ARTIFACT_CONTENT, namespace="#1", artifact_type="_dh-work-item-head-v1", name="head"
+    )
+    artifact = ContentRef(kind=ContentKind.ARTIFACT_CONTENT, namespace="#1", artifact_type="test", name="report")
+    store.put(ContentWrite(reference=head, content="private"))
+    store.put(ContentWrite(reference=artifact, content="public"))
+    backend = GitHubBackend(cache=FileCache(tmp_path), artifact_provider=MagicMock(), contents=store)
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+
+    records = backend.list_content(ContentQuery(kind=ContentKind.ARTIFACT_CONTENT, owner_reference="#1"))
+
+    assert [(record.reference, record.content) for record in records] == [(artifact, "public")]
 
 
 def test_two_plans_for_one_owner_remain_distinct(store: _GitHubContentsStore) -> None:

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -288,6 +288,19 @@ def test_line_wrapped_native_blob_is_accepted(store: _GitHubContentsStore, repos
     assert record.content == "body"
 
 
+def test_native_blob_rejects_non_whitespace_base64_garbage(
+    store: _GitHubContentsStore, repository: _Repository
+) -> None:
+    store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
+    original_get_blob = repository.get_git_blob
+    repository.get_git_blob = MagicMock(
+        side_effect=lambda sha: SimpleNamespace(content=f"{original_get_blob(sha).content}!")
+    )
+
+    with pytest.raises(ContentUnavailableError, match="envelope"):
+        store.list(ContentQuery(kind=ContentKind.PLAN))
+
+
 def test_get_many_fetches_only_requested_blobs(store: _GitHubContentsStore, repository: _Repository) -> None:
     requested = ContentRef(
         kind=ContentKind.ARTIFACT_CONTENT, namespace="#1", artifact_type="_dh-work-item-head-v1", name="head"
@@ -401,6 +414,23 @@ def test_backend_migrates_validated_legacy_revision_on_first_write(tmp_path: Pat
     legacy.get.return_value = ContentRecord(reference=missing, content="legacy", revision="current")
     with pytest.raises(ContentConflictError):
         backend.put_content(ContentWrite(reference=missing, content="native", expected_revision="stale"))
+
+    with pytest.raises(ContentConflictError, match="already exists"):
+        backend.put_content(ContentWrite(reference=missing, content="replacement", create_only=True))
+
+
+def test_backend_native_pagination_fetches_each_blob_once(
+    tmp_path: Path, store: _GitHubContentsStore, repository: _Repository
+) -> None:
+    for number in range(101):
+        store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name=f"P{number:03}"), content="body"))
+    backend = GitHubBackend(cache=FileCache(tmp_path), plan_persistence=MagicMock(), contents=store)
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+
+    records = backend.list_content(ContentQuery(kind=ContentKind.PLAN, offset=100, limit=1))
+
+    assert [record.reference.name for record in records] == ["P100"]
+    assert len(repository.blob_requests) == 101
 
 
 def test_backend_lists_native_content_when_legacy_migration_is_unavailable(

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -61,6 +61,7 @@ class _Repository:
         self.foreign_revision = 0
         self.mutate_after_tree = False
         self.advance_after_write = False
+        self.blob_requests: list[str] = []
         self._blobs: dict[str, str] = {}
         self._next_sha = 0
 
@@ -119,6 +120,7 @@ class _Repository:
         )
 
     def get_git_blob(self, sha: str) -> SimpleNamespace:
+        self.blob_requests.append(sha)
         return SimpleNamespace(content=b64encode(self._blobs[sha].encode()).decode())
 
     def _sha(self) -> str:
@@ -270,6 +272,35 @@ def test_malformed_native_blob_fails_closed(store: _GitHubContentsStore, reposit
         store.list(ContentQuery(kind=ContentKind.PLAN))
 
 
+def test_line_wrapped_native_blob_is_accepted(store: _GitHubContentsStore, repository: _Repository) -> None:
+    store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
+    original_get_blob = repository.get_git_blob
+
+    def line_wrapped_blob(sha: str) -> SimpleNamespace:
+        encoded = original_get_blob(sha).content
+        return SimpleNamespace(content="\n".join(encoded[index : index + 8] for index in range(0, len(encoded), 8)))
+
+    repository.get_git_blob = MagicMock(side_effect=line_wrapped_blob)
+
+    [record] = store.list(ContentQuery(kind=ContentKind.PLAN))
+
+    assert record.content == "body"
+
+
+def test_get_many_fetches_only_requested_blobs(store: _GitHubContentsStore, repository: _Repository) -> None:
+    requested = ContentRef(
+        kind=ContentKind.ARTIFACT_CONTENT, namespace="#1", artifact_type="_dh-work-item-head-v1", name="head"
+    )
+    unrelated = ContentRef(kind=ContentKind.ARTIFACT_CONTENT, namespace="#1", artifact_type="report", name="report")
+    store.put(ContentWrite(reference=requested, content="head"))
+    store.put(ContentWrite(reference=unrelated, content="artifact"))
+
+    [record] = store.get_many([requested])
+
+    assert record.reference == requested
+    assert repository.blob_requests == ["sha-1"]
+
+
 def test_backend_hides_private_work_item_heads_from_artifact_listing(
     tmp_path: Path, store: _GitHubContentsStore
 ) -> None:
@@ -282,6 +313,12 @@ def test_backend_hides_private_work_item_heads_from_artifact_listing(
     backend = GitHubBackend(cache=FileCache(tmp_path), artifact_provider=MagicMock(), contents=store)
     backend.try_get_github = MagicMock(return_value=MagicMock())
 
+    records = backend.list_content(ContentQuery(kind=ContentKind.ARTIFACT_CONTENT, owner_reference="#1"))
+
+    assert [(record.reference, record.content) for record in records] == [(artifact, "public")]
+
+    backend._cache.cache_content(ContentRecord(reference=head, content="private"))
+    backend.try_get_github = MagicMock(return_value=None)
     records = backend.list_content(ContentQuery(kind=ContentKind.ARTIFACT_CONTENT, owner_reference="#1"))
 
     assert [(record.reference, record.content) for record in records] == [(artifact, "public")]

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -384,6 +384,25 @@ def test_backend_prefers_v1_content_and_falls_back_to_legacy(tmp_path: Path, sto
     legacy.get.assert_called_once_with(missing)
 
 
+def test_backend_migrates_validated_legacy_revision_on_first_write(tmp_path: Path, store: _GitHubContentsStore) -> None:
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    legacy = MagicMock()
+    legacy.get.return_value = ContentRecord(reference=reference, content="legacy", revision="legacy-revision")
+    backend = GitHubBackend(cache=FileCache(tmp_path), plan_persistence=legacy, contents=store)
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+
+    migrated = backend.put_content(
+        ContentWrite(reference=reference, content="native", expected_revision="legacy-revision")
+    )
+
+    assert (migrated.content, store.get(reference).content) == ("native", "native")
+
+    missing = ContentRef(kind=ContentKind.PLAN, name="P2")
+    legacy.get.return_value = ContentRecord(reference=missing, content="legacy", revision="current")
+    with pytest.raises(ContentConflictError):
+        backend.put_content(ContentWrite(reference=missing, content="native", expected_revision="stale"))
+
+
 def test_backend_lists_native_content_when_legacy_migration_is_unavailable(
     tmp_path: Path, store: _GitHubContentsStore
 ) -> None:

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -22,6 +22,7 @@ from backlog_core.models import (
     ContentRef,
     ContentUnavailableError,
     ContentWrite,
+    UnsupportedCapabilityError,
 )
 from github import GithubException
 from pydantic import BaseModel
@@ -316,6 +317,11 @@ def test_backend_hides_private_work_item_heads_from_artifact_listing(
     records = backend.list_content(ContentQuery(kind=ContentKind.ARTIFACT_CONTENT, owner_reference="#1"))
 
     assert [(record.reference, record.content) for record in records] == [(artifact, "public")]
+
+    with pytest.raises(UnsupportedCapabilityError, match="provider-private"):
+        backend.get_content(head)
+    with pytest.raises(UnsupportedCapabilityError, match="provider-private"):
+        backend.put_content(ContentWrite(reference=head, content="replacement"))
 
     backend._cache.cache_content(ContentRecord(reference=head, content="private"))
     backend.try_get_github = MagicMock(return_value=None)

--- a/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
+++ b/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
@@ -4,12 +4,14 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from backlog_core.backends._github_work_item_versions import root_revision
 from backlog_core.backends.github_backend import GitHubBackend, _GitHubPlanPersistence
 from backlog_core.file_cache import FileCache, _ProviderSnapshotCheckpoint
 from backlog_core.models import (
     BacklogError,
     BacklogItem,
     ContentKind,
+    ContentNotFoundError,
     ContentQuery,
     ContentRecord,
     ContentRef,
@@ -178,6 +180,8 @@ def test_github_reconcile_conflict_preserves_snapshot_checkpoint(tmp_path: Path)
         "assignees": [],
     }
     backend.get_github = MagicMock(return_value=repository)
+    backend._contents = MagicMock()
+    backend._contents.get.side_effect = ContentNotFoundError("head missing")
     backend._graphql_request = MagicMock(return_value={"repository": {"i0": observed_issue}})
     backend._update_issues_graphql_batch = MagicMock()
 
@@ -186,7 +190,7 @@ def test_github_reconcile_conflict_preserves_snapshot_checkpoint(tmp_path: Path)
 
     # Then: the body remains unwritten, the conflict is reported, and the prior global watermark remains durable
     assert result.conflicts == 1
-    assert result.patch_results[0].revision == "rev-1"
+    assert result.patch_results[0].revision == root_revision("#1", "node-1", str(observed_issue["body"]))
     backend._update_issues_graphql_batch.assert_not_called()
     assert FileCache(tmp_path)._get_snapshot_checkpoint() == old_checkpoint
 

--- a/plugins/development-harness/tests_backlog/test_github_sync_provider.py
+++ b/plugins/development-harness/tests_backlog/test_github_sync_provider.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Protocol
 from unittest.mock import MagicMock
 
+import backlog_core.backends.github_backend as github_backend_module
 import pytest
+from backlog_core.backends._github_work_item_versions import render_work_item_comment, root_revision, work_item_head_ref
 from backlog_core.backends.github_backend import GitHubBackend, _GitHubDispatchPersistence
+from backlog_core.backends.memory_backend import InMemoryBackend
 from backlog_core.file_cache import FileCache
 from backlog_core.models import (
     ArtifactManifest,
@@ -22,7 +26,6 @@ from backlog_core.models import (
     ProviderPatch,
     ReconcileRequest,
     ReconcileScope,
-    UnsupportedCapabilityError,
 )
 from sam_schema.core.artifact_registry_client import ArtifactRegistryClient, PlanIndexUnavailableError
 from sam_schema.core.plan_id_index import PlanIndexEntry, _serialize_index_yaml
@@ -34,6 +37,25 @@ class _RemoteArtifactProviderFakeSpec(Protocol):
     def read_artifact_content_from_remote(self, owner: int, artifact_type: str, path: str) -> str | None: ...
 
     def list_artifact_content_from_remote(self, owner: int, artifact_type: str, path_prefix: str) -> dict[str, str]: ...
+
+
+class _InMemoryContents:
+    def __init__(self) -> None:
+        self._backend = InMemoryBackend()
+
+    def list(self, query: ContentQuery) -> Sequence[ContentRecord]:
+        return self._backend.list_content(query)
+
+    def get(self, reference: ContentRef) -> ContentRecord:
+        return self._backend.get_content(reference)
+
+    def put(self, request: ContentWrite) -> ContentRecord:
+        return self._backend.put_content(request)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_contents_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github_backend_module, "_GitHubContentsStore", lambda _repository: _InMemoryContents())
 
 
 def _issue(number: int, revision: str = "rev-1") -> dict[str, object]:
@@ -57,6 +79,7 @@ def test_github_sync_provider_normalizes_bounded_snapshot() -> None:
     repository = MagicMock(full_name="owner/repo")
     backend.get_github = MagicMock(return_value=repository)
     backend._fetch_issues_graphql = MagicMock(return_value=[_issue(1)])
+    backend._fetch_issue_comments_graphql = MagicMock(return_value=[])
 
     # When: reconciliation fetches an initial snapshot
     snapshot = backend._fetch_snapshot(ReconcileRequest(scope=ReconcileScope.INITIAL))
@@ -64,7 +87,7 @@ def test_github_sync_provider_normalizes_bounded_snapshot() -> None:
     # Then: the normalized provider item retains body, labels, and revision
     assert snapshot.items[0].reference == "#1"
     assert snapshot.items[0].labels == ["feature"]
-    assert snapshot.items[0].revision == "rev-1"
+    assert snapshot.items[0].revision == root_revision("#1", "node-1", "body")
     assert backend._fetch_issues_graphql.call_args.kwargs["first"] == 100
 
 
@@ -74,6 +97,7 @@ def test_github_sync_provider_forwards_label_scope_to_snapshot_query() -> None:
     repository = MagicMock(full_name="owner/repo")
     backend.get_github = MagicMock(return_value=repository)
     backend._fetch_issues_graphql = MagicMock(return_value=[_issue(1)])
+    backend._fetch_issue_comments_graphql = MagicMock(return_value=[])
 
     # When: the adapter fetches the provider snapshot
     backend._fetch_snapshot(ReconcileRequest(scope=ReconcileScope.INITIAL, label="review"))
@@ -88,6 +112,7 @@ def test_github_sync_provider_reports_conflict_without_mutation() -> None:
     repository = MagicMock(full_name="owner/repo")
     backend.get_github = MagicMock(return_value=repository)
     backend._graphql_request = MagicMock(return_value={"repository": {"i0": _issue(1, revision="rev-2")}})
+    backend._fetch_issue_comments_graphql = MagicMock(return_value=[])
     backend._update_issues_graphql_batch = MagicMock()
     patch = ProviderPatch(provider_id="node-1", reference="#1", expected_revision="rev-1", body="updated")
 
@@ -106,6 +131,7 @@ def test_github_sync_provider_targeted_fetch_uses_alias_batch_and_emits_tombston
     backend.get_github = MagicMock(return_value=repository)
     backend._fetch_issue_graphql = MagicMock()
     backend._fetch_issues_graphql = MagicMock()
+    backend._fetch_issue_comments_graphql = MagicMock(return_value=[])
     backend._graphql_request = MagicMock(return_value={"repository": {"i0": _issue(1), "i1": None}})
 
     # When: reconciliation asks only for those linked references
@@ -141,7 +167,7 @@ def test_github_sync_provider_bounds_targeted_aliases_to_one_hundred() -> None:
     ] == [100, 1]
 
 
-def test_github_sync_provider_rejects_body_change_without_mutation() -> None:
+def test_github_sync_provider_publishes_body_change_as_audit_comment() -> None:
     # Given: a body patch whose current provider revision matches
     backend = GitHubBackend()
     repository = MagicMock(full_name="owner/repo")
@@ -150,14 +176,35 @@ def test_github_sync_provider_rejects_body_change_without_mutation() -> None:
     backend._fetch_issues_graphql = MagicMock()
     backend._graphql_request = MagicMock(return_value={"repository": {"i0": _issue(1)}})
     backend._update_issues_graphql_batch = MagicMock()
-    patch = ProviderPatch(provider_id="node-1", reference="#1", expected_revision="rev-1", body="updated")
+    root = root_revision("#1", "node-1", "body")
+    backend._contents = MagicMock()
+    backend._contents.get.side_effect = ContentNotFoundError("head missing")
+    backend._contents.put.return_value = ContentRecord(
+        reference=work_item_head_ref("#1"), content="", revision="head-1"
+    )
+    comments: list[dict[str, str]] = []
+    backend._fetch_issue_comments_graphql = MagicMock(side_effect=lambda *_args: list(comments))
 
-    # When: the adapter classifies the unsafe body change
+    def add_comment(_repo: object, _issue_id: str, body: str) -> str:
+        comments.append({
+            "id": "comment-1",
+            "body": body,
+            "url": "https://example.test/comments/comment-1",
+            "author": "agent",
+            "created_at": "2026-08-12T00:00:00Z",
+            "updated_at": "2026-08-12T00:00:00Z",
+        })
+        return "comment-1"
+
+    backend._add_comment_graphql = MagicMock(side_effect=add_comment)
+    patch = ProviderPatch(provider_id="node-1", reference="#1", expected_revision=root, body="updated")
+
+    # When: the adapter publishes the rendered body
     results = backend._apply_patches([patch])
 
-    # Then: no conditional GitHub mutation exists, so the observed revision is a conflict
-    assert results[0].status == "conflict"
-    assert results[0].revision == "rev-1"
+    # Then: the Issue body is untouched and the validated audit comment projects the revision
+    assert (results[0].status, results[0].revision) == ("applied", "head-1")
+    assert comments[0]["body"] == render_work_item_comment(root, "updated")
     backend._update_issues_graphql_batch.assert_not_called()
     backend._fetch_issue_graphql.assert_not_called()
     backend._fetch_issues_graphql.assert_not_called()
@@ -170,14 +217,17 @@ def test_github_sync_provider_omits_matching_patch_body() -> None:
     backend.get_github = MagicMock(return_value=repository)
     backend._graphql_request = MagicMock(return_value={"repository": {"i0": _issue(1)}})
     backend._update_issues_graphql_batch = MagicMock()
-    patch = ProviderPatch(provider_id="node-1", reference="#1", expected_revision="rev-1", body="body")
+    backend._fetch_issue_comments_graphql = MagicMock(return_value=[])
+    patch = ProviderPatch(
+        provider_id="node-1", reference="#1", expected_revision=root_revision("#1", "node-1", "body"), body="body"
+    )
 
     # When: patch application reaches the preflight equality check
     results = backend._apply_patches([patch])
 
     # Then: no mutation is sent and the existing revision is returned as applied
     assert results[0].status == "applied"
-    assert results[0].revision == "rev-1"
+    assert results[0].revision == root_revision("#1", "node-1", "body")
     backend._update_issues_graphql_batch.assert_not_called()
 
 
@@ -190,6 +240,7 @@ def test_github_backend_reconcile_owns_snapshot_cache_and_engine(tmp_path: Path)
     remote_issue = _issue(1)
     remote_issue["body"] = backend.render_issue_body(BacklogItem())
     backend._fetch_issues_graphql = MagicMock(return_value=[remote_issue])
+    backend._fetch_issue_comments_graphql = MagicMock(return_value=[])
 
     # When: callers invoke the backend's one reconciliation capability
     result = backend.reconcile(ReconcileRequest(scope=ReconcileScope.INITIAL))
@@ -203,7 +254,7 @@ def test_github_backend_reconcile_owns_snapshot_cache_and_engine(tmp_path: Path)
     assert cache._work_item_snapshots()[0][1].metadata.sync_fingerprint
 
 
-def test_github_content_provider_fails_closed_on_plan_creation(tmp_path: Path) -> None:
+def test_github_content_provider_creates_plan_in_native_contents(tmp_path: Path) -> None:
     # Given: a reachable provider and a new logical plan identity
     artifact_provider = MagicMock()
     remote_content: dict[tuple[int, str, str], str] = {}
@@ -219,11 +270,11 @@ def test_github_content_provider_fails_closed_on_plan_creation(tmp_path: Path) -
     backend.try_get_github = MagicMock(return_value=MagicMock())
     reference = ContentRef(kind=ContentKind.PLAN, name="P1")
 
-    # When: a new plan is requested without a provider CAS revision
-    with pytest.raises(UnsupportedCapabilityError):
-        backend.put_content(ContentWrite(reference=reference, content="v1", owner_reference="#1"))
+    # When: a new plan is written through the provider-native Contents store
+    record = backend.put_content(ContentWrite(reference=reference, content="v1", owner_reference="#1"))
 
-    # Then: no Gist content or index mutation is reported or performed
+    # Then: the write succeeds without mutating the read-only Gist migration layer
+    assert (record.reference, record.content, record.owner_reference, record.pending) == (reference, "v1", "#1", False)
     assert remote_content == {}
 
 
@@ -479,7 +530,7 @@ def test_github_plan_get_uses_stale_cache_when_index_is_unavailable(tmp_path: Pa
     artifact_provider.store_artifact_content.assert_not_called()
 
 
-def test_github_plan_put_queues_when_index_is_unavailable(tmp_path: Path) -> None:
+def test_github_plan_put_uses_native_store_when_legacy_index_is_unavailable(tmp_path: Path) -> None:
     # Given: an online GitHub API with an unavailable authoritative plan index
     cache = FileCache(tmp_path)
     artifact_provider = MagicMock()
@@ -488,12 +539,12 @@ def test_github_plan_put_queues_when_index_is_unavailable(tmp_path: Path) -> Non
     backend.try_get_github = MagicMock(return_value=MagicMock())
     request = ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="Pnew"), content="new plan")
 
-    # When: a plan write cannot read its authoritative index
+    # When: a plan write bypasses the read-only migration index
     record = backend.put_content(request)
 
-    # Then: the mutation is queued without storing a replacement empty index
-    assert record.pending is True
-    assert len(cache.pending_mutations()) == 1
+    # Then: the native write succeeds without storing a replacement legacy index
+    assert record.pending is False
+    assert cache.pending_mutations() == []
     artifact_provider.store_artifact_content.assert_not_called()
 
 
@@ -527,8 +578,8 @@ def test_github_plan_content_outage_uses_provider_cache(tmp_path: Path, operatio
             assert (result.content, result.stale) == ("cached plan", True)
         case "put":
             result = backend.put_content(ContentWrite(reference=reference, content="queued plan"))
-            assert result.pending is True
-            assert len(cache.pending_mutations()) == 1
+            assert (result.content, result.pending) == ("queued plan", False)
+            assert cache.pending_mutations() == []
         case unreachable:
             pytest.fail(f"unexpected operation: {unreachable}")
 
@@ -560,8 +611,8 @@ def test_github_dispatch_content_outage_uses_provider_cache(tmp_path: Path, oper
             assert (result.content, result.stale) == ('{"state":"cached"}', True)
         case "put":
             result = backend.put_content(ContentWrite(reference=reference, content='{"state":"queued"}'))
-            assert result.pending is True
-            assert len(cache.pending_mutations()) == 1
+            assert (result.content, result.pending) == ('{"state":"queued"}', False)
+            assert cache.pending_mutations() == []
         case unreachable:
             pytest.fail(f"unexpected operation: {unreachable}")
 
@@ -612,7 +663,7 @@ def test_github_content_provider_keeps_complete_artifact_identity(tmp_path: Path
     ]
     backend.try_get_github = MagicMock(return_value=None)
 
-    # When: reconnect discovery sees every queued artifact mutation as unsupported
+    # When: reconnect discovery replays every queued artifact mutation
     for index, reference in enumerate(references):
         backend.put_content(ContentWrite(reference=reference, content=f"content-{index}"))
     backend.try_get_github = MagicMock(return_value=MagicMock())
@@ -620,12 +671,12 @@ def test_github_content_provider_keeps_complete_artifact_identity(tmp_path: Path
 
     # Then: owner, type, and ID remain distinct without any Gist mutation
     assert [record.reference for record in listed] == [references[0], references[2]]
-    assert [mutation.write.reference for mutation in backend._cache.pending_mutations()] == references
+    assert backend._cache.pending_mutations() == []
     artifact_provider.store_artifact_content.assert_not_called()
 
 
-def test_github_content_provider_replay_retains_unsupported_artifact_writes(tmp_path: Path) -> None:
-    # Given: two durable offline writes that GitHub cannot atomically publish
+def test_github_content_provider_replays_native_artifact_writes(tmp_path: Path) -> None:
+    # Given: two durable offline writes waiting for native publication
     cache = FileCache(tmp_path)
     artifact_provider = MagicMock()
     backend = GitHubBackend(cache=cache, artifact_provider=artifact_provider)
@@ -641,9 +692,9 @@ def test_github_content_provider_replay_retains_unsupported_artifact_writes(tmp_
     # When: reconnect discovery attempts replay
     backend.list_content(ContentQuery(kind=ContentKind.ARTIFACT_CONTENT, owner_reference="#1"))
 
-    # Then: unsupported writes remain durable and no Gist mutation is attempted
-    assert [mutation.write.reference for mutation in cache.pending_mutations()] == references
-    assert all(cache.get_content(reference).pending for reference in references)
+    # Then: both writes publish and leave the durable queue
+    assert cache.pending_mutations() == []
+    assert all(not cache.get_content(reference).pending for reference in references)
     artifact_provider.store_artifact_content.assert_not_called()
 
 
@@ -698,7 +749,7 @@ def test_github_plan_replay_coalesces_sequential_offline_writes(tmp_path: Path) 
     plan_persistence = MagicMock()
     plan_persistence.put.side_effect = put
     plan_persistence.get.side_effect = lambda _reference: remote
-    backend = GitHubBackend(cache=cache, plan_persistence=plan_persistence)
+    backend = GitHubBackend(cache=cache, plan_persistence=plan_persistence, contents=plan_persistence)
     backend.try_get_github = MagicMock(return_value=None)
     backend.put_content(ContentWrite(reference=reference, content="first", expected_revision="rev-1"))
     backend.put_content(ContentWrite(reference=reference, content="latest", expected_revision="rev-1"))

--- a/plugins/development-harness/tests_backlog/test_github_sync_provider.py
+++ b/plugins/development-harness/tests_backlog/test_github_sync_provider.py
@@ -210,6 +210,23 @@ def test_github_sync_provider_publishes_body_change_as_audit_comment() -> None:
     backend._fetch_issues_graphql.assert_not_called()
 
 
+def test_github_sync_provider_continues_after_audit_comment_failure() -> None:
+    backend = GitHubBackend(contents=_InMemoryContents())
+    repository = MagicMock(full_name="owner/repo")
+    backend.get_github = MagicMock(return_value=repository)
+    backend._fetch_targeted_issues = MagicMock(return_value={"#1": _issue(1), "#2": _issue(2)})
+    backend._add_comment_graphql = MagicMock(side_effect=[BacklogError("comment unavailable"), "comment-2"])
+    root_one = root_revision("#1", "node-1", "body")
+    root_two = root_revision("#2", "node-2", "body")
+
+    results = backend._apply_patches([
+        ProviderPatch(provider_id="node-1", reference="#1", expected_revision=root_one, body="first"),
+        ProviderPatch(provider_id="node-2", reference="#2", expected_revision=root_two, body="second"),
+    ])
+
+    assert [(result.reference, result.status) for result in results] == [("#1", "error"), ("#2", "applied")]
+
+
 def test_github_sync_provider_omits_matching_patch_body() -> None:
     # Given: a patch body that already matches the revision-preflight body
     backend = GitHubBackend()

--- a/plugins/development-harness/tests_backlog/test_github_sync_provider.py
+++ b/plugins/development-harness/tests_backlog/test_github_sync_provider.py
@@ -227,6 +227,23 @@ def test_github_sync_provider_continues_after_audit_comment_failure() -> None:
     assert [(result.reference, result.status) for result in results] == [("#1", "error"), ("#2", "applied")]
 
 
+def test_github_sync_provider_rejects_empty_audit_comment_identity() -> None:
+    contents = _InMemoryContents()
+    backend = GitHubBackend(contents=contents)
+    repository = MagicMock(full_name="owner/repo")
+    backend.get_github = MagicMock(return_value=repository)
+    backend._fetch_targeted_issues = MagicMock(return_value={"#1": _issue(1)})
+    backend._add_comment_graphql = MagicMock(return_value="")
+    root = root_revision("#1", "node-1", "body")
+
+    [result] = backend._apply_patches([
+        ProviderPatch(provider_id="node-1", reference="#1", expected_revision=root, body="updated")
+    ])
+
+    assert (result.status, result.message) == ("error", "GitHub work-item audit comment response was invalid")
+    assert contents.list(ContentQuery(kind=ContentKind.ARTIFACT_CONTENT)) == []
+
+
 def test_github_sync_provider_omits_matching_patch_body() -> None:
     # Given: a patch body that already matches the revision-preflight body
     backend = GitHubBackend()

--- a/plugins/development-harness/tests_backlog/test_github_work_item_versions.py
+++ b/plugins/development-harness/tests_backlog/test_github_work_item_versions.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from _thread import LockType
+from collections.abc import Sequence
+from threading import Barrier, Lock, Thread
+from unittest.mock import MagicMock
+
+import pytest
+from backlog_core.backend_types import IssueCommentNode
+from backlog_core.backends._github_work_item_versions import (
+    WorkItemHead,
+    parse_work_item_comment,
+    parse_work_item_head,
+    render_work_item_comment,
+    root_revision,
+    work_item_head_ref,
+)
+from backlog_core.backends.github_backend import GitHubBackend
+from backlog_core.models import (
+    ContentConflictError,
+    ContentNotFoundError,
+    ContentQuery,
+    ContentRecord,
+    ContentRef,
+    ContentUnavailableError,
+    ContentWrite,
+    PatchResult,
+    ProviderPatch,
+    ReconcileRequest,
+    ReconcileScope,
+)
+
+
+def _comment(comment_id: str, parent_revision: str, body: str) -> IssueCommentNode:
+    return IssueCommentNode(
+        id=comment_id,
+        body=render_work_item_comment(parent_revision, body),
+        url=f"https://example.test/comments/{comment_id}",
+        author="agent",
+        created_at="2026-08-12T00:00:00Z",
+        updated_at="2026-08-12T00:00:00Z",
+    )
+
+
+def test_github_work_item_head_binds_initial_content_to_issue_identity_and_root() -> None:
+    # Given: a human-owned Issue body with no prior agent head
+    root = root_revision("#42", "issue-node", "Human-owned body")
+
+    # When: an initial agent body is made into the authoritative head envelope
+    head = WorkItemHead.create("#42", root, root, "rendered body", "comment-1")
+
+    # Then: the head preserves the exact root and auditable projection identity
+    assert (head.issue_reference, head.parent_revision, head.root_revision, head.body, head.comment_id) == (
+        "#42",
+        root,
+        root,
+        "rendered body",
+        "comment-1",
+    )
+
+
+def test_github_work_item_head_subsequent_publish_chains_from_prior_head_sha() -> None:
+    # Given: an existing authoritative head revision and validated first projection
+    root = root_revision("#42", "issue-node", "Human-owned body")
+    first = WorkItemHead.create("#42", root, root, "first rendered", "comment-1")
+
+    # When: the next head uses the previous Contents SHA as its parent revision
+    second = WorkItemHead.create("#42", "head-sha-1", first.root_revision, "second rendered", "comment-2")
+
+    # Then: the new head preserves root provenance while chaining from the actual prior head
+    assert (second.parent_revision, second.root_revision, second.body) == ("head-sha-1", root, "second rendered")
+
+
+def test_github_work_item_root_revision_changes_when_human_body_changes() -> None:
+    # Given: two human Issue bodies for the same Issue
+    # When: their canonical root revisions are calculated
+    # Then: identity-bound digests distinguish a human body edit and a different Issue
+    assert root_revision("#42", "issue-node", "before") != root_revision("#42", "issue-node", "after")
+    assert root_revision("#42", "issue-node", "before") != root_revision("#42", "other-node", "before")
+
+
+def test_github_work_item_sibling_heads_preserve_common_parent_and_distinct_audits() -> None:
+    # Given: two prospective heads based on the same observed root
+    root = root_revision("#42", "issue-node", "Human-owned body")
+
+    # When: each writer constructs its independent audit proposal
+    siblings = [
+        WorkItemHead.create("#42", root, root, "writer one", "comment-1"),
+        WorkItemHead.create("#42", root, root, "writer two", "comment-2"),
+    ]
+
+    # Then: CAS receives the same parent while audit identity and content remain distinct
+    assert {head.parent_revision for head in siblings} == {root}
+    assert len({(head.digest, head.comment_id) for head in siblings}) == 2
+
+
+@pytest.mark.parametrize(
+    ("comment", "error"),
+    [
+        (None, "missing"),
+        ({**_comment("comment-1", "root", "rendered"), "body": "forged"}, "invalid"),
+        ({**_comment("comment-1", "root", "rendered"), "id": "other"}, "identity"),
+    ],
+)
+def test_github_work_item_rejects_missing_forged_or_replaced_audit_comment(
+    comment: IssueCommentNode | None, error: str
+) -> None:
+    # Given: an authoritative head requiring comment-1 with the rendered digest
+    head = WorkItemHead.create("#42", "root", "root", "rendered", "comment-1")
+
+    # When: audit projection validation receives an invalid remote comment state
+    with pytest.raises(ContentUnavailableError, match=error):
+        parse_work_item_comment(head, comment)
+
+    # Then: malformed, edited, or deleted audit data cannot project as authoritative content
+
+
+def test_github_work_item_rejects_digest_mismatch_in_authoritative_head() -> None:
+    # Given: a serialized head envelope with content altered after its digest was computed
+    valid = WorkItemHead.create("#42", "root", "root", "rendered", "comment-1").model_dump()
+    valid["body"] = "tampered"
+
+    # When: the head crosses the Contents envelope boundary
+    with pytest.raises(ValueError, match="digest"):
+        WorkItemHead.model_validate(valid)
+
+    # Then: a Contents SHA alone cannot make tampered logical head content valid
+
+
+class _ContentsFake:
+    def __init__(self, barrier: Barrier | None = None) -> None:
+        self._barrier = barrier
+        self._records: dict[str, ContentRecord] = {}
+        self._lock = Lock()
+        self._revision = 0
+
+    def get(self, reference: ContentRef) -> ContentRecord:
+        try:
+            return self._records[reference.model_dump_json()]
+        except KeyError as exc:
+            raise ContentNotFoundError("head missing") from exc
+
+    def list(self, query: ContentQuery) -> Sequence[ContentRecord]:
+        del query
+        return []
+
+    def put(self, request: ContentWrite) -> ContentRecord:
+        if request.create_only and self._barrier is not None:
+            self._barrier.wait()
+        key = request.reference.model_dump_json()
+        with self._lock:
+            current = self._records.get(key)
+            if request.create_only and current is not None:
+                raise ContentConflictError("head exists")
+            if request.expected_revision and (current is None or current.revision != request.expected_revision):
+                raise ContentConflictError("head changed")
+            self._revision += 1
+            record = ContentRecord(
+                reference=request.reference, content=request.content, revision=f"head-{self._revision}"
+            )
+            self._records[key] = record
+            return record
+
+
+def _issue(body: str = "Human-owned body") -> dict[str, object]:
+    return {
+        "id": "issue-node",
+        "number": 42,
+        "title": "Human title",
+        "body": body,
+        "state": "OPEN",
+        "labels": [{"id": "label-1", "name": "feature"}],
+        "updatedAt": "changed-without-semantic-authority",
+        "createdAt": "2026-08-12T00:00:00Z",
+        "milestone": None,
+        "assignees": [],
+    }
+
+
+def _backend(
+    contents: _ContentsFake, comments: dict[str, IssueCommentNode], comment_lock: LockType | None = None
+) -> GitHubBackend:
+    backend = GitHubBackend(contents=contents)
+    repository = MagicMock(full_name="owner/repo")
+    backend.get_github = MagicMock(return_value=repository)
+    backend._fetch_targeted_issues = MagicMock(
+        side_effect=lambda _repo, _owner, _name, references: {ref: _issue() for ref in references}
+    )
+    backend._fetch_issues_graphql = MagicMock(return_value=[_issue()])
+    backend._fetch_comment_by_id_graphql = MagicMock(side_effect=lambda _repo, comment_id: comments[comment_id])
+
+    lock = comment_lock or Lock()
+
+    def add_comment(_repo: object, _issue_id: str, body: str) -> str:
+        with lock:
+            comment_id = f"comment-{len(comments) + 1}"
+            comments[comment_id] = IssueCommentNode(
+                id=comment_id,
+                body=body,
+                url=f"https://example.test/comments/{comment_id}",
+                author="agent",
+                created_at="2026-08-12T00:00:00Z",
+                updated_at="2026-08-12T00:00:00Z",
+            )
+        return comment_id
+
+    backend._add_comment_graphql = MagicMock(side_effect=add_comment)
+    return backend
+
+
+def test_github_work_item_backend_publishes_initial_then_subsequent_contents_heads() -> None:
+    # Given: an Issue with no head and a deterministic Contents CAS fake
+    comments: dict[str, IssueCommentNode] = {}
+    contents = _ContentsFake()
+    backend = _backend(contents, comments)
+    root = root_revision("#42", "issue-node", "Human-owned body")
+
+    # When: the first and second rendered bodies publish against their observed authoritative revisions
+    [first] = backend._apply_patches([
+        ProviderPatch(provider_id="issue-node", reference="#42", expected_revision=root, body="first")
+    ])
+    [second] = backend._apply_patches([
+        ProviderPatch(provider_id="issue-node", reference="#42", expected_revision=first.revision, body="second")
+    ])
+
+    # Then: Contents SHAs become revisions and both append-only audit comments remain intact
+    assert (first.status, second.status, second.revision) == ("applied", "applied", "head-2")
+    assert [(comment_id, comment["body"].split("\n", 1)[1]) for comment_id, comment in comments.items()] == [
+        ("comment-1", "first"),
+        ("comment-2", "second"),
+    ]
+
+
+def test_github_work_item_backend_human_body_change_invalidates_prior_head() -> None:
+    # Given: a stored head rooted in the prior human Issue body
+    comments: dict[str, IssueCommentNode] = {"comment-1": _comment("comment-1", "root", "rendered")}
+    contents = _ContentsFake()
+    old_root = root_revision("#42", "issue-node", "before")
+    head = WorkItemHead.create("#42", old_root, old_root, "rendered", "comment-1")
+    contents.put(ContentWrite(reference=work_item_head_ref("#42"), content=head.model_dump_json(), create_only=True))
+    backend = _backend(contents, comments)
+    backend._fetch_issues_graphql = MagicMock(return_value=[_issue("after")])
+    backend._fetch_targeted_issues = MagicMock(return_value={"#42": _issue("after")})
+
+    # When: snapshot sees a human body whose identity-bound root digest differs
+    [item] = backend._fetch_snapshot(ReconcileRequest(scope=ReconcileScope.INITIAL)).items
+
+    # Then: the obsolete head is ignored and the human Issue body/root become current
+    assert (item.body, item.revision) == ("after", root_revision("#42", "issue-node", "after"))
+
+    # When: an agent publishes from the new root revision
+    [patched] = backend._apply_patches([
+        ProviderPatch(provider_id="issue-node", reference="#42", expected_revision=item.revision, body="new rendered")
+    ])
+
+    # Then: the stale head is replaced through its old Contents SHA and binds the new root
+    stored = parse_work_item_head(contents.get(work_item_head_ref("#42")).content)
+    assert (patched.status, stored.root_revision, stored.body) == ("applied", item.revision, "new rendered")
+
+
+def test_github_work_item_backend_concurrent_initial_cas_has_one_winner_and_two_audit_comments() -> None:
+    # Given: two writers racing through the same initial Contents create-only boundary
+    comments: dict[str, IssueCommentNode] = {}
+    contents = _ContentsFake(Barrier(2))
+    comment_lock = Lock()
+    root = root_revision("#42", "issue-node", "Human-owned body")
+    results: list[PatchResult] = []
+
+    def publish(body: str) -> None:
+        backend = _backend(contents, comments, comment_lock)
+        results.append(
+            backend._apply_patches([
+                ProviderPatch(provider_id="issue-node", reference="#42", expected_revision=root, body=body)
+            ])[0]
+        )
+
+    # When: both writers append an audit comment and attempt the same head CAS
+    writers = [Thread(target=publish, args=("one",)), Thread(target=publish, args=("two",))]
+    for writer in writers:
+        writer.start()
+    for writer in writers:
+        writer.join()
+
+    # Then: one Contents head wins, while both comments remain forensic evidence
+    assert sorted(result.status for result in results) == ["applied", "conflict"]
+    assert sorted(comment["body"].split("\n", 1)[1] for comment in comments.values()) == ["one", "two"]

--- a/plugins/development-harness/tests_backlog/test_github_work_item_versions.py
+++ b/plugins/development-harness/tests_backlog/test_github_work_item_versions.py
@@ -141,8 +141,15 @@ class _ContentsFake:
             raise ContentNotFoundError("head missing") from exc
 
     def list(self, query: ContentQuery) -> Sequence[ContentRecord]:
-        del query
-        return []
+        records = [
+            record
+            for record in self._records.values()
+            if record.reference.kind == query.kind
+            and query.search.casefold() in record.reference.name.casefold()
+            and (query.owner_reference is None or record.owner_reference == query.owner_reference)
+        ]
+        records.sort(key=lambda record: record.reference.model_dump_json())
+        return records[query.offset : query.offset + query.limit]
 
     def put(self, request: ContentWrite) -> ContentRecord:
         if request.create_only and self._barrier is not None:
@@ -256,6 +263,46 @@ def test_github_work_item_backend_human_body_change_invalidates_prior_head() -> 
     # Then: the stale head is replaced through its old Contents SHA and binds the new root
     stored = parse_work_item_head(contents.get(work_item_head_ref("#42")).content)
     assert (patched.status, stored.root_revision, stored.body) == ("applied", item.revision, "new rendered")
+
+
+def test_github_work_item_snapshot_batches_heads_and_audit_comments() -> None:
+    contents = _ContentsFake()
+    issues = [_issue(), {**_issue(), "id": "issue-node-43", "number": 43}]
+    first_root = root_revision("#42", "issue-node", "Human-owned body")
+    second_root = root_revision("#43", "issue-node-43", "Human-owned body")
+    heads = [
+        WorkItemHead.create("#42", first_root, first_root, "first", "comment-1"),
+        WorkItemHead.create("#43", second_root, second_root, "second", "comment-2"),
+    ]
+    for reference, head in zip(("#42", "#43"), heads, strict=True):
+        contents.put(
+            ContentWrite(reference=work_item_head_ref(reference), content=head.model_dump_json(), create_only=True)
+        )
+    backend = _backend(contents, {})
+    backend._contents = MagicMock(wraps=contents)
+    backend._fetch_issues_graphql = MagicMock(return_value=issues)
+    backend._graphql_request = MagicMock(
+        return_value={
+            "nodes": [
+                {
+                    "id": f"comment-{index}",
+                    "body": render_work_item_comment(head.parent_revision, head.body),
+                    "url": f"https://example.test/comments/{index}",
+                    "author": {"login": "agent"},
+                    "createdAt": "2026-08-12T00:00:00Z",
+                    "updatedAt": "2026-08-12T00:00:00Z",
+                }
+                for index, head in enumerate(heads, 1)
+            ]
+        }
+    )
+
+    snapshot = backend._fetch_snapshot(ReconcileRequest(scope=ReconcileScope.INITIAL))
+
+    assert [(item.reference, item.body) for item in snapshot.items] == [("#42", "first"), ("#43", "second")]
+    backend._contents.get.assert_not_called()
+    backend._contents.list.assert_called_once()
+    backend._graphql_request.assert_called_once()
 
 
 def test_github_work_item_backend_concurrent_initial_cas_has_one_winner_and_two_audit_comments() -> None:


### PR DESCRIPTION
## Summary
- store plans, artifacts, dispatch plans, and work-item heads as versioned GitHub Contents envelopes
- use blob SHA compare-and-swap with bounded unrelated-branch retry and coherent tree discovery
- preserve Gist/index data as read-only migration fallback and keep Issue bodies human-owned
- publish work-item bodies through validated audit comments plus a Contents-CAS authoritative head

## Validation
- 100 focused provider/CAS tests passed
- changed-file Ruff and ty checks passed
- bare staged-file `uv run prek run` passed
- independent code review PASS
- manual QA PASS for create/update/conflict/list/replay/work-item re-root

## Tracking
- closes claude_skills-ece.24
- closes claude_skills-ece.28
- closes claude_skills-ece.34
- closes claude_skills-ece.40
- follow-up claude_skills-ece.66 tracks extraction of the oversized GitHub adapter