### PR TITLE
fix(frustration-analyzer): support Python 3.14

### DIFF
--- a/plugins/frustration-analyzer/mcp/server.py
+++ b/plugins/frustration-analyzer/mcp/server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S uv --quiet run --active --script
 # /// script
-# requires-python = ">=3.11,<3.14"
+# requires-python = ">=3.11,<3.15"
 # dependencies = [
 #     "fastmcp>=3.0.0rc1,<4",
 #     "duckdb>=0.10.0",

--- a/tests/test_frustration_analyzer_python_compatibility.py
+++ b/tests/test_frustration_analyzer_python_compatibility.py
@@ -1,0 +1,25 @@
+"""Regression checks for the frustration-analyzer interpreter contract."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+PLUGIN = ROOT / "plugins" / "frustration-analyzer"
+
+
+def read_pep_723_metadata(script: Path) -> dict[str, object]:
+    """Parse the inline PEP 723 block without importing the MCP server."""
+    lines = script.read_text(encoding="utf-8").splitlines()
+    start = lines.index("# /// script") + 1
+    end = lines.index("# ///", start)
+    metadata = "\n".join(line.removeprefix("# ") for line in lines[start:end])
+    return tomllib.loads(metadata)
+
+
+def test_frustration_analyzer_declares_python_312_through_314_support() -> None:
+    """The server metadata includes every interpreter the plugin supports."""
+    metadata = read_pep_723_metadata(PLUGIN / "mcp" / "server.py")
+
+    assert metadata["requires-python"] == ">=3.11,<3.15"


### PR DESCRIPTION
## Summary

Manual partial extraction from PR #2787 ("feat: enable Codex plugin compatibility"), commit `5093e39b` ("fix(frustration-analyzer): support Python 3.14"). This is a standalone, Codex-independent correctness fix: `main` still pins `plugins/frustration-analyzer/mcp/server.py`'s PEP 723 `requires-python` ceiling below 3.14, so the MCP server refuses to start under a Python 3.14 interpreter today.

## What was included

- `plugins/frustration-analyzer/mcp/server.py` — raised the PEP 723 `requires-python` bound from `>=3.11,<3.14` to `>=3.11,<3.15`.
- `tests/test_frustration_analyzer_python_compatibility.py` — new regression test that parses the inline PEP 723 block via `tomllib` and asserts the declared bound.

## What was deliberately dropped, and why

- The source commit also touched `plugins/frustration-analyzer/.mcp.codex.json`, removing a `--python 3.12` pin from the Codex launcher args. That file does not exist on `main` — it was added by a separate, Codex-only commit in PR #2787 — so this hunk has no target here and was dropped entirely.
- The source commit's second test function, `test_codex_mcp_launcher_defers_interpreter_selection_to_pep_723`, asserted against the contents of that same `.mcp.codex.json` file. It was removed (not skipped) from the extracted test file, since its target file is absent from `main`.

## Test plan

- [x] `uv run ruff check --fix` on touched files — 1 auto-fixed formatting issue, clean after
- [x] `uv run ruff format` on touched files — no changes
- [x] `uv run ty check` on touched files — all checks passed
- [x] `uv run pytest tests/test_frustration_analyzer_python_compatibility.py -v` — 1 passed (confirms the Codex-only test function is absent, not skipped)
- [x] `uv run prek run --files <touched files>` — all applicable hooks passed