### PR TITLE
docs(agents): note no git stash on the primary checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,6 +385,7 @@ this file) was removed to avoid two files drifting out of sync.
 13. **prek stash conflict**: prek stashes unstaged changes before running hooks. If a formatter hook (ruff-format, etc.) modifies staged files and the stash cannot restore cleanly, prek rolls back the hook's changes and the commit fails ("Stashed changes conflicted..."). Fix: `git add -u` to stage the hook's auto-fixes, then retry the commit — the second attempt has nothing left to stash.
 14. **Dependency security upgrades**: use `uv add "pkg>=X.Y.Z"` (updates `pyproject.toml` and `uv.lock` atomically with explicit version output) rather than `uv lock --upgrade-package pkg` (silent) or manually verifying line numbers in `uv.lock` (4000+ lines — line numbers do not correspond reliably to package versions). Confirm with `uv tree | grep pkg`.
 15. **`.claude/` vs `docs/`**: `.claude/` is Claude Code configuration; `docs/` is project documentation. Check for an existing directory convention (`ls` the likely parent) before choosing where to create a new file.
+16. **No `git stash` on the primary checkout**: compare against a clean baseline in an isolated worktree instead — other agents may be mid-write there.
 
 ## File Locations Quick Reference
 


### PR DESCRIPTION
## Summary
- Adds a single-line gotcha to AGENTS.md: don't `git stash` on the primary checkout, even for a quick clean-baseline comparison — use an isolated worktree instead, since other agents may have in-progress writes the stash can't see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)