### PR TITLE
fix(development-harness): use resolved repo slug for GraphQL owner/name split

### DIFF
--- a/plugins/development-harness/backlog_core/artifact_provider.py
+++ b/plugins/development-harness/backlog_core/artifact_provider.py
@@ -483,7 +483,7 @@ class GitHubGistArtifactProvider:
         item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         try:
             repo = get_github(self._repo)
-            owner, repo_name = self._repo.split("/", 1)
+            owner, repo_name = repo.full_name.split("/", 1)
             issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
             body = issue.get("body") or ""
 
@@ -528,7 +528,7 @@ class GitHubGistArtifactProvider:
         item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         try:
             repo = get_github(self._repo)
-            owner, repo_name = self._repo.split("/", 1)
+            owner, repo_name = repo.full_name.split("/", 1)
             issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
             body = issue.get("body") or ""
 
@@ -593,7 +593,7 @@ class GitHubGistArtifactProvider:
         item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         try:
             repo = get_github(self._repo)
-            owner, repo_name = self._repo.split("/", 1)
+            owner, repo_name = repo.full_name.split("/", 1)
             issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
             body = issue.get("body") or ""
 
@@ -625,7 +625,7 @@ class GitHubGistArtifactProvider:
         """
         item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         repo = get_github(self._repo)
-        owner, repo_name = self._repo.split("/", 1)
+        owner, repo_name = repo.full_name.split("/", 1)
         issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
         body = issue.get("body") or ""
 
@@ -659,7 +659,7 @@ class GitHubGistArtifactProvider:
         """
         item_id = _require_int_item_id("GitHubGistArtifactProvider", item_id)
         repo = get_github(self._repo)
-        owner, repo_name = self._repo.split("/", 1)
+        owner, repo_name = repo.full_name.split("/", 1)
         issue = _fetch_issue_graphql(repo, owner, repo_name, item_id)
         gist = self._get_gist(item_id, issue.get("body") or "")
         if gist is None:

--- a/plugins/development-harness/tests/test_artifact_content_storage.py
+++ b/plugins/development-harness/tests/test_artifact_content_storage.py
@@ -75,10 +75,17 @@ def _make_mock_repo() -> MagicMock:
     """Return a minimal MagicMock suitable as a PyGithub Repository object.
 
     Returns:
-        MagicMock with no pre-configured attributes — _graphql_request is
-        mocked at the module level, so the repo object is only passed through.
+        MagicMock with ``full_name`` configured to match the ``owner/repo``
+        slug used across these tests -- artifact_provider.py derives owner
+        and repo name from ``repo.full_name`` (the established convention
+        throughout gh_client.py), not from the provider's stored repo
+        string, so an unconfigured mock's auto-generated ``full_name``
+        attribute would fail to unpack. ``_graphql_request`` is mocked at
+        the module level; only ``full_name`` needs a real value here.
     """
-    return MagicMock()
+    repo = MagicMock()
+    repo.full_name = "owner/repo"
+    return repo
 
 
 def _manifest_record(manifest: ArtifactManifest) -> ContentRecord:

--- a/plugins/development-harness/tests/test_frontend_parity.py
+++ b/plugins/development-harness/tests/test_frontend_parity.py
@@ -48,7 +48,7 @@ def _get_project_slug() -> str:
     return dh_paths.compute_slug(project_root)
 
 
-def run_cli(args: list[str], *, timeout: int = 30, env: dict[str, str] | None = None) -> dict[str, Any]:
+def run_cli(args: list[str], *, timeout: int = 180, env: dict[str, str] | None = None) -> dict[str, Any]:
     """Run ``uv run <cli.py> <args>`` and return parsed JSON output.
 
     Args:
@@ -135,6 +135,7 @@ class TestCLIForeignCWD:
             ["uv", "run", str(_CLI_PATH), "plan", "list", "--limit", "1"],
             capture_output=True,
             text=True,
+            timeout=180,
             cwd=tmp_path,
             env={**os.environ, **extra_env, "DH_STATE_HOME": str(state_home), "DH_PROJECT_ROOT": str(_REPO_ROOT)},
             check=False,

--- a/plugins/development-harness/tests/test_github_dispatch_persistence.py
+++ b/plugins/development-harness/tests/test_github_dispatch_persistence.py
@@ -190,7 +190,7 @@ def test_github_gist_provider_lists_matching_gist_files(monkeypatch: pytest.Monk
         "sam-plan--other.yaml": SimpleNamespace(content="other"),
     }
     monkeypatch.setattr(provider, "_get_gist", lambda item_id, body: gist)
-    monkeypatch.setattr("backlog_core.artifact_provider.get_github", lambda repo: MagicMock())
+    monkeypatch.setattr("backlog_core.artifact_provider.get_github", lambda repo: MagicMock(full_name="owner/repo"))
     monkeypatch.setattr("backlog_core.artifact_provider._fetch_issue_graphql", lambda *args: {"body": ""})
 
     files = provider.list_artifact_content_from_remote(42, "dispatch-plan", "dispatch-plan/")

--- a/plugins/development-harness/tests_backlog/test_artifact_provider.py
+++ b/plugins/development-harness/tests_backlog/test_artifact_provider.py
@@ -68,10 +68,13 @@ def mock_repo(mocker: MockerFixture) -> MagicMock:
     Why: Provider tests must not make real HTTP calls. The artifact_provider calls
          _fetch_issue_graphql (query) and _update_issue_graphql (mutation), both of
          which unpack repo.requester.graphql_query() as (headers, response). A bare
-         MagicMock() unpacks to 0 values and raises ValueError.
+         MagicMock() unpacks to 0 values and raises ValueError. Likewise, the owner/
+         repo split reads repo.full_name (the established gh_client.py convention),
+         which must be configured for the same reason.
     """
     mock = mocker.patch("backlog_core.artifact_provider.get_github")
     repo = MagicMock()
+    repo.full_name = "owner/repo"
     repo.requester.graphql_query.return_value = (
         {},
         {
@@ -142,6 +145,7 @@ def _make_mock_github_provider(worktree: Path, mocker: MockerFixture) -> Artifac
     """Construct a mocked GitHubGistArtifactProvider for protocol testing."""
     mock = mocker.patch("backlog_core.artifact_provider.get_github")
     repo = MagicMock()
+    repo.full_name = "owner/test-repo"
     repo.requester.graphql_query.return_value = (
         {},
         {

--- a/plugins/development-harness/tests_backlog/test_github_gist_artifact_provider.py
+++ b/plugins/development-harness/tests_backlog/test_github_gist_artifact_provider.py
@@ -75,10 +75,13 @@ def mock_github_repo(mocker: MockerFixture) -> MagicMock:
     How: Patch backlog_core.artifact_provider.get_github; configure graphql_query
          to return a valid 2-tuple.
     Why: Provider uses _fetch_issue_graphql / _update_issue_graphql which unpack
-         (headers, data) from repo.requester.graphql_query.
+         (headers, data) from repo.requester.graphql_query. The owner/repo split
+         reads repo.full_name (the established gh_client.py convention), which
+         must be configured for the same reason.
     """
     mock = mocker.patch("backlog_core.artifact_provider.get_github")
     repo = MagicMock()
+    repo.full_name = "owner/repo"
     repo.requester.graphql_query.return_value = _make_graphql_return()
     mock.return_value = repo
     return repo


### PR DESCRIPTION
## Summary

- `GitHubGistArtifactProvider` methods split `self._repo` directly instead of the resolved `repo.full_name` returned by `get_github()`. In normal operation `create_backend()` constructs `GitHubBackend()`/`GitHubGistArtifactProvider` with `repo=""`, relying entirely on `get_github()`'s internal `resolve_repo()` fallback to fill in the default repo slug from git-remote/env discovery. `get_github()` resolves that slug locally to fetch the `Repository` object, but never returns the resolved string to the caller — so every one of the 5 call sites in `artifact_provider.py` re-split the still-empty `self._repo`, raising `ValueError: not enough values to unpack (expected 2, got 1)` on `"".split("/", 1)`.
- Fix: split `repo.full_name` (the `Repository` object `get_github()` already returns, carrying the resolved slug) instead of `self._repo`, at all 5 identical call sites — matching the pattern already used correctly elsewhere in the same backend (`backlog_core/backends/github_backend.py`: `repo = self.get_github(); owner, repo_name = repo.full_name.split("/", 1)`).
- Also bumps two CLI-subprocess timeouts in `test_frontend_parity.py` from 30s to 180s. With the split bug fixed, `plan list` now runs the GitHub content-listing path to completion instead of crashing on the very first item; against this repo's real, growing GitHub-issues-backed backlog, the existing serial per-item GraphQL fetch pattern in `github_backend.py`'s `_list_all_content`/`list_content` legitimately takes ~65s end-to-end (verified: correct JSON is returned), which the previous 30s timeout no longer accommodates. That N+1 GraphQL pattern is a separate, pre-existing performance characteristic — previously masked because the split bug crashed before the loop could run to completion — and is out of scope for this fix; flagging it separately for the backlog.

## Test plan

- [x] Reproduced the failure first: `uv run pytest plugins/development-harness/tests/test_frontend_parity.py::TestParityInfrastructure::test_cli_plan_list_returns_json "plugins/development-harness/tests/test_frontend_parity.py::TestCLIForeignCWD::test_cli_runs_from_a_foreign_cwd" -v --no-cov` — all 3 failed with the `ValueError` before the fix.
- [x] Same 3 tests pass after the fix (84.36s wall time, dominated by live GitHub API round trips).
- [x] Full regression run: `uv run pytest plugins/development-harness/tests/test_frontend_parity.py plugins/development-harness/backlog_core/tests/ -v --no-cov` — 515 passed, 0 failed.
- [x] `uv run ruff check --fix`, `uv run ruff format`, `uv run ty check` on both changed files — all clean.
- [x] `uv run prek run --files <changed files>` — all hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)