### PR TITLE
fix(scientific-method): resolve experiment state to project root, not launcher cwd

### DIFF
--- a/plugins/scientific-method/.claude-plugin/plugin.json
+++ b/plugins/scientific-method/.claude-plugin/plugin.json
@@ -13,7 +13,10 @@
         "run",
         "--script",
         "${CLAUDE_PLUGIN_ROOT}/mcp/experiment-registry/server.py"
-      ]
+      ],
+      "env": {
+        "CLAUDE_PROJECT_DIR": "${CLAUDE_PROJECT_DIR}"
+      }
     }
   }
 }

--- a/plugins/scientific-method/mcp/experiment-registry/project_root.py
+++ b/plugins/scientific-method/mcp/experiment-registry/project_root.py
@@ -1,0 +1,37 @@
+"""Project-root resolution for the experiment-registry MCP server.
+
+Isolated from ``server.py`` so it can be imported and unit-tested without
+pulling in FastMCP tool registration, and so its module name does not collide
+with other plugins' ``server.py`` files under ty's shared ``extra-paths``
+environment (see ``pyproject.toml`` ``[tool.ty.environment]``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def resolve_project_root(project_root: str | None) -> Path:
+    """Resolve the project root to use for experiment state.
+
+    Priority: explicit *project_root* argument, then the launcher-provided
+    ``CLAUDE_PROJECT_DIR`` environment variable (set by this plugin's
+    ``.claude-plugin/plugin.json`` mcpServers.env entry via
+    ``${CLAUDE_PROJECT_DIR}`` substitution), then the process working
+    directory. ``Path.cwd()`` alone is not a safe default — MCP server
+    subprocesses are sometimes launched with a cwd inside the installed
+    plugin cache rather than the project being worked on.
+
+    Args:
+        project_root: Optional project root path supplied by the caller.
+
+    Returns:
+        Resolved project root directory.
+    """
+    if project_root:
+        return Path(project_root)
+    env_root = os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
+    if env_root:
+        return Path(env_root)
+    return Path.cwd()

--- a/plugins/scientific-method/mcp/experiment-registry/server.py
+++ b/plugins/scientific-method/mcp/experiment-registry/server.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
+from project_root import resolve_project_root
 from pydantic import Field
 
 from models import StepExtension
@@ -36,17 +37,17 @@ _loader = RegistryLoader()
 
 
 def _make_state_manager(project_root: str | None) -> StateManager:
-    """Return a StateManager rooted at *project_root* (defaults to cwd).
+    """Return a StateManager rooted at the resolved project root.
 
     Args:
-        project_root: Optional project root path. Falls back to the current
-            working directory when ``None`` or empty.
+        project_root: Optional project root path. See
+            :func:`project_root.resolve_project_root` for fallback order when
+            ``None`` or empty.
 
     Returns:
         A configured ``StateManager`` instance.
     """
-    root = Path(project_root) if project_root else Path(Path.cwd())
-    return StateManager(project_root=root, loader=_loader)
+    return StateManager(project_root=resolve_project_root(project_root), loader=_loader)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/scientific-method/mcp/experiment-registry/tests/test_project_root.py
+++ b/plugins/scientific-method/mcp/experiment-registry/tests/test_project_root.py
@@ -1,0 +1,54 @@
+"""Tests for experiment-registry project-root resolution.
+
+Covers the bug where an omitted ``project_root`` argument resolved to
+``Path.cwd()`` even when the process cwd is not the consuming project (e.g. an
+installed plugin cache directory under a launcher like Codex).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_root import resolve_project_root
+
+
+def test_resolve_project_root_uses_explicit_argument(tmp_path: Path, monkeypatch) -> None:
+    """An explicit project_root argument wins over env var and cwd."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "env-root"))
+    explicit = tmp_path / "explicit-root"
+
+    resolved = resolve_project_root(str(explicit))
+
+    assert resolved == explicit
+
+
+def test_resolve_project_root_falls_back_to_env_var_when_cwd_differs(tmp_path: Path, monkeypatch) -> None:
+    """Omitted project_root resolves to CLAUDE_PROJECT_DIR, not the launcher cwd.
+
+    Reproduces the bot-reported bug: a launcher (e.g. Codex) starts the server
+    with cwd inside the installed plugin cache while the real project lives
+    elsewhere. Before the fix, this resolved to the cache directory (cwd, via
+    ``Path.cwd()``) and experiment state was written to the wrong location.
+    """
+    project_root = tmp_path / "consuming-project"
+    plugin_cache_cwd = tmp_path / "plugin-cache"
+    project_root.mkdir()
+    plugin_cache_cwd.mkdir()
+
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_root))
+    monkeypatch.chdir(plugin_cache_cwd)
+
+    resolved = resolve_project_root(None)
+
+    assert resolved == project_root
+    assert resolved != Path.cwd()
+
+
+def test_resolve_project_root_falls_back_to_cwd_when_env_var_unset(tmp_path: Path, monkeypatch) -> None:
+    """Preserves existing behavior: no env var, no argument -> cwd."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    resolved = resolve_project_root(None)
+
+    assert resolved == tmp_path


### PR DESCRIPTION
## Summary

- `experiment-registry`'s MCP server (`plugins/scientific-method/mcp/experiment-registry/server.py`) fell back to `Path.cwd()` whenever a caller omitted `project_root`. When the server subprocess is launched with a cwd that isn't the consuming project (e.g. an installed plugin cache directory under a launcher such as Codex), experiment state and artifacts were written under the wrong root — invisible to `list_experiments` run from the actual project, and subject to disappearing on plugin cache updates.
- `project_root` resolution now checks, in order: the explicit argument, then the `CLAUDE_PROJECT_DIR` environment variable, then `Path.cwd()` as a last resort. `CLAUDE_PROJECT_DIR` is now forwarded into the server subprocess via a new `mcpServers.env` entry in `.claude-plugin/plugin.json` using the documented `${CLAUDE_PROJECT_DIR}` substitution.
- The resolution logic was extracted into a new `project_root.py` module rather than kept inline in `server.py`. This makes it unit-testable without importing FastMCP tool registration, and avoids a latent module-name collision under `ty`'s shared `[tool.ty.environment] extra-paths` list (multiple plugins ship a same-named `server.py`, e.g. `plugins/agentskill-kaizen/mcp/server.py`) — discovered while writing the reproduction test, fixed without touching any linting-suppression config.

This addresses a P1 bot finding surfaced during review of PR #2787, but is an independent fix to a pre-existing defect on `main` — it does not depend on or touch anything from that PR.

## Root cause

`server.py`'s `_make_state_manager` used `root = Path(project_root) if project_root else Path(Path.cwd())`, trusting the MCP server subprocess's working directory as the project root whenever the caller didn't supply one explicitly. That assumption breaks under any launcher that starts the subprocess with a cwd outside the consuming project.

## Test plan

- [x] Added `plugins/scientific-method/mcp/experiment-registry/tests/test_project_root.py` — reproduces the bug (cwd inside a `plugin-cache/` dir, `CLAUDE_PROJECT_DIR` pointing at the real `consuming-project/` dir) and asserts resolution matches the project, not cwd.
- [x] Confirmed via `git stash` on the pre-fix logic that this test fails as expected before the fix, and passes after restoring it.
- [x] `uv run pytest plugins/scientific-method/mcp/experiment-registry/tests/` — 100 passed.
- [x] `uv run ruff check --fix`, `uv run ruff format`, `uv run ty check` — clean on all touched files (`server.py`, `project_root.py`, `tests/test_project_root.py`, `plugin.json`).
- [x] `uv run prek run --files <touched files>` — all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)