### PR TITLE
fix(development-harness): heal stale empty BacklogItem.reference on load

### DIFF
--- a/plugins/development-harness/backlog_core/backends/github_work_items.py
+++ b/plugins/development-harness/backlog_core/backends/github_work_items.py
@@ -422,6 +422,28 @@ class _GitHubWorkItemSync:
         return heads, comments
 
 
+def _stable_reference(item: BacklogItem) -> str:
+    """Return the opaque backend reference an item should carry.
+
+    ``BacklogItem.reference`` is not kept in sync with ``metadata.issue`` by
+    the model's ``_sync_metadata`` validator (unlike ``priority``/``issue``
+    and the other backward-compatible flat fields) — nothing guarantees the
+    two stay aligned once a record is persisted. A record written before this
+    field was populated consistently (or one round-tripped through a code
+    path that never set it) can reach disk with ``reference=""`` while
+    ``metadata.issue`` is a real GitHub issue reference. Every write already
+    self-heals through this exact fallback (see ``put_work_item``); reads
+    must apply it identically so a stale on-disk record recovers on next
+    load instead of tripping every ``reference``-gated write forever.
+
+    Returns:
+        ``item.reference`` when set, else ``item.issue``, else a stable hash
+        of the title as a last-resort opaque key for an item never linked to
+        a provider issue.
+    """
+    return item.reference or item.issue or hashlib.sha256(item.title.encode()).hexdigest()
+
+
 class _GitHubReconciliation:
     """Drive the reconciliation cycle between the private cache and the provider."""
 
@@ -459,7 +481,7 @@ class _GitHubReconciliation:
 
     def put_work_item(self, item: BacklogItem) -> None:
         """Persist a work-item intent for provider reconciliation."""
-        reference = item.reference or item.issue or hashlib.sha256(item.title.encode()).hexdigest()
+        reference = _stable_reference(item)
         self._cache._queue_work_item(reference, item.model_copy(update={"reference": reference}))
 
     def reconcile(self, request: ReconcileRequest) -> ReconcileResult:
@@ -528,12 +550,23 @@ class _GitHubReconciliation:
     ) -> list[LogicalCacheRecord]:
         """Merge cached work-item snapshots with queued mutations.
 
+        Snapshot items are healed through :func:`_stable_reference` before
+        being keyed. Without this, a snapshot persisted with
+        ``reference=""`` (see :func:`_stable_reference` docstring) collides
+        with every other unhealed snapshot under the same empty-string key —
+        silently dropping all but the last one loaded — and separately
+        leaves ``reference``-gated writes (groom, resolve) permanently
+        broken for that item, since nothing else ever revisits an
+        already-cached record to repair it.
+
         Returns:
             One logical cache record per work-item reference.
         """
-        records_by_reference = {
-            item.reference: LogicalCacheRecord(key=key, item=item) for key, item in self._cache._work_item_snapshots()
-        }
+        records_by_reference: dict[str, LogicalCacheRecord] = {}
+        for key, item in self._cache._work_item_snapshots():
+            reference = _stable_reference(item)
+            healed_item = item if reference == item.reference else item.model_copy(update={"reference": reference})
+            records_by_reference[reference] = LogicalCacheRecord(key=key, item=healed_item)
         for mutation in (
             pending_work_items if pending_work_items is not None else self._cache._pending_work_item_mutations()
         ):

--- a/plugins/development-harness/tests/test_github_reference_healing.py
+++ b/plugins/development-harness/tests/test_github_reference_healing.py
@@ -1,0 +1,226 @@
+"""GitHub backend work-item reference healing — regression tests.
+
+Tests: ``_GitHubReconciliation.load_records`` (via the public
+       ``GitHubBackend.list_work_items``/``get_work_item``/``put_work_item``
+       surface) heals a stale on-disk ``BacklogItem.reference=""`` from
+       ``metadata.issue`` instead of propagating it forever, and no longer
+       collides two distinct items under the shared empty-string key.
+How: Inject a ``FileCache`` rooted at ``tmp_path`` into ``GitHubBackend`` and
+     write raw legacy snapshot files directly through
+     ``FileCache._save_work_item_snapshot`` — reproducing the on-disk shape
+     of an item persisted before ``reference`` was populated consistently,
+     without requiring live GitHub network access.
+Why: Backlog item #2900 — ``backlog groom``/``backlog resolve`` raised
+     ``BacklogError: Item has no backend reference`` for a real, valid,
+     open GitHub-backed item (#983) whose local cache snapshot carried
+     ``reference=""`` while ``metadata.issue == "#983"``. ``view``/`update
+     --status`` worked because those code paths never read
+     ``item.reference``; ``groom``/``resolve`` do, and the reconciliation
+     compose/checkpoint functions blindly propagated the already-empty
+     ``local.reference`` on every subsequent sync, so the record never
+     self-healed. Root cause: ``_GitHubReconciliation.load_records`` keyed
+     its snapshot dict by the *unhealed* ``item.reference`` field, which
+     both surfaced the crash (an item found by title/issue still carried an
+     empty ``.reference``) and could silently drop distinct legacy items
+     that collided under the shared ``""`` key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from backlog_core import operations as ops
+from backlog_core.backend_protocol import reset_config, set_config
+from backlog_core.backend_types import BacklogConfig
+from backlog_core.backends.github_backend import GitHubBackend
+from backlog_core.file_cache import FileCache
+from backlog_core.models import BacklogItem, BacklogItemMetadata, ReconcileResult
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def _stale_legacy_item(*, title: str, issue: str) -> BacklogItem:
+    """Build a ``BacklogItem`` shaped like a pre-healing on-disk record.
+
+    Mirrors a record written before ``reference`` was populated
+    consistently: ``metadata.issue`` is set but ``reference`` was never
+    backfilled, matching the shape found in backlog item #983's actual
+    cache file (see docstring above).
+
+    Returns:
+        A ``BacklogItem`` with ``reference=""`` and ``metadata.issue`` set.
+    """
+    return BacklogItem(
+        title=title,
+        metadata=BacklogItemMetadata(source="test", added="2026-01-01", priority="P1", item_type="Bug", issue=issue),
+    )
+
+
+def _backend_with_stale_snapshot(tmp_path: Path, *, key: str, title: str, issue: str) -> GitHubBackend:
+    """Return a GitHubBackend whose cache holds one stale legacy snapshot.
+
+    Returns:
+        A GitHubBackend backed by an isolated FileCache pre-seeded with a
+        raw legacy snapshot (bypassing ``put_work_item``'s normalization,
+        so the write matches how the real stale record on disk was found).
+    """
+    backend = GitHubBackend(cache=FileCache(tmp_path))
+    backend._cache._save_work_item_snapshot(key, _stale_legacy_item(title=title, issue=issue))
+    return backend
+
+
+class TestListWorkItemsHealsStaleReference:
+    """list_work_items()/get_work_item() heal an empty on-disk reference."""
+
+    def test_list_work_items_heals_reference_from_issue(self, tmp_path: Path) -> None:
+        """A snapshot with reference='' and issue='#983' loads with reference='#983'."""
+        backend = _backend_with_stale_snapshot(tmp_path, key="#983", title="Stale item", issue="#983")
+
+        items = backend.list_work_items()
+
+        assert len(items) == 1
+        assert items[0].reference == "#983"
+        assert items[0].issue == "#983"
+
+    def test_get_work_item_finds_item_by_healed_reference(self, tmp_path: Path) -> None:
+        """get_work_item(reference) succeeds once reference is healed to match issue.
+
+        This is the exact lookup ``_apply_groomed_update``/``resolve_item``
+        depend on: they read ``item.reference`` from a ``list_work_items()``
+        result, then pass it straight to ``get_work_item``/
+        ``update_item_metadata``. Before the fix, ``item.reference`` from
+        ``list_work_items()`` was ``""`` and this lookup was never
+        exercised at all — the crash occurred earlier at the ``not
+        item.reference`` guard.
+        """
+        backend = _backend_with_stale_snapshot(tmp_path, key="#983", title="Stale item", issue="#983")
+
+        listed = backend.list_work_items()[0]
+        found = backend.get_work_item(listed.reference)
+
+        assert found.title == "Stale item"
+        assert found.reference == "#983"
+
+    def test_put_work_item_after_healing_persists_the_repaired_reference(self, tmp_path: Path) -> None:
+        """Writing back a healed item durably repairs the on-disk reference.
+
+        Reproduces the groom/resolve write path: read the (now-healed) item,
+        mutate it, and persist through put_work_item. The repaired
+        reference must round-trip through a fresh load, not just survive in
+        memory for the current call.
+        """
+        backend = _backend_with_stale_snapshot(tmp_path, key="#983", title="Stale item", issue="#983")
+
+        item = backend.list_work_items()[0]
+        backend.put_work_item(item.model_copy(update={"description": "groomed"}))
+        # A second, independent backend instance over the same cache root
+        # proves the repair reached durable storage, not just this process's
+        # in-memory pending-mutation queue.
+        reloaded_backend = GitHubBackend(cache=FileCache(tmp_path))
+
+        reloaded = reloaded_backend.get_work_item("#983")
+
+        assert reloaded.reference == "#983"
+        assert reloaded.description == "groomed"
+
+
+class TestDistinctStaleSnapshotsDoNotCollide:
+    """Two legacy items sharing an empty reference must not collapse into one."""
+
+    def test_two_snapshots_with_empty_reference_are_both_returned(self, tmp_path: Path) -> None:
+        """Keying by the unhealed empty-string reference silently drops one item.
+
+        Before healing at the read boundary, ``load_records()`` built its
+        dict as ``{item.reference: record for ...}`` — two on-disk items
+        that both carried ``reference=""`` collapsed onto the same ``""``
+        key, and only the last one loaded (glob order) survived. Healing
+        each item's key from its own ``metadata.issue`` before insertion
+        keeps them distinct.
+        """
+        backend = GitHubBackend(cache=FileCache(tmp_path))
+        backend._cache._save_work_item_snapshot("#100", _stale_legacy_item(title="First stale item", issue="#100"))
+        backend._cache._save_work_item_snapshot("#200", _stale_legacy_item(title="Second stale item", issue="#200"))
+
+        items = backend.list_work_items()
+
+        titles = {item.title for item in items}
+        references = {item.reference for item in items}
+        assert titles == {"First stale item", "Second stale item"}
+        assert references == {"#100", "#200"}
+
+
+class TestPutWorkItemNormalization:
+    """put_work_item's existing reference-from-issue fallback is unchanged."""
+
+    def test_put_work_item_derives_reference_from_issue_when_unset(self, tmp_path: Path) -> None:
+        """An item passed to put_work_item with reference='' still normalizes from issue.
+
+        Regression guard for the shared ``_stable_reference`` helper: the
+        fallback that already existed inline in ``put_work_item`` must keep
+        behaving identically now that ``load_records`` reuses it.
+        """
+        backend = GitHubBackend(cache=FileCache(tmp_path))
+        item = BacklogItem(title="New item", issue="#555")
+        assert item.reference == ""
+
+        backend.put_work_item(item)
+        found = backend.get_work_item("#555")
+
+        assert found.reference == "#555"
+
+
+class TestGroomAndResolveOperationsNoLongerRaise:
+    """operations.groom_item/resolve_item no longer crash on a stale legacy record.
+
+    Exercises the two public functions named in the original bug report
+    end-to-end through the operations layer, against the exact backend
+    class (``GitHubBackend``) and on-disk shape (a legacy snapshot with
+    ``reference=""``) that reproduced the defect. Only the two GitHub
+    network boundary methods (``check_open_prs_for_issue``,
+    ``resolve_github_issue``) are mocked; reference resolution, item
+    lookup, and the local cache write-back all run for real.
+    """
+
+    def test_resolve_item_succeeds_on_a_stale_legacy_record(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """resolve_item on a stale-reference item returns resolved=True, not BacklogError.
+
+        Before the fix this raised ``BacklogError: Item has no backend
+        reference`` at the ``reference = item.reference; if not reference:
+        raise`` guard in ``resolve_item`` — the same defect ``groom_item``
+        hit, sourced from the same unhealed ``list_work_items()`` read.
+        """
+        backend = _backend_with_stale_snapshot(tmp_path, key="#2900", title="Stale bug item", issue="#2900")
+        mocker.patch.object(backend, "check_open_prs_for_issue", return_value=[])
+        mocker.patch.object(backend, "resolve_github_issue")
+        set_config(BacklogConfig(backend=backend))
+
+        try:
+            result = ops.resolve_item(selector="#2900", summary="Fixed the reference-healing root cause")
+        finally:
+            reset_config()
+
+        assert result["resolved"] is True
+        assert result["summary"] == "Fixed the reference-healing root cause"
+
+    def test_groom_item_succeeds_on_a_stale_legacy_record(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """groom_item on a stale-reference item writes the section, not BacklogError.
+
+        Reproduces the exact reported repro command:
+        ``backlog groom --selector "#983" --section "..." --content "..."``
+        against an item whose cache snapshot carries ``reference=""``.
+        """
+        backend = _backend_with_stale_snapshot(tmp_path, key="#983", title="Stale docs item", issue="#983")
+        # _reconcile_groomed_item posts the write-back through backend.reconcile(),
+        # which reaches live GitHub via the provider snapshot/patch boundary —
+        # mock it at that boundary rather than skip reconciliation.
+        mocker.patch.object(backend, "reconcile", return_value=ReconcileResult())
+        set_config(BacklogConfig(backend=backend))
+
+        try:
+            result = ops.groom_item(selector="#983", section="RT-ICA", content="verification content")
+        finally:
+            reset_config()
+
+        assert result["groomed_updated"] is True


### PR DESCRIPTION
## Summary
- `groom` and `resolve` operations raised `BacklogError: Item has no backend reference` for valid, open GitHub-backed items, while `view`/`update --status` worked fine on the same items.
- Root cause: `_GitHubReconciliation.load_records()` keyed its in-memory snapshot by the raw, unhealed `BacklogItem.reference` field read straight off disk. A record persisted before `reference` was populated consistently reaches disk with `reference=""` while `metadata.issue` holds the real GitHub issue reference. `groom_item`/`_apply_groomed_update` and `resolve_item` both hard-guard on `if not item.reference: raise BacklogError(...)`. The write path (`put_work_item`) already had a fallback (`item.reference or item.issue or hash(title)`); the read path never applied the same normalization, so a stale record never self-healed and broke every subsequent groom/resolve call for that item — permanently.
- A second-order symptom of the same bug: two distinct legacy records both carrying `reference=""` would collide under the shared empty-string dict key in `load_records()`, silently dropping one from `list_work_items()`.
- Fix: factored the existing write-side fallback into a shared `_stable_reference()` helper and applied it symmetrically at the read boundary, so a stale on-disk record self-heals the moment it's loaded.

Closes #2900.

## Test plan
- [x] Added `plugins/development-harness/tests/test_github_reference_healing.py` — 7 tests covering reference healing on `list_work_items`/`get_work_item`, durable repair round-trip, collision-avoidance for two distinct stale records, `put_work_item` normalization regression guard, and end-to-end `operations.resolve_item`/`operations.groom_item` runs against a `GitHubBackend`+`FileCache` fixture reproducing the exact on-disk shape.
- [x] Falsification check: reverted the fix in a temp copy — 3 of the 5 core tests failed exactly as predicted (the two healing tests + the collision test); the 2 unrelated `put_work_item`-normalization tests still passed.
- [x] `uv run ruff check --fix`, `uv run ruff format`, `uv run ty check`, `uv run prek run --files` — all pass.
- [x] Full `plugins/development-harness/` suite: 4756 passed, 42 skipped, 5 xfailed, no failures.
- [x] Verified against this repo's real GitHub-backend item #983: `reference` on disk went from `''` to `'#983'` after one groom call.

## Notes (not addressed, out of scope)
- The offline pending-mutation queue in this repo's live cache shows `"1 failure(s)"` on every GitHub-backend reconcile — pre-existing, unrelated to the reference-healing defect. Will file separately.
- `BacklogItem.reference` is structurally disconnected from `metadata.issue` — not kept in sync by the `_sync_metadata` model validator like the other backward-compatible flat fields. This fix heals the read boundary; a deeper fix folding `reference` under the same validator-enforced invariant is a larger, more invasive model change outside this task's scope.
- `backlog update --selector ... --status "done"` silently no-ops rather than erroring (noticed during original bug investigation) — separate, unfiled concern, confirmed still present, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)