### PR TITLE
fix(agentskill-kaizen): unify trace_fitness end-check into one general rule

### DIFF
--- a/plugins/agentskill-kaizen/mcp/process_model.py
+++ b/plugins/agentskill-kaizen/mcp/process_model.py
@@ -259,23 +259,26 @@ def _walk_reference_trie(root: _TrieNode, tools: Sequence[str]) -> _TrieWalkResu
     way to guess which reference branch, if any, the trace meant to
     rejoin, so re-syncing would just be a different kind of guess.
 
-    A break that lands on the trace's final token fails two independent
-    checks at that one position -- the transition leading into it, and the
-    trace's end check -- since the trace also terminates there. That is
-    exactly the case where unmatched_positions == 1 while the walk ended
-    off-path: once a break happens, every later position is also counted
-    (see above), so unmatched_positions can only equal 1 if the break itself
-    occurred at the last token. missing_tokens counts that position twice;
-    unmatched_positions (used for consumed_tokens) still counts it once,
-    since only one token was actually produced there.
+    The end check is independent of the transition/start checks that
+    unmatched_positions already counts: it fails whenever the walk did not
+    stay on-path for its entire length AND land on a genuine reference-
+    session ending, regardless of how many earlier positions also broke.
+    A trace whose sole break lands on its final token therefore fails two
+    independent checks at that one position -- the transition leading into
+    it, and the end check -- since the trace also terminates there; a trace
+    that goes off-path earlier and never re-syncs still independently fails
+    the end check, on top of every off-path position already counted by
+    unmatched_positions. missing_tokens counts the final position (or the
+    off-path ending) up to twice; unmatched_positions (used for
+    consumed_tokens) still counts each token once, since only one token was
+    actually produced there.
 
     Returns:
-        missing_tokens: unmatched_positions, plus one more if the walk
-            stayed on-path throughout but ended at a position that isn't a
-            genuine reference-session ending, or if the sole break landed on
-            the trace's final token (see above).
+        missing_tokens: unmatched_positions, plus one more unless the walk
+            stayed on-path for its entire length and landed on a genuine
+            reference-session ending (see above).
         unmatched_positions: count of positions that failed to match the
-            reference trie (excludes both endpoint-mismatch penalties).
+            reference trie (excludes the endpoint-mismatch penalty).
     """
     node = root
     on_path = True
@@ -287,7 +290,7 @@ def _walk_reference_trie(root: _TrieNode, tools: Sequence[str]) -> _TrieWalkResu
             unmatched_positions += 1
             on_path = False
     missing_tokens = unmatched_positions
-    if (on_path and not node.is_end) or (not on_path and unmatched_positions == 1):
+    if not (on_path and node.is_end):
         missing_tokens += 1
     return _TrieWalkResult(missing_tokens=missing_tokens, unmatched_positions=unmatched_positions)
 
@@ -302,10 +305,13 @@ def _trace_fitness(missing_tokens: int, observed_transitions: Sequence[Transitio
     from a denominator that counted transitions alone. An empty trace has
     exactly one check (empty_trace_mismatch).
 
-    missing_tokens already carries the double-count for a break landing on
-    the trace's final token (transition-in check and end check both fail at
-    that one position) -- see _walk_reference_trie -- so this denominator
-    only needs the plain check count, not any further adjustment.
+    missing_tokens already carries the independent end-check penalty for any
+    walk that didn't stay on-path for its entire length and land on a
+    genuine reference-session ending -- including a double-count when that
+    failure coincides with the trace's final token (transition-in check and
+    end check both fail at that one position) -- see _walk_reference_trie --
+    so this denominator only needs the plain check count, not any further
+    adjustment.
 
     Returns:
         Fitness in [0.0, 1.0]: the fraction of checks that passed.

--- a/plugins/agentskill-kaizen/tests/test_process_model.py
+++ b/plugins/agentskill-kaizen/tests/test_process_model.py
@@ -31,10 +31,12 @@ def test_check_sequence_conformance_flags_unseen_transition() -> None:
     assert diagnostics["matching"].trace_is_fit is True
     assert diagnostics["matching"].trace_fitness == pytest.approx(1.0)
     assert diagnostics["drifted"].trace_is_fit is False
-    assert diagnostics["drifted"].missing_tokens == 2
-    # 2 of 4 checks (2 transitions + start + end) fail: both transitions are
-    # wrong, but start/end still match -- see the denominator fix below.
-    assert diagnostics["drifted"].trace_fitness == pytest.approx(0.5)
+    # 3 of 4 checks (2 transitions + start + end) fail: the start (Read)
+    # passes, but both transitions are off-path once Bash breaks the walk,
+    # and the end check independently fails too since Write is only reached
+    # by an off-path token, not a genuine on-path reference-session ending.
+    assert diagnostics["drifted"].missing_tokens == 3
+    assert diagnostics["drifted"].trace_fitness == pytest.approx(0.25)
 
 
 def test_check_sequence_conformance_partial_credit_for_a_late_deviation() -> None:
@@ -80,8 +82,12 @@ def test_check_sequence_conformance_bad_start_diverges_the_whole_trace() -> None
 
     diagnostics = result[0]
     assert diagnostics.trace_is_fit is False
-    assert diagnostics.missing_tokens == 2
-    assert diagnostics.trace_fitness == pytest.approx(1 / 3)
+    # All 3 checks fail (start + 1 transition + end): the start check fails
+    # immediately (A is never a valid reference start), and since the walk
+    # is off-path from position 0, neither the A->B transition nor the end
+    # check gets independent credit for being valid elsewhere in isolation.
+    assert diagnostics.missing_tokens == 3
+    assert diagnostics.trace_fitness == pytest.approx(0.0)
 
 
 def test_check_sequence_conformance_rejects_a_spliced_path_across_branches() -> None:


### PR DESCRIPTION
## Summary

- `_walk_reference_trie`'s `missing_tokens` bumped the end-check penalty only in the narrow case where a trace's *sole* break landed on its final token (`unmatched_positions == 1`), leaving multi-position off-path suffixes undercounted relative to the module's own stated "start check + transition checks + end check" categorical scoring model.
- Root-caused and reproduced against real code: reference `A->B->C` vs target `A->X->Y` scored `missing_tokens=2` / `trace_fitness=0.5` instead of the categorically correct `3` / `0.25` (Codex review finding on PR #2883, commit `8a7a3145`, resolves `claude_skills-zsp`).
- Replaced the two narrow bump conditions with the fully general rule: the end check independently fails whenever the walk did **not** stay on-path for its entire length **and** land on a genuine reference-session ending, regardless of how many earlier positions already broke. This is a net simplification of the condition, and preserves the trie's deliberate anti-path-splicing design (no re-sync, no independent-set credit) — only the end-check counting was inconsistent, the path-walking logic itself was already correct.

## Why option (a) — redesign, not document-as-limitation

The bd item offered two options: (a) redesign `missing_tokens` as the fully general categorical count, or (b) document the position-based model's undercounting as a known, accepted limitation. I chose (a) because:

1. The fix is a **simplification**, not added complexity — the two narrow `unmatched_positions == 1` / `on_path and not is_end` branches collapse into a single `not (on_path and node.is_end)` check.
2. `trace_is_fit` (bool) was already correct in every known case; only the continuous `trace_fitness` score's precision was at stake, and the general rule is a strict correctness improvement to that score with no new tradeoffs — there was no principled reason to keep the narrower, inconsistent rule once the simpler general one was available.
3. The PR-review cycle that produced the two narrow patches (PR #2883) was already re-deriving toward this general rule one case at a time; formalizing it now stops a fourth narrow patch from being needed for the next off-path shape someone reports.

## Test changes

Two currently-passing tests encoded the old narrow-case semantics and needed their expected values updated to the categorically-correct figures (both audited by manual trie walk-through and confirmed against the running code):

- `test_check_sequence_conformance_flags_unseen_transition` ("drifted" case): `missing_tokens` 2→3, `trace_fitness` 0.5→0.25
- `test_check_sequence_conformance_bad_start_diverges_the_whole_trace`: `missing_tokens` 2→3, `trace_fitness` 1/3→0.0

All other tests in `test_process_model.py` (including the two existing "terminal break" regression tests, the prefix-trace test, the path-splicing test, and the single-token tests) were individually walked through against the new formula and are unaffected. `test_server.py`'s `TestCheckConformance` tests don't assert exact `missing_tokens`/`trace_fitness`/`consumed_tokens` values, so none needed changes.

## Test plan

- [x] `uv run pytest plugins/agentskill-kaizen/tests/ -v --no-cov` — 74 passed
- [x] `uv run ruff check --fix` / `uv run ruff format` on changed files — clean
- [x] `uv run ty check` on changed files — clean
- [x] `uv run prek run --files <changed files>` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)