### PR TITLE
feat(mcp): extract generic bounded-subprocess runner from PR #2787

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,6 +402,7 @@ this file) was removed to avoid two files drifting out of sync.
 14. **Dependency security upgrades**: use `uv add "pkg>=X.Y.Z"` (updates `pyproject.toml` and `uv.lock` atomically with explicit version output) rather than `uv lock --upgrade-package pkg` (silent) or manually verifying line numbers in `uv.lock` (4000+ lines — line numbers do not correspond reliably to package versions). Confirm with `uv tree | grep pkg`.
 15. **`.claude/` vs `docs/`**: `.claude/` is Claude Code configuration; `docs/` is project documentation. Check for an existing directory convention (`ls` the likely parent) before choosing where to create a new file.
 16. **No `git stash` on the primary checkout**: compare against a clean baseline in an isolated worktree instead — other agents may be mid-write there.
+17. **Bounded subprocess execution**: `scripts/run_bounded.py` runs a command with a timeout and terminates its full process group (POSIX process-group signals; `taskkill /T /F` on Windows) on expiry, including descendants a bare `subprocess.run(timeout=...)` would leave behind. Wrap any external command invocation that may hang or spawn children with `uv run --script scripts/run_bounded.py --timeout-seconds <n> -- <command>`.
 
 ## File Locations Quick Reference
 

--- a/scripts/run_bounded.py
+++ b/scripts/run_bounded.py
@@ -29,7 +29,12 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def terminate_process_tree(process: subprocess.Popen[object]) -> None:
+def terminate_windows_process_tree(pid: int) -> None:
+    """Terminate a Windows process and all of its descendants."""
+    subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], check=False)
+
+
+def terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
     """Terminate the isolated process group, escalating after a short grace period."""
     if os.name == "posix":
         try:
@@ -37,7 +42,8 @@ def terminate_process_tree(process: subprocess.Popen[object]) -> None:
         except ProcessLookupError:
             return
     else:
-        process.terminate()
+        terminate_windows_process_tree(process.pid)
+        return
 
     try:
         process.wait(timeout=TERMINATION_GRACE_SECONDS)
@@ -62,10 +68,7 @@ def run_command(command: list[str], timeout_seconds: float) -> int:
     if not command:
         raise ValueError("A command is required after --")
 
-    process = subprocess.Popen(
-        command,
-        start_new_session=os.name == "posix",
-    )
+    process = subprocess.Popen(command, start_new_session=os.name == "posix")
     try:
         return process.wait(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:

--- a/scripts/run_bounded.py
+++ b/scripts/run_bounded.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Run one command with a timeout and terminate its process group on expiry."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+
+TIMEOUT_EXIT_CODE = 124
+TERMINATION_GRACE_SECONDS = 0.5
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=5.0,
+        help="Maximum command duration before process-tree termination. Default: 5.",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def terminate_process_tree(process: subprocess.Popen[object]) -> None:
+    """Terminate the isolated process group, escalating after a short grace period."""
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+    else:
+        process.terminate()
+
+    try:
+        process.wait(timeout=TERMINATION_GRACE_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+    else:
+        process.kill()
+    process.wait()
+
+
+def run_command(command: list[str], timeout_seconds: float) -> int:
+    """Run a command and return its exit status, or 124 after a timeout."""
+    if timeout_seconds <= 0:
+        raise ValueError("--timeout-seconds must be greater than zero")
+    if not command:
+        raise ValueError("A command is required after --")
+
+    process = subprocess.Popen(
+        command,
+        start_new_session=os.name == "posix",
+    )
+    try:
+        return process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        terminate_process_tree(process)
+        print(f"timed out after {timeout_seconds:g} seconds", file=sys.stderr)
+        return TIMEOUT_EXIT_CODE
+
+
+def main() -> int:
+    """Run the parsed command within the selected timeout."""
+    args = create_parser().parse_args()
+    try:
+        command = args.command[1:] if args.command[:1] == ["--"] else args.command
+        return run_command(command, args.timeout_seconds)
+    except (OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_bounded.py
+++ b/scripts/run_bounded.py
@@ -7,7 +7,9 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -17,7 +19,11 @@ TERMINATION_GRACE_SECONDS = 0.5
 
 
 def create_parser() -> argparse.ArgumentParser:
-    """Create the command-line parser."""
+    """Create the command-line parser.
+
+    Returns:
+        A configured parser accepting ``--timeout-seconds`` and the trailing command.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--timeout-seconds",
@@ -30,39 +36,71 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def terminate_windows_process_tree(pid: int) -> None:
-    """Terminate a Windows process and all of its descendants."""
-    subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], check=False)
+    """Terminate a Windows process and all of its descendants.
+
+    Args:
+        pid: Process ID of the tree's root process.
+    """
+    taskkill = shutil.which("taskkill") or "taskkill"
+    subprocess.run([taskkill, "/PID", str(pid), "/T", "/F"], check=False)
+
+
+def process_group_is_alive(pgid: int) -> bool:
+    """Probe whether any process remains in the given process group.
+
+    Args:
+        pgid: Process group ID to probe, typically the group leader's PID.
+
+    Returns:
+        ``True`` if at least one process in the group is still alive.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    return True
 
 
 def terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
     """Terminate the isolated process group, escalating after a short grace period."""
-    if os.name == "posix":
-        try:
-            os.killpg(process.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            return
-    else:
+    if os.name != "posix":
         terminate_windows_process_tree(process.pid)
         return
 
     try:
-        process.wait(timeout=TERMINATION_GRACE_SECONDS)
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
         return
-    except subprocess.TimeoutExpired:
-        pass
 
-    if os.name == "posix":
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            return
-    else:
-        process.kill()
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=TERMINATION_GRACE_SECONDS)
+
+    # The leader's wait() can return before its descendants exit — a descendant
+    # that ignores SIGTERM keeps the process group alive after the leader is
+    # reaped. Probe the group itself rather than trusting the leader's status.
+    if not process_group_is_alive(process.pid):
+        return
+
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
     process.wait()
 
 
 def run_command(command: list[str], timeout_seconds: float) -> int:
-    """Run a command and return its exit status, or 124 after a timeout."""
+    """Run a command and return its exit status, or 124 after a timeout.
+
+    Args:
+        command: Argv of the command to run.
+        timeout_seconds: Maximum duration before the process tree is terminated.
+
+    Returns:
+        The command's exit status, or ``TIMEOUT_EXIT_CODE`` if it was terminated.
+
+    Raises:
+        ValueError: If ``timeout_seconds`` is not positive or ``command`` is empty.
+    """
     if timeout_seconds <= 0:
         raise ValueError("--timeout-seconds must be greater than zero")
     if not command:
@@ -78,7 +116,12 @@ def run_command(command: list[str], timeout_seconds: float) -> int:
 
 
 def main() -> int:
-    """Run the parsed command within the selected timeout."""
+    """Run the parsed command within the selected timeout.
+
+    Returns:
+        The wrapped command's exit status, ``TIMEOUT_EXIT_CODE`` on timeout, or ``2``
+        on an invalid invocation.
+    """
     args = create_parser().parse_args()
     try:
         command = args.command[1:] if args.command[:1] == ["--"] else args.command

--- a/tests/test_run_bounded.py
+++ b/tests/test_run_bounded.py
@@ -1,0 +1,77 @@
+"""Behavioral tests for the bounded subprocess runner."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+RUNNER = Path(__file__).parents[1] / "scripts" / "run_bounded.py"
+
+
+def run_runner(*arguments: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the standalone runner under the current test interpreter."""
+    return subprocess.run(
+        [sys.executable, str(RUNNER), *arguments],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_runner_relays_a_successful_childs_output_and_status() -> None:
+    """A completed command retains its stdout and exit status."""
+    result = run_runner(
+        "--timeout-seconds",
+        "1",
+        "--",
+        sys.executable,
+        "-c",
+        "print('bounded-success')",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "bounded-success\n"
+    assert result.stderr == ""
+
+
+def test_runner_times_out_and_returns_the_timeout_status() -> None:
+    """A hung command is terminated instead of inheriting an unbounded wait."""
+    start = time.monotonic()
+    result = run_runner(
+        "--timeout-seconds",
+        "0.1",
+        "--",
+        sys.executable,
+        "-c",
+        "import time; time.sleep(30)",
+    )
+    elapsed = time.monotonic() - start
+
+    assert result.returncode == 124
+    assert elapsed < 3
+    assert "timed out after 0.1 seconds" in result.stderr
+
+
+def test_runner_timeout_terminates_a_sleeping_grandchild() -> None:
+    """Timeout cleanup reaches descendants that inherit the child process group."""
+    child_program = (
+        "import subprocess, sys, time; "
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)']); "
+        "time.sleep(30)"
+    )
+    start = time.monotonic()
+    result = run_runner(
+        "--timeout-seconds",
+        "0.1",
+        "--",
+        sys.executable,
+        "-c",
+        child_program,
+    )
+    elapsed = time.monotonic() - start
+
+    assert result.returncode == 124
+    assert elapsed < 3

--- a/tests/test_run_bounded.py
+++ b/tests/test_run_bounded.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
@@ -47,6 +48,49 @@ def test_runner_timeout_terminates_a_sleeping_grandchild() -> None:
     )
     start = time.monotonic()
     result = run_runner("--timeout-seconds", "0.1", "--", sys.executable, "-c", child_program)
+    elapsed = time.monotonic() - start
+
+    assert result.returncode == 124
+    assert elapsed < 3
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group SIGKILL escalation is POSIX-only")
+def test_runner_reaps_a_descendant_that_ignores_sigterm(tmp_path: Path) -> None:
+    """A descendant that survives the leader's SIGTERM is still reaped via group SIGKILL.
+
+    Regression test for the gap where ``terminate_process_tree`` trusted the leader's
+    ``wait()`` outcome: if the leader dies from the default SIGTERM action while a
+    descendant traps and ignores SIGTERM, the leader's ``wait()`` returns before the
+    process group is actually empty, and the old code returned without ever escalating
+    to SIGKILL. The descendant inherits this runner's stdout/stderr pipes, so an
+    un-reaped descendant is observable as ``run_runner`` blocking until the descendant's
+    sleep elapses on its own, rather than returning within the grace period — confirmed
+    by running this exact assertion against the pre-fix implementation, where it
+    consistently takes ~5s (the descendant's full sleep) instead of failing outright.
+
+    The descendant writes a readiness marker only after installing its SIGTERM handler,
+    and the leader waits for that marker before its own sleep, so the runner's short
+    timeout cannot fire before the descendant is actually ignoring SIGTERM — without
+    this rendezvous, a fast timeout can race the descendant's signal-handler
+    installation and mask the regression.
+    """
+    ready_file = tmp_path / "descendant.ready"
+    descendant_program = (
+        "import signal, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        f"open({str(ready_file)!r}, 'w').close()\n"
+        "time.sleep(5)\n"
+    )
+    leader_program = (
+        "import os, subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, '-c', {descendant_program!r}])\n"
+        f"ready_file = {str(ready_file)!r}\n"
+        "while not os.path.exists(ready_file): time.sleep(0.01)\n"
+        "time.sleep(5)\n"
+    )
+
+    start = time.monotonic()
+    result = run_runner("--timeout-seconds", "1", "--", sys.executable, "-c", leader_program)
     elapsed = time.monotonic() - start
 
     assert result.returncode == 124

--- a/tests/test_run_bounded.py
+++ b/tests/test_run_bounded.py
@@ -7,30 +7,20 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+from scripts import run_bounded
 
 RUNNER = Path(__file__).parents[1] / "scripts" / "run_bounded.py"
 
 
 def run_runner(*arguments: str) -> subprocess.CompletedProcess[str]:
     """Invoke the standalone runner under the current test interpreter."""
-    return subprocess.run(
-        [sys.executable, str(RUNNER), *arguments],
-        capture_output=True,
-        check=False,
-        text=True,
-    )
+    return subprocess.run([sys.executable, str(RUNNER), *arguments], capture_output=True, check=False, text=True)
 
 
 def test_runner_relays_a_successful_childs_output_and_status() -> None:
     """A completed command retains its stdout and exit status."""
-    result = run_runner(
-        "--timeout-seconds",
-        "1",
-        "--",
-        sys.executable,
-        "-c",
-        "print('bounded-success')",
-    )
+    result = run_runner("--timeout-seconds", "1", "--", sys.executable, "-c", "print('bounded-success')")
 
     assert result.returncode == 0
     assert result.stdout == "bounded-success\n"
@@ -40,14 +30,7 @@ def test_runner_relays_a_successful_childs_output_and_status() -> None:
 def test_runner_times_out_and_returns_the_timeout_status() -> None:
     """A hung command is terminated instead of inheriting an unbounded wait."""
     start = time.monotonic()
-    result = run_runner(
-        "--timeout-seconds",
-        "0.1",
-        "--",
-        sys.executable,
-        "-c",
-        "import time; time.sleep(30)",
-    )
+    result = run_runner("--timeout-seconds", "0.1", "--", sys.executable, "-c", "import time; time.sleep(30)")
     elapsed = time.monotonic() - start
 
     assert result.returncode == 124
@@ -63,15 +46,24 @@ def test_runner_timeout_terminates_a_sleeping_grandchild() -> None:
         "time.sleep(30)"
     )
     start = time.monotonic()
-    result = run_runner(
-        "--timeout-seconds",
-        "0.1",
-        "--",
-        sys.executable,
-        "-c",
-        child_program,
-    )
+    result = run_runner("--timeout-seconds", "0.1", "--", sys.executable, "-c", child_program)
     elapsed = time.monotonic() - start
 
     assert result.returncode == 124
     assert elapsed < 3
+
+
+def test_runner_uses_taskkill_to_terminate_the_windows_process_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows timeout cleanup terminates descendants as well as the direct child."""
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        assert check is False
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(run_bounded.subprocess, "run", fake_run)
+
+    run_bounded.terminate_windows_process_tree(4242)
+
+    assert commands == [["taskkill", "/PID", "4242", "/T", "/F"]]


### PR DESCRIPTION
## Summary

Extracts a self-contained, Codex-independent utility from the large open PR #2787: a generic
bounded-subprocess runner (`scripts/run_bounded.py`) that runs a command with a timeout and
terminates its full process group (POSIX and Windows) on expiry.

- Cherry-picked `80958809` ("test(mcp): bound external client commands" — introduces
  `scripts/run_bounded.py`, `tests/test_run_bounded.py`) and `7d9ce322` ("fix(runtime): terminate
  Windows process trees" — patches the same file to use `taskkill /PID <pid> /T /F` on Windows)
  from `codex-plugin-usability-port` onto current `main`. Both apply cleanly as sequential
  cherry-picks except for one expected `AGENTS.md` conflict (that branch's numbered gotchas list
  has diverged from `main`'s); resolved by keeping `main`'s existing item and adding a new one
  documenting `run_bounded.py`.
- Fixes an additional open bot finding from PR #2787 (P2 severity, unaddressed): on POSIX, if the
  process leader dies from the default SIGTERM action while a descendant traps and ignores
  SIGTERM, the leader's own `wait()` returning was treated as proof the whole process group was
  gone — so the SIGKILL escalation never fired and the descendant survived indefinitely. This is
  the POSIX-side counterpart to the Windows fix already present in `7d9ce322`. Fixed by probing
  `process_group_is_alive()` after the grace period and escalating to SIGKILL regardless of
  whether the leader has already exited.
- Added a regression test for the POSIX fix. It uses a readiness rendezvous (the descendant
  writes a marker file only after installing its SIGTERM handler; the leader waits for it before
  its own sleep) so the runner's short timeout cannot race the descendant's signal-handler
  installation, and an elapsed-time oracle (an un-reaped descendant inherits the runner's
  stdout/stderr pipes, so `run_runner` blocks until the descendant's sleep naturally expires
  instead of returning within the grace period). Falsified against the pre-fix implementation,
  which consistently blocks for the descendant's full sleep (~5s) instead of returning within the
  ~1s grace window.

## Note for the human reviewer

This utility currently has no callers outside the Codex validation flow in PR #2787 — confirm
whether it's wanted standalone, or whether this PR should instead just fix the POSIX bug in place
on the feature branch.

## Test plan

- [x] `uv run ruff check --fix` / `uv run ruff format` on touched files
- [x] `uv run ty check` on touched files
- [x] `uv run pytest tests/test_run_bounded.py -v` — 5 passed
- [x] `uv run prek run --files scripts/run_bounded.py tests/test_run_bounded.py AGENTS.md` — all hooks pass
- [x] New regression test falsified against the pre-fix implementation (fails as expected: `elapsed 5.3s < 3` assertion fails; passes against the fix at ~1.1s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)