### PR TITLE
fix(github): close native CAS post-merge findings

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.13",
+  "version": "9.0.14",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -1062,7 +1062,17 @@ class GitHubBackend:
                 raise ContentConflictError("Content already exists") from exc
             if legacy.revision != request.expected_revision:
                 raise ContentConflictError("Content revision no longer matches") from exc
-            return self._contents.put(request.model_copy(update={"expected_revision": "", "create_only": True}))
+            return self._contents.put(
+                request.model_copy(
+                    update={
+                        "owner_reference": (
+                            request.owner_reference if request.owner_reference is not None else legacy.owner_reference
+                        ),
+                        "expected_revision": "",
+                        "create_only": True,
+                    }
+                )
+            )
         return self._contents.put(request)
 
     def _with_legacy_content(self, query: ContentQuery, current: list[ContentRecord]) -> list[ContentRecord]:

--- a/plugins/development-harness/docs/backend-providers.md
+++ b/plugins/development-harness/docs/backend-providers.md
@@ -105,6 +105,26 @@ The same rule applies to remote work-item reconciliation: provider snapshots
 and local item files are private cache records, while the remote provider owns
 the accepted state.
 
+### GitHub contract
+
+GitHub stores plans, artifact manifests, artifact content, and dispatch plans as
+versioned repository content. Treat each returned revision as opaque: pass it
+unchanged on updates so GitHub can reject stale writes. Repository permissions
+must allow Contents reads and writes; work-item reconciliation also requires
+Issue and comment reads and writes.
+
+The Issue body remains the human-owned work-item root. Reconciliation versions
+agent-rendered bodies through a provider-private head plus validated audit
+comments. These private records are not available through public content list,
+get, or put operations.
+
+Legacy Gist and index records are read-only migration sources. Their first
+successful update validates the legacy revision, preserves its owner reference,
+and creates the native record atomically. Native records take precedence after
+creation. A malformed or truncated native record is an integrity failure; stop
+instead of selecting legacy or cached content. A transport outage may return an
+explicitly stale private-cache record under the remote-provider rules above.
+
 </provider_contract>
 
 <consumer_workflow>

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -400,7 +400,9 @@ def test_backend_prefers_v1_content_and_falls_back_to_legacy(tmp_path: Path, sto
 def test_backend_migrates_validated_legacy_revision_on_first_write(tmp_path: Path, store: _GitHubContentsStore) -> None:
     reference = ContentRef(kind=ContentKind.PLAN, name="P1")
     legacy = MagicMock()
-    legacy.get.return_value = ContentRecord(reference=reference, content="legacy", revision="legacy-revision")
+    legacy.get.return_value = ContentRecord(
+        reference=reference, owner_reference="#7", content="legacy", revision="legacy-revision"
+    )
     backend = GitHubBackend(cache=FileCache(tmp_path), plan_persistence=legacy, contents=store)
     backend.try_get_github = MagicMock(return_value=MagicMock())
 
@@ -408,7 +410,7 @@ def test_backend_migrates_validated_legacy_revision_on_first_write(tmp_path: Pat
         ContentWrite(reference=reference, content="native", expected_revision="legacy-revision")
     )
 
-    assert (migrated.content, store.get(reference).content) == ("native", "native")
+    assert (migrated.content, migrated.owner_reference, store.get(reference).content) == ("native", "#7", "native")
 
     missing = ContentRef(kind=ContentKind.PLAN, name="P2")
     legacy.get.return_value = ContentRecord(reference=missing, content="legacy", revision="current")


### PR DESCRIPTION
## Summary
- preserve legacy owner references during first native CAS migration
- document the GitHub provider CAS, permission, reconciliation, and migration contract

## Validation
- focused migration regression
- Ruff and ty on changed Python files
- bare `uv run prek run`

Tracks `claude_skills-ece.67`.