### PR TITLE
feat(development-harness): add standalone SAM CLI and pytest runner wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,22 @@ with the caller's own asyncio event loop. Suppress banner/log noise with the `FA
 above rather than redirecting stderr to `/dev/null`, which would also hide real errors. `--json`
 output is wrapped: unwrap with `json.loads(json.loads(stdout)["content"][0]["text"])`.
 
+Two further PEP 723 wrappers let the development-harness plugin run standalone, without the
+per-plugin `pyproject.toml`/project env this repo intentionally removed:
+
+```bash
+uv run plugins/development-harness/scripts/run_sam_cli.py --help    # SAM CLI, self-resolving
+uv run plugins/development-harness/tests/run_pytest.py              # Run plugin test suites
+```
+
+`run_sam_cli.py` is a thin wrapper around `sam_schema.cli:app`. `run_pytest.py` `os.chdir`s to the
+plugin root and forwards to `pytest.main()`, defaulting to `["tests", "tests_sam",
+"sam_schema/tests", "backlog_core/tests"]` when no paths are given, and always injecting
+`--asyncio-mode=auto` and `--strict-config` — a standalone bundle has no parent `pyproject.toml` to
+supply `asyncio_mode = "auto"`, so pytest's strict default would otherwise silently skip this
+repo's intentionally-undecorated async tests, and `--strict-config` turns invalid or unavailable
+pytest configuration into a hard failure instead of a silently degraded warning.
+
 ## Plugin Structure
 
 Every plugin follows this pattern:

--- a/plugins/development-harness/scripts/run_sam_cli.py
+++ b/plugins/development-harness/scripts/run_sam_cli.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env -S uv --quiet run --active --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "fastmcp>=3.0.2",
+#   "gitpython>=3.1.0",
+#   "markdown-it-py>=3.0.0",
+#   "marko>=2.0.0",
+#   "pydantic>=2.12.3",
+#   "pygithub>=2.8.1",
+#   "ruamel.yaml>=0.18.0",
+#   "tiktoken>=0.12.0",
+#   "typer>=0.21.2",
+# ]
+# ///
+"""PEP 723 wrapper for the SAM CLI."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_plugin_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_plugin_root))
+
+from sam_schema.cli import app
+
+app()

--- a/plugins/development-harness/tests/run_pytest.py
+++ b/plugins/development-harness/tests/run_pytest.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env -S uv --quiet run --active --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "cryptography>=48.0.1",
+#   "fastmcp[tasks]>=3.2.0",
+#   "gitpython>=3.1.0",
+#   "hypothesis>=6.0.0",
+#   "markdown-it-py>=3.0.0",
+#   "marko>=2.2.2",
+#   "pygments>=2.20.0",
+#   "pygithub>=2.8.1",
+#   "pydantic>=2.12.3",
+#   "pytest-asyncio>=1.1.0",
+#   "pytest-cov>=6.2.1",
+#   "pytest-mock>=3.12",
+#   "pytest-xdist>=3.5.0",
+#   "pytest>=8.4.1",
+#   "ruamel.yaml>=0.18.0",
+#   "tiktoken>=0.12.0",
+#   "tomlkit>=0.13.0",
+#   "typer>=0.21.0",
+# ]
+# ///
+"""Run development-harness tests without a plugin-local project environment."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_TEST_PATHS = ["tests", "tests_sam", "sam_schema/tests", "backlog_core/tests"]
+_REQUIRED_ARGS = ["--asyncio-mode=auto", "--strict-config"]
+
+
+def main() -> int:
+    """Run the plugin test suites from the bundle root and forward arguments.
+
+    A standalone bundle has no parent ``pyproject.toml`` to supply
+    ``asyncio_mode = "auto"``, so pytest's strict default would silently skip
+    this repo's intentionally-undecorated async tests. ``--strict-config``
+    turns invalid or unavailable pytest configuration into a hard failure
+    instead of a silently degraded warning.
+
+    Returns:
+        The pytest process exit code.
+    """
+    os.chdir(_PLUGIN_ROOT)
+    args = sys.argv[1:] or _DEFAULT_TEST_PATHS
+    return pytest.main([*_REQUIRED_ARGS, *args])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Manual partial-extraction from PR #2787, commit `095d323c` ("refactor(dh): remove plugin project manifest"). That commit bundled two clean, Codex-independent PEP 723 wrapper scripts together with an unrelated `pyproject.toml` dependency-floor regression; this PR takes only the wrappers.

- Adds `plugins/development-harness/scripts/run_sam_cli.py` — a thin PEP 723 wrapper around `sam_schema.cli:app`, letting the SAM CLI run standalone (no per-plugin project env, matching this repo's "no uv workspace" convention).
- Adds `plugins/development-harness/tests/run_pytest.py` — a PEP 723 wrapper that `os.chdir`s to the plugin root and runs `pytest.main()` against the plugin's test suites, for running development-harness tests from a distributed bundle without this repo's root `pyproject.toml`.
- Folds in two open bot review findings from #2787 against `run_pytest.py` that were never addressed on that branch: it now always passes `--asyncio-mode=auto` (a standalone bundle has no parent `pyproject.toml` to supply `asyncio_mode = "auto"`, so pytest's strict default would silently skip this repo's intentionally-undecorated async tests) and `--strict-config` (so invalid/unavailable pytest configuration fails hard instead of silently degrading to a warning).
- Documents both scripts in root `AGENTS.md`'s "MCP Server Scripts" section, alongside the existing `run_backlog_server.py` / `run_sam_server.py` entries.

**Deliberately excluded:** commit `095d323c` also rewrote root `pyproject.toml`, lowering ~30 dev-dependency floors (e.g. `pytest` 9.1.1→8.4.1, `pygithub` 2.9.0→2.1.1, `ty` 0.0.65→0.0.25) and dropping `click`/`python-dotenv` entirely. That diff has the shape of a stale `uv sync` from a different environment overwriting the file, not an intentional change, and persisted unmodified to the branch tip. This PR does not touch `pyproject.toml` at all — verified via `git diff --stat` against `main`.

## Test plan

- [x] `git diff --stat` against `main` shows no `pyproject.toml` line
- [x] `uv run ruff check --fix` / `uv run ruff format` on both new files — clean
- [x] `uv run ty check` on both new files — clean
- [x] `uv run prek run --files AGENTS.md plugins/development-harness/scripts/run_sam_cli.py plugins/development-harness/tests/run_pytest.py` — all hooks pass
- [x] `uv run --script plugins/development-harness/scripts/run_sam_cli.py --help` — runs, prints Typer help
- [x] `uv run --script plugins/development-harness/tests/run_pytest.py --collect-only -q tests/test_dh_config.py` — runs, collects tests from the plugin root

🤖 Generated with [Claude Code](https://claude.com/claude-code)