### PR TITLE
fix(development-harness): register critical pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ addopts = [
 ]
 asyncio_mode = "auto"
 markers = [
+    "critical: marks tests covering critical-path code requiring stronger correctness guarantees (e.g. round-trip property tests)",
     "cross_backend: marks tests that run only in the test-cross-backend CI matrix job",
     "demos: marks tests as demonstration tests",
     "e2e: marks tests as end-to-end tests",


### PR DESCRIPTION
## Summary
- `test_beads_models.py` uses `@pytest.mark.critical` on a Hypothesis round-trip property test, but `critical` was never declared in `[tool.pytest.ini_options] markers` in `pyproject.toml`
- With `--strict-markers` enabled, this failed collection of the entire file in all 8 pytest-xdist workers (8 identical errors, 0 tests collected)

## Root cause
Registered `critical` in the markers list, matching the existing format/convention of neighboring entries. Description text derived from the marker's actual (sole) usage site via grep, not invented.

## Test plan
- [x] Reproduced: `uv run pytest plugins/development-harness/tests_backlog/test_beads_models.py -v --tb=long --no-cov` → 8 identical marker-registration errors, 0 items collected
- [x] After fix: same command → 57 passed, 0 errors
- [x] Repo-wide: `uv run pytest --collect-only -q` → 4791/4901 collected, no marker-registration errors anywhere else
- [x] `ruff check --fix`, `prek run --files pyproject.toml` — clean

Closes claude_skills-les

🤖 Generated with [Claude Code](https://claude.com/claude-code)