### PR TITLE
style(docs): apply ruff format to fenced Python code blocks

### DIFF
--- a/plugins/development-harness/backlog_core/ARCHITECTURE.md
+++ b/plugins/development-harness/backlog_core/ARCHITECTURE.md
@@ -450,14 +450,18 @@ implementation details.
   class ContentProviderError(Exception):
       """Base error for logical content capability failures."""
 
+
   class ContentUnavailableError(ContentProviderError):
       """Requested content is not available from the selected backend."""
+
 
   class ContentConflictError(ContentProviderError):
       """The expected revision no longer matches provider state."""
 
+
   class UnsupportedCapabilityError(ContentProviderError):
       """The selected backend does not implement logical content storage."""
+
 
   class ContentKind(StrEnum):
       PLAN = "plan"
@@ -465,11 +469,13 @@ implementation details.
       ARTIFACT_MANIFEST = "artifact_manifest"
       ARTIFACT_CONTENT = "artifact_content"
 
+
   class ContentRef(BaseModel):
       kind: ContentKind
       namespace: str = ""
       artifact_type: str = ""
       name: str
+
 
   class ContentQuery(BaseModel):
       kind: ContentKind
@@ -477,6 +483,7 @@ implementation details.
       search: str = ""
       offset: int = Field(default=0, ge=0)
       limit: int = Field(default=100, ge=1, le=100)
+
 
   class ContentRecord(BaseModel):
       reference: ContentRef
@@ -486,11 +493,13 @@ implementation details.
       stale: bool = False
       pending: bool = False
 
+
   class ContentWrite(BaseModel):
       reference: ContentRef
       content: str
       owner_reference: str | None = None
       expected_revision: str = ""
+
 
   @runtime_checkable
   class ContentProvider(Protocol):

--- a/research/agent-frameworks/agentscope.md
+++ b/research/agent-frameworks/agentscope.md
@@ -214,7 +214,7 @@ All agent communication is async-native:
 
 ```python
 msg = await agent(msg)  # Calling convention
-await hub.add(agent4)    # MsgHub operations
+await hub.add(agent4)  # MsgHub operations
 ```
 
 This enables concurrent multi-agent execution, realtime voice streaming, and human-in-the-loop interruption without blocking.
@@ -279,6 +279,7 @@ from agentscope.memory import InMemoryMemory
 from agentscope.tool import Toolkit, execute_python_code, execute_shell_command
 import os, asyncio
 
+
 async def main():
     toolkit = Toolkit()
     toolkit.register_tool_function(execute_python_code)
@@ -287,11 +288,7 @@ async def main():
     agent = ReActAgent(
         name="Friday",
         sys_prompt="You're a helpful assistant named Friday.",
-        model=DashScopeChatModel(
-            model_name="qwen-max",
-            api_key=os.environ["DASHSCOPE_API_KEY"],
-            stream=True,
-        ),
+        model=DashScopeChatModel(model_name="qwen-max", api_key=os.environ["DASHSCOPE_API_KEY"], stream=True),
         memory=InMemoryMemory(),
         formatter=DashScopeChatFormatter(),
         toolkit=toolkit,
@@ -305,6 +302,7 @@ async def main():
         msg = await user(msg)
         if msg.get_text_content() == "exit":
             break
+
 
 asyncio.run(main())
 ```
@@ -342,11 +340,10 @@ Fine-grained MCP control:
 from agentscope.mcp import HttpStatelessClient
 from agentscope.tool import Toolkit
 
+
 async def fine_grained_mcp_control():
     client = HttpStatelessClient(
-        name="gaode_mcp",
-        transport="streamable_http",
-        url=f"https://mcp.amap.com/mcp?key={os.environ['GAODE_API_KEY']}",
+        name="gaode_mcp", transport="streamable_http", url=f"https://mcp.amap.com/mcp?key={os.environ['GAODE_API_KEY']}"
     )
 
     # Obtain MCP tool as local callable

--- a/research/agent-frameworks/agno.md
+++ b/research/agent-frameworks/agno.md
@@ -204,15 +204,9 @@ from agno.agent import Agent
 from agno.knowledge.pdf import PDFKnowledge
 from agno.vectordb.pgvector import PgVector
 
-knowledge = PDFKnowledge(
-    path="./documents/",
-    vector_db=PgVector(table_name="documents"),
-)
+knowledge = PDFKnowledge(path="./documents/", vector_db=PgVector(table_name="documents"))
 
-agent = Agent(
-    knowledge=knowledge,
-    search_knowledge=True,
-)
+agent = Agent(knowledge=knowledge, search_knowledge=True)
 ```
 
 ---

--- a/research/agent-frameworks/google-adk.md
+++ b/research/agent-frameworks/google-adk.md
@@ -212,7 +212,7 @@ root_agent = Agent(
     model="gemini-2.5-flash",
     instruction="You are a helpful assistant. Answer user questions using Google Search when needed.",
     description="An assistant that can search the web.",
-    tools=[google_search]
+    tools=[google_search],
 )
 ```
 
@@ -221,22 +221,14 @@ root_agent = Agent(
 ```python
 from google.adk.agents import LlmAgent
 
-greeter = LlmAgent(
-    name="greeter",
-    model="gemini-2.5-flash",
-    instruction="Greet users warmly."
-)
-task_executor = LlmAgent(
-    name="task_executor",
-    model="gemini-2.5-flash",
-    instruction="Execute user tasks."
-)
+greeter = LlmAgent(name="greeter", model="gemini-2.5-flash", instruction="Greet users warmly.")
+task_executor = LlmAgent(name="task_executor", model="gemini-2.5-flash", instruction="Execute user tasks.")
 
 coordinator = LlmAgent(
     name="Coordinator",
     model="gemini-2.5-flash",
     description="I coordinate greetings and tasks.",
-    sub_agents=[greeter, task_executor]
+    sub_agents=[greeter, task_executor],
 )
 ```
 
@@ -249,11 +241,7 @@ from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 agent = LlmAgent(
     name="mcp_agent",
     model="gemini-2.5-flash",
-    tools=[
-        McpToolset(
-            connection_params={"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem"]},
-        )
-    ]
+    tools=[McpToolset(connection_params={"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem"]})],
 )
 ```
 
@@ -262,15 +250,13 @@ agent = LlmAgent(
 ```python
 from google.adk.agents import LlmAgent
 
+
 def get_weather(city: str) -> dict:
     """Get current weather for a city."""
     return {"city": city, "temperature": 22, "unit": "celsius"}
 
-agent = LlmAgent(
-    name="weather_agent",
-    model="gemini-2.5-flash",
-    tools=[get_weather]
-)
+
+agent = LlmAgent(name="weather_agent", model="gemini-2.5-flash", tools=[get_weather])
 ```
 
 ### Evaluation

--- a/research/agent-frameworks/micro-agent.md
+++ b/research/agent-frameworks/micro-agent.md
@@ -187,10 +187,15 @@ import asyncio
 from main import run_agent
 
 # task_name used for output filenames; prompt defines agent role and task
-asyncio.run(run_agent("code_analysis", """
+asyncio.run(
+    run_agent(
+        "code_analysis",
+        """
 You are a code analyst. Examine the project structure, identify main modules,
 analyze dependencies, and generate a structured report.
-"""))
+""",
+    )
+)
 # Output: visualization/code_analysis_record.json
 #         visualization/code_analysis.html
 ```

--- a/research/agent-infrastructure/trustgraph.md
+++ b/research/agent-infrastructure/trustgraph.md
@@ -295,10 +295,8 @@ from trustgraph.api import Api
 api = Api(url="http://localhost:8088/")
 
 # Execute a GraphRAG query
-response = api.flow().id("default").graph_rag(
-    query="What are the main topics?",
-    user="trustgraph",
-    collection="default"
+response = (
+    api.flow().id("default").graph_rag(query="What are the main topics?", user="trustgraph", collection="default")
 )
 
 # Use async variant for concurrent requests

--- a/research/agent-infrastructure/vibium.md
+++ b/research/agent-infrastructure/vibium.md
@@ -87,6 +87,7 @@ vibe.go('https://example.com')
 
 ```python
 from vibium.async_api import browser
+
 bro = await browser.start()
 vibe = await bro.page()
 await vibe.go("https://example.com")

--- a/research/ai-observability/compression-monitor.md
+++ b/research/ai-observability/compression-monitor.md
@@ -129,8 +129,11 @@ ghost_terms (first 30): ["schema", "immutable", "constraint", ...]
 
 ```python
 from negative_space_log import NegativeSpaceLog
+
 log = NegativeSpaceLog("agent_skips.jsonl")
-skip_id = log.log_skip(cycle_id="turn_42", option_considered="rewrite_module", criterion="time_budget_exceeded", significance="medium")
+skip_id = log.log_skip(
+    cycle_id="turn_42", option_considered="rewrite_module", criterion="time_budget_exceeded", significance="medium"
+)
 # Later, after outcome observed:
 log.log_resolution(skip_id, outcome="option_taken")
 ```
@@ -253,6 +256,7 @@ python semantic_drift.py --pre outputs_before.jsonl --post outputs_after.jsonl
 
 ```python
 from negative_space_log import NegativeSpaceLog
+
 log = NegativeSpaceLog("agent_skips.jsonl")
 skip_id = log.log_skip(cycle_id="t42", option_considered="rewrite", criterion="time_budget", significance="medium")
 # Later: log.log_resolution(skip_id, outcome="option_taken")

--- a/research/ai-observability/logfire.md
+++ b/research/ai-observability/logfire.md
@@ -195,12 +195,12 @@ logfire auth
 import logfire
 
 logfire.configure()
-logfire.info('Hello, {name}!', name='world')
+logfire.info("Hello, {name}!", name="world")
 
 # Manual spans
-with logfire.span('Processing {item}', item='data'):
+with logfire.span("Processing {item}", item="data"):
     # ... processing code ...
-    logfire.debug('Step completed')
+    logfire.debug("Step completed")
 ```
 
 ### OpenAI Instrumentation
@@ -213,10 +213,7 @@ client = openai.Client()
 logfire.configure()
 logfire.instrument_openai()
 
-response = client.chat.completions.create(
-    model='gpt-4',
-    messages=[{'role': 'user', 'content': 'Hello!'}],
-)
+response = client.chat.completions.create(model="gpt-4", messages=[{"role": "user", "content": "Hello!"}])
 ```
 
 ### Anthropic Instrumentation
@@ -231,9 +228,9 @@ logfire.instrument_anthropic()
 
 response = client.messages.create(
     max_tokens=1000,
-    model='claude-3-haiku-20240307',
-    system='You are a helpful assistant.',
-    messages=[{'role': 'user', 'content': 'Hello!'}],
+    model="claude-3-haiku-20240307",
+    system="You are a helpful assistant.",
+    messages=[{"role": "user", "content": "Hello!"}],
 )
 ```
 
@@ -260,8 +257,8 @@ import logfire
 logfire.configure()
 logfire.instrument_pydantic_ai()
 
-agent = Agent('openai:gpt-4', system_prompt='You are helpful.')
-result = agent.run_sync('Hello!')
+agent = Agent("openai:gpt-4", system_prompt="You are helpful.")
+result = agent.run_sync("Hello!")
 ```
 
 ### MCP Server Configuration (Claude Code)

--- a/research/ai-research-tools/OpenSpace.md
+++ b/research/ai-research-tools/OpenSpace.md
@@ -205,12 +205,14 @@ openspace --model "anthropic/claude-sonnet-4-5" --query "Create a monitoring das
 import asyncio
 from openspace import OpenSpace
 
+
 async def main():
     async with OpenSpace() as cs:
         result = await cs.execute("Analyze GitHub trending repos and create a report")
         print(result["response"])
         for skill in result.get("evolved_skills", []):
             print(f"  Evolved: {skill['name']} ({skill['origin']})")
+
 
 asyncio.run(main())
 ```

--- a/research/api-frameworks/fastapi.md
+++ b/research/api-frameworks/fastapi.md
@@ -198,9 +198,11 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
+
 
 @app.get("/items/{item_id}")
 def read_item(item_id: int, q: str | None = None):
@@ -228,14 +230,17 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
+
 class Item(BaseModel):
     name: str
     price: float
     is_offer: bool | None = None
 
+
 @app.post("/items/")
 def create_item(item: Item):
     return {"item_name": item.name, "price": item.price}
+
 
 @app.put("/items/{item_id}")
 def update_item(item_id: int, item: Item):
@@ -250,12 +255,14 @@ from typing import Annotated
 
 app = FastAPI()
 
+
 async def get_db():
     db = DatabaseSession()
     try:
         yield db
     finally:
         db.close()
+
 
 @app.get("/users/{user_id}")
 async def read_user(user_id: int, db: Annotated[Database, Depends(get_db)]):
@@ -272,10 +279,12 @@ from typing import Annotated
 app = FastAPI()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
+
 @app.post("/token")
 async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]):
     # Validate credentials, return JWT
     return {"access_token": token, "token_type": "bearer"}
+
 
 @app.get("/users/me")
 async def read_users_me(token: Annotated[str, Depends(oauth2_scheme)]):
@@ -290,9 +299,11 @@ from fastapi import FastAPI, BackgroundTasks
 
 app = FastAPI()
 
+
 def send_notification(email: str, message: str):
     # Send email in background
     pass
+
 
 @app.post("/notify/{email}")
 async def notify(email: str, background_tasks: BackgroundTasks):
@@ -306,6 +317,7 @@ async def notify(email: str, background_tasks: BackgroundTasks):
 from fastapi import FastAPI, WebSocket
 
 app = FastAPI()
+
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):

--- a/research/api-frameworks/motia.md
+++ b/research/api-frameworks/motia.md
@@ -180,8 +180,9 @@ config = {
     "type": "event",
     "subscribes": ["message.sent"],
     "emits": ["message.processed"],
-    "flows": ["messaging"]
+    "flows": ["messaging"],
 }
+
 
 async def handler(input_data, context):
     text = input_data.get("text")

--- a/research/api-frameworks/robyn.md
+++ b/research/api-frameworks/robyn.md
@@ -143,9 +143,11 @@ from robyn import Robyn, Request
 
 app = Robyn(__file__)
 
+
 @app.get("/")
 def h(request: Request):
     return "Hello, world"
+
 
 app.start(port=8080, host="0.0.0.0")
 ```

--- a/research/api-frameworks/tornado.md
+++ b/research/api-frameworks/tornado.md
@@ -191,19 +191,21 @@ pip install pycares
 import asyncio
 import tornado.web
 
+
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
         self.write("Hello, world")
 
+
 def make_app():
-    return tornado.web.Application([
-        (r"/", MainHandler),
-    ])
+    return tornado.web.Application([(r"/", MainHandler)])
+
 
 async def main():
     app = make_app()
     app.listen(8888)
     await asyncio.Event().wait()
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -214,6 +216,7 @@ if __name__ == "__main__":
 ```python
 import tornado.web
 import tornado.httpclient
+
 
 class AsyncHandler(tornado.web.RequestHandler):
     async def get(self):
@@ -228,6 +231,7 @@ class AsyncHandler(tornado.web.RequestHandler):
 import tornado.websocket
 import tornado.web
 
+
 class ChatHandler(tornado.websocket.WebSocketHandler):
     connections = set()
 
@@ -241,9 +245,8 @@ class ChatHandler(tornado.websocket.WebSocketHandler):
     def on_close(self):
         self.connections.discard(self)
 
-app = tornado.web.Application([
-    (r"/ws", ChatHandler),
-])
+
+app = tornado.web.Application([(r"/ws", ChatHandler)])
 ```
 
 ### Running Blocking Code
@@ -255,12 +258,11 @@ from concurrent.futures import ThreadPoolExecutor
 
 executor = ThreadPoolExecutor(max_workers=4)
 
+
 class BlockingHandler(tornado.web.RequestHandler):
     async def get(self):
         loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(
-            executor, self.blocking_operation
-        )
+        result = await loop.run_in_executor(executor, self.blocking_operation)
         self.write(result)
 
     def blocking_operation(self):
@@ -273,11 +275,10 @@ class BlockingHandler(tornado.web.RequestHandler):
 ```python
 import tornado.web
 
+
 class TemplateHandler(tornado.web.RequestHandler):
     def get(self):
-        self.render("template.html",
-                    title="My Page",
-                    items=["a", "b", "c"])
+        self.render("template.html", title="My Page", items=["a", "b", "c"])
 ```
 
 ```html

--- a/research/api-frameworks/violit.md
+++ b/research/api-frameworks/violit.md
@@ -120,8 +120,8 @@ Execution: `python app.py --native` spawns a native window (GTK on Linux, Cocoa 
 From README theme families and app initialization:
 
 ```python
-app = vl.App(theme='cyberpunk')  # Set at init
-app.set_theme('ocean')            # Change at runtime
+app = vl.App(theme="cyberpunk")  # Set at init
+app.set_theme("ocean")  # Change at runtime
 ```
 
 Theme families documented in `doc/LLM_REFERENCE.md` (lines 316-323):
@@ -169,21 +169,22 @@ The reactive foundation consists of two primary classes:
 STATIC_STORE = {}  # Static components (built once at app init)
 GLOBAL_STORE = TTLCache(maxsize=1000, ttl=1800)  # User sessions (1800s TTL)
 
+
 def get_session_store():
     sid = session_ctx.get()
     if sid is None:
         return STATIC_STORE
     if sid not in GLOBAL_STORE:
         GLOBAL_STORE[sid] = {
-            'states': {},
-            'tracker': DependencyTracker(),  # Maps state names → component IDs
-            'builders': {},
-            'actions': {},
-            'component_count': 0,
-            'fragment_components': {},
-            'order': [],
-            'sidebar_order': [],
-            'theme': Theme(initial_theme)
+            "states": {},
+            "tracker": DependencyTracker(),  # Maps state names → component IDs
+            "builders": {},
+            "actions": {},
+            "component_count": 0,
+            "fragment_components": {},
+            "order": [],
+            "sidebar_order": [],
+            "theme": Theme(initial_theme),
         }
     return GLOBAL_STORE[sid]
 ```
@@ -342,21 +343,21 @@ python app.py --reload
 **State Creation and Reactivity** (from `doc/LLM_REFERENCE.md`, lines 78-96):
 
 ```python
-count = app.state(0)           # Create with default value
+count = app.state(0)  # Create with default value
 name = app.state("", key="user_name")  # With explicit key
 
 # Reading
-count.value    # → 0
-count()        # Shorthand
+count.value  # → 0
+count()  # Shorthand
 
 # Writing
-count.set(5)       # Preferred in callbacks
-count.value = 5    # Also works
+count.set(5)  # Preferred in callbacks
+count.value = 5  # Also works
 
 # Reactivity rules:
-app.text(count)                   # ✅ Reactive (State object)
-app.text(count.value)             # ❌ Not reactive (frozen value)
-app.text("Count: " + count)       # ✅ Reactive (operator overload)
+app.text(count)  # ✅ Reactive (State object)
+app.text(count.value)  # ❌ Not reactive (frozen value)
+app.text("Count: " + count)  # ✅ Reactive (operator overload)
 app.text(lambda: f"Count: {count.value}")  # ✅ Reactive (lambda)
 ```
 
@@ -397,8 +398,8 @@ with app.sidebar:
 ```python
 # All input widgets return State objects
 name = app.text_input("Name", value="Alice")  # State[str]
-age = app.number_input("Age", value=25)        # State[int]
-tags = app.multiselect("Tags", ["A", "B"])    # State[List[str]]
+age = app.number_input("Age", value=25)  # State[int]
+tags = app.multiselect("Tags", ["A", "B"])  # State[List[str]]
 
 # Access current values in callbacks
 app.button("Greet", on_click=lambda: app.toast(f"Hello {name.value}!"))
@@ -444,6 +445,7 @@ Dash requires callback registration with `@callback` decorators specifying Input
 def update(n):
     return f"Value: {n}"
 
+
 # Violit (automatic reactivity)
 count = app.state(0)
 app.button("Click", on_click=lambda: count.set(count.value + 1))
@@ -456,7 +458,7 @@ Panel uses Param for state binding, NiceGUI uses Vue.js binding syntax. Both req
 
 ```python
 # NiceGUI (explicit binding)
-ui.label().bind_text_from(count, 'val', backward=lambda x: f'Value: {x}')
+ui.label().bind_text_from(count, "val", backward=lambda x: f"Value: {x}")
 
 # Violit (implicit reactivity)
 app.text("Value: " + count)  # No binding declaration
@@ -470,8 +472,11 @@ Reflex compiles Python to JavaScript, requiring class-based state and a build st
 # Reflex (class + compile)
 class State(rx.State):
     count: int = 0
+
     def increment(self):
         self.count += 1
+
+
 # Requires: reflex init, reflex run
 
 # Violit (pure Python, no compile)

--- a/research/async-libraries/aiomqtt.md
+++ b/research/async-libraries/aiomqtt.md
@@ -166,9 +166,11 @@ pip install git+https://github.com/empicano/aiomqtt
 import asyncio
 import aiomqtt
 
+
 async def main():
     async with aiomqtt.Client("test.mosquitto.org") as client:
         await client.publish("temperature/outside", payload=28.4)
+
 
 asyncio.run(main())
 ```
@@ -179,11 +181,13 @@ asyncio.run(main())
 import asyncio
 import aiomqtt
 
+
 async def main():
     async with aiomqtt.Client("test.mosquitto.org") as client:
         await client.subscribe("temperature/#")
         async for message in client.messages:
             print(message.payload)
+
 
 asyncio.run(main())
 ```
@@ -193,6 +197,7 @@ asyncio.run(main())
 ```python
 import asyncio
 import aiomqtt
+
 
 async def main():
     client = aiomqtt.Client("test.mosquitto.org")
@@ -207,6 +212,7 @@ async def main():
             print(f"Connection lost; Reconnecting in {interval} seconds ...")
             await asyncio.sleep(interval)
 
+
 asyncio.run(main())
 ```
 
@@ -219,14 +225,18 @@ from contextlib import asynccontextmanager
 from fastapi import Depends, FastAPI
 import aiomqtt
 
+
 async def listen(client):
     async for message in client.messages:
         print(message.payload)
 
+
 client = None
+
 
 async def get_mqtt():
     yield client
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -242,6 +252,7 @@ async def lifespan(app: FastAPI):
             await task
         except asyncio.CancelledError:
             pass
+
 
 app = FastAPI(lifespan=lifespan)
 ```

--- a/research/async-libraries/anyio.md
+++ b/research/async-libraries/anyio.md
@@ -184,15 +184,18 @@ pip install anyio[trio]
 ```python
 from anyio import run, create_task_group, sleep
 
+
 async def worker(name: str, delay: float) -> None:
     await sleep(delay)
     print(f"{name} complete")
+
 
 async def main() -> None:
     async with create_task_group() as tg:
         tg.start_soon(worker, "A", 1.0)
         tg.start_soon(worker, "B", 0.5)
     print("All workers done")
+
 
 # Run on asyncio (default)
 run(main)
@@ -210,10 +213,12 @@ run(main, backend="asyncio", backend_options={"use_uvloop": True})
 from anyio import create_task_group, create_tcp_listener, TASK_STATUS_IGNORED
 from anyio.abc import TaskStatus
 
+
 async def server(port: int, *, task_status: TaskStatus[None] = TASK_STATUS_IGNORED):
     async with await create_tcp_listener(local_port=port) as listener:
         task_status.started()  # Signal ready
         await listener.serve(handler)
+
 
 async def main():
     async with create_task_group() as tg:
@@ -225,6 +230,7 @@ async def main():
 
 ```python
 from anyio import move_on_after, sleep
+
 
 async def with_timeout():
     with move_on_after(5.0) as scope:
@@ -240,15 +246,18 @@ async def with_timeout():
 from anyio import create_task_group
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
+
 async def producer(send: MemoryObjectSendStream[int]):
     async with send:
         for i in range(10):
             await send.send(i)
 
+
 async def consumer(receive: MemoryObjectReceiveStream[int]):
     async with receive:
         async for item in receive:
             print(item)
+
 
 async def main():
     send, receive = create_memory_object_stream[int](max_buffer_size=10)

--- a/research/async-libraries/asyncssh.md
+++ b/research/async-libraries/asyncssh.md
@@ -224,8 +224,8 @@ The reverse tunnel pattern for Claude Code orchestration:
 ### SSHListener Lifecycle
 
 ```python
-async with await conn.forward_remote_port('', 0, 'localhost', 8080) as listener:
-    port = listener.get_port()   # OS-assigned dynamic port
+async with await conn.forward_remote_port("", 0, "localhost", 8080) as listener:
+    port = listener.get_port()  # OS-assigned dynamic port
     # All connections to server:port are forwarded to localhost:8080
 # listener.close() called automatically on context exit
 ```
@@ -254,15 +254,14 @@ Core dependency: `cryptography>=39.0` (PyCA).
 import asyncio
 import asyncssh
 
+
 async def run_command():
     async with asyncssh.connect(
-        'example.com',
-        username='deploy',
-        client_keys=['~/.ssh/id_ed25519'],
-        known_hosts='~/.ssh/known_hosts'
+        "example.com", username="deploy", client_keys=["~/.ssh/id_ed25519"], known_hosts="~/.ssh/known_hosts"
     ) as conn:
-        result = await conn.run('uname -a', check=True)
+        result = await conn.run("uname -a", check=True)
         print(result.stdout)
+
 
 asyncio.run(run_command())
 ```
@@ -273,31 +272,31 @@ asyncio.run(run_command())
 import asyncio
 import asyncssh
 
+
 class MySSHServer(asyncssh.SSHServer):
     def connection_made(self, conn):
-        print(f'Connection from {conn.get_extra_info("peername")}')
+        print(f"Connection from {conn.get_extra_info('peername')}")
 
     def password_auth_supported(self):
         return True
 
     def validate_password(self, username, password):
-        return username == 'agent' and password == 'secret'
+        return username == "agent" and password == "secret"
 
     def session_requested(self):
         return asyncssh.SSHServerProcess(handle_session)
 
+
 async def handle_session(process):
-    process.stdout.write('Hello from server\n')
+    process.stdout.write("Hello from server\n")
     await process.stdout.drain()
     process.exit(0)
 
+
 async def start_server():
-    await asyncssh.listen(
-        host='0.0.0.0', port=2222,
-        server_factory=MySSHServer,
-        server_host_keys=['server_key']
-    )
+    await asyncssh.listen(host="0.0.0.0", port=2222, server_factory=MySSHServer, server_host_keys=["server_key"])
     await asyncio.get_event_loop().create_future()  # run forever
+
 
 asyncio.run(start_server())
 ```
@@ -308,13 +307,15 @@ asyncio.run(start_server())
 import asyncio
 import asyncssh
 
+
 async def setup_reverse_tunnel():
-    async with asyncssh.connect('relay.example.com', username='tunnel') as conn:
+    async with asyncssh.connect("relay.example.com", username="tunnel") as conn:
         # Forward relay:8080 → local:3000
-        async with await conn.forward_remote_port('', 8080, 'localhost', 3000) as listener:
+        async with await conn.forward_remote_port("", 8080, "localhost", 3000) as listener:
             actual_port = listener.get_port()
-            print(f'Listening on relay port {actual_port}')
+            print(f"Listening on relay port {actual_port}")
             await asyncio.sleep(3600)  # hold tunnel open
+
 
 asyncio.run(setup_reverse_tunnel())
 ```
@@ -325,36 +326,38 @@ asyncio.run(setup_reverse_tunnel())
 import asyncio
 import asyncssh
 
+
 # --- On the controller (publicly reachable) ---
 async def on_agent_connected(conn: asyncssh.SSHClientConnection):
     """Called when a firewalled agent dials in."""
-    result = await conn.run('hostname')
-    print(f'Agent hostname: {result.stdout.strip()}')
+    result = await conn.run("hostname")
+    print(f"Agent hostname: {result.stdout.strip()}")
     async with await conn.start_sftp_client() as sftp:
-        await sftp.get('/remote/result.json', '/local/result.json')
+        await sftp.get("/remote/result.json", "/local/result.json")
+
 
 async def run_controller():
     acceptor = asyncssh.listen_reverse(
-        host='0.0.0.0',
+        host="0.0.0.0",
         port=9922,
         acceptor=on_agent_connected,
         options=asyncssh.SSHClientConnectionOptions(
             known_hosts=None,  # Accept any host key for demo
-            username='controller'
-        )
+            username="controller",
+        ),
     )
     async with await acceptor:
         await asyncio.get_event_loop().create_future()
 
+
 # --- On the firewalled agent ---
 async def run_agent():
     async with asyncssh.connect_reverse(
-        'controller.example.com',
+        "controller.example.com",
         9922,
         options=asyncssh.SSHServerConnectionOptions(
-            server_host_keys=['agent_host_key'],
-            authorized_client_keys='authorized_keys'
-        )
+            server_host_keys=["agent_host_key"], authorized_client_keys="authorized_keys"
+        ),
     ):
         await asyncio.get_event_loop().create_future()  # hold open
 ```
@@ -365,23 +368,25 @@ async def run_agent():
 import asyncio
 import asyncssh
 
+
 async def sftp_example():
-    async with asyncssh.connect('fileserver.example.com', username='deploy') as conn:
+    async with asyncssh.connect("fileserver.example.com", username="deploy") as conn:
         async with await conn.start_sftp_client() as sftp:
             # Upload
-            await sftp.put('local_file.txt', '/remote/path/file.txt')
+            await sftp.put("local_file.txt", "/remote/path/file.txt")
 
             # Download
-            await sftp.get('/remote/path/result.json', 'local_result.json')
+            await sftp.get("/remote/path/result.json", "local_result.json")
 
             # Directory operations
-            await sftp.makedirs('/remote/new/nested/dir')
-            files = await sftp.listdir('/remote/path')
+            await sftp.makedirs("/remote/new/nested/dir")
+            files = await sftp.listdir("/remote/path")
             print(files)
 
             # Metadata
-            attrs = await sftp.stat('/remote/path/file.txt')
-            print(f'Size: {attrs.size}')
+            attrs = await sftp.stat("/remote/path/file.txt")
+            print(f"Size: {attrs.size}")
+
 
 asyncio.run(sftp_example())
 ```
@@ -392,16 +397,18 @@ asyncio.run(sftp_example())
 import asyncio
 import asyncssh
 
+
 async def jump_host():
     # Connect to bastion, then tunnel to internal host through it
-    async with asyncssh.connect('bastion.corp.com', username='user') as bastion:
+    async with asyncssh.connect("bastion.corp.com", username="user") as bastion:
         async with asyncssh.connect(
-            '10.0.1.50',        # internal host, not internet-reachable
-            username='deploy',
-            tunnel=bastion      # route through bastion connection
+            "10.0.1.50",  # internal host, not internet-reachable
+            username="deploy",
+            tunnel=bastion,  # route through bastion connection
         ) as internal:
-            result = await internal.run('ls /var/app')
+            result = await internal.run("ls /var/app")
             print(result.stdout)
+
 
 asyncio.run(jump_host())
 ```
@@ -412,15 +419,15 @@ asyncio.run(jump_host())
 import asyncssh
 
 # Generate Ed25519 key
-key = asyncssh.generate_private_key('ssh-ed25519', comment='agent-key')
-key.write_private_key('agent_key')
-key.write_public_key('agent_key.pub')
+key = asyncssh.generate_private_key("ssh-ed25519", comment="agent-key")
+key.write_private_key("agent_key")
+key.write_public_key("agent_key.pub")
 
 # Generate RSA 4096-bit key
-rsa_key = asyncssh.generate_private_key('ssh-rsa', key_size=4096)
+rsa_key = asyncssh.generate_private_key("ssh-rsa", key_size=4096)
 
 # Import existing key from string/bytes
-imported = asyncssh.import_private_key(open('~/.ssh/id_ed25519').read())
+imported = asyncssh.import_private_key(open("~/.ssh/id_ed25519").read())
 ```
 
 ---

--- a/research/async-libraries/trio.md
+++ b/research/async-libraries/trio.md
@@ -170,8 +170,10 @@ conda install -c conda-forge trio
 ```python
 import trio
 
+
 async def main():
     print("Hello from Trio!")
+
 
 trio.run(main)
 ```
@@ -181,10 +183,12 @@ trio.run(main)
 ```python
 import trio
 
+
 async def fetch_page(url):
     print(f"Fetching {url}")
     await trio.sleep(1)  # Simulate I/O
     print(f"Done with {url}")
+
 
 async def main():
     async with trio.open_nursery() as nursery:
@@ -194,6 +198,7 @@ async def main():
     # All three fetches complete before reaching here
     print("All pages fetched!")
 
+
 trio.run(main)
 ```
 
@@ -202,9 +207,11 @@ trio.run(main)
 ```python
 import trio
 
+
 async def slow_operation():
     await trio.sleep(10)
     return "completed"
+
 
 async def main():
     with trio.move_on_after(5) as cancel_scope:
@@ -214,6 +221,7 @@ async def main():
     if cancel_scope.cancelled_caught:
         print("Operation timed out after 5 seconds")
 
+
 trio.run(main)
 ```
 
@@ -222,12 +230,15 @@ trio.run(main)
 ```python
 import trio
 
+
 async def echo_server(server_stream):
     async for data in server_stream:
         await server_stream.send_all(data)
 
+
 async def main():
     await trio.serve_tcp(echo_server, 8000)
+
 
 trio.run(main)
 ```
@@ -237,21 +248,25 @@ trio.run(main)
 ```python
 import trio
 
+
 async def producer(send_channel):
     async with send_channel:
         for i in range(10):
             await send_channel.send(i)
+
 
 async def consumer(receive_channel):
     async with receive_channel:
         async for value in receive_channel:
             print(f"Received: {value}")
 
+
 async def main():
     send_channel, receive_channel = trio.open_memory_channel(0)
     async with trio.open_nursery() as nursery:
         nursery.start_soon(producer, send_channel)
         nursery.start_soon(consumer, receive_channel)
+
 
 trio.run(main)
 ```

--- a/research/code-auditing/rope.md
+++ b/research/code-auditing/rope.md
@@ -200,14 +200,14 @@ from rope.base.project import Project
 from rope.refactor.rename import Rename
 
 # Initialize project from filesystem
-project = Project('.')
+project = Project(".")
 
 # Get a Python module
-mod = project.get_file('mymodule.py')
+mod = project.get_file("mymodule.py")
 
 # Perform rename refactoring
 renamer = Rename(project, mod, offset=42)  # offset = char position of symbol
-changes = renamer.get_changes('new_name')  # Generate change set
+changes = renamer.get_changes("new_name")  # Generate change set
 
 # Apply changes atomically
 project.do(changes)
@@ -230,8 +230,8 @@ SOURCE: README.rst "How to use Rope in my IDE or Text editor?" link, rope/refact
 ```python
 # rope configuration
 set_prefer_modern_dialect = True
-python_path = ['src', 'vendor']
-ignored_resources = ['*.pyc', '__pycache__', '.git']
+python_path = ["src", "vendor"]
+ignored_resources = ["*.pyc", "__pycache__", ".git"]
 ```
 
 SOURCE: rope/base/prefs.py behavior (accessed 2026-03-29)

--- a/research/coding-agents/openhands.md
+++ b/research/coding-agents/openhands.md
@@ -110,10 +110,7 @@ The core Python library powering all OpenHands products.
 from openhands import Agent, Tool
 
 # Define custom agent
-agent = Agent(
-    model="claude-3-5-sonnet",
-    tools=[Tool.bash, Tool.file_edit, Tool.web_browse]
-)
+agent = Agent(model="claude-3-5-sonnet", tools=[Tool.bash, Tool.file_edit, Tool.web_browse])
 
 # Run on code task
 result = agent.run("Fix the authentication bug in login.py")

--- a/research/context-management/jina-ai.md
+++ b/research/context-management/jina-ai.md
@@ -140,15 +140,9 @@ curl https://api.jina.ai/v1/embeddings \
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    api_key="<YOUR_JINA_API_KEY>",
-    base_url="https://api.jina.ai/v1"
-)
+client = OpenAI(api_key="<YOUR_JINA_API_KEY>", base_url="https://api.jina.ai/v1")
 
-response = client.embeddings.create(
-    model="jina-embeddings-v3",
-    input=["Your text here"]
-)
+response = client.embeddings.create(model="jina-embeddings-v3", input=["Your text here"])
 ```
 
 ### Reranker API

--- a/research/context-management/mempalace.md
+++ b/research/context-management/mempalace.md
@@ -145,6 +145,7 @@ MemPalace includes a temporal entity-relationship graph for tracking facts with 
 
 ```python
 from mempalace.knowledge_graph import KnowledgeGraph
+
 kg = KnowledgeGraph()
 kg.add_triple("Kai", "works_on", "Orion", valid_from="2025-06-01")
 kg.invalidate("Kai", "works_on", "Orion", ended="2026-03-01")

--- a/research/context-management/microsoft-graphrag.md
+++ b/research/context-management/microsoft-graphrag.md
@@ -179,16 +179,10 @@ from graphrag.api import build_index, local_search, global_search
 await build_index(root="./graphrag_project")
 
 # Local search for entity questions
-result = await local_search(
-    root="./graphrag_project",
-    query="What are the healing properties of chamomile?"
-)
+result = await local_search(root="./graphrag_project", query="What are the healing properties of chamomile?")
 
 # Global search for thematic questions
-result = await global_search(
-    root="./graphrag_project",
-    query="What are the main themes across all documents?"
-)
+result = await global_search(root="./graphrag_project", query="What are the main themes across all documents?")
 ```
 
 ### Azure OpenAI Configuration

--- a/research/context-management/simplemem-cross.md
+++ b/research/context-management/simplemem-cross.md
@@ -202,14 +202,14 @@ This compositional architecture ensures SimpleMem's core algorithm (semantic str
 import asyncio
 from cross.orchestrator import create_orchestrator
 
+
 async def main():
     # Create orchestrator
     orch = create_orchestrator(project="my-project")
 
     # Start session with automatic context injection
     result = await orch.start_session(
-        content_session_id="session-001",
-        user_prompt="Continue building the REST API authentication",
+        content_session_id="session-001", user_prompt="Continue building the REST API authentication"
     )
     memory_session_id = result["memory_session_id"]
     print(result["context"])  # Previous context automatically injected
@@ -217,10 +217,7 @@ async def main():
     # Record events during session
     await orch.record_message(memory_session_id, "User asked about JWT auth")
     await orch.record_tool_use(
-        memory_session_id,
-        tool_name="read_file",
-        tool_input="auth/jwt.py",
-        tool_output="class JWTHandler: ...",
+        memory_session_id, tool_name="read_file", tool_input="auth/jwt.py", tool_output="class JWTHandler: ..."
     )
 
     # Finalize and persist observations
@@ -229,6 +226,7 @@ async def main():
 
     await orch.end_session(memory_session_id)
     orch.close()
+
 
 asyncio.run(main())
 ```
@@ -265,11 +263,11 @@ FastAPI REST server with 8 endpoints:
 
 ```python
 orch = create_orchestrator(
-    project="my-project",          # Project identifier
-    tenant_id="team-alpha",        # Multi-tenant isolation
+    project="my-project",  # Project identifier
+    tenant_id="team-alpha",  # Multi-tenant isolation
     db_path="~/.simplemem-cross/cross_memory.db",  # SQLite location
     lancedb_path="~/.simplemem-cross/lancedb_cross",  # Vector DB location
-    max_context_tokens=2000,       # Token budget for injection
+    max_context_tokens=2000,  # Token budget for injection
 )
 ```
 

--- a/research/data-infrastructure/chroma.md
+++ b/research/data-infrastructure/chroma.md
@@ -55,17 +55,11 @@ From README: "The core API is only 4 functions" — `create_collection()`, `add(
 
 ```python
 import chromadb
+
 client = chromadb.Client()
 collection = client.create_collection("all-my-documents")
-collection.add(
-    documents=["This is document1"],
-    metadatas=[{"source": "notion"}],
-    ids=["doc1"]
-)
-results = collection.query(
-    query_texts=["This is a query"],
-    n_results=2
-)
+collection.add(documents=["This is document1"], metadatas=[{"source": "notion"}], ids=["doc1"])
+results = collection.query(query_texts=["This is a query"], n_results=2)
 ```
 
 ### 2. Automatic Embedding

--- a/research/data-infrastructure/cocoindex.md
+++ b/research/data-infrastructure/cocoindex.md
@@ -135,15 +135,11 @@ pip install -U cocoindex
 ```python
 import cocoindex
 
+
 @cocoindex.flow_def(name="TextEmbedding")
-def text_embedding_flow(
-    flow_builder: cocoindex.FlowBuilder,
-    data_scope: cocoindex.DataScope,
-):
+def text_embedding_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
     # 1. Add a data source
-    data_scope["documents"] = flow_builder.add_source(
-        cocoindex.sources.LocalFile(path="markdown_files")
-    )
+    data_scope["documents"] = flow_builder.add_source(cocoindex.sources.LocalFile(path="markdown_files"))
 
     # 2. Add a collector for vector index output
     doc_embeddings = data_scope.add_collector()
@@ -152,23 +148,15 @@ def text_embedding_flow(
     with data_scope["documents"].row() as doc:
         # Split into chunks
         doc["chunks"] = doc["content"].transform(
-            cocoindex.functions.SplitRecursively(),
-            language="markdown",
-            chunk_size=2000,
-            chunk_overlap=500,
+            cocoindex.functions.SplitRecursively(), language="markdown", chunk_size=2000, chunk_overlap=500
         )
         with doc["chunks"].row() as chunk:
             # Embed each chunk
             chunk["embedding"] = chunk["text"].transform(
-                cocoindex.functions.SentenceTransformerEmbed(
-                    model="sentence-transformers/all-MiniLM-L6-v2"
-                )
+                cocoindex.functions.SentenceTransformerEmbed(model="sentence-transformers/all-MiniLM-L6-v2")
             )
             doc_embeddings.collect(
-                filename=doc["filename"],
-                location=chunk["location"],
-                text=chunk["text"],
-                embedding=chunk["embedding"],
+                filename=doc["filename"], location=chunk["location"], text=chunk["text"], embedding=chunk["embedding"]
             )
 
     # 4. Export to Postgres vector index
@@ -177,10 +165,7 @@ def text_embedding_flow(
         cocoindex.targets.Postgres(),
         primary_key_fields=["filename", "location"],
         vector_indexes=[
-            cocoindex.VectorIndexDef(
-                field_name="embedding",
-                metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY,
-            )
+            cocoindex.VectorIndexDef(field_name="embedding", metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY)
         ],
     )
 ```

--- a/research/data-infrastructure/dolt.md
+++ b/research/data-infrastructure/dolt.md
@@ -315,13 +315,7 @@ The recommended Python approach is to use any MySQL client library against a run
 import mysql.connector
 
 # Connect to Dolt like any MySQL database
-conn = mysql.connector.connect(
-    host="127.0.0.1",
-    port=3306,
-    user="root",
-    password="",
-    database="myapp"
-)
+conn = mysql.connector.connect(host="127.0.0.1", port=3306, user="root", password="", database="myapp")
 cursor = conn.cursor()
 
 # Version control operations via stored procedures
@@ -347,10 +341,10 @@ pip install doltpy
 from doltpy.cli import Dolt
 
 # CLI-wrapper approach (wraps dolt binary)
-db = Dolt.init('/path/to/mydb')
+db = Dolt.init("/path/to/mydb")
 db.sql("INSERT INTO tasks VALUES (...)")
-db.add('tasks')
-db.commit(message='Add task via Python')
+db.add("tasks")
+db.commit(message="Add task via Python")
 ```
 
 Note: doltpy is in low-maintenance mode as of 2024. New projects should use `mysql.connector`, `pymysql`, or `sqlalchemy` with `dolt sql-server`.

--- a/research/data-infrastructure/helix-db.md
+++ b/research/data-infrastructure/helix-db.md
@@ -284,16 +284,10 @@ pip install helix-db  # or: pip install -e sdks/python
 from helixdb import Client, Predicate, g, param, define_params, read_batch, write_batch
 
 add_user_params = define_params({"name": param.string()})
-add_user = (
-    write_batch()
-    .var_as("user", g().add_n("User", {"name": add_user_params.name}))
-    .returning(["user"])
-)
+add_user = write_batch().var_as("user", g().add_n("User", {"name": add_user_params.name})).returning(["user"])
 
 client = Client("http://localhost:6969")
-new_user = client.query().dynamic(
-    add_user.to_dynamic_request(add_user_params, {"name": "John Doe"})
-).send()
+new_user = client.query().dynamic(add_user.to_dynamic_request(add_user_params, {"name": "John Doe"})).send()
 print("new user:", new_user)
 ```
 

--- a/research/data-infrastructure/honker.md
+++ b/research/data-infrastructure/honker.md
@@ -134,8 +134,8 @@ Jobs, events, and notifications are INSERTs into caller's open transaction:
 
 ```python
 with db.transaction() as tx:
-    tx.execute("INSERT INTO orders (user_id) VALUES (?)", [42])           # business write
-    queue.enqueue({"to": "alice@example.com"}, tx=tx)                     # enqueue in same tx
+    tx.execute("INSERT INTO orders (user_id) VALUES (?)", [42])  # business write
+    queue.enqueue({"to": "alice@example.com"}, tx=tx)  # enqueue in same tx
     # COMMIT: both rows committed, or neither
     # ROLLBACK: both dropped
 ```
@@ -186,6 +186,7 @@ Task decorators:
 def send_email(to: str, subject: str) -> dict:
     ...
     return {"sent_at": time.time()}
+
 
 # Caller
 r = send_email("alice@example.com", "Hi")
@@ -282,16 +283,20 @@ from sqlalchemy import event, create_engine, text
 
 engine = create_engine("sqlite:///app.db")
 
+
 @event.listens_for(engine, "connect")
 def _load_honker(conn, _):
     conn.enable_load_extension(True)
     conn.load_extension("/path/to/libhonker_ext")
     conn.execute("SELECT honker_bootstrap()")
 
+
 with Session(engine) as s, s.begin():
     s.add(Order(user_id=42))
-    s.execute(text("SELECT honker_enqueue(:q, :p, NULL, NULL, 0, 3, NULL)"),
-              {"q": "emails", "p": '{"to":"alice@example.com"}'})
+    s.execute(
+        text("SELECT honker_enqueue(:q, :p, NULL, NULL, 0, 3, NULL)"),
+        {"q": "emails", "p": '{"to":"alice@example.com"}'},
+    )
 
 # Workers run as separate process
 # honker.open("app.db")

--- a/research/data-infrastructure/motherduck.md
+++ b/research/data-infrastructure/motherduck.md
@@ -121,13 +121,13 @@ uvx mcp-server-motherduck  # or: pip install mcp-server-motherduck
 import duckdb
 
 # Browser-based auth (interactive sessions)
-con = duckdb.connect('md:')
+con = duckdb.connect("md:")
 
 # Token-based auth (automated scripts / CI)
-con = duckdb.connect('md:?motherduck_token=<your_token>')
+con = duckdb.connect("md:?motherduck_token=<your_token>")
 
 # Connect to a specific database
-con = duckdb.connect('md:my_db')
+con = duckdb.connect("md:my_db")
 
 # Dual Execution: join local file with cloud table
 con.sql("ATTACH 'md:my_db'")

--- a/research/data-infrastructure/pandera.md
+++ b/research/data-infrastructure/pandera.md
@@ -132,14 +132,10 @@ from pandera import Column, DataFrameSchema
 schema = DataFrameSchema({
     "column1": Column(int, checks=pa.Check.gt(0)),
     "column2": Column(str),
-    "column3": Column(float, nullable=True)
+    "column3": Column(float, nullable=True),
 })
 
-df = pd.DataFrame({
-    "column1": [1, 2, 3],
-    "column2": ["a", "b", "c"],
-    "column3": [1.5, 2.5, None]
-})
+df = pd.DataFrame({"column1": [1, 2, 3], "column2": ["a", "b", "c"], "column3": [1.5, 2.5, None]})
 
 validated_df = schema.validate(df)
 ```
@@ -150,6 +146,7 @@ validated_df = schema.validate(df)
 import pandera as pa
 from pandera.typing import Series
 
+
 class MySchema(pa.DataFrameModel):
     column1: int = pa.Field(gt=0)
     column2: str
@@ -157,6 +154,7 @@ class MySchema(pa.DataFrameModel):
 
     class Config:
         strict = True
+
 
 validated_df = MySchema.validate(df)
 ```
@@ -166,6 +164,7 @@ validated_df = MySchema.validate(df)
 ```python
 import pytest
 from hypothesis import given
+
 
 @given(MySchema.strategy(size=10))
 def test_data_processing_function(df):
@@ -179,11 +178,14 @@ def test_data_processing_function(df):
 from fastapi import FastAPI, UploadFile
 from pandera.typing.fastapi import UploadFile as PanderaUploadFile
 
+
 class MySchema(pa.DataFrameModel):
     column1: int
     column2: str
 
+
 app = FastAPI()
+
 
 @app.post("/validate")
 async def validate_data(file: PanderaUploadFile[MySchema]):

--- a/research/data-infrastructure/polars-documentation.md
+++ b/research/data-infrastructure/polars-documentation.md
@@ -93,10 +93,7 @@ The core query engine is implemented in Rust, providing:
 Polars offers "Lazy & eager execution: with query optimization out of the box" (SOURCE: <https://github.com/pola-rs/polars> README, accessed 2026-08-11). The eager `DataFrame` API executes operations immediately; the lazy `LazyFrame` API (entered via `scan_*` readers or `.lazy()`) defers execution until `.collect()` so the optimizer can rewrite the plan. The API emphasizes method chaining and expression-based operations:
 
 ```python
-df.select([
-    pl.col("column_name").cast(pl.Float64),
-    (pl.col("amount") * 1.10).alias("increased_amount")
-])
+df.select([pl.col("column_name").cast(pl.Float64), (pl.col("amount") * 1.10).alias("increased_amount")])
 ```
 
 ---
@@ -126,13 +123,7 @@ import polars as pl
 df = pl.read_csv("data.csv")
 
 # Filter and select
-result = df.filter(
-    pl.col("age") > 25
-).select([
-    "name",
-    "salary",
-    (pl.col("salary") * 1.1).alias("projected_salary")
-])
+result = df.filter(pl.col("age") > 25).select(["name", "salary", (pl.col("salary") * 1.1).alias("projected_salary")])
 
 print(result)
 ```

--- a/research/database-libraries/duckdb-python-client.md
+++ b/research/database-libraries/duckdb-python-client.md
@@ -62,6 +62,7 @@ The Python client exposes two primary entry points:
 
 ```python
 import duckdb
+
 duckdb.sql("SELECT 42").show()
 ```
 
@@ -70,7 +71,7 @@ Executes queries on an in-memory database stored globally within the Python modu
 **Persistent database connections** (via `duckdb.connect()`):
 
 ```python
-conn = duckdb.connect('my_database.duckdb')
+conn = duckdb.connect("my_database.duckdb")
 result = conn.execute("SELECT * FROM my_table").fetchall()
 ```
 
@@ -100,6 +101,7 @@ The `@duckdb.create_function` decorator allows users to define custom functions 
 @duckdb.create_function
 def my_custom_function(x):
     return x * 2
+
 
 conn.execute("SELECT my_custom_function(10)").fetchall()
 ```
@@ -215,7 +217,7 @@ duckdb.sql("SELECT 42 AS answer").show()
 **2. Persistent database:**
 
 ```python
-conn = duckdb.connect('my_database.duckdb')
+conn = duckdb.connect("my_database.duckdb")
 conn.execute("CREATE TABLE numbers (id INTEGER, value DOUBLE)")
 conn.execute("INSERT INTO numbers VALUES (1, 3.14), (2, 2.71)")
 conn.execute("SELECT * FROM numbers WHERE value > 3").show()
@@ -234,9 +236,7 @@ print(result)
 **4. Reading remote Parquet files:**
 
 ```python
-result = duckdb.sql(
-    "SELECT COUNT(*) FROM 's3://my-bucket/data.parquet'"
-)
+result = duckdb.sql("SELECT COUNT(*) FROM 's3://my-bucket/data.parquet'")
 ```
 
 **5. User-defined function:**
@@ -245,6 +245,7 @@ result = duckdb.sql(
 @duckdb.create_function
 def double(x):
     return x * 2
+
 
 duckdb.sql("SELECT double(5)").show()
 ```
@@ -271,11 +272,7 @@ Common connection parameters:
 - `timeout=30000`: Query timeout in milliseconds
 
 ```python
-conn = duckdb.connect(
-    'my_db.duckdb',
-    read_only=False,
-    config={'memory_limit': '2GB', 'threads': 8}
-)
+conn = duckdb.connect("my_db.duckdb", read_only=False, config={"memory_limit": "2GB", "threads": 8})
 ```
 
 ---
@@ -334,7 +331,7 @@ Claude Code workflows can use DuckDB's in-memory mode for:
 Agents can build validation pipelines:
 
 ```python
-conn = duckdb.connect(':memory:')
+conn = duckdb.connect(":memory:")
 conn.execute("CREATE TABLE raw_data AS SELECT * FROM 'input.csv'")
 conn.execute("SELECT COUNT(*) FROM raw_data WHERE id IS NULL")  # null checks
 ```

--- a/research/developer-tools/google-ai-studio.md
+++ b/research/developer-tools/google-ai-studio.md
@@ -144,10 +144,7 @@ from google import genai
 
 client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 
-response = client.models.generate_content(
-    model="gemini-2.5-flash",
-    contents="Explain how AI works in a few words",
-)
+response = client.models.generate_content(model="gemini-2.5-flash", contents="Explain how AI works in a few words")
 print(response.text)
 ```
 
@@ -157,13 +154,11 @@ print(response.text)
 from openai import OpenAI
 
 client = OpenAI(
-    api_key=os.environ["GEMINI_API_KEY"],
-    base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+    api_key=os.environ["GEMINI_API_KEY"], base_url="https://generativelanguage.googleapis.com/v1beta/openai/"
 )
 
 response = client.chat.completions.create(
-    model="gemini-2.5-flash",
-    messages=[{"role": "user", "content": "Explain how AI works"}],
+    model="gemini-2.5-flash", messages=[{"role": "user", "content": "Explain how AI works"}]
 )
 print(response.choices[0].message.content)
 ```
@@ -179,9 +174,7 @@ client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 response = client.models.generate_content(
     model="gemini-2.5-flash",
     contents="What are the latest AI news today?",
-    config=types.GenerateContentConfig(
-        tools=[types.Tool(google_search=types.GoogleSearch())]
-    ),
+    config=types.GenerateContentConfig(tools=[types.Tool(google_search=types.GoogleSearch())]),
 )
 print(response.text)
 ```

--- a/research/developer-tools/jina-reader.md
+++ b/research/developer-tools/jina-reader.md
@@ -165,19 +165,13 @@ curl -H 'Accept: application/json' 'https://s.jina.ai/What%20is%20Claude%20Code%
 import httpx
 
 # Read a URL
-response = httpx.get(
-    f"https://r.jina.ai/{url}",
-    headers={"Authorization": "Bearer <YOUR_JINA_API_KEY>"}
-)
+response = httpx.get(f"https://r.jina.ai/{url}", headers={"Authorization": "Bearer <YOUR_JINA_API_KEY>"})
 markdown_content = response.text
 
 # Search the web
 response = httpx.get(
     "https://s.jina.ai/claude+code+plugins",
-    headers={
-        "Accept": "application/json",
-        "Authorization": "Bearer <YOUR_JINA_API_KEY>"
-    }
+    headers={"Accept": "application/json", "Authorization": "Bearer <YOUR_JINA_API_KEY>"},
 )
 results = response.json()  # list of {title, content, url}
 ```

--- a/research/developer-tools/libtmux.md
+++ b/research/developer-tools/libtmux.md
@@ -66,14 +66,15 @@ The tmux hierarchy maps exactly to Python classes, each a dataclass with live st
 ```python
 import libtmux
 
-server = libtmux.Server()                          # connects to default tmux socket
-server = libtmux.Server(socket_name="my-server")   # isolated socket
+server = libtmux.Server()  # connects to default tmux socket
+server = libtmux.Server(socket_name="my-server")  # isolated socket
 
 session: libtmux.Session = server.new_session(
     session_name="dev",
     start_directory="/home/user/project",
-    attach=False,                                   # background, no attach
-    x=220, y=50,                                   # explicit dimensions for headless
+    attach=False,  # background, no attach
+    x=220,
+    y=50,  # explicit dimensions for headless
 )
 window: libtmux.Window = session.new_window(window_name="editor", attach=False)
 pane: libtmux.Pane = window.split(direction=libtmux.PaneDirection.Below, shell="bash")
@@ -86,12 +87,12 @@ SOURCE: [libtmux README](https://raw.githubusercontent.com/tmux-python/libtmux/m
 ### Pane.send_keys — Keystroke Injection
 
 ```python
-pane.send_keys("echo 'hello world'")           # sends text + Enter
-pane.send_keys("echo hey", enter=False)        # sends text without Enter
-pane.send_keys("q", literal=True)             # sends literal key, not tmux key binding
-pane.enter()                                   # sends Enter alone
-pane.clear()                                   # sends Ctrl-L (clear screen)
-pane.reset()                                   # sends 'reset' command
+pane.send_keys("echo 'hello world'")  # sends text + Enter
+pane.send_keys("echo hey", enter=False)  # sends text without Enter
+pane.send_keys("q", literal=True)  # sends literal key, not tmux key binding
+pane.enter()  # sends Enter alone
+pane.clear()  # sends Ctrl-L (clear screen)
+pane.reset()  # sends 'reset' command
 ```
 
 `suppress_history=True` prepends a space to avoid writing to shell history (default: False since v0.14).
@@ -129,6 +130,7 @@ new_pane = window.split()
 
 # Split with direction
 from libtmux.constants import PaneDirection
+
 right_pane = window.split(direction=PaneDirection.Right)
 
 # Split with specific size (percentage or cells)
@@ -139,10 +141,7 @@ pane = window.split(size=20)
 pane = window.split(shell="python3 -m http.server 8080")
 
 # Split with working directory and environment
-pane = window.split(
-    start_directory="/home/user/project",
-    environment={"VIRTUAL_ENV": "/home/user/.venv"}
-)
+pane = window.split(start_directory="/home/user/project", environment={"VIRTUAL_ENV": "/home/user/.venv"})
 ```
 
 SOURCE: [src/libtmux/pane.py split](https://raw.githubusercontent.com/tmux-python/libtmux/master/src/libtmux/pane.py) (accessed 2026-03-01)
@@ -166,9 +165,9 @@ active_pane = window.active_pane
 active_window = session.active_window
 
 # Traverse hierarchy bidirectionally
-pane.window        # Window containing this pane
-pane.session       # Session containing this pane
-window.session     # Session containing this window
+pane.window  # Window containing this pane
+pane.session  # Session containing this pane
+window.session  # Session containing this window
 ```
 
 Supported lookup operators: exact (default), `__startswith`, `__endswith`, `__contains`, `__regex`, `__icontains`, `__in`.
@@ -208,8 +207,8 @@ session.cmd("send-keys", "-t", f"{session.name}:0", "ls", "Enter")
 
 # On Pane
 result = pane.cmd("capture-pane", "-p")
-print(result.stdout)   # list[str]
-print(result.stderr)   # list[str]
+print(result.stdout)  # list[str]
+print(result.stderr)  # list[str]
 ```
 
 `.cmd()` properly passes the socket name/path so commands always target the correct tmux server.
@@ -241,6 +240,7 @@ Register by installing libtmux; fixtures are auto-discovered via the `Framework 
 from libtmux.server import Server
 from libtmux.session import Session
 
+
 def test_tool_creates_windows(session: Session) -> None:
     """Receives a fresh, isolated tmux session."""
     window = session.new_window(window_name="test-window")
@@ -250,6 +250,7 @@ def test_tool_creates_windows(session: Session) -> None:
     lines = pane.capture_pane()
     assert any("test output" in line for line in lines)
     # Cleanup is automatic — session and server torn down after test
+
 
 def test_multi_server(server: Server) -> None:
     """Receives a fresh tmux server on an isolated socket."""
@@ -265,13 +266,13 @@ SOURCE: [src/libtmux/pytest_plugin.py](https://raw.githubusercontent.com/tmux-py
 ### Pane Position Introspection
 
 ```python
-pane.at_top     # bool — pane is at top edge of window
+pane.at_top  # bool — pane is at top edge of window
 pane.at_bottom  # bool — pane is at bottom edge of window
-pane.at_left    # bool — pane is at left edge of window
-pane.at_right   # bool — pane is at right edge of window
-pane.height     # str — height in rows
-pane.width      # str — columns
-pane.index      # str — pane index within window
+pane.at_left  # bool — pane is at left edge of window
+pane.at_right  # bool — pane is at right edge of window
+pane.height  # str — height in rows
+pane.width  # str — columns
+pane.index  # str — pane index within window
 ```
 
 SOURCE: [src/libtmux/pane.py properties](https://raw.githubusercontent.com/tmux-python/libtmux/master/src/libtmux/pane.py) (accessed 2026-03-01)
@@ -343,10 +344,10 @@ SOURCE: [src/libtmux/exc.py](https://raw.githubusercontent.com/tmux-python/libtm
 ```python
 from libtmux.common import get_version, has_version, has_gt_version
 
-get_version()           # LooseVersion of running tmux binary
-has_version("3.2")      # bool — exact match
-has_gt_version("3.0")   # bool — strictly greater
-has_gte_version("3.2a") # bool — greater or equal
+get_version()  # LooseVersion of running tmux binary
+has_version("3.2")  # bool — exact match
+has_gt_version("3.0")  # bool — strictly greater
+has_gte_version("3.2a")  # bool — greater or equal
 ```
 
 ---
@@ -385,13 +386,7 @@ from libtmux.constants import PaneDirection
 server = libtmux.Server(socket_name="claude-agent")
 
 # Create a session with explicit dimensions (needed in headless/TTY-less environments)
-session = server.new_session(
-    session_name="workspace",
-    start_directory="/home/user/project",
-    attach=False,
-    x=220,
-    y=50,
-)
+session = server.new_session(session_name="workspace", start_directory="/home/user/project", attach=False, x=220, y=50)
 
 # Get the initial window and pane
 window = session.active_window
@@ -406,6 +401,7 @@ main_pane.send_keys("python run_agent.py --task build")
 
 # Capture output from monitor pane
 import time
+
 time.sleep(2)  # wait for command to produce output
 output_lines = monitor_pane.capture_pane(start=-100, end="-")
 errors = [line for line in output_lines if "ERROR" in line]
@@ -426,8 +422,8 @@ server = libtmux.Server(socket_name="headless-test")
 session = server.new_session(
     session_name="ci-run",
     attach=False,
-    x=200,   # explicit width required without TTY
-    y=50,    # explicit height required without TTY
+    x=200,  # explicit width required without TTY
+    y=50,  # explicit height required without TTY
 )
 ```
 
@@ -437,11 +433,7 @@ Without `x`/`y`, tmux in headless mode may default to 80x24 or fail to start. Th
 
 ```python
 # Pass environment variables to new sessions/panes
-session = server.new_session(
-    session_name="env-test",
-    attach=False,
-    environment={"API_KEY": "secret", "DEBUG": "1"},
-)
+session = server.new_session(session_name="env-test", attach=False, environment={"API_KEY": "secret", "DEBUG": "1"})
 pane = window.split(environment={"NODE_ENV": "test"})
 ```
 
@@ -460,6 +452,7 @@ subprocess.run(["tmux", "capture-pane", "-t", "mysession", "-p"])
 
 # libtmux equivalent (typed, no parsing)
 import libtmux
+
 server = libtmux.Server(socket_name="claude-pty")
 with server.new_session("tool-run", attach=False, x=160, y=50) as session:
     pane = session.active_window.active_pane
@@ -487,11 +480,7 @@ def create_dev_workspace(project_path: str) -> dict:
     # Test pane (bottom, 30% height)
     test_pane = window.split(direction=libtmux.PaneDirection.Below, size="30%")
 
-    return {
-        "session": session,
-        "server_pane": server_pane,
-        "test_pane": test_pane,
-    }
+    return {"session": session, "server_pane": server_pane, "test_pane": test_pane}
 ```
 
 ### Application: Output Polling for Long-Running Processes
@@ -500,6 +489,7 @@ Agents running shell commands need to monitor output. libtmux's `capture_pane()`
 
 ```python
 import time
+
 
 def wait_for_output(pane: libtmux.Pane, pattern: str, timeout: float = 30.0) -> list[str]:
     """Poll pane output until pattern appears or timeout."""

--- a/research/developer-tools/loguru.md
+++ b/research/developer-tools/loguru.md
@@ -55,6 +55,7 @@ Loguru is a drop-in replacement for Python's standard `logging` module that elim
 
 ```python
 from loguru import logger
+
 logger.debug("Works immediately, outputs to stderr")
 ```
 
@@ -96,6 +97,7 @@ Custom levels via `logger.level("AGENT_STEP", no=25)`.
 @logger.catch(default=None)
 def risky(a, b):
     return a / b
+
 
 result = risky(10, 0)  # Returns None, error logged with full traceback
 
@@ -142,11 +144,11 @@ logger.opt(depth=1).info("Use parent stack frame")
 ### File Rotation, Retention, and Compression
 
 ```python
-logger.add("app.log", rotation="500 MB")      # Size-based
-logger.add("app.log", rotation="12:00")        # Time-based (daily at noon)
-logger.add("app.log", rotation="1 week")       # Duration-based
-logger.add("app.log", retention="10 days")     # Auto-cleanup old files
-logger.add("app.log", compression="gz")        # Compress on rotation
+logger.add("app.log", rotation="500 MB")  # Size-based
+logger.add("app.log", rotation="12:00")  # Time-based (daily at noon)
+logger.add("app.log", rotation="1 week")  # Duration-based
+logger.add("app.log", retention="10 days")  # Auto-cleanup old files
+logger.add("app.log", compression="gz")  # Compress on rotation
 ```
 
 ### stdlib Compatibility
@@ -161,9 +163,9 @@ Three integration patterns:
 
 ```python
 # In library code:
-logger.disable("my_library")   # All logging becomes no-op
+logger.disable("my_library")  # All logging becomes no-op
 # In application code:
-logger.enable("my_library")    # Re-enable
+logger.enable("my_library")  # Re-enable
 ```
 
 ### Environment Variable Configuration
@@ -173,8 +175,8 @@ Default stderr handler configurable via: `LOGURU_FORMAT`, `LOGURU_LEVEL`, `LOGUR
 ### Multiprocess-Safe Enqueue
 
 ```python
-logger.add("file.log", enqueue=True)   # Messages via multiprocessing-safe queue
-await logger.complete()                  # Wait for all enqueued messages
+logger.add("file.log", enqueue=True)  # Messages via multiprocessing-safe queue
+await logger.complete()  # Wait for all enqueued messages
 ```
 
 ---
@@ -254,6 +256,7 @@ logger.add(sys.stderr, level="WARNING", colorize=True)
 with logger.contextualize(request_id="abc-123"):
     logger.info("Processing request")
 
+
 # Catch exceptions
 @logger.catch
 def main():
@@ -266,6 +269,7 @@ def main():
 import logging
 import inspect
 
+
 class InterceptHandler(logging.Handler):
     def emit(self, record):
         try:
@@ -275,12 +279,14 @@ class InterceptHandler(logging.Handler):
         frame, depth = inspect.currentframe(), 0
         while frame:
             filename = frame.f_code.co_filename
-            if depth > 0 and not (filename == logging.__file__ or
-                ("importlib" in filename and "_bootstrap" in filename)):
+            if depth > 0 and not (
+                filename == logging.__file__ or ("importlib" in filename and "_bootstrap" in filename)
+            ):
                 break
             frame = frame.f_back
             depth += 1
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
 ```

--- a/research/developer-tools/scrapling-skill.md
+++ b/research/developer-tools/scrapling-skill.md
@@ -124,7 +124,7 @@ SOURCE: troubleshooting.md "Cloudflare 403 + Just a moment" section and "cf_clea
 FetcherSession template enables login workflows with automatic cookie persistence:
 
 ```python
-with FetcherSession(impersonate='chrome') as s:
+with FetcherSession(impersonate="chrome") as s:
     login_resp = s.post(LOGIN_URL, data=LOGIN_DATA)
     for url in TARGET_URLS:
         page = s.get(url)  # Cookies from login automatically sent
@@ -281,8 +281,9 @@ SOURCE: SKILL.md frontmatter, README.md "Usage" section (accessed 2026-03-13)
 
    ```python
    from scrapling.fetchers import Fetcher
-   page = Fetcher.get("https://example.com/blog", impersonate='chrome', timeout=30)
-   results = page.css('article h1::text').getall()
+
+   page = Fetcher.get("https://example.com/blog", impersonate="chrome", timeout=30)
+   results = page.css("article h1::text").getall()
    ```
 
 ### Example 2: Cloudflare-Protected Site
@@ -297,12 +298,9 @@ SOURCE: SKILL.md frontmatter, README.md "Usage" section (accessed 2026-03-13)
 
    ```python
    from scrapling.fetchers import StealthyFetcher
+
    page = StealthyFetcher.fetch(
-       "https://protected.example.com",
-       headless=True,
-       solve_cloudflare=True,
-       timeout=60000,
-       network_idle=True
+       "https://protected.example.com", headless=True, solve_cloudflare=True, timeout=60000, network_idle=True
    )
    ```
 
@@ -318,8 +316,9 @@ SOURCE: SKILL.md frontmatter, README.md "Usage" section (accessed 2026-03-13)
 
    ```python
    from scrapling.fetchers import FetcherSession
-   with FetcherSession(impersonate='chrome') as s:
-       s.post(LOGIN_URL, data={'username': '...', 'password': '...'})
+
+   with FetcherSession(impersonate="chrome") as s:
+       s.post(LOGIN_URL, data={"username": "...", "password": "..."})
        for url in TARGET_URLS:
            page = s.get(url)
    ```
@@ -336,8 +335,9 @@ SOURCE: SKILL.md frontmatter, README.md "Usage" section (accessed 2026-03-13)
 
    ```python
    from scrapling.parser import Selector
+
    page = Selector(html_string)
-   links = page.css('a::attr(href)').getall()
+   links = page.css("a::attr(href)").getall()
    ```
 
 SOURCE: README.md "Examples" and all templates (accessed 2026-03-13)

--- a/research/developer-tools/scrapling.md
+++ b/research/developer-tools/scrapling.md
@@ -160,25 +160,27 @@ docker pull pyd4vinci/scrapling
 # HTTP request with TLS impersonation
 from scrapling.fetchers import Fetcher, FetcherSession
 
-with FetcherSession(impersonate='chrome') as session:
-    page = session.get('https://quotes.toscrape.com/', stealthy_headers=True)
-    quotes = page.css('.quote .text::text').getall()
+with FetcherSession(impersonate="chrome") as session:
+    page = session.get("https://quotes.toscrape.com/", stealthy_headers=True)
+    quotes = page.css(".quote .text::text").getall()
 
 # Stealth mode: bypass Cloudflare Turnstile
 from scrapling.fetchers import StealthyFetcher
 
-page = StealthyFetcher.fetch('https://nopecha.com/demo/cloudflare', headless=True)
-data = page.css('#padded_content a').getall()
+page = StealthyFetcher.fetch("https://nopecha.com/demo/cloudflare", headless=True)
+data = page.css("#padded_content a").getall()
 
 # Adaptive scraping: survive page redesigns
 from scrapling.fetchers import StealthyFetcher
+
 StealthyFetcher.adaptive = True
-page = StealthyFetcher.fetch('https://example.com', headless=True)
-products = page.css('.product', auto_save=True)   # store signatures
-products = page.css('.product', adaptive=True)    # later: find even after redesign
+page = StealthyFetcher.fetch("https://example.com", headless=True)
+products = page.css(".product", auto_save=True)  # store signatures
+products = page.css(".product", adaptive=True)  # later: find even after redesign
 
 # Full crawler with pause/resume
 from scrapling.spiders import Spider, Response
+
 
 class QuotesSpider(Spider):
     name = "quotes"
@@ -186,14 +188,12 @@ class QuotesSpider(Spider):
     concurrent_requests = 10
 
     async def parse(self, response: Response):
-        for quote in response.css('.quote'):
-            yield {
-                "text": quote.css('.text::text').get(),
-                "author": quote.css('.author::text').get(),
-            }
-        next_page = response.css('.next a')
+        for quote in response.css(".quote"):
+            yield {"text": quote.css(".text::text").get(), "author": quote.css(".author::text").get()}
+        next_page = response.css(".next a")
         if next_page:
-            yield response.follow(next_page[0].attrib['href'])
+            yield response.follow(next_page[0].attrib["href"])
+
 
 result = QuotesSpider(crawldir="./crawl_data").start()
 result.items.to_json("quotes.json")

--- a/research/developer-tools/tmuxp.md
+++ b/research/developer-tools/tmuxp.md
@@ -128,17 +128,12 @@ from tmuxp.workspace import loader
 from tmuxp.workspace.builder import WorkspaceBuilder
 
 # Load config from file
-session_config = config_reader.ConfigReader._from_file(
-    pathlib.Path("./mysession.yaml")
-)
+session_config = config_reader.ConfigReader._from_file(pathlib.Path("./mysession.yaml"))
 
 # Or from a dict directly
 session_config = {
     "session_name": "orchestrator",
-    "windows": [
-        {"window_name": "agent-1", "panes": ["bash"]},
-        {"window_name": "agent-2", "panes": ["bash"]},
-    ],
+    "windows": [{"window_name": "agent-1", "panes": ["bash"]}, {"window_name": "agent-2", "panes": ["bash"]}],
 }
 
 # Build the session
@@ -148,8 +143,8 @@ builder.build()
 
 # Access the created session object
 session = builder.session
-print(session.name)         # "orchestrator"
-print(session.windows)      # list of libtmux.Window objects
+print(session.name)  # "orchestrator"
+print(session.windows)  # list of libtmux.Window objects
 ```
 
 `WorkspaceBuilder.build()` accepts optional parameters:
@@ -166,6 +161,7 @@ Plugins hook into the session lifecycle via a base class with four extension poi
 
 ```python
 from tmuxp.plugin import TmuxpPlugin
+
 
 class MyPlugin(TmuxpPlugin):
     def before_workspace_builder(self, session):

--- a/research/embedded-ui-libraries/lvgl.md
+++ b/research/embedded-ui-libraries/lvgl.md
@@ -270,10 +270,12 @@ import lvgl as lv
 
 # Register display driver (ILI9341)
 from ili9XXX import ili9341
+
 disp = ili9341()
 
 # Register touch driver (XPT2046)
 from xpt2046 import xpt2046
+
 touch = xpt2046()
 
 # Create UI
@@ -284,9 +286,11 @@ btn.align(lv.ALIGN.CENTER, 0, 0)
 label = lv.label(btn)
 label.set_text("Press me")
 
+
 # Event callback
 def on_click(evt):
     label.set_text("Clicked!")
+
 
 btn.add_event_cb(on_click, lv.EVENT.CLICKED, None)
 ```

--- a/research/insights/2026-03-13-msgspec-utilization.md
+++ b/research/insights/2026-03-13-msgspec-utilization.md
@@ -40,6 +40,7 @@ def _read_jsonl(file_path: str) -> list[dict[str, Any]]:
 ```python
 import msgspec
 
+
 def _read_jsonl(file_path: str) -> list[dict[str, Any]]:
     """Read a JSONL file and return a list of parsed records."""
     records: list[dict[str, Any]] = []
@@ -53,6 +54,7 @@ def _read_jsonl(file_path: str) -> list[dict[str, Any]]:
 ```python
 import msgspec
 
+
 class SessionRecord(msgspec.Struct):
     sessionId: str
     timestamp: str
@@ -60,15 +62,12 @@ class SessionRecord(msgspec.Struct):
     message: dict[str, object] | None = None
     toolUseResult: dict[str, object] | None = None
 
+
 def _read_jsonl(file_path: str) -> list[SessionRecord]:
     """Read a JSONL file and return a list of validated session records."""
     records: list[SessionRecord] = []
     with pathlib.Path(file_path).open(encoding="utf-8") as fh:
-        records.extend(
-            msgspec.json.decode(stripped, type=SessionRecord)
-            for line in fh
-            if (stripped := line.strip())
-        )
+        records.extend(msgspec.json.decode(stripped, type=SessionRecord) for line in fh if (stripped := line.strip()))
     return records
 ```
 
@@ -132,8 +131,10 @@ text = _extract_text(content)
 ```python
 import msgspec
 
+
 class Message(msgspec.Struct):
     content: str | list[dict[str, object]]
+
 
 class SessionRecord(msgspec.Struct):
     sessionId: str
@@ -141,6 +142,7 @@ class SessionRecord(msgspec.Struct):
     type: str
     message: Message | None = None
     toolUseResult: dict[str, object] | None = None
+
 
 def _iter_user_messages(path: Path, *, min_length: int, session_filter: str | None):
     """Yield (session_id, timestamp, index, text) for user messages in *path*."""

--- a/research/insights/2026-03-15-zvec-utilization.md
+++ b/research/insights/2026-03-15-zvec-utilization.md
@@ -30,19 +30,17 @@ from typing import List
 
 # Initialize once during agent startup
 schema = zvec.CollectionSchema(
-    name="codebase_semantic_index",
-    vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 1536)
+    name="codebase_semantic_index", vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 1536)
 )
 code_index = zvec.create_and_open(path="./codebase_index", schema=schema)
+
 
 # Step 2 enhancement: After identifying files to research
 def find_related_code(query: str, top_k: int = 10) -> List[dict]:
     """Semantic search for related code files/snippets."""
-    results = code_index.query(
-        zvec.VectorQuery("embedding", vector=embed(query)),
-        topk=top_k
-    )
+    results = code_index.query(zvec.VectorQuery("embedding", vector=embed(query)), topk=top_k)
     return results  # [{'id': file_path, 'score': relevance, ...}]
+
 
 # Agent usage: Instead of pure grep/glob fallback
 file_matches = find_related_code("authentication and authorization flows")
@@ -82,31 +80,24 @@ import zvec
 research_index = zvec.create_and_open(
     path="./research_vector_index",
     schema=zvec.CollectionSchema(
-        name="research_entries",
-        vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 1536)
-    )
+        name="research_entries", vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 1536)
+    ),
 )
+
 
 # On new research entry creation
 def index_research_entry(filepath: str, entry_title: str, entry_text: str):
     """Add entry to semantic index."""
     entry_embedding = embed_text(entry_text)  # Embed problem + features + use cases
-    research_index.insert([
-        zvec.Doc(
-            id=filepath,
-            vectors={"embedding": entry_embedding}
-        )
-    ])
+    research_index.insert([zvec.Doc(id=filepath, vectors={"embedding": entry_embedding})])
+
 
 # Cross-referencer query pattern
 def find_related_entries(query_text: str, topk: int = 8) -> List[str]:
     """Find semantically related research entries."""
     query_embedding = embed_text(query_text)
-    results = research_index.query(
-        zvec.VectorQuery("embedding", vector=query_embedding),
-        topk=topk
-    )
-    return [result['id'] for result in results]  # File paths
+    results = research_index.query(zvec.VectorQuery("embedding", vector=query_embedding), topk=topk)
+    return [result["id"] for result in results]  # File paths
 ```
 
 ---
@@ -145,32 +136,27 @@ memory_index_path = f"./.claude/agent-memory/{agent_name}/vector_index"
 memory_index = zvec.create_and_open(
     path=memory_index_path,
     schema=zvec.CollectionSchema(
-        name=f"{agent_name}_memory",
-        vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 1536)
-    )
+        name=f"{agent_name}_memory", vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 1536)
+    ),
 )
+
 
 # When agent updates memory file
 def index_memory_entry(memory_text: str, source_file: str, timestamp: str):
     """Add or update memory entry in semantic index."""
-    entry_id = hashlib.md5(
-        f"{source_file}:{timestamp}".encode()
-    ).hexdigest()
+    entry_id = hashlib.md5(f"{source_file}:{timestamp}".encode()).hexdigest()
 
     embedding = embed_text(memory_text)
-    memory_index.insert([
-        zvec.Doc(id=entry_id, vectors={"embedding": embedding})
-    ])
+    memory_index.insert([zvec.Doc(id=entry_id, vectors={"embedding": embedding})])
+
 
 # Agent query pattern: retrieve relevant past memories
 def retrieve_memory(query: str, topk: int = 5) -> List[dict]:
     """Find semantically relevant memory entries."""
     query_embedding = embed_text(query)
-    results = memory_index.query(
-        zvec.VectorQuery("embedding", vector=query_embedding),
-        topk=topk
-    )
+    results = memory_index.query(zvec.VectorQuery("embedding", vector=query_embedding), topk=topk)
     return results  # [{id, score, ...}]
+
 
 # Usage in agent: Before writing new memory, check similarity
 similar_memories = retrieve_memory("error handling in async functions")

--- a/research/insights/2026-03-19-gitnexus-utilization.md
+++ b/research/insights/2026-03-19-gitnexus-utilization.md
@@ -38,7 +38,7 @@ The `detect_changes` tool (line 134-144 in research entry) maps git diffs to aff
 # Pseudo-code showing tool call pattern from research entry line 133-143
 impact_result = gitnexus_impact({
     "target": "function_or_class_name",
-    "direction": "upstream"  # Find all callers
+    "direction": "upstream",  # Find all callers
 })
 
 # Returns depth-grouped results:
@@ -57,10 +57,7 @@ impact_result = gitnexus_impact({
 
 ```python
 # From research entry line 144, detect_changes maps diffs to execution flows
-changed_impact = gitnexus_detect_changes({
-    "scope": "staged",
-    "repo": repo_name
-})
+changed_impact = gitnexus_detect_changes({"scope": "staged", "repo": repo_name})
 
 # Returns: {
 #   "changed_symbols": ["validateUser", "authCache.clear"],

--- a/research/insights/2026-03-19-simplemem-cross-utilization.md
+++ b/research/insights/2026-03-19-simplemem-cross-utilization.md
@@ -25,6 +25,7 @@ The context-gathering agent reads task files and performs expensive codebase res
 from cross.orchestrator import create_orchestrator
 import asyncio
 
+
 async def gather_context(task_file_path):
     # Initialize SimpleMem-Cross orchestrator (once per feature)
     orch = create_orchestrator(project="claude-skills", tenant_id="context-gathering")
@@ -34,8 +35,7 @@ async def gather_context(task_file_path):
 
     # Start session: auto-inject relevant prior findings
     result = await orch.start_session(
-        content_session_id=task_info["task_id"],
-        user_prompt=f"Gather context for: {task_info['name']}"
+        content_session_id=task_info["task_id"], user_prompt=f"Gather context for: {task_info['name']}"
     )
 
     # Prior context automatically injected in result["context"]
@@ -48,7 +48,7 @@ async def gather_context(task_file_path):
     # Record discoveries as messages (SimpleMem-Cross heuristic extractor will identify "discovered", "found", etc.)
     await orch.record_message(
         result["memory_session_id"],
-        f"Discovered patterns in {discovered_context['modules']}: {discovered_context['patterns']}"
+        f"Discovered patterns in {discovered_context['modules']}: {discovered_context['patterns']}",
     )
 
     # Finalize session: observations extracted, stored, vectorized
@@ -99,21 +99,17 @@ The implement-feature skill loops through ready tasks, delegates each to an agen
 from cross.orchestrator import create_orchestrator
 import asyncio
 
+
 async def implement_feature_loop(task_file_path):
     plan_id = extract_plan_id(task_file_path)  # e.g., "P3"
     feature_slug = extract_feature_slug(task_file_path)  # e.g., "integrate-sam"
 
     # Initialize SimpleMem-Cross for this feature
-    orch = create_orchestrator(
-        project="claude-skills",
-        tenant_id=f"feature-{feature_slug}",
-        max_context_tokens=3000
-    )
+    orch = create_orchestrator(project="claude-skills", tenant_id=f"feature-{feature_slug}", max_context_tokens=3000)
 
     # Start session: auto-inject patterns from similar past features
     result = await orch.start_session(
-        content_session_id=f"implement-{feature_slug}",
-        user_prompt=f"Execute feature: {feature_slug}"
+        content_session_id=f"implement-{feature_slug}", user_prompt=f"Execute feature: {feature_slug}"
     )
 
     prior_patterns = result["context"]  # e.g., "Prior features used python-cli-architect for similar tasks"
@@ -137,9 +133,9 @@ async def implement_feature_loop(task_file_path):
                     "task_id": task_id,
                     "agent": agent_name,
                     "skills": task.get("skills", []),
-                    "dependencies": task.get("dependencies", [])
+                    "dependencies": task.get("dependencies", []),
                 },
-                tool_output={"status": "delegated"}
+                tool_output={"status": "delegated"},
             )
 
             # Delegate task (existing logic: Skill(skill="start-task", args=...))
@@ -152,8 +148,7 @@ async def implement_feature_loop(task_file_path):
             task_result = get_task_result(task_id)
             if task_result.decision or task_result.learning:
                 await orch.record_message(
-                    result["memory_session_id"],
-                    f"Agent {agent_name} decided: {task_result.decision}"
+                    result["memory_session_id"], f"Agent {agent_name} decided: {task_result.decision}"
                 )
 
     # Finalize: observations extracted (decisions, learnings, discoveries)
@@ -165,10 +160,7 @@ async def implement_feature_loop(task_file_path):
     # }
 
     # Search for similar prior implementations (optional post-feature analysis)
-    similar = await orch.search(
-        query=f"features with pattern={prior_patterns}",
-        max_results=3
-    )
+    similar = await orch.search(query=f"features with pattern={prior_patterns}", max_results=3)
 
     await orch.end_session(result["memory_session_id"])
     orch.close()
@@ -221,15 +213,15 @@ from datetime import datetime, UTC
 # Global orchestrator (singleton per session)
 _memory_orch = None
 
+
 def get_memory_orchestrator():
     global _memory_orch
     if not _memory_orch:
         _memory_orch = create_orchestrator(
-            project="claude-skills",
-            tenant_id="task-execution",
-            db_path="~/.simplemem-cross/task_execution.db"
+            project="claude-skills", tenant_id="task-execution", db_path="~/.simplemem-cross/task_execution.db"
         )
     return _memory_orch
+
 
 async def handle_subagent_stop(hook_input):
     """Handle SubagentStop event: task completed."""
@@ -247,10 +239,7 @@ async def handle_subagent_stop(hook_input):
     # Record task completion
     orch = get_memory_orchestrator()
     if memory_session_id:
-        await orch.record_message(
-            memory_session_id,
-            f"Task {task_id} completed at {datetime.now(UTC).isoformat()}"
-        )
+        await orch.record_message(memory_session_id, f"Task {task_id} completed at {datetime.now(UTC).isoformat()}")
 
     # Update task status in sam (existing logic)
     sam_update_status(task_file_path, task_id, SamTaskStatus.COMPLETE)
@@ -259,6 +248,7 @@ async def handle_subagent_stop(hook_input):
     if memory_session_id:
         report = await orch.stop_session(memory_session_id)
         # observations_count includes auto-detected task completion insights
+
 
 async def handle_post_tool_use(hook_input):
     """Handle PostToolUse event: Write/Edit/Bash used during task."""
@@ -278,11 +268,12 @@ async def handle_post_tool_use(hook_input):
             memory_session_id,
             tool_name=hook_input["tool_name"],  # "Write", "Edit", "Bash"
             tool_input=hook_input["tool_input"],  # auto-redacted by SimpleMem-Cross
-            tool_output=hook_input.get("tool_output", "")
+            tool_output=hook_input.get("tool_output", ""),
         )
 
         # Update LastActivity in task (existing logic)
         update_last_activity(...)
+
 
 # Async wrapper for hook entry point
 def handle_hook(hook_input):

--- a/research/insights/2026-03-24-claude-code-cli-power-patterns-utilization.md
+++ b/research/insights/2026-03-24-claude-code-cli-power-patterns-utilization.md
@@ -122,9 +122,9 @@ task_complexity = classify_task(task_content)
 # Returns: "low" (boilerplate, docs), "medium" (feature impl), "high" (architecture)
 
 effort_level = {
-    "low": "low",        # Fast, cheap, deterministic
+    "low": "low",  # Fast, cheap, deterministic
     "medium": "medium",
-    "high": "high",      # Deep reasoning, slower
+    "high": "high",  # Deep reasoning, slower
 }[task_complexity]
 ```
 

--- a/research/insights/2026-03-24-vibium-utilization.md
+++ b/research/insights/2026-03-24-vibium-utilization.md
@@ -65,7 +65,7 @@ bro = await browser.start()
 vibe = await bro.page()
 await vibe.go("https://example.com")
 snapshot = await vibe.map()  # Returns @e1, @e2, etc.
-await vibe.click("@e1")      # Use reference directly
+await vibe.click("@e1")  # Use reference directly
 await vibe.screenshot("page.png")
 ```
 

--- a/research/insights/2026-03-25-samuraizer-utilization.md
+++ b/research/insights/2026-03-25-samuraizer-utilization.md
@@ -51,24 +51,20 @@ SOURCE: `research/ai-research-tools/samuraizer.md` §API Reference, §Architectu
 # With Samuraizer as backend:
 # 1. POST /analyze — Samuraizer fetches, extracts, summarizes, stores
 import httpx
+
 response = httpx.post(
-    f"{SAMURAIZER_URL}/analyze",
-    json={"url": "https://github.com/zomry1/Samuraizer", "tags": ["ai-research-tools"]}
+    f"{SAMURAIZER_URL}/analyze", json={"url": "https://github.com/zomry1/Samuraizer", "tags": ["ai-research-tools"]}
 )
 entry_id = response.json()["id"]
 
 # 2. GET /search/semantic — replace Grep/Glob cross-referencing
 results = httpx.get(
-    f"{SAMURAIZER_URL}/search/semantic",
-    params={"q": "vector search knowledge base security research", "limit": 8}
+    f"{SAMURAIZER_URL}/search/semantic", params={"q": "vector search knowledge base security research", "limit": 8}
 ).json()
 # Returns semantically similar entries without keyword matching
 
 # 3. POST /chat — RAG over full corpus (no current equivalent)
-answer = httpx.post(
-    f"{SAMURAIZER_URL}/chat",
-    json={"message": "Which entries cover RAG architecture patterns?"}
-).json()
+answer = httpx.post(f"{SAMURAIZER_URL}/chat", json={"message": "Which entries cover RAG architecture patterns?"}).json()
 ```
 
 API endpoints are documented in `research/ai-research-tools/samuraizer.md` §API Reference.

--- a/research/insights/2026-04-03-mission-control-utilization.md
+++ b/research/insights/2026-04-03-mission-control-utilization.md
@@ -34,9 +34,9 @@ async def spawn_convoy_with_cost_tracking(team_config, agents_to_spawn, mission_
         payload={
             "title": team_config["team_name"],
             "cost_cap_usd": 50.0,  # from swarm config
-            "agents": len(agents_to_spawn)
+            "agents": len(agents_to_spawn),
         },
-        headers={"Authorization": f"Bearer {MC_API_TOKEN}"}
+        headers={"Authorization": f"Bearer {MC_API_TOKEN}"},
     )
 
     # 2. Spawn agents locally, tagging them with task_id
@@ -46,15 +46,14 @@ async def spawn_convoy_with_cost_tracking(team_config, agents_to_spawn, mission_
             name=agent["name"],
             subagent_type=agent["type"],
             prompt=agent["prompt"],
-            env={"MC_TASK_ID": task_id, "MC_URL": mission_control_url}
+            env={"MC_TASK_ID": task_id, "MC_URL": mission_control_url},
         )
 
     # 3. Periodically check cost cap
     async def poll_cost():
         while team_active:
             cost_resp = await get_from_mission_control(
-                f"{mission_control_url}/api/tasks/{task_id}",
-                headers={"Authorization": f"Bearer {MC_API_TOKEN}"}
+                f"{mission_control_url}/api/tasks/{task_id}", headers={"Authorization": f"Bearer {MC_API_TOKEN}"}
             )
             if cost_resp["cost_usd"] > cost_resp["cost_cap_usd"]:
                 SendMessage(type="broadcast", content="Cost cap exceeded — shutting down")

--- a/research/insights/2026-04-08-codegraphcontext-utilization.md
+++ b/research/insights/2026-04-08-codegraphcontext-utilization.md
@@ -82,17 +82,11 @@ client = CodeGraphContextClient()
 client.add_code_to_graph(repo_path=task_file["project_path"])
 
 # When task requires modifying a function, get complete impact:
-impact = client.analyze_code_relationships(
-    query_type="callers",
-    target="process_payment"
-)
+impact = client.analyze_code_relationships(query_type="callers", target="process_payment")
 # Returns exact list: [{name: "order_handler", file: "...", line: ...}, ...]
 
 # Get what the function calls (to understand dependencies):
-callees = client.analyze_code_relationships(
-    query_type="callees",
-    target="process_payment"
-)
+callees = client.analyze_code_relationships(query_type="callees", target="process_payment")
 
 # Include in context manifest:
 context_manifest = f"""

--- a/research/insights/2026-04-08-mempalace-utilization.md
+++ b/research/insights/2026-04-08-mempalace-utilization.md
@@ -33,8 +33,8 @@ session_data = json.load(open(".claude/context/active-task-{session_id}.json"))
 
 # Prepare a session record for storage
 session_record = f"""
-Session: {session_data.get('session_id')}
-Task: {session_data.get('task_id')}
+Session: {session_data.get("session_id")}
+Task: {session_data.get("task_id")}
 Agent Type: [extracted from task file]
 Completed: {datetime.now().isoformat()}
 Outcome: [status from task file]
@@ -44,12 +44,13 @@ Skills Loaded: [parsed from task frontmatter]
 # Store via MemPalace Python API or MCP call
 # Using Python SDK (no API calls):
 from mempalace.palace_graph import add_to_room
+
 add_to_room(
     wing=project_slug,
     room="session-metadata",
     hall="hall_events",
     content=session_record,
-    metadata={"session_id": session_id, "task_id": task_id}
+    metadata={"session_id": session_id, "task_id": task_id},
 )
 
 # Then delete the ephemeral file as normal
@@ -80,18 +81,13 @@ MemPalace's `search_memories()` API and `mempalace_search` MCP tool enable this 
 from mempalace.searcher import search_memories
 
 # Step 2: Research Everything
-files_to_research = [
-    "backlog_core/server.py",
-    "backlog_core/models.py",
-    "plugins/development-harness/hooks/"
-]
+files_to_research = ["backlog_core/server.py", "backlog_core/models.py", "plugins/development-harness/hooks/"]
 
 # Before reading fresh docs, query what prior agents discovered
 discoveries = {}
 for file_path in files_to_research:
     prior_findings = search_memories(
-        query=f"gotcha constraint issue discovered in {file_path}",
-        palace_path="~/.mempalace/palace"
+        query=f"gotcha constraint issue discovered in {file_path}", palace_path="~/.mempalace/palace"
     )
     if prior_findings:
         discoveries[file_path] = prior_findings
@@ -141,7 +137,7 @@ kg.add_triple(
     subject=f"agent:{reviewed_agent_name}",
     predicate="produces_pattern",
     object=pattern_name,
-    valid_from=datetime.now().isoformat()
+    valid_from=datetime.now().isoformat(),
 )
 
 # Also write agent diary with specific example

--- a/research/insights/2026-04-12-pandera-utilization.md
+++ b/research/insights/2026-04-12-pandera-utilization.md
@@ -21,20 +21,29 @@ The python-pytest-architect agent (lines 3, 22, 40-42 of its agent file) explici
 # Before (manual hypothesis strategy)
 from hypothesis import given, strategies as st
 
-@given(st.lists(st.dictionaries({
-    'customer_id': st.integers(min_value=1),
-    'purchase_amount': st.floats(min_value=0.01, max_value=10000),
-    'purchase_date': st.dates(min_value=date(2020, 1, 1))
-}), min_size=1, max_size=100))
+
+@given(
+    st.lists(
+        st.dictionaries({
+            "customer_id": st.integers(min_value=1),
+            "purchase_amount": st.floats(min_value=0.01, max_value=10000),
+            "purchase_date": st.dates(min_value=date(2020, 1, 1)),
+        }),
+        min_size=1,
+        max_size=100,
+    )
+)
 def test_transaction_processing(transactions_list):
     df = pd.DataFrame(transactions_list)
     result = process_transactions(df)
     assert result.shape[0] > 0
 
+
 # After (Pandera schema-driven)
 import pandera as pa
 from pandera.typing import Series
 from hypothesis import given
+
 
 class TransactionSchema(pa.DataFrameModel):
     customer_id: int = pa.Field(gt=0)
@@ -43,6 +52,7 @@ class TransactionSchema(pa.DataFrameModel):
 
     class Config:
         strict = True
+
 
 @given(TransactionSchema.strategy(size=10))
 def test_transaction_processing(df):

--- a/research/insights/2026-04-25-honker-utilization.md
+++ b/research/insights/2026-04-25-honker-utilization.md
@@ -23,6 +23,7 @@ import honker
 db = honker.open("~/.dh/projects/{slug}/dispatch.db")
 queue = db.queue("dispatch-items")
 
+
 # Current: INSERT into custom items table
 # Proposed: enqueue as honker job
 @queue.task(retries=3, timeout_s=3600)
@@ -30,6 +31,7 @@ def execute_dispatch_item(milestone: int, wave_num: int, issue: int):
     # Spawn claude session for this item
     pid = spawn_claude_worker(...)
     return {"pid": pid, "started_at": now_iso()}
+
 
 # Caller: task_id = execute_dispatch_item(5, 1, 42)
 # result = task_id.get(timeout=10)  # blocks until worker runs it
@@ -73,12 +75,9 @@ pipeline_stream = db.stream("pipeline-lifecycle")
 # Publish stage transition event atomically with artifact
 with db.transaction() as tx:
     artifact_registry.register(issue, "architect", path, tx=tx)
-    pipeline_stream.publish({
-        "stage": "S2",
-        "event": "architect-complete",
-        "issue": issue,
-        "timestamp": now_iso()
-    }, tx=tx)
+    pipeline_stream.publish(
+        {"stage": "S2", "event": "architect-complete", "issue": issue, "timestamp": now_iso()}, tx=tx
+    )
 
 # Consumer: code-reviewer agent subscribes
 async for event in pipeline_stream.subscribe(consumer="code-reviewer"):

--- a/research/insights/2026-04-26-tolaria-utilization.md
+++ b/research/insights/2026-04-26-tolaria-utilization.md
@@ -33,6 +33,7 @@ This moves research-context-agent from a transactional search-and-match workflow
 ```python
 # Pseudo-code: research-context-agent enhanced with tolaria MCP
 
+
 def phase_1_absorb(research_file_path):
     research_content = read_file(research_file_path)
 
@@ -45,17 +46,19 @@ def phase_1_absorb(research_file_path):
 
     return research_content
 
+
 def phase_2_search_and_match(research_content):
     opportunities = find_integration_opportunities_in_repo()  # existing: Grep/Glob search
 
     # NEW: Also search tolaria vault for patterns and prior integrations
     vault_context = mcp_call("vault_context")
     for opportunity in opportunities:
-        related_notes = mcp_call("search_notes", query=opportunity['skill_name'])
+        related_notes = mcp_call("search_notes", query=opportunity["skill_name"])
         if related_notes:
-            opportunity['vault_references'] = related_notes  # link to vault
+            opportunity["vault_references"] = related_notes  # link to vault
 
     return opportunities
+
 
 def write_integration_opportunities_section(opportunities):
     # NEW: Before writing to research file, create/update tolaria notes
@@ -63,22 +66,21 @@ def write_integration_opportunities_section(opportunities):
         note_data = {
             "type": "opportunity",
             "belongs_to": extract_tool_name(research_file_path),
-            "related_to": opportunity['skill_name'],
+            "related_to": opportunity["skill_name"],
             "status": "proposed",
-            "links": opportunity.get('vault_references', [])
+            "links": opportunity.get("vault_references", []),
         }
 
         # Register the opportunity as a note in tolaria vault
-        mcp_call("create_note",
-                 title=f"Integration: {opportunity['skill_name']} + {tool_name}",
-                 frontmatter=note_data,
-                 content=opportunity['description'])
+        mcp_call(
+            "create_note",
+            title=f"Integration: {opportunity['skill_name']} + {tool_name}",
+            frontmatter=note_data,
+            content=opportunity["description"],
+        )
 
         # Link the research entry to the opportunity
-        mcp_call("link_notes",
-                 from_note="research.md",
-                 to_note=f"opportunity-{opportunity['id']}",
-                 relationship="has")
+        mcp_call("link_notes", from_note="research.md", to_note=f"opportunity-{opportunity['id']}", relationship="has")
 ```
 
 **Grounding in Research**: Lines 82-88 of tolaria.md document the MCP server's 14 tools. Lines 22-30 of tolaria.md describe the Semantic Field Names (type, status, belongs_to, related_to) that enable relationships. Lines 287-304 of ARCHITECTURE.md in tolaria repo specify tool names and signatures. Lines 419-435 of tolaria.md sketch "Integration Opportunities" including "AI Skill Development: Use Tolaria as a test environment for multi-agent orchestration. Store agent specifications as Type documents, log agent interactions as activity records, use the MCP server to coordinate agent handoffs."
@@ -128,11 +130,13 @@ A tolaria vault preloaded with these reusable components would allow context-gat
 ```python
 # Pseudo-code: context-gathering enhanced with tolaria MCP
 
+
 def step_1_understand_task(task_file_path):
     task = read_file(task_file_path)
     modules_involved = extract_modules_from_task(task)
 
     return task, modules_involved
+
 
 def step_2_research_everything_with_vault(task, modules_involved):
     context = {}
@@ -145,22 +149,25 @@ def step_2_research_everything_with_vault(task, modules_involved):
             # Context already documented in vault; link to it
             context[module] = {
                 "source": "tolaria_vault",
-                "note_title": vault_note['title'],
-                "note_status": vault_note['status'],
-                "snippet": vault_note['snippet'],
-                "wikilink": f"[[{vault_note['filename']}]]"
+                "note_title": vault_note["title"],
+                "note_status": vault_note["status"],
+                "snippet": vault_note["snippet"],
+                "wikilink": f"[[{vault_note['filename']}]]",
             }
         else:
             # Context not in vault; research from codebase (existing behavior)
             context[module] = research_module_in_codebase(module)
 
             # NEW: After researching, store in tolaria vault for future reuse
-            mcp_call("create_note",
-                     title=f"Module: {module}",
-                     frontmatter={"type": "module", "status": "documented"},
-                     content=context[module]['full_description'])
+            mcp_call(
+                "create_note",
+                title=f"Module: {module}",
+                frontmatter={"type": "module", "status": "documented"},
+                content=context[module]["full_description"],
+            )
 
     return context
+
 
 def step_3_write_context_manifest(context_manifest):
     # Include vault references in the manifest
@@ -168,7 +175,7 @@ def step_3_write_context_manifest(context_manifest):
     manifest_section += "### Modules and Dependencies\n"
 
     for module, info in context.items():
-        if info.get('source') == 'tolaria_vault':
+        if info.get("source") == "tolaria_vault":
             manifest_section += f"- {module}: [[{info['note_title']}]] (cached in vault)\n"
         else:
             manifest_section += f"- {module}: (researched from codebase; consider archiving to vault)\n"

--- a/research/insights/2026-04-29-openspec-mcp-utilization.md
+++ b/research/insights/2026-04-29-openspec-mcp-utilization.md
@@ -29,11 +29,9 @@ with open(f"plan/tasks/{task_id}.yaml") as f:
     # write back
 
 # OpenSpec MCP pattern: agent calls MCP tool directly
-mcp_client.call_tool("openspec_update_task", {
-    "task_id": task_id,
-    "status": "complete",
-    "output": "implementation details"
-})
+mcp_client.call_tool(
+    "openspec_update_task", {"task_id": task_id, "status": "complete", "output": "implementation details"}
+)
 
 # Get progress for status report
 progress = mcp_client.call_tool("openspec_get_progress_summary", {})

--- a/research/insights/2026-05-10-awesome-codex-skills-issue-triage-utilization.md
+++ b/research/insights/2026-05-10-awesome-codex-skills-issue-triage-utilization.md
@@ -31,11 +31,15 @@ open_issues = backlog_list_issues(milestone=title, state="open")
 for issue in open_issues:
     # One subprocess per issue
     subprocess.run([
-        "uv", "run",
+        "uv",
+        "run",
         ".claude/skills/gh/scripts/github_project_setup.py",
-        "issue", "set-milestone",
-        "--issue", str(issue.number),
-        "--milestone", chosen_milestone_number
+        "issue",
+        "set-milestone",
+        "--issue",
+        str(issue.number),
+        "--milestone",
+        chosen_milestone_number,
     ])
 ```
 

--- a/research/llm-infrastructure/airllm.md
+++ b/research/llm-infrastructure/airllm.md
@@ -62,6 +62,7 @@ The `AutoModel` class detects the model architecture automatically and instantia
 
 ```python
 from airllm import AutoModel
+
 model = AutoModel.from_pretrained("garage-bAInd/Platypus2-70B-instruct")
 ```
 
@@ -204,22 +205,19 @@ from airllm import AutoModel
 model = AutoModel.from_pretrained("garage-bAInd/Platypus2-70B-instruct")
 
 # Tokenize
-input_text = ['What is the capital of United States?']
+input_text = ["What is the capital of United States?"]
 input_tokens = model.tokenizer(
     input_text,
     return_tensors="pt",
     return_attention_mask=False,
     truncation=True,
     max_length=128,
-    padding=False  # Some models require padding=False
+    padding=False,  # Some models require padding=False
 )
 
 # Generate
 generation_output = model.generate(
-    input_tokens['input_ids'].cuda(),
-    max_new_tokens=20,
-    use_cache=True,
-    return_dict_in_generate=True
+    input_tokens["input_ids"].cuda(), max_new_tokens=20, use_cache=True, return_dict_in_generate=True
 )
 
 # Decode
@@ -270,13 +268,13 @@ An MCP server wrapping AirLLM inference could expose LLM completion as a tool to
 ```python
 # Hypothetical AirLLM MCP server
 class AirLLMCompletionServer:
-    def __init__(self, model_id, compression='4bit'):
+    def __init__(self, model_id, compression="4bit"):
         self.model = AutoModel.from_pretrained(model_id, compression=compression)
 
     @mcp_tool
     def complete(self, prompt: str, max_tokens: int = 100) -> str:
         tokens = self.model.tokenizer(prompt, return_tensors="pt")
-        output = self.model.generate(tokens['input_ids'].cuda(), max_new_tokens=max_tokens)
+        output = self.model.generate(tokens["input_ids"].cuda(), max_new_tokens=max_tokens)
         return self.model.tokenizer.decode(output.sequences[0])
 ```
 

--- a/research/llm-infrastructure/glm5-exacto.md
+++ b/research/llm-infrastructure/glm5-exacto.md
@@ -156,16 +156,11 @@ pip install openai
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    api_key="sk-or-...",
-    base_url="https://openrouter.ai/api/v1"
-)
+client = OpenAI(api_key="sk-or-...", base_url="https://openrouter.ai/api/v1")
 
 # Basic completion
 response = client.chat.completions.create(
-    model="z-ai/glm-5:exacto",
-    messages=[{"role": "user", "content": "Explain agentic workflows"}],
-    max_tokens=4000
+    model="z-ai/glm-5:exacto", messages=[{"role": "user", "content": "Explain agentic workflows"}], max_tokens=4000
 )
 
 # With tool use
@@ -178,11 +173,11 @@ response = client.chat.completions.create(
             "function": {
                 "name": "run_code",
                 "description": "Execute Python code",
-                "parameters": {"type": "object", "properties": {...}}
-            }
+                "parameters": {"type": "object", "properties": {...}},
+            },
         }
     ],
-    max_tokens=8000
+    max_tokens=8000,
 )
 
 # With reasoning enabled
@@ -190,7 +185,7 @@ response = client.chat.completions.create(
     model="z-ai/glm-5:exacto",
     messages=[{"role": "user", "content": "Solve this math problem..."}],
     reasoning={"type": "enabled", "budget_tokens": 5000},
-    max_tokens=4000
+    max_tokens=4000,
 )
 ```
 

--- a/research/llm-infrastructure/localai.md
+++ b/research/llm-infrastructure/localai.md
@@ -187,12 +187,11 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="http://localhost:8080/v1",
-    api_key="not-needed"  # LocalAI doesn't require an API key by default
+    api_key="not-needed",  # LocalAI doesn't require an API key by default
 )
 
 response = client.chat.completions.create(
-    model="llama-3.2-1b-instruct",
-    messages=[{"role": "user", "content": "Hello, LocalAI!"}]
+    model="llama-3.2-1b-instruct", messages=[{"role": "user", "content": "Hello, LocalAI!"}]
 )
 print(response.choices[0].message.content)
 ```
@@ -201,10 +200,7 @@ print(response.choices[0].message.content)
 
 ```python
 response = client.images.generate(
-    prompt="A beautiful sunset over mountains",
-    model="stablediffusion",
-    n=1,
-    size="512x512"
+    prompt="A beautiful sunset over mountains", model="stablediffusion", n=1, size="512x512"
 )
 print(response.data[0].url)
 ```
@@ -213,10 +209,7 @@ print(response.data[0].url)
 
 ```python
 with open("audio.mp3", "rb") as f:
-    transcript = client.audio.transcriptions.create(
-        model="whisper-1",
-        file=f
-    )
+    transcript = client.audio.transcriptions.create(model="whisper-1", file=f)
 print(transcript.text)
 ```
 

--- a/research/llm-infrastructure/quantum-free-router.md
+++ b/research/llm-infrastructure/quantum-free-router.md
@@ -55,10 +55,7 @@ Source: architecture.md lines 41–54, examples/openai-python.py.
 ```python
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="http://127.0.0.1:4000/v1",
-    api_key="local-dev",
-)
+client = OpenAI(base_url="http://127.0.0.1:4000/v1", api_key="local-dev")
 
 response = client.chat.completions.create(
     model="opencode/deepseek-v4-flash-free",

--- a/research/llm-infrastructure/tensorzero.md
+++ b/research/llm-infrastructure/tensorzero.md
@@ -193,11 +193,7 @@ with TensorZeroGateway.build_embedded(...) as t0:
     response = t0.inference(
         model_name="openai::gpt-4o-mini",
         # Switch providers easily: "anthropic::claude-sonnet-4-5"
-        input={
-            "messages": [
-                {"role": "user", "content": "Write a haiku about TensorZero."}
-            ]
-        },
+        input={"messages": [{"role": "user", "content": "Write a haiku about TensorZero."}]},
     )
 ```
 
@@ -211,8 +207,7 @@ client = OpenAI()
 patch_openai_client(client, ...)
 
 response = client.chat.completions.create(
-    model="tensorzero::model_name::openai::gpt-4o-mini",
-    messages=[{"role": "user", "content": "Hello!"}],
+    model="tensorzero::model_name::openai::gpt-4o-mini", messages=[{"role": "user", "content": "Hello!"}]
 )
 ```
 
@@ -220,11 +215,7 @@ response = client.chat.completions.create(
 
 ```python
 # Record feedback for optimization
-t0.feedback(
-    inference_id=response.inference_id,
-    metric_name="user_rating",
-    value=5,
-)
+t0.feedback(inference_id=response.inference_id, metric_name="user_rating", value=5)
 ```
 
 ### Running Evaluations (CLI)

--- a/research/mcp-ecosystem/cocoindex-code.md
+++ b/research/mcp-ecosystem/cocoindex-code.md
@@ -230,17 +230,17 @@ Returns:
     "success": bool,
     "results": [
         {
-            "file_path": str,      # Relative file path
-            "language": str,       # Detected language
-            "content": str,        # Code snippet
-            "start_line": int,     # 1-indexed start line
-            "end_line": int,       # 1-indexed end line
-            "score": float         # Similarity score (0-1)
+            "file_path": str,  # Relative file path
+            "language": str,  # Detected language
+            "content": str,  # Code snippet
+            "start_line": int,  # 1-indexed start line
+            "end_line": int,  # 1-indexed end line
+            "score": float,  # Similarity score (0-1)
         }
     ],
     "total_returned": int,
     "offset": int,
-    "message": str | None
+    "message": str | None,
 }
 ```
 

--- a/research/mcp-ecosystem/retio-pagemap.md
+++ b/research/mcp-ecosystem/retio-pagemap.md
@@ -188,6 +188,7 @@ from pagemap.browser_session import BrowserSession
 from pagemap.page_map_builder import build_page_map_live, build_page_map_offline
 from pagemap.serializer import to_agent_prompt, to_json
 
+
 async def main():
     async with BrowserSession() as session:
         page_map = await build_page_map_live(session, "https://example.com/product/123")
@@ -199,11 +200,12 @@ async def main():
         print(to_json(page_map))
 
         # Direct field access
-        print(page_map.page_type)        # "product_detail"
-        print(page_map.interactables)    # [Interactable(ref=1, role="button", ...)]
-        print(page_map.pruned_context)   # compressed HTML
-        print(page_map.images)           # ["https://cdn.example.com/img.jpg"]
-        print(page_map.metadata)         # {"name": "...", "price": "..."}
+        print(page_map.page_type)  # "product_detail"
+        print(page_map.interactables)  # [Interactable(ref=1, role="button", ...)]
+        print(page_map.pruned_context)  # compressed HTML
+        print(page_map.images)  # ["https://cdn.example.com/img.jpg"]
+        print(page_map.metadata)  # {"name": "...", "price": "..."}
+
 
 # Offline processing without browser
 html = open("page.html").read()

--- a/research/ml-infrastructure/jax.md
+++ b/research/ml-infrastructure/jax.md
@@ -130,22 +130,27 @@ pip install -U "jax[tpu]"
 import jax
 import jax.numpy as jnp
 
+
 # Define a simple function
 def f(x):
-    return x ** 2 + 2 * x + 1
+    return x**2 + 2 * x + 1
+
 
 # Automatic differentiation
 x = 3.0
 print(jax.grad(f)(x))  # Output: 8.0 (derivative of f at x=3)
+
 
 # Compile with JIT for performance
 @jax.jit
 def compiled_f(x):
     return jnp.sin(x) + jnp.cos(x)
 
+
 # Vectorize over batch dimension
 def loss_fn(params, x, y):
     return jnp.mean((params * x - y) ** 2)
+
 
 # Compute gradients efficiently across batches
 batched_grad = jax.vmap(jax.grad(loss_fn), in_axes=(None, 0, 0))
@@ -161,9 +166,11 @@ from jax import grad, jit
 # Initialize parameters
 params = jnp.array([1.0, 2.0, 3.0])
 
+
 # Define loss function
 def loss(params, x, y):
     return jnp.mean((params @ x - y) ** 2)
+
 
 # Compiled gradient function
 grad_loss = jit(grad(loss))

--- a/research/ml-infrastructure/ray.md
+++ b/research/ml-infrastructure/ray.md
@@ -190,9 +190,11 @@ import ray
 
 ray.init()
 
+
 @ray.remote
 def process_data(x):
     return x * 2
+
 
 # Execute in parallel
 futures = [process_data.remote(i) for i in range(10)]
@@ -211,6 +213,7 @@ class Counter:
         self.value += 1
         return self.value
 
+
 counter = Counter.remote()
 ray.get([counter.increment.remote() for _ in range(10)])
 ```
@@ -222,15 +225,8 @@ from ray import serve
 from ray.serve.llm import LLMConfig, build_openai_app
 
 llm_config = LLMConfig(
-    model_loading_config=dict(
-        model_id="meta-llama/Llama-2-7b-chat-hf",
-    ),
-    deployment_config=dict(
-        autoscaling_config=dict(
-            min_replicas=1,
-            max_replicas=4,
-        )
-    ),
+    model_loading_config=dict(model_id="meta-llama/Llama-2-7b-chat-hf"),
+    deployment_config=dict(autoscaling_config=dict(min_replicas=1, max_replicas=4)),
 )
 
 app = build_openai_app(llm_config)
@@ -242,6 +238,7 @@ serve.run(app)
 ```python
 from ray import serve
 
+
 @serve.deployment
 class MCPToolServer:
     async def handle_tool_call(self, tool_name: str, arguments: dict):
@@ -249,6 +246,7 @@ class MCPToolServer:
         if tool_name == "search":
             return await self.search(arguments["query"])
         return {"error": "Unknown tool"}
+
 
 # Deploy with autoscaling
 serve.run(MCPToolServer.bind())
@@ -275,16 +273,15 @@ ds.write_parquet("s3://bucket/output/")
 from ray.train.torch import TorchTrainer
 from ray.train import ScalingConfig
 
+
 def train_func():
     # Training loop with automatic DDP
     model = ...
     for epoch in range(10):
         train_epoch(model)
 
-trainer = TorchTrainer(
-    train_func,
-    scaling_config=ScalingConfig(num_workers=4, use_gpu=True),
-)
+
+trainer = TorchTrainer(train_func, scaling_config=ScalingConfig(num_workers=4, use_gpu=True))
 result = trainer.fit()
 ```
 

--- a/research/ml-infrastructure/trainloop.md
+++ b/research/ml-infrastructure/trainloop.md
@@ -101,6 +101,7 @@ TrainLoop operates as a managed service (no self-hosted installation). Access is
 ```python
 # 3-line SDK integration for data collection
 import trainloop
+
 trainloop.init("api_key")
 trainloop.log_preference(prompt, response, score)
 ```
@@ -111,15 +112,9 @@ trainloop.log_preference(prompt, response, score)
 import openai
 
 # Point to TrainLoop's fine-tuned model endpoint
-client = openai.OpenAI(
-    api_key="trainloop_api_key",
-    base_url="https://api.trainloop.ai/v1"
-)
+client = openai.OpenAI(api_key="trainloop_api_key", base_url="https://api.trainloop.ai/v1")
 
-response = client.chat.completions.create(
-    model="your-fine-tuned-model",
-    messages=[{"role": "user", "content": "..."}]
-)
+response = client.chat.completions.create(model="your-fine-tuned-model", messages=[{"role": "user", "content": "..."}])
 ```
 
 **Current Access**: Limited beta — application required at <https://app.trainloop.ai/auth>

--- a/research/ml-infrastructure/zvec.md
+++ b/research/ml-infrastructure/zvec.md
@@ -140,10 +140,7 @@ pip install zvec
 import zvec
 
 # Define collection schema
-schema = zvec.CollectionSchema(
-    name="example",
-    vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 4),
-)
+schema = zvec.CollectionSchema(name="example", vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 4))
 
 # Create and open collection
 collection = zvec.create_and_open(path="./zvec_example", schema=schema)
@@ -155,10 +152,7 @@ collection.insert([
 ])
 
 # Query the collection
-results = collection.query(
-    zvec.VectorQuery(field_name="embedding", vector=[0.4, 0.3, 0.3, 0.1]),
-    topk=10
-)
+results = collection.query(zvec.VectorQuery(field_name="embedding", vector=[0.4, 0.3, 0.3, 0.1]), topk=10)
 ```
 
 **Source**: GitHub README.md — Python API examples (accessed 2026-08-10)

--- a/research/prompt-engineering/nano-banana-pro-prompting.md
+++ b/research/prompt-engineering/nano-banana-pro-prompting.md
@@ -162,9 +162,7 @@ client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 response = client.models.generate_content(
     model="gemini-3-pro-image-preview",
     contents="A cinematic wide shot of a futuristic sports car speeding through a rainy Tokyo street at night.",
-    config=types.GenerateContentConfig(
-        response_modalities=["IMAGE", "TEXT"],
-    ),
+    config=types.GenerateContentConfig(response_modalities=["IMAGE", "TEXT"]),
 )
 
 for part in response.candidates[0].content.parts:

--- a/research/python-runtimes/rustpython.md
+++ b/research/python-runtimes/rustpython.md
@@ -252,6 +252,7 @@ def compute(n):
         total += i
     return total
 
+
 # Enable JIT for this function
 compute.__jit__()
 

--- a/research/research-agent-patterns/ai-data-science-team.md
+++ b/research/research-agent-patterns/ai-data-science-team.md
@@ -136,17 +136,9 @@ llm = ChatOpenAI(model_name="gpt-4o-mini")
 
 df = pd.read_csv("data/sales.csv")
 
-agent = DataWranglingAgent(
-    model=llm,
-    n_samples=50,
-    log=True,
-    log_path="logs/",
-)
+agent = DataWranglingAgent(model=llm, n_samples=50, log=True, log_path="logs/")
 
-result = agent.invoke_agent(
-    user_instructions="Group by region and calculate total revenue per region",
-    data_raw=df,
-)
+result = agent.invoke_agent(user_instructions="Group by region and calculate total revenue per region", data_raw=df)
 
 df_wrangled = agent.get_data_wrangled()
 code = agent.get_data_wrangling_function()  # retrieve the generated Python function
@@ -165,7 +157,9 @@ llm = ChatOllama(model="llama3.1:8b")
 from ai_data_science_team.multiagents import DataScienceTeam
 
 team = DataScienceTeam(model=llm)
-response = team.invoke({"messages": [{"role": "user", "content": "Load data.csv, clean it, and show a correlation heatmap"}]})
+response = team.invoke({
+    "messages": [{"role": "user", "content": "Load data.csv, clean it, and show a correlation heatmap"}]
+})
 ```
 
 ---

--- a/research/research-agent-patterns/github-patterns.md
+++ b/research/research-agent-patterns/github-patterns.md
@@ -599,6 +599,7 @@ User ─▶ System ─▶ LeadResearcher ─▶ Subagents (A,B,...) ─▶ Memor
 ```python
 class Synthesis(BaseModel):
     """LeadResearcher synthesis output from findings."""
+
     executive_summary: str
     findings: list[Finding]
     gaps_or_open_questions: list[str] = Field(default_factory=list)
@@ -615,29 +616,28 @@ class Finding(BaseModel):
 
 class Plan(BaseModel):
     """Plan created by LeadResearcher for this iteration."""
+
     steps: list[Subtask] = Field(default_factory=list, description="Sub-tasks to execute now.")
-    continue_research: bool = Field(
-        description="True to continue iterative loop after current steps are done."
-    )
+    continue_research: bool = Field(description="True to continue iterative loop after current steps are done.")
     rationale: str
 
 
 class Subtask(BaseModel):
     id: str = Field(description="Unique ID for the sub-task, short (e.g. 'A' or 'B').")
     aspect: str = Field(description="What this sub-agent should research.")
-    target_depth: str = Field(
-        description="Depth like 'quick scan', 'deep dive', 'verify claims'."
-    )
+    target_depth: str = Field(description="Depth like 'quick scan', 'deep dive', 'verify claims'.")
 
 
 class CitationRequest(BaseModel):
     """What we give the CitationAgent."""
+
     draft_report_markdown: str
     bibliography: dict[str, str]  # (url -> "Author, Title, Year" etc.)
 
 
 class FinalReport(BaseModel):
     """What the CitationAgent returns after inserting citations."""
+
     markdown_with_citations: str
 ```
 
@@ -662,9 +662,7 @@ async def research_pipeline(user_query: str) -> str:
         iteration += 1
 
         # --- Plan the next iteration
-        plan_res = await planner.run(
-            f"User query:\n{user_query}\n\nMemory:\n{json.dumps(deps.memory.all(), indent=2)}"
-        )
+        plan_res = await planner.run(f"User query:\n{user_query}\n\nMemory:\n{json.dumps(deps.memory.all(), indent=2)}")
         plan = plan_res.output
         # Persist the plan to memory for traceability
         deps.memory.save(f"plan_iter_{iteration}", plan.model_dump_json())
@@ -706,13 +704,7 @@ async def research_pipeline(user_query: str) -> str:
             break
 
     # --- Final drafting
-    draft_md_lines: list[str] = [
-        f"# Research report",
-        "",
-        f"**User query**: {user_query}",
-        "",
-        "## Executive summary",
-    ]
+    draft_md_lines: list[str] = [f"# Research report", "", f"**User query**: {user_query}", "", "## Executive summary"]
 
     # Aggregate the last synthesis
     last_synth_json = deps.memory.recall(f"synthesis_iter_{iteration}") or ""
@@ -739,9 +731,7 @@ async def research_pipeline(user_query: str) -> str:
     cite_req = CitationRequest(draft_report_markdown=draft_md, bibliography=biblio)
     final = (
         await citation.run(
-            "Insert citations into the draft and add a 'References' section at the end.",
-            deps=deps,
-            input=cite_req,
+            "Insert citations into the draft and add a 'References' section at the end.", deps=deps, input=cite_req
         )
     ).output
 
@@ -758,7 +748,7 @@ def make_subagent() -> Agent[Deps, Finding]:
     It must return a structured Finding.
     """
     sub = Agent[Deps, Finding](
-        'openai:gpt-4o-mini',
+        "openai:gpt-4o-mini",
         instructions=(
             "You are a precise research sub-agent. "
             "Goal: research the requested aspect, collect a few high-quality sources, "
@@ -791,7 +781,7 @@ def make_subagent() -> Agent[Deps, Finding]:
 ```python
 def make_citation_agent() -> Agent[Deps, FinalReport]:
     cite = Agent[Deps, FinalReport](
-        'openai:gpt-4o-mini',
+        "openai:gpt-4o-mini",
         instructions=(
             "You are a precise citation agent. "
             "Given a draft markdown and a bibliography mapping citation keys to URLs, "
@@ -1108,7 +1098,7 @@ ctx.deps.memory.save(cite_key, str(url))
 # Final pass: CitationAgent receives
 CitationRequest(
     draft_report_markdown=draft_md,
-    bibliography=biblio  # { "[cite:12345]": "https://..." }
+    bibliography=biblio,  # { "[cite:12345]": "https://..." }
 )
 
 # CitationAgent inserts citations and builds References section

--- a/research/research-agent-patterns/ollama-subagents-web-search-claude-code.md
+++ b/research/research-agent-patterns/ollama-subagents-web-search-claude-code.md
@@ -142,27 +142,18 @@ print(response)
 # Search agent pattern with tool calls
 from ollama import chat, web_fetch, web_search
 
-available_tools = {'web_search': web_search, 'web_fetch': web_fetch}
-messages = [{'role': 'user', 'content': "research the postgres 18 release notes"}]
+available_tools = {"web_search": web_search, "web_fetch": web_fetch}
+messages = [{"role": "user", "content": "research the postgres 18 release notes"}]
 
 while True:
-    response = chat(
-        model='minimax-m2.5:cloud',
-        messages=messages,
-        tools=[web_search, web_fetch],
-        think=True
-    )
+    response = chat(model="minimax-m2.5:cloud", messages=messages, tools=[web_search, web_fetch], think=True)
     messages.append(response.message)
     if response.message.tool_calls:
         for tool_call in response.message.tool_calls:
             fn = available_tools.get(tool_call.function.name)
             if fn:
                 result = fn(**tool_call.function.arguments)
-                messages.append({
-                    'role': 'tool',
-                    'content': str(result)[:8000],
-                    'tool_name': tool_call.function.name
-                })
+                messages.append({"role": "tool", "content": str(result)[:8000], "tool_name": tool_call.function.name})
     else:
         break
 ```

--- a/research/serialization-libraries/msgspec.md
+++ b/research/serialization-libraries/msgspec.md
@@ -84,12 +84,15 @@ conda install -c conda-forge msgspec
 ```python
 import msgspec
 
+
 # Define schema using type annotations
 class User(msgspec.Struct):
     """A user account"""
+
     name: str
     groups: set[str] = set()
     email: str | None = None
+
 
 # Encode
 alice = User("alice", groups={"admin", "engineering"})
@@ -127,6 +130,7 @@ msgspec.toml.encode(alice)
 ```python
 class Config(msgspec.Struct, frozen=True, order=True, kw_only=True):
     """An immutable, orderable configuration"""
+
     timeout: int
     retries: int = 3
 ```
@@ -296,8 +300,10 @@ SOURCE: README.md validation example
 ```python
 import msgspec
 
+
 class User(msgspec.Struct):
     """A user account"""
+
     name: str
     groups: set[str] = set()
     email: str | None = None
@@ -344,6 +350,7 @@ SOURCE: API documentation and format module listing
 ```python
 class Config(msgspec.Struct, frozen=True, order=True, kw_only=True):
     """An immutable, orderable configuration"""
+
     timeout: int
     retries: int = 3
 ```

--- a/research/skill-generation-tools/claude-scientific-skills.md
+++ b/research/skill-generation-tools/claude-scientific-skills.md
@@ -191,7 +191,7 @@ sc.settings.verbosity = 3
 sc.settings.set_figure_params(dpi=80)
 
 # Load 10X data
-adata = sc.read_10x_h5('path/to/data.h5')
+adata = sc.read_10x_h5("path/to/data.h5")
 
 # QC and preprocessing
 sc.pp.calculate_qc_metrics(adata)

--- a/research/skill-generation-tools/skillsmp.md
+++ b/research/skill-generation-tools/skillsmp.md
@@ -114,9 +114,7 @@ import requests
 
 headers = {"Authorization": f"Bearer {api_key}"}
 resp = requests.get(
-    "https://skillsmp.com/api/skills",
-    params={"query": "code review", "category": "development"},
-    headers=headers,
+    "https://skillsmp.com/api/skills", params={"query": "code review", "category": "development"}, headers=headers
 )
 skills = resp.json()
 ```


### PR DESCRIPTION
## Summary
- `uv run ruff format` reformats fenced Python code blocks inside markdown, not just `.py` files. 76 markdown files (research entries + one ARCHITECTURE.md) had drifted from `ruff format --check .`. Zero non-markdown files touched — this is purely code-block style inside docs.
- Closes `claude_skills-0ap`.

## Test plan
- [x] `uv run ruff format --check .` — 2784 files clean, 0 drift remaining
- [x] `uv run prek run --files <changed files>` — markdownlint, research-entry validation, all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)