### PR TITLE
docs(graph): align task execution with teammode

### DIFF
--- a/.agents/skills/graph-engineering/SKILL.md
+++ b/.agents/skills/graph-engineering/SKILL.md
@@ -15,8 +15,10 @@ prompts. It has two halves:
    and adapted for LLM-era agents.
 2. **Task graphs** — how agents work. Nodes are jobs, edges are execution dependencies:
    parallel fan-out, separate verifier contexts, the stop rule, the human gate.
-   Read [references/task-graphs.md](references/task-graphs.md) when the request is about
-   orchestrating agents rather than building memory.
+   Read [references/task-graphs.md](./references/task-graphs.md) when the request is about
+   orchestrating agents rather than building memory. The task graph decides the execution
+   shape once; use teammode only for a ready parallel component whose members must coordinate.
+   Keep serial chains with one agent and perfectly isolated parallel nodes as plain subagents.
 
 Core mental model: a knowledge graph is a **product with a schema**, not a pile of triples.
 Quality comes from the pipeline order — model the domain BEFORE extracting, fuse BEFORE storing,
@@ -58,7 +60,7 @@ skip stages 3 (ontology) or 8 (fusion) — they are where real-world graphs fail
    attributes BEFORE extraction. Start minimal: 5-15 entity types, 10-30 relation types.
    Two rules from the course: every relation gets a precise verb name (`ACQUIRED`, not
    `RELATED_TO`), and if two types are always queried together, merge them.
-   Details and worked examples: [references/modeling.md](references/modeling.md)
+   Details and worked examples: [references/modeling.md](./references/modeling.md)
 
 4. **Entity extraction (NER)** — Extract typed entities from sources. Method ladder: exact
    rules/dictionaries for closed vocabularies → LLM extraction with the ontology in the prompt
@@ -71,7 +73,7 @@ skip stages 3 (ontology) or 8 (fusion) — they are where real-world graphs fail
 6. **Event extraction** — For dynamic domains (news, logs, transactions), extract events as
    first-class nodes (trigger + typed arguments + time), not just static edges.
    Extraction methods, prompt patterns, and failure modes for stages 4-6:
-   [references/extraction.md](references/extraction.md)
+   [references/extraction.md](./references/extraction.md)
 
 7. **Quality gate** — Before fusion, sample and score: entity precision (are extracted
    entities real and correctly typed?), relation precision (does the source sentence actually
@@ -82,12 +84,12 @@ skip stages 3 (ontology) or 8 (fusion) — they are where real-world graphs fail
 8. **Knowledge fusion** — Merge duplicates within and across sources: same real-world entity,
    different surface forms ("SEU" = "Southeast University" = "东南大学"). Blocking + matching +
    merge policy. Skipping this is the #1 cause of useless graphs.
-   Matching strategies: [references/fusion-and-llm.md](references/fusion-and-llm.md)
+   Matching strategies: [references/fusion-and-llm.md](./references/fusion-and-llm.md)
 
 9. **Serve to LLMs (KG × LLM)** — Make the graph useful to agents: GraphRAG retrieval
    (subgraph → context), graph-as-memory (agent writes facts back through stages 4-8), and
    LLM-as-reasoner over paths. Patterns and pitfalls:
-   [references/fusion-and-llm.md](references/fusion-and-llm.md)
+   [references/fusion-and-llm.md](./references/fusion-and-llm.md)
 
 ## Working Rules
 
@@ -103,14 +105,14 @@ skip stages 3 (ontology) or 8 (fusion) — they are where real-world graphs fail
 
 ## Reference Files
 
-- [references/curriculum.md](references/curriculum.md) — Full translated curriculum of the
+- [references/curriculum.md](./references/curriculum.md) — Full translated curriculum of the
   source course with per-lecture summaries and links to the original Chinese slide decks.
   Read when the user wants theory depth, the academic grounding, or the original materials.
-- [references/modeling.md](references/modeling.md) — Knowledge representation & ontology
+- [references/modeling.md](./references/modeling.md) — Knowledge representation & ontology
   engineering (course lectures 2-3). Read during stages 2-3.
-- [references/extraction.md](references/extraction.md) — Entity, relation, and event
+- [references/extraction.md](./references/extraction.md) — Entity, relation, and event
   extraction from rules to LLM prompting (lectures 4-7). Read during stages 4-7.
-- [references/fusion-and-llm.md](references/fusion-and-llm.md) — Knowledge fusion and
+- [references/fusion-and-llm.md](./references/fusion-and-llm.md) — Knowledge fusion and
   KG × LLM integration (lectures 8-9). Read during stages 8-9.
 
 ## Credits

--- a/.agents/skills/graph-engineering/references/task-graphs.md
+++ b/.agents/skills/graph-engineering/references/task-graphs.md
@@ -74,18 +74,26 @@ The runtime MUST consume that graph without adding dependencies or redesigning t
 | Irreversible action | Stop at the human gate |
 
 Initialize teammode only when the first coordination-connected parallel component becomes ready.
-Map graph facts directly into the existing team fields:
+For the installed Codex `omo:teammode` v4.19.4 controller, map graph facts into its supported
+`add-member` inputs:
 
-- node scope and file ownership become member `focus`;
-- node acceptance criteria and QA become member `deliverable`;
+- node scope and file ownership become `--focus`;
+- node acceptance criteria and QA become `--deliverable`;
 - graph dependencies determine which members may start in the current wave;
-- overlapping file ownership requires separate worktrees;
+- overlapping file ownership means the nodes cannot share a wave: repartition ownership or
+  serialize them;
 - the merge owner remains the leader, never another implicit member.
+
+With another runtime, put the same scope and acceptance criteria in its supported task description
+or spawn prompt instead of inventing `focus` or `deliverable` state fields.
 
 Disband the team when that component and its verification join finish. Do not keep team state for
 serial work, isolated subagents, later human gates, or hypothetical future waves. When teammode is
 unavailable, preserve the topology and use the available serial or plain-subagent runtime instead.
 This boundary avoids a second planner, a graph-to-team compiler, and duplicate orchestration state.
+
+Runtime basis: OpenAI, [Subagents](https://developers.openai.com/codex/subagents) (accessed
+2026-08-13), and the installed `omo:teammode` v4.19.4 skill and controller contract.
 
 ## The human gate
 

--- a/.agents/skills/graph-engineering/references/task-graphs.md
+++ b/.agents/skills/graph-engineering/references/task-graphs.md
@@ -6,6 +6,7 @@
 - [Fake edges](#fake-edges)
 - [The diamond pattern](#the-diamond-pattern)
 - [The stop rule](#the-stop-rule)
+- [Execution handoff](#execution-handoff)
 - [The human gate](#the-human-gate)
 - [Guardrails](#guardrails)
 
@@ -57,6 +58,34 @@ The decision procedure:
 3. Never let findings merge without one owner of the merge.
 
 More agents is not a strategy. The shape of the work decides.
+
+## Execution handoff
+
+Design the topology once, then hand each ready component to the smallest runtime that fits it.
+Graph engineering owns the nodes, real dependencies, verification joins, and human gates.
+The runtime MUST consume that graph without adding dependencies or redesigning the split.
+
+| Ready component | Runtime |
+|---|---|
+| Serial chain | Keep it with the leader or one worker |
+| Parallel nodes that never exchange results | Use plain subagents |
+| Parallel nodes that must exchange findings or coordinate a shared boundary | Use teammode |
+| Fan-in verification | Start a fresh verifier only after every incoming node finishes |
+| Irreversible action | Stop at the human gate |
+
+Initialize teammode only when the first coordination-connected parallel component becomes ready.
+Map graph facts directly into the existing team fields:
+
+- node scope and file ownership become member `focus`;
+- node acceptance criteria and QA become member `deliverable`;
+- graph dependencies determine which members may start in the current wave;
+- overlapping file ownership requires separate worktrees;
+- the merge owner remains the leader, never another implicit member.
+
+Disband the team when that component and its verification join finish. Do not keep team state for
+serial work, isolated subagents, later human gates, or hypothetical future waves. When teammode is
+unavailable, preserve the topology and use the available serial or plain-subagent runtime instead.
+This boundary avoids a second planner, a graph-to-team compiler, and duplicate orchestration state.
 
 ## The human gate
 

--- a/.agents/skills/graph-engineering/references/task-graphs.md
+++ b/.agents/skills/graph-engineering/references/task-graphs.md
@@ -92,8 +92,11 @@ serial work, isolated subagents, later human gates, or hypothetical future waves
 unavailable, preserve the topology and use the available serial or plain-subagent runtime instead.
 This boundary avoids a second planner, a graph-to-team compiler, and duplicate orchestration state.
 
-Runtime basis: OpenAI, [Subagents](https://developers.openai.com/codex/subagents) (accessed
-2026-08-13), and the installed `omo:teammode` v4.19.4 skill and controller contract.
+Runtime basis: OpenAI, [Subagents](https://developers.openai.com/codex/subagents), and LazyCodex's
+version-pinned [`teammode` wave mapping](https://github.com/code-yeongyu/lazycodex/blob/10f95587d3aeacf208cc1fee88a91315962d31e8/plugins/omo/components/teammode/skills/teammode/SKILL.md#L248-L261)
+and [`team.mjs` member inputs](https://github.com/code-yeongyu/lazycodex/blob/10f95587d3aeacf208cc1fee88a91315962d31e8/plugins/omo/components/teammode/skills/teammode/scripts/team.mjs#L7-L14)
+(all accessed 2026-08-13). This repository's one-writer rule intentionally tightens the upstream
+worktree guidance for overlapping files.
 
 ## The human gate
 

--- a/.agents/skills/graph-engineering/references/task-graphs.md
+++ b/.agents/skills/graph-engineering/references/task-graphs.md
@@ -69,9 +69,11 @@ The runtime MUST consume that graph without adding dependencies or redesigning t
 |---|---|
 | Serial chain | Keep it with the leader or one worker |
 | Parallel nodes that never exchange results | Use plain subagents |
-| Parallel nodes that must exchange findings or coordinate a shared boundary | Use teammode |
+| Independent parallel nodes that need non-blocking coordination at a shared boundary | Use teammode |
 | Fan-in verification | Start a fresh verifier only after every incoming node finishes |
 | Irreversible action | Stop at the human gate |
+
+If one node needs another node's finding, draw an edge and start the consumer in a later wave.
 
 Initialize teammode only when the first coordination-connected parallel component becomes ready.
 For the installed Codex `omo:teammode` v4.19.4 controller, map graph facts into its supported


### PR DESCRIPTION
## Summary
- make graph-engineering the single owner of task topology
- route only coordination-connected parallel components through teammode
- reuse existing team wave/state machinery instead of adding a graph compiler

## Validation
- `uvx skilllint@latest check .agents/skills/graph-engineering`
- `uv run prek run` on the exact staged files
- read-only Luna invocation returned the intended serial / plain-subagent / teammode routing