### PR TITLE
fix(development-harness): batch GitHub content blob fetches via GraphQL

### DIFF
--- a/plugins/development-harness/backlog_core/backends/github_contents.py
+++ b/plugins/development-harness/backlog_core/backends/github_contents.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import json
-from base64 import b64decode
-from binascii import Error as Base64Error
 from collections.abc import Callable, Mapping, Sequence as SequenceABC, Sequence as SequenceType
 from typing import Protocol, TypeAlias, runtime_checkable
 from urllib.parse import quote
 
 from github import GithubException
 
+from backlog_core import gh_client
 from backlog_core.models import (
+    BacklogError,
     ContentConflictError,
     ContentNotFoundError,
     ContentQuery,
@@ -27,7 +27,12 @@ _NOT_FOUND = 404
 _CONFLICT_STATUSES = frozenset({409, 422})
 _MAX_CONTENT_BYTES = 1_000_000
 _WRITE_ATTEMPTS = 3
-_BASE64_WHITESPACE = str.maketrans("", "", " \t\r\n\v\f")
+# Bounded aliased GraphQL batch size for blob fetches, matching the
+# gh_client._BATCH_CHUNK_SIZE precedent for batches that carry full text
+# bodies (not just small metadata fields like _TARGET_BATCH_SIZE=100's
+# issue-node batches) -- content records can be up to _MAX_CONTENT_BYTES
+# each, so a smaller chunk keeps a single GraphQL response bounded.
+_BLOB_BATCH_SIZE = 25
 ContentRecords: TypeAlias = list[ContentRecord]
 
 
@@ -63,20 +68,26 @@ class _GitTree(Protocol):
     def truncated(self) -> bool: ...
 
 
-class _GitBlob(Protocol):
-    @property
-    def content(self) -> str: ...
+class _Requester(Protocol):
+    def graphql_query(
+        self, query: str, variables: dict[str, object]
+    ) -> tuple[dict[str, object], dict[str, object]]: ...
 
 
 class _ContentsRepository(Protocol):
     @property
     def default_branch(self) -> str: ...
 
+    @property
+    def full_name(self) -> str: ...
+
+    @property
+    def requester(self) -> _Requester: ...
+
     def get_contents(self, path: str, ref: str) -> _ContentsFile | SequenceType[_ContentsFile]: ...
     def create_file(self, path: str, message: str, content: str, branch: str) -> Mapping[str, object]: ...
     def update_file(self, path: str, message: str, content: str, sha: str, branch: str) -> Mapping[str, object]: ...
     def get_git_tree(self, sha: str, recursive: bool) -> _GitTree: ...
-    def get_git_blob(self, sha: str) -> _GitBlob: ...
 
 
 class _GitHubContentsStore:
@@ -95,11 +106,13 @@ class _GitHubContentsStore:
             raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
         if tree.truncated:
             raise _GitHubContentIntegrityError("GitHub content discovery tree was truncated")
-        records = [
-            self._from_blob(repository, entry.path, entry.sha)
+        matching = [
+            entry
             for entry in tree.tree
             if entry.type == "blob" and entry.path.startswith(self._kind_prefix(query.kind.value))
         ]
+        blobs = self._fetch_blobs_graphql(repository, [entry.sha for entry in matching])
+        records = [self._parse(entry.path, blobs[entry.sha], entry.sha) for entry in matching]
         filtered = [
             record
             for record in records
@@ -125,11 +138,9 @@ class _GitHubContentsStore:
         if tree.truncated:
             raise _GitHubContentIntegrityError("GitHub content discovery tree was truncated")
         paths = {self._path(reference) for reference in references}
-        return [
-            self._from_blob(repository, entry.path, entry.sha)
-            for entry in tree.tree
-            if entry.type == "blob" and entry.path in paths
-        ]
+        matching = [entry for entry in tree.tree if entry.type == "blob" and entry.path in paths]
+        blobs = self._fetch_blobs_graphql(repository, [entry.sha for entry in matching])
+        return [self._parse(entry.path, blobs[entry.sha], entry.sha) for entry in matching]
 
     def get(self, reference: ContentRef) -> ContentRecord:
         repository = self._repository()
@@ -222,16 +233,59 @@ class _GitHubContentsStore:
             raise _GitHubContentIntegrityError(f"GitHub content path is not a file: {path}")
         return self._parse(path, file.decoded_content, file.sha)
 
-    def _from_blob(self, repository: _ContentsRepository, path: str, sha: str) -> ContentRecord:
-        try:
-            encoded = repository.get_git_blob(sha).content
-        except GithubException as exc:
-            raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
-        try:
-            content = b64decode(encoded.translate(_BASE64_WHITESPACE), validate=True)
-        except (Base64Error, ValueError) as exc:
-            raise _GitHubContentIntegrityError(f"GitHub content envelope is invalid: {path}") from exc
-        return self._parse(path, content, sha)
+    def _fetch_blobs_graphql(self, repository: _ContentsRepository, shas: SequenceType[str]) -> dict[str, bytes]:
+        """Fetch blob content for every sha in one bounded aliased GraphQL request per chunk.
+
+        Replaces one get_git_blob REST call per blob (N+1 against the tree
+        listing) with _BLOB_BATCH_SIZE blobs per GraphQL round trip, mirroring
+        _GitHubBackend._fetch_targeted_issues's bounded aliased-query pattern.
+        GraphQL's Blob.text returns already-decoded UTF8 content directly (no
+        base64 step, unlike the REST get_git_blob response).
+
+        Returns:
+            Mapping of blob sha to its decoded content bytes.
+
+        Raises:
+            ContentUnavailableError: On GraphQL transport failure.
+            _GitHubContentIntegrityError: If a requested blob is missing,
+                binary, or otherwise not decodable text.
+        """
+        unique_shas = list(dict.fromkeys(shas))
+        if not unique_shas:
+            return {}
+        owner, repo_name = repository.full_name.split("/", 1)
+        blobs: dict[str, bytes] = {}
+        for offset in range(0, len(unique_shas), _BLOB_BATCH_SIZE):
+            chunk = unique_shas[offset : offset + _BLOB_BATCH_SIZE]
+            declarations = ", ".join(f"$sha{index}: GitObjectID!" for index in range(len(chunk)))
+            aliases = "\n".join(
+                f"      b{index}: object(oid: $sha{index}) {{ ... on Blob {{ text isBinary }} }}"
+                for index in range(len(chunk))
+            )
+            query = (
+                f"query BlobBatch($owner: String!, $repo: String!, {declarations}) {{\n"
+                f"  repository(owner: $owner, name: $repo) {{\n{aliases}\n  }}\n}}"
+            )
+            variables: dict[str, object] = {"owner": owner, "repo": repo_name}
+            variables.update({f"sha{index}": sha for index, sha in enumerate(chunk)})
+            try:
+                data = gh_client._graphql_request(repository, query, variables)
+            except BacklogError as exc:
+                raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
+            repository_data = data.get("repository")
+            if not isinstance(repository_data, dict):
+                raise ContentUnavailableError("GraphQL blob batch response omitted repository data")
+            for index, sha in enumerate(chunk):
+                alias = f"b{index}"
+                node = repository_data.get(alias)
+                if (
+                    not isinstance(node, dict)
+                    or node.get("isBinary") is not False
+                    or not isinstance(node.get("text"), str)
+                ):
+                    raise _GitHubContentIntegrityError(f"GitHub content blob is invalid or missing: {sha}")
+                blobs[sha] = node["text"].encode()
+        return blobs
 
     def _parse(self, path: str, content: bytes, revision: str) -> ContentRecord:
         try:

--- a/plugins/development-harness/backlog_core/gh_client.py
+++ b/plugins/development-harness/backlog_core/gh_client.py
@@ -15,7 +15,7 @@ import logging
 import os
 import re
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from github import Auth, Github, GithubException
 from typing_extensions import TypedDict
@@ -53,6 +53,24 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from github.Repository import Repository
+
+
+class _GraphQLRequester(Protocol):
+    def graphql_query(self, query: str, variables: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]: ...
+
+
+class _GraphQLCapable(Protocol):
+    """Structural minimum _graphql_request needs -- narrower than the full Repository surface.
+
+    Lets callers outside gh_client (e.g. github_contents.py's _ContentsRepository Protocol,
+    used for test-fake substitution) pass their own repository stand-in without depending on
+    PyGithub's concrete Repository type -- any object exposing .requester.graphql_query(...)
+    satisfies this, including a real Repository.
+    """
+
+    @property
+    def requester(self) -> _GraphQLRequester: ...
+
 
 logger = logging.getLogger(__name__)
 
@@ -463,7 +481,7 @@ def _parse_search_pr_node(raw: dict[str, Any]) -> SearchPRNode | None:
 # ---------------------------------------------------------------------------
 
 
-def _graphql_request(repo: Repository, query: str, variables: dict[str, object] | None = None) -> dict[str, Any]:
+def _graphql_request(repo: _GraphQLCapable, query: str, variables: dict[str, object] | None = None) -> dict[str, Any]:
     """Execute a raw GraphQL query using PyGithub's requester.
 
     Follows the same pattern as ``_resolve_labels_graphql``.  Raises
@@ -472,7 +490,9 @@ def _graphql_request(repo: Repository, query: str, variables: dict[str, object] 
     ``UnknownObjectException`` for NOT_FOUND / 404 responses).
 
     Args:
-        repo: PyGithub Repository object (provides requester access).
+        repo: Any object exposing ``.requester.graphql_query(...)`` -- a real
+            PyGithub Repository, or a narrower structural stand-in (e.g. a
+            test fake) satisfying just that surface.
         query: GraphQL query or mutation string.
         variables: Optional dict of GraphQL variables.
 

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from base64 import b64encode
 from pathlib import Path
-from types import SimpleNamespace
 from typing import TypeAlias
 from unittest.mock import MagicMock
 
@@ -50,9 +48,36 @@ class _Tree(BaseModel):
     truncated: bool = False
 
 
+class _FakeRequester:
+    """Simulates PyGithub's requester.graphql_query for the aliased blob-batch query.
+
+    Only understands the shape _fetch_blobs_graphql actually sends ($sha0,
+    $sha1, ... variables aliased b0, b1, ...) -- not a general GraphQL engine.
+    """
+
+    def __init__(self, repository: _Repository) -> None:
+        self._repository = repository
+        self.call_count = 0
+        self.override: dict[str, object] | None = None
+
+    def graphql_query(self, query: str, variables: dict[str, object]) -> tuple[dict[str, object], dict[str, object]]:
+        self.call_count += 1
+        if self.override is not None:
+            return {}, self.override
+        sha_keys = sorted((key for key in variables if key.startswith("sha")), key=lambda key: int(key[3:]))
+        repository_data: dict[str, object] = {}
+        for index, key in enumerate(sha_keys):
+            sha = str(variables[key])
+            self._repository.blob_requests.append(sha)
+            content = self._repository._blobs.get(sha)
+            repository_data[f"b{index}"] = None if content is None else {"text": content, "isBinary": False}
+        return {}, {"data": {"repository": repository_data}}
+
+
 class _Repository:
     def __init__(self) -> None:
         self.default_branch = "main"
+        self.full_name = "owner/repo"
         self.files: dict[str, _File] = {}
         self.create_race = False
         self.conflict_update = False
@@ -65,6 +90,7 @@ class _Repository:
         self.blob_requests: list[str] = []
         self._blobs: dict[str, str] = {}
         self._next_sha = 0
+        self.requester = _FakeRequester(self)
 
     def get_contents(self, path: str, ref: str) -> _File:
         self.branches.append(ref)
@@ -119,10 +145,6 @@ class _Repository:
         return _Tree(
             tree=[_TreeEntry(path=path, sha=file.sha) for path, file in snapshot.items()], truncated=self.tree_truncated
         )
-
-    def get_git_blob(self, sha: str) -> SimpleNamespace:
-        self.blob_requests.append(sha)
-        return SimpleNamespace(content=b64encode(self._blobs[sha].encode()).decode())
 
     def _sha(self) -> str:
         self._next_sha += 1
@@ -267,37 +289,35 @@ def test_malformed_native_content_does_not_fall_back_to_legacy(
 
 def test_malformed_native_blob_fails_closed(store: _GitHubContentsStore, repository: _Repository) -> None:
     store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
-    repository.get_git_blob = MagicMock(return_value=SimpleNamespace(content="not-base64!"))
+    repository.requester.override = {"data": {"repository": {"b0": {"text": "not-json", "isBinary": False}}}}
 
     with pytest.raises(ContentUnavailableError, match="envelope"):
         store.list(ContentQuery(kind=ContentKind.PLAN))
 
 
-def test_line_wrapped_native_blob_is_accepted(store: _GitHubContentsStore, repository: _Repository) -> None:
+def test_binary_native_blob_fails_closed(store: _GitHubContentsStore, repository: _Repository) -> None:
     store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
-    original_get_blob = repository.get_git_blob
+    repository.requester.override = {"data": {"repository": {"b0": {"text": None, "isBinary": True}}}}
 
-    def line_wrapped_blob(sha: str) -> SimpleNamespace:
-        encoded = original_get_blob(sha).content
-        return SimpleNamespace(content="\n".join(encoded[index : index + 8] for index in range(0, len(encoded), 8)))
-
-    repository.get_git_blob = MagicMock(side_effect=line_wrapped_blob)
-
-    [record] = store.list(ContentQuery(kind=ContentKind.PLAN))
-
-    assert record.content == "body"
+    with pytest.raises(ContentUnavailableError, match="invalid or missing"):
+        store.list(ContentQuery(kind=ContentKind.PLAN))
 
 
-def test_native_blob_rejects_non_whitespace_base64_garbage(
+def test_missing_native_blob_fails_closed(store: _GitHubContentsStore, repository: _Repository) -> None:
+    store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
+    repository.requester.override = {"data": {"repository": {"b0": None}}}
+
+    with pytest.raises(ContentUnavailableError, match="invalid or missing"):
+        store.list(ContentQuery(kind=ContentKind.PLAN))
+
+
+def test_blob_batch_graphql_transport_failure_fails_closed(
     store: _GitHubContentsStore, repository: _Repository
 ) -> None:
     store.put(ContentWrite(reference=ContentRef(kind=ContentKind.PLAN, name="P1"), content="body"))
-    original_get_blob = repository.get_git_blob
-    repository.get_git_blob = MagicMock(
-        side_effect=lambda sha: SimpleNamespace(content=f"{original_get_blob(sha).content}!")
-    )
+    repository.requester.override = {"errors": [{"message": "rate limited"}]}
 
-    with pytest.raises(ContentUnavailableError, match="envelope"):
+    with pytest.raises(ContentUnavailableError, match="discovery failed"):
         store.list(ContentQuery(kind=ContentKind.PLAN))
 
 
@@ -433,6 +453,10 @@ def test_backend_native_pagination_fetches_each_blob_once(
 
     assert [record.reference.name for record in records] == ["P100"]
     assert len(repository.blob_requests) == 101
+    # Regression guard for the N+1 fix: 101 blobs must reach the server as 5
+    # batched GraphQL requests (ceil(101/_BLOB_BATCH_SIZE)=ceil(101/25)), not
+    # 101 individual round trips.
+    assert repository.requester.call_count == 5
 
 
 def test_backend_lists_native_content_when_legacy_migration_is_unavailable(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,6 +358,9 @@ max-complexity = 12
     "private-member-access",
     "too-many-public-methods",
 ]
+# GitHubContentsStore batches blob fetches via a bounded aliased GraphQL query (avoiding an N+1
+# REST call per blob) — SLF001 protocol-delegation justification matches github_backend.py above
+"**/backlog_core/backends/github_contents.py" = ["private-member-access"]
 # InMemoryBackend implements the full BacklogBackend Protocol surface — PLR0904 and DOC201 do not apply
 # DOC201 — single-line docstrings already state the return value; formal Returns sections add no information
 "**/backlog_core/backends/memory_backend.py" = [


### PR DESCRIPTION
## Summary

- `_GitHubContentsStore.list_all()`/`get_many()` fetched one Git tree (one REST call) but then called `get_git_blob(sha)` once per matching blob entry — an N+1 against the GitHub REST API that scales linearly with backlog content volume (`claude_skills-6z7`).
- Replaced with bounded aliased GraphQL queries (up to 25 blobs per request), mirroring `GitHubBackend._fetch_targeted_issues`'s existing bounded-batch precedent — N blobs now cost `ceil(N/25)` requests instead of N.
- `gh_client._graphql_request`'s `repo` parameter is widened from the concrete PyGithub `Repository` type to a minimal `_GraphQLCapable` Protocol (just `.requester.graphql_query(...)`), so `github_contents.py`'s own testable `_ContentsRepository` Protocol can satisfy it without depending on PyGithub's concrete type. A real `Repository` still satisfies it unchanged.
- GraphQL's `Blob.text` field also returns already-decoded UTF8 content directly, so the REST path's base64-decode step (and its line-wrapping-whitespace handling) is gone entirely.

## Test plan

- [x] `uv run ruff check` / `uv run ruff format` — clean
- [x] `uv run ty check` — clean
- [x] `uv run prek run --files <changed files>` — all hooks pass
- [x] `uv run pytest plugins/development-harness/tests/test_github_contents.py` — 27/27 pass, including a new regression test asserting 101 blobs across a paginated listing resolve in exactly 5 batched GraphQL requests (`ceil(101/25)`), not 101 individual round trips
- [x] Full `plugins/development-harness/tests/` + `tests_backlog/` suite run; the only failures/errors present (`test_sections_index_consistency.py`, `test_beads_models.py`, `test_artifact_provider.py`) are confirmed pre-existing via `git stash` — identical failures reproduce on clean `main` before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)