### PR TITLE
fix(development-harness): stop clobbering pending artifact-manifest writes on read

### DIFF
--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -355,7 +355,11 @@ class _GitHubContentCache:
         except (BacklogError, ContentUnavailableError, OSError):
             self._cache.queue_write(self._queue_base(request, cached), request)
             return self._cache.get_content(request.reference)
-        self._cache.cache_content(record)
+        # This write just landed directly against the provider for this exact
+        # reference, so it is authoritative over whatever pending mutation the
+        # cache may still be holding for it -- acknowledge_pending=True lets it
+        # supersede that entry instead of being silently refused.
+        self._cache.cache_content(record, acknowledge_pending=True)
         self._cache.discard_pending(request.reference)
         return record
 

--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -279,13 +279,18 @@ class _GitHubContentCache:
         A reference whose queued write is still pending after
         :meth:`replay_pending` (e.g. blocked by a branch-protection ruleset
         that rejects direct Contents API commits) is served from the cache
-        instead of being re-read online. Some legacy fallback readers (the
-        artifact-manifest Gist reader in particular) never raise
-        ``ContentNotFoundError`` for a reference with no remote data yet —
-        they return an empty-but-valid record instead — so a successful
-        online read cannot be trusted to mean "this write landed". Trusting
-        it anyway would silently overwrite the cache with that empty record,
-        discarding the caller's own unacknowledged write.
+        instead of trusting the online read's returned content. Some legacy
+        fallback readers (the artifact-manifest Gist reader in particular)
+        never raise ``ContentNotFoundError`` for a reference with no remote
+        data yet — they return an empty-but-valid record instead — so a
+        successful online read cannot be trusted to mean "this write landed".
+        Trusting it anyway would silently overwrite the cache with that empty
+        record, discarding the caller's own unacknowledged write. The online
+        read is still attempted for its own sake in this case, because a
+        genuine ``_GitHubContentIntegrityError`` (corrupt remote data) is a
+        signal callers must still see even while a write for the same
+        reference is stuck pending -- only the read's *content* is untrusted,
+        not evidence that the remote copy is broken.
 
         Returns:
             The provider or cached logical content record.
@@ -300,6 +305,12 @@ class _GitHubContentCache:
         self.replay_pending()
         cached = self.cached_content(reference)
         if cached is not None and cached.pending:
+            try:
+                self._provider._read_online_content(reference, cached)
+            except _GitHubContentIntegrityError:
+                raise
+            except (ContentNotFoundError, BacklogError, ContentUnavailableError, OSError):
+                pass
             return self._cache.get_content(reference, stale=True)
         try:
             record = self._provider._read_online_content(reference, cached)
@@ -345,6 +356,7 @@ class _GitHubContentCache:
             self._cache.queue_write(self._queue_base(request, cached), request)
             return self._cache.get_content(request.reference)
         self._cache.cache_content(record)
+        self._cache.discard_pending(request.reference)
         return record
 
     def replay_pending(self) -> None:

--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -276,6 +276,17 @@ class _GitHubContentCache:
     def get_content(self, reference: ContentRef) -> ContentRecord:
         """Read authoritative content or an explicitly stale cached copy.
 
+        A reference whose queued write is still pending after
+        :meth:`replay_pending` (e.g. blocked by a branch-protection ruleset
+        that rejects direct Contents API commits) is served from the cache
+        instead of being re-read online. Some legacy fallback readers (the
+        artifact-manifest Gist reader in particular) never raise
+        ``ContentNotFoundError`` for a reference with no remote data yet —
+        they return an empty-but-valid record instead — so a successful
+        online read cannot be trusted to mean "this write landed". Trusting
+        it anyway would silently overwrite the cache with that empty record,
+        discarding the caller's own unacknowledged write.
+
         Returns:
             The provider or cached logical content record.
 
@@ -288,6 +299,8 @@ class _GitHubContentCache:
             return self._cache.get_content(reference, stale=True)
         self.replay_pending()
         cached = self.cached_content(reference)
+        if cached is not None and cached.pending:
+            return self._cache.get_content(reference, stale=True)
         try:
             record = self._provider._read_online_content(reference, cached)
         except ContentNotFoundError:

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -46,11 +46,33 @@ class FileCache:
                 return record.model_copy(update={"stale": stale})
         raise ContentUnavailableError(str(reference.model_dump(mode="json")))
 
-    def cache_content(self, record: ContentRecord) -> None:
-        """Durably replace one provider-observed content record."""
-        self._state.transaction(
-            lambda state: (state.model_copy(update={"records": self._replace_record(state.records, record)}), None)
-        )
+    def cache_content(self, record: ContentRecord, *, acknowledge_pending: bool = False) -> None:
+        """Durably replace one provider-observed content record.
+
+        A cached record already marked ``pending`` represents a queued mutation
+        whose content and ``pending`` flag must survive routine online reads
+        (``list_content``, ``get_content``) until that mutation is acknowledged
+        -- otherwise a discovery read can silently clobber an unacknowledged
+        write with older provider content. This method enforces that invariant
+        directly so every caller gets it for free instead of duplicating a
+        guard clause.
+
+        Args:
+            record: The provider-observed content record to store.
+            acknowledge_pending: Pass ``True`` only when this call itself is
+                landing the authoritative write for ``record.reference`` (a
+                direct foreground write that supersedes whatever was queued).
+                Defaults to ``False`` so a routine cache-refresh read never
+                overwrites a still-pending reference.
+        """
+
+        def replace(state: _CacheState) -> tuple[_CacheState, None]:
+            existing = next((entry for entry in state.records if entry.reference == record.reference), None)
+            if existing is not None and existing.pending and not acknowledge_pending:
+                return state, None
+            return state.model_copy(update={"records": self._replace_record(state.records, record)}), None
+
+        self._state.transaction(replace)
 
     def queue_write(self, record: ContentRecord, write: ContentWrite) -> PendingMutation:
         """Atomically cache an offline write and append its deduplicated mutation.
@@ -100,7 +122,7 @@ class FileCache:
         """Return pending mutations in durable insertion order."""
         return list(self._load_state().pending)
 
-    def discard_pending(self, reference: ContentRef) -> None:
+    def discard_pending(self, reference: ContentRef) -> bool:
         """Drop any queued mutation for a reference without touching cached content.
 
         Called after a direct online write for a reference lands successfully --
@@ -108,15 +130,17 @@ class FileCache:
         reference (``put_content`` always calls ``replay_pending`` first), so a
         mutation still queued for it afterward is stale, superseded intent that
         must never be replayed against the fresher record it would land on top of.
+
+        Returns:
+            ``True`` if a queued mutation for ``reference`` was found and
+            removed, ``False`` if nothing was queued for it.
         """
-        self._state.transaction(
-            lambda state: (
-                state.model_copy(
-                    update={"pending": [entry for entry in state.pending if entry.write.reference != reference]}
-                ),
-                None,
-            )
-        )
+
+        def discard(state: _CacheState) -> tuple[_CacheState, bool]:
+            remaining = [entry for entry in state.pending if entry.write.reference != reference]
+            return state.model_copy(update={"pending": remaining}), len(remaining) != len(state.pending)
+
+        return self._state.transaction(discard)
 
     def _queue_work_item(self, key: str, item: BacklogItem) -> _PendingWorkItemMutation:
         payload = json.dumps(item.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -100,6 +100,24 @@ class FileCache:
         """Return pending mutations in durable insertion order."""
         return list(self._load_state().pending)
 
+    def discard_pending(self, reference: ContentRef) -> None:
+        """Drop any queued mutation for a reference without touching cached content.
+
+        Called after a direct online write for a reference lands successfully --
+        that write already ran ahead of :meth:`pending_mutations` for the same
+        reference (``put_content`` always calls ``replay_pending`` first), so a
+        mutation still queued for it afterward is stale, superseded intent that
+        must never be replayed against the fresher record it would land on top of.
+        """
+        self._state.transaction(
+            lambda state: (
+                state.model_copy(
+                    update={"pending": [entry for entry in state.pending if entry.write.reference != reference]}
+                ),
+                None,
+            )
+        )
+
     def _queue_work_item(self, key: str, item: BacklogItem) -> _PendingWorkItemMutation:
         payload = json.dumps(item.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
         mutation = _PendingWorkItemMutation(

--- a/plugins/development-harness/tests/test_github_content_safety.py
+++ b/plugins/development-harness/tests/test_github_content_safety.py
@@ -267,6 +267,59 @@ def test_fresh_online_write_discards_stale_pending_mutation_for_same_reference(t
     assert record.content == "B"
 
 
+class _LegacyPlanStore:
+    """Minimal ``_PlanPersistence`` double exposing one legacy PLAN record."""
+
+    def __init__(self, record: ContentRecord) -> None:
+        self._record = record
+
+    def list(self, query: ContentQuery) -> Sequence[ContentRecord]:
+        return [self._record]
+
+    def get(self, reference: ContentRef) -> ContentRecord:
+        return self._record
+
+    def put(self, request: ContentWrite) -> ContentRecord:
+        raise NotImplementedError
+
+
+def test_list_content_does_not_clobber_pending_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A queued PLAN write stuck behind a conflicting legacy record must survive ``list_content()``.
+
+    Regression test for a review finding on PR #2906: ``list_content()``'s per-record
+    cache-refresh loop called ``FileCache.cache_content()`` unconditionally for every
+    legacy/online record, with no pending guard -- unlike ``get_content()``'s guarded
+    read path. A create-only write queued for a PLAN reference that conflicts with an
+    existing legacy plan-index record can never land through replay
+    (``ContentConflictError`` on every attempt), so the reference stays pending
+    forever. Before the fix, the very next ``list_content()`` call clobbered that
+    cached pending record with the older legacy content and reset ``pending`` back to
+    ``False`` -- silently discarding the caller's own unacknowledged write and
+    reopening the exact clobber bug PR #2906 fixed for ``get_content()``.
+    """
+    reference = ContentRef(kind=ContentKind.PLAN, name="P123")
+    legacy = ContentRecord(reference=reference, content="legacy content", revision="legacy-rev")
+    contents = MagicMock()
+    contents.get.side_effect = ContentNotFoundError("not in contents api")
+    contents.list.return_value = []
+    cache = FileCache(tmp_path / "github-cache")
+    base = ContentRecord(reference=reference, content="", revision="")
+    cache.queue_write(base, ContentWrite(reference=reference, content="pending write", create_only=True))
+    backend = GitHubBackend(cache=cache, plan_persistence=_LegacyPlanStore(legacy), contents=contents)
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        backend,
+        "_write_online_content",
+        lambda request, cached: (_ for _ in ()).throw(ContentConflictError("stuck behind legacy record")),
+    )
+
+    backend.list_content(ContentQuery(kind=ContentKind.PLAN))
+
+    cached = backend._cache.get_content(reference)
+    assert (cached.content, cached.pending) == ("pending write", True)
+    assert len(backend._cache.pending_mutations()) == 1
+
+
 class _UnavailablePlanPersistence:
     def list(self, query: ContentQuery) -> Sequence[ContentRecord]:
         raise OSError("GitHub unavailable")

--- a/plugins/development-harness/tests/test_github_content_safety.py
+++ b/plugins/development-harness/tests/test_github_content_safety.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from backlog_core.backends.github_backend import GitHubBackend, _GitHubPlanPersistence
+from backlog_core.backends.github_contents import _GitHubContentIntegrityError
 from backlog_core.file_cache import FileCache
 from backlog_core.models import (
     ArtifactManifest,
@@ -167,9 +168,7 @@ def test_pending_artifact_manifest_write_is_not_clobbered_by_empty_legacy_read(t
     contents = MagicMock()
     contents.get.side_effect = ContentNotFoundError("not in contents api")
     provider = MagicMock()
-    empty_manifest = MagicMock()
-    empty_manifest.model_dump_json.return_value = '{"issue_number":1,"artifacts":[]}'
-    provider.get_manifest.return_value = empty_manifest
+    provider.get_manifest.return_value = ArtifactManifest(issue_number=1)
     backend = GitHubBackend(cache=cache, artifact_provider=provider, contents=contents)
     backend.try_get_github = MagicMock(return_value=MagicMock())
 
@@ -178,6 +177,94 @@ def test_pending_artifact_manifest_write_is_not_clobbered_by_empty_legacy_read(t
     assert (record.content, record.pending) == (manifest_with_entry, True)
     provider.get_manifest.assert_called()
     assert len(backend._cache.pending_mutations()) == 1
+
+
+def test_pending_write_still_surfaces_integrity_error_on_underlying_reference(tmp_path: Path) -> None:
+    """A stuck pending write must not mask a genuine remote integrity error.
+
+    Regression test for a visibility gap introduced by the pending-guard fix
+    above: routing straight to the stale cache once ``cached.pending`` is
+    True skips ``_read_online_content`` entirely, so a real
+    ``_GitHubContentIntegrityError`` on that same reference (e.g. a truncated
+    or malformed Contents API blob) never runs and is silently withheld from
+    every ``get_content`` caller for as long as the write stays stuck.
+    """
+    reference = ContentRef(kind=ContentKind.ARTIFACT_MANIFEST, namespace="1", name="manifest")
+    base = ContentRecord(reference=reference, content="", revision="")
+    cache = FileCache(tmp_path / "github-cache")
+    cache.queue_write(base, ContentWrite(reference=reference, content="queued", create_only=True))
+
+    contents = MagicMock()
+    contents.get.side_effect = _GitHubContentIntegrityError("corrupt blob")
+    provider = MagicMock()
+    provider.get_manifest.return_value = ArtifactManifest(issue_number=1)
+    backend = GitHubBackend(cache=cache, artifact_provider=provider, contents=contents)
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+
+    with pytest.raises(_GitHubContentIntegrityError):
+        backend.get_content(reference)
+
+
+def test_fresh_online_write_discards_stale_pending_mutation_for_same_reference(tmp_path: Path) -> None:
+    """A landed direct write must dequeue any stale pending write for its reference.
+
+    Regression test: ``put_content``'s online-write success path previously
+    never touched ``state.pending``, so a queued create-only write that lost
+    its first replay attempt (e.g. against a legacy record) stayed queued
+    forever. Using a persistence double that -- unlike the real
+    ``_GitHubContentsStore`` -- performs no create-only/revision
+    self-validation on ``put`` isolates the offline-mutation-cache contract
+    itself: on the *next* replay this stale write would silently land and
+    clobber content that a fresh, unconditional write had already
+    superseded, unless the cache dequeues it as soon as that fresh write
+    lands.
+    """
+
+    class _NaiveContentsStore:
+        """Minimal, non-validating ``_ContentPersistence`` double.
+
+        The `_ContentPersistence` Protocol's ``put`` contract does not itself
+        require create-only/revision validation -- only the concrete
+        production `_GitHubContentsStore` happens to add it. This double
+        omits that defense-in-depth deliberately, to prove the offline cache
+        contract stays safe without relying on it.
+        """
+
+        def __init__(self) -> None:
+            self._record: ContentRecord | None = None
+
+        def list(self, query: ContentQuery) -> Sequence[ContentRecord]:
+            return [self._record] if self._record is not None else []
+
+        def get(self, reference: ContentRef) -> ContentRecord:
+            if self._record is None:
+                raise ContentNotFoundError(str(reference))
+            return self._record
+
+        def put(self, request: ContentWrite) -> ContentRecord:
+            self._record = ContentRecord(reference=request.reference, content=request.content, revision="rev")
+            return self._record
+
+    reference = ContentRef(kind=ContentKind.ARTIFACT_MANIFEST, namespace="1", name="manifest")
+    cache = FileCache(tmp_path / "github-cache")
+    provider = MagicMock()
+    provider.get_manifest.return_value = ArtifactManifest(issue_number=1)
+    naive_store = _NaiveContentsStore()
+    backend = GitHubBackend(cache=cache, artifact_provider=provider, contents=naive_store)
+
+    backend.try_get_github = MagicMock(return_value=None)
+    backend.put_content(ContentWrite(reference=reference, content="A", create_only=True))
+    assert len(backend._cache.pending_mutations()) == 1
+
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+    written = backend.put_content(ContentWrite(reference=reference, content="B"))
+
+    assert written.content == "B"
+    assert backend._cache.pending_mutations() == []
+
+    record = backend.get_content(reference)
+
+    assert record.content == "B"
 
 
 class _UnavailablePlanPersistence:

--- a/plugins/development-harness/tests/test_github_content_safety.py
+++ b/plugins/development-harness/tests/test_github_content_safety.py
@@ -12,6 +12,7 @@ from backlog_core.models import (
     ArtifactManifest,
     ContentConflictError,
     ContentKind,
+    ContentNotFoundError,
     ContentQuery,
     ContentRecord,
     ContentRef,
@@ -141,6 +142,42 @@ def test_online_artifact_read_remains_available(tmp_path: Path) -> None:
     assert (record.content, record.pending, record.stale) == ("stored", False, False)
     contents.get.assert_called_once_with(reference)
     provider.store_artifact_content.assert_not_called()
+
+
+def test_pending_artifact_manifest_write_is_not_clobbered_by_empty_legacy_read(tmp_path: Path) -> None:
+    """A queued manifest write that cannot land yet must stay visible to readers.
+
+    Regression test for backlog item #2899: ``artifact_register`` reported
+    success but the artifact was invisible to ``artifact_list``/``artifact_get``
+    immediately after. Root cause -- ``GitHubGistArtifactProvider.get_manifest``
+    (the legacy fallback ``read_legacy`` uses for ``ARTIFACT_MANIFEST``) never
+    raises ``ContentNotFoundError`` for an item with no manifest data yet; it
+    returns a valid, empty manifest instead. Before the fix, ``get_content``
+    trusted that empty read as authoritative and cached it over the top of the
+    still-pending queued write (e.g. one blocked by a branch-protection ruleset
+    that rejects direct Contents API commits), erasing the just-registered
+    artifact from view.
+    """
+    reference = ContentRef(kind=ContentKind.ARTIFACT_MANIFEST, namespace="1", name="manifest")
+    base = ContentRecord(reference=reference, content="", revision="")
+    manifest_with_entry = '{"issue_number":1,"artifacts":[{"artifact_type":"feature-context","artifact_id":"x.md"}]}'
+    cache = FileCache(tmp_path / "github-cache")
+    cache.queue_write(base, ContentWrite(reference=reference, content=manifest_with_entry, create_only=True))
+
+    contents = MagicMock()
+    contents.get.side_effect = ContentNotFoundError("not in contents api")
+    provider = MagicMock()
+    empty_manifest = MagicMock()
+    empty_manifest.model_dump_json.return_value = '{"issue_number":1,"artifacts":[]}'
+    provider.get_manifest.return_value = empty_manifest
+    backend = GitHubBackend(cache=cache, artifact_provider=provider, contents=contents)
+    backend.try_get_github = MagicMock(return_value=MagicMock())
+
+    record = backend.get_content(reference)
+
+    assert (record.content, record.pending) == (manifest_with_entry, True)
+    provider.get_manifest.assert_called()
+    assert len(backend._cache.pending_mutations()) == 1
 
 
 class _UnavailablePlanPersistence:


### PR DESCRIPTION
## Summary
- `artifact register` reported `content_stored:true`, but the very next `artifact list`/`artifact get` for the same item returned zero results.
- Root cause: writes go through `GitHubBackend.put_content()`, which tries a direct Contents API commit and fails because this repo's ruleset blocks direct commits to `main` — it correctly falls back to a durably-queued pending write. But the next `get_content()` call retries the doomed commit, then falls through to a fresh online read. For `ContentKind.ARTIFACT_MANIFEST`, that read (`GitHubGistArtifactProvider.get_manifest()`) returns a valid *empty* manifest rather than raising not-found — and `get_content()` had no way to tell "confirmed empty" from "my own write just hasn't landed," so it cached the empty read straight over the still-pending write.
- Fix: after `replay_pending()`, check for a still-pending unacknowledged mutation on the reference before trusting a fresh online read for that content kind.

Closes #2899.

## Test plan
- [x] Added `test_pending_artifact_manifest_write_is_not_clobbered_by_empty_legacy_read` in `plugins/development-harness/tests/test_github_content_safety.py`, reproducing the exact root cause via mocked collaborators.
- [x] Live verification against a fresh item (#76): register → list → get all succeed with the artifact visible; a second register for a different artifact_type on the same item accumulates correctly.
- [x] `uv run ruff check --fix`, `uv run ruff format`, `uv run ty check` — clean on both touched files.
- [x] `uv run pytest plugins/development-harness/tests/ plugins/development-harness/backlog_core/tests/` — 3051 passed, 39 skipped, 5 xfailed, 0 failed.

## Notes (flagged, not fixed here)
- **Bigger architectural gap**: the actual GitHub Contents API commit for artifact/plan content never lands while this repo's branch-protection ruleset blocks direct commits to `main` — content stays queued-and-retrying forever in the local `~/.dh/projects/.../github-cache` and is invisible to any other machine/worktree/CI that doesn't share that cache. This fix restores read-your-own-writes correctness for a single local cache; it doesn't make the underlying commit succeed. Whether artifact/plan writes should go through a PR instead of a direct branch commit is a separate, larger design question. Will file separately.
- Two items (#983, #2899) have permanently-stuck pending mutations in this machine's local cache from the bug reproduction — not part of the repo, doesn't affect other checkouts, left in place as reproduction evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)