### PR TITLE
docs(plugin-creator): add skill subdirectory-namespace warning to reference skills

### DIFF
--- a/plugins/plugin-creator/docs/skill-subdirectory-warning.md
+++ b/plugins/plugin-creator/docs/skill-subdirectory-warning.md
@@ -1,0 +1,14 @@
+# Skill Subdirectory Warning
+
+Skill directories nested under `skills/` silently fail to register — Claude Code only discovers
+`skills/<name>/SKILL.md`, not `skills/<group>/<name>/SKILL.md`. Subdirectory colon-namespacing
+(`plugin:group:skill-name`) is a `commands/` feature only; it does not extend to `skills/`.
+
+- `skills/testing/foo/SKILL.md` → **DEAD — not registered**
+- `skills/foo/SKILL.md` → `/plugin:foo` — **correct**
+
+All skill directories must sit directly under `skills/` — one level deep only. Do not create
+grouping subdirectories to organize related skills.
+
+SOURCE: `.claude/rules/markdown-file-references.md`, section "Subdirectory Namespaces — Skills Do
+NOT Support This" (repo-internal convention; added via commit `ea33cf2e`, 2026-03-22).

--- a/plugins/plugin-creator/skills/claude-plugins-reference-2026/SKILL.md
+++ b/plugins/plugin-creator/skills/claude-plugins-reference-2026/SKILL.md
@@ -183,6 +183,13 @@ skills/
 - Claude can invoke them automatically based on task context
 - Skills can include supporting files alongside SKILL.md
 
+**Subdirectory Warning**: Skill directories nested under `skills/` silently fail to register — only `skills/<name>/SKILL.md` is discovered, not `skills/<group>/<name>/SKILL.md`. Subdirectory colon-namespacing (`plugin:group:skill-name`) is a `commands/` feature only; it does not extend to `skills/`.
+
+- `skills/testing/foo/SKILL.md` → **DEAD — not registered**
+- `skills/foo/SKILL.md` → `/plugin:foo` — **correct**
+
+All skill directories must sit directly under `skills/` — one level deep only. Do not create grouping subdirectories.
+
 ### Agents
 
 Plugins can provide specialized subagents for specific tasks that Claude can invoke automatically when appropriate.

--- a/plugins/plugin-creator/skills/claude-plugins-reference-2026/SKILL.md
+++ b/plugins/plugin-creator/skills/claude-plugins-reference-2026/SKILL.md
@@ -183,12 +183,7 @@ skills/
 - Claude can invoke them automatically based on task context
 - Skills can include supporting files alongside SKILL.md
 
-**Subdirectory Warning**: Skill directories nested under `skills/` silently fail to register — only `skills/<name>/SKILL.md` is discovered, not `skills/<group>/<name>/SKILL.md`. Subdirectory colon-namespacing (`plugin:group:skill-name`) is a `commands/` feature only; it does not extend to `skills/`.
-
-- `skills/testing/foo/SKILL.md` → **DEAD — not registered**
-- `skills/foo/SKILL.md` → `/plugin:foo` — **correct**
-
-All skill directories must sit directly under `skills/` — one level deep only. Do not create grouping subdirectories.
+[Skill subdirectory warning](../../docs/skill-subdirectory-warning.md) — nested skill directories silently fail to register, with a wrong/right example; read before organizing related skills into grouping subdirectories.
 
 ### Agents
 

--- a/plugins/plugin-creator/skills/claude-skills-overview-2026/SKILL.md
+++ b/plugins/plugin-creator/skills/claude-skills-overview-2026/SKILL.md
@@ -229,12 +229,7 @@ Supporting files can also live at the skill root (e.g., `reference.md`, `forms.m
 
 ### Subdirectory Warning — Skills Must Be One Level Deep
 
-Skill directories nested under `skills/` silently fail to register — Claude Code only discovers `skills/<name>/SKILL.md`, not `skills/<group>/<name>/SKILL.md`. Subdirectory colon-namespacing (`plugin:group:skill-name`) is a `commands/` feature only; it does not extend to `skills/`.
-
-- `skills/testing/foo/SKILL.md` → **DEAD — not registered**
-- `skills/foo/SKILL.md` → `/plugin:foo` — **correct**
-
-All skill directories must sit directly under `skills/`. Do not create grouping subdirectories to organize related skills — this is unrelated to the "Automatic Discovery from Nested Directories" behavior below, which discovers separate `.claude/skills/` roots in subdirectories of your project, not grouping folders inside a single `skills/` directory.
+[Skill subdirectory warning](../../docs/skill-subdirectory-warning.md) — nested skill directories silently fail to register, with a wrong/right example; read before organizing related skills into grouping subdirectories. Unrelated to the "Automatic Discovery from Nested Directories" behavior below, which discovers separate `.claude/skills/` roots in subdirectories of your project, not grouping folders inside a single `skills/` directory.
 
 ### Location Priority (Highest to Lowest)
 

--- a/plugins/plugin-creator/skills/claude-skills-overview-2026/SKILL.md
+++ b/plugins/plugin-creator/skills/claude-skills-overview-2026/SKILL.md
@@ -227,6 +227,15 @@ skill-name/
 
 Supporting files can also live at the skill root (e.g., `reference.md`, `forms.md`). Reference them from SKILL.md so Claude knows what each file contains and when to load it.
 
+### Subdirectory Warning — Skills Must Be One Level Deep
+
+Skill directories nested under `skills/` silently fail to register — Claude Code only discovers `skills/<name>/SKILL.md`, not `skills/<group>/<name>/SKILL.md`. Subdirectory colon-namespacing (`plugin:group:skill-name`) is a `commands/` feature only; it does not extend to `skills/`.
+
+- `skills/testing/foo/SKILL.md` → **DEAD — not registered**
+- `skills/foo/SKILL.md` → `/plugin:foo` — **correct**
+
+All skill directories must sit directly under `skills/`. Do not create grouping subdirectories to organize related skills — this is unrelated to the "Automatic Discovery from Nested Directories" behavior below, which discovers separate `.claude/skills/` roots in subdirectories of your project, not grouping folders inside a single `skills/` directory.
+
 ### Location Priority (Highest to Lowest)
 
 1. **Managed/Enterprise** - System-level (see [managed settings](/en/permissions#managed-settings))


### PR DESCRIPTION
## Summary
- Adds the "skills nested under `skills/` silently fail to register" warning (with a wrong/right example) to `claude-plugins-reference-2026` and `claude-skills-overview-2026` — the two plugin-creator reference skills plugin authors and audit agents actually consult, which previously lacked it despite the canonical rule existing in `.claude/rules/markdown-file-references.md` since commit `ea33cf2e`.
- Verified `plugins/development-harness/CLAUDE.md`/`README.md` invocation paths were already flat — no edit needed there.

Closes #983.

## Test plan
- [x] `uv run prek run --files` on both modified files — all hooks pass
- [x] Verified via grep neither file contained the warning before this change
- [x] Verified via grep that dh CLAUDE.md/README.md have no `dh:group:skill`-style paths

## Notes
Implemented directly rather than through the SAM grooming/planning pipeline: `backlog groom` and `artifact register`/`list` both hit backend defects for this item during grooming (filed as #2900 and #2899 — `BacklogError: Item has no backend reference` and a register/list read-after-write mismatch). The item's existing RT-ICA content plus fresh verification fully scoped the fix, so routing through the broken pipeline added no value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)