### PR TITLE
refactor(development-harness): dedup status-label writers and dead-guard comments

### DIFF
--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -926,6 +926,20 @@ class SQLiteBackend:
     # Status mutations
     # ------------------------------------------------------------------
 
+    def _tag_issue(self, item: BacklogItem, tag: str) -> None:
+        """Insert a status tag for the item's issue row, ignoring duplicates.
+
+        Args:
+            item: BacklogItem carrying the issue reference in ``item.metadata.issue``.
+            tag: Status tag to record, e.g. ``"verified"`` or ``"blocked"``.
+        """
+        raw_issue = getattr(item.metadata, "issue", "") or ""
+        if not raw_issue:
+            return
+        num = int(str(raw_issue).lstrip("#"))
+        self._conn.execute("INSERT OR IGNORE INTO item_tags (issue_number, tag) VALUES (?, ?)", (num, tag))
+        self._conn.commit()
+
     @_serialized_connection_operation
     def apply_status_in_progress(self, item: BacklogItem, repo: str = "", output: Output | None = None) -> None:
         """Store an in-progress tag on the item's issue row.
@@ -935,12 +949,7 @@ class SQLiteBackend:
             repo: Ignored.
             output: Ignored.
         """
-        raw_issue = getattr(item.metadata, "issue", "") or ""
-        if not raw_issue:
-            return
-        num = int(str(raw_issue).lstrip("#"))
-        self._conn.execute("INSERT OR IGNORE INTO item_tags (issue_number, tag) VALUES (?, 'in-progress')", (num,))
-        self._conn.commit()
+        self._tag_issue(item, "in-progress")
 
     @_serialized_connection_operation
     def apply_status_verified(self, item: BacklogItem, repo: str = "", output: Output | None = None) -> None:
@@ -951,12 +960,7 @@ class SQLiteBackend:
             repo: Ignored.
             output: Ignored.
         """
-        raw_issue = getattr(item.metadata, "issue", "") or ""
-        if not raw_issue:
-            return
-        num = int(str(raw_issue).lstrip("#"))
-        self._conn.execute("INSERT OR IGNORE INTO item_tags (issue_number, tag) VALUES (?, 'verified')", (num,))
-        self._conn.commit()
+        self._tag_issue(item, "verified")
 
     @_serialized_connection_operation
     def apply_status_groomed(self, item: BacklogItem, repo: str = "", output: Output | None = None) -> None:
@@ -967,12 +971,7 @@ class SQLiteBackend:
             repo: Ignored.
             output: Ignored.
         """
-        raw_issue = getattr(item.metadata, "issue", "") or ""
-        if not raw_issue:
-            return
-        num = int(str(raw_issue).lstrip("#"))
-        self._conn.execute("INSERT OR IGNORE INTO item_tags (issue_number, tag) VALUES (?, 'groomed')", (num,))
-        self._conn.commit()
+        self._tag_issue(item, "groomed")
 
     @_serialized_connection_operation
     def apply_status_blocked(self, item: BacklogItem, repo: str = "", output: Output | None = None) -> None:
@@ -983,12 +982,7 @@ class SQLiteBackend:
             repo: Ignored.
             output: Ignored.
         """
-        raw_issue = getattr(item.metadata, "issue", "") or ""
-        if not raw_issue:
-            return
-        num = int(str(raw_issue).lstrip("#"))
-        self._conn.execute("INSERT OR IGNORE INTO item_tags (issue_number, tag) VALUES (?, 'blocked')", (num,))
-        self._conn.commit()
+        self._tag_issue(item, "blocked")
 
     @_serialized_connection_operation
     def sync_groomed_to_github_issue(

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -122,7 +122,7 @@ class FileCache:
         """Return pending mutations in durable insertion order."""
         return list(self._load_state().pending)
 
-    def discard_pending(self, reference: ContentRef) -> bool:
+    def discard_pending(self, reference: ContentRef) -> None:
         """Drop any queued mutation for a reference without touching cached content.
 
         Called after a direct online write for a reference lands successfully --
@@ -130,17 +130,13 @@ class FileCache:
         reference (``put_content`` always calls ``replay_pending`` first), so a
         mutation still queued for it afterward is stale, superseded intent that
         must never be replayed against the fresher record it would land on top of.
-
-        Returns:
-            ``True`` if a queued mutation for ``reference`` was found and
-            removed, ``False`` if nothing was queued for it.
         """
 
-        def discard(state: _CacheState) -> tuple[_CacheState, bool]:
+        def discard(state: _CacheState) -> tuple[_CacheState, None]:
             remaining = [entry for entry in state.pending if entry.write.reference != reference]
-            return state.model_copy(update={"pending": remaining}), len(remaining) != len(state.pending)
+            return state.model_copy(update={"pending": remaining}), None
 
-        return self._state.transaction(discard)
+        self._state.transaction(discard)
 
     def _queue_work_item(self, key: str, item: BacklogItem) -> _PendingWorkItemMutation:
         payload = json.dumps(item.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))

--- a/plugins/development-harness/backlog_core/gh_client.py
+++ b/plugins/development-harness/backlog_core/gh_client.py
@@ -1440,6 +1440,67 @@ def fetch_item_status(item: BacklogItem, repo: str = "", output: Output | None =
         return ""
 
 
+def _apply_status_label(
+    repository: Repository,
+    owner: str,
+    repo_name: str,
+    num: int,
+    *,
+    label: str,
+    colour: str = "",
+    description: str = "",
+    removes: tuple[str, ...] = (),
+    create_if_missing: bool = True,
+    already_message: str,
+    applied_message: str,
+    output: Output,
+) -> None:
+    """Fetch an issue's labels and add ``label``, optionally removing others.
+
+    Shared by all four ``apply_status_*`` public functions — see ADR-003 for
+    the fetch-then-update pattern and ADR-004 for why label creation stays REST.
+
+    Args:
+        repository: PyGithub Repository to operate on.
+        owner: Repository owner login, from ``repository.full_name.split("/", 1)``.
+        repo_name: Repository name, from ``repository.full_name.split("/", 1)``.
+        num: Issue number.
+        label: Status label to add, e.g. ``"status:verified"``.
+        colour: Hex colour for label auto-creation. Required when ``create_if_missing``.
+        description: Description for label auto-creation. Required when ``create_if_missing``.
+        removes: Label names to drop from the desired set (e.g. the prior lifecycle state).
+        create_if_missing: Whether to auto-create ``label`` via REST when absent (ADR-004).
+        already_message: Info message when ``label`` is already present.
+        applied_message: Info message after the label update succeeds.
+        output: Output collector for status/warning messages.
+
+    Raises:
+        GithubException: On GitHub API failure other than label-not-found (404)
+            during label creation. GraphQL label-update failures emit a warning
+            via ``output`` instead of raising.
+    """
+    issue = _fetch_issue_graphql(repository, owner, repo_name, num)
+    current_names = [lbl["name"] for lbl in issue["labels"]]
+    if label in current_names:
+        output.info(already_message)
+        return
+    if create_if_missing:
+        try:
+            repository.get_label(label)
+        except GithubException as e:
+            if e.status != _HTTP_NOT_FOUND:
+                raise
+            repository.create_label(name=label, color=colour, description=description)
+    try:
+        desired_names = [n for n in current_names if n not in removes] + [label]
+        id_map = _resolve_label_ids_graphql(repository, owner, repo_name, desired_names)
+        desired_ids = [id_map[n] for n in desired_names if n in id_map]
+        _update_issue_graphql(repository, issue["id"], label_ids=desired_ids)
+        output.info(applied_message)
+    except BacklogError as e:
+        output.warn(f"  WARNING: Could not set status: {e}")
+
+
 def apply_status_in_progress(item: BacklogItem, repo: str = "", output: Output | None = None) -> None:
     """Set GitHub issue label to status:in-progress.
 
@@ -1454,17 +1515,18 @@ def apply_status_in_progress(item: BacklogItem, repo: str = "", output: Output |
             msg = f"Invalid issue ref: {item.issue!r}"
             raise ValueError(msg)
         owner, repo_name = repository.full_name.split("/", 1)
-        issue = _fetch_issue_graphql(repository, owner, repo_name, num)
-        current_names = [lbl["name"] for lbl in issue["labels"]]
-        if "status:in-progress" in current_names:
-            out.info("  Status: already in-progress")
-            return
-        # Compute desired label set: add in-progress, remove needs-grooming
-        desired_names = [n for n in current_names if n != "status:needs-grooming"] + ["status:in-progress"]
-        id_map = _resolve_label_ids_graphql(repository, owner, repo_name, desired_names)
-        desired_ids = [id_map[n] for n in desired_names if n in id_map]
-        _update_issue_graphql(repository, issue["id"], label_ids=desired_ids)
-        out.info("  Status: in-progress")
+        _apply_status_label(
+            repository,
+            owner,
+            repo_name,
+            num,
+            label="status:in-progress",
+            removes=("status:needs-grooming",),
+            create_if_missing=False,
+            already_message="  Status: already in-progress",
+            applied_message="  Status: in-progress",
+            output=out,
+        )
     except BacklogError as e:
         out.warn(f"  WARNING: Could not set status: {e}")
 
@@ -1496,29 +1558,19 @@ def apply_status_verified(item: BacklogItem, repo: str = "", output: Output | No
         msg = f"Invalid issue ref: {item.issue!r}"
         raise ValueError(msg)
     owner, repo_name = repository.full_name.split("/", 1)
-    issue = _fetch_issue_graphql(repository, owner, repo_name, num)
-    current_names = [lbl["name"] for lbl in issue["labels"]]
-    if "status:verified" in current_names:
-        out.info("  Status: already verified")
-        return
-    # Ensure status:verified label exists — label creation stays REST (ADR-004)
-    try:
-        repository.get_label("status:verified")
-    except GithubException as e:
-        if e.status != _HTTP_NOT_FOUND:
-            raise
-        repository.create_label(
-            name="status:verified", color="0e8a16", description="Quality gates passed via /complete-implementation"
-        )
-    # Compute desired label set: add verified, remove in-progress
-    try:
-        desired_names = [n for n in current_names if n != "status:in-progress"] + ["status:verified"]
-        id_map = _resolve_label_ids_graphql(repository, owner, repo_name, desired_names)
-        desired_ids = [id_map[n] for n in desired_names if n in id_map]
-        _update_issue_graphql(repository, issue["id"], label_ids=desired_ids)
-        out.info("  Status: verified")
-    except BacklogError as e:
-        out.warn(f"  WARNING: Could not set status: {e}")
+    _apply_status_label(
+        repository,
+        owner,
+        repo_name,
+        num,
+        label="status:verified",
+        colour="0e8a16",
+        description="Quality gates passed via /complete-implementation",
+        removes=("status:in-progress",),
+        already_message="  Status: already verified",
+        applied_message="  Status: verified",
+        output=out,
+    )
 
 
 def apply_status_groomed(item: BacklogItem, repo: str = "", output: Output | None = None) -> None:
@@ -1549,29 +1601,19 @@ def apply_status_groomed(item: BacklogItem, repo: str = "", output: Output | Non
         msg = f"Invalid issue ref: {item.issue!r}"
         raise ValueError(msg)
     owner, repo_name = repository.full_name.split("/", 1)
-    issue = _fetch_issue_graphql(repository, owner, repo_name, num)
-    current_names = [lbl["name"] for lbl in issue["labels"]]
-    if "status:groomed" in current_names:
-        out.info("  Status: already groomed")
-        return
-    # Ensure status:groomed label exists — label creation stays REST (ADR-004)
-    try:
-        repository.get_label("status:groomed")
-    except GithubException as e:
-        if e.status != _HTTP_NOT_FOUND:
-            raise
-        repository.create_label(
-            name="status:groomed", color="0075ca", description="Grooming complete — all sections written and approved"
-        )
-    # Compute desired label set: add groomed, remove needs-grooming
-    try:
-        desired_names = [n for n in current_names if n != "status:needs-grooming"] + ["status:groomed"]
-        id_map = _resolve_label_ids_graphql(repository, owner, repo_name, desired_names)
-        desired_ids = [id_map[n] for n in desired_names if n in id_map]
-        _update_issue_graphql(repository, issue["id"], label_ids=desired_ids)
-        out.info("  Status: groomed")
-    except BacklogError as e:
-        out.warn(f"  WARNING: Could not set status: {e}")
+    _apply_status_label(
+        repository,
+        owner,
+        repo_name,
+        num,
+        label="status:groomed",
+        colour="0075ca",
+        description="Grooming complete — all sections written and approved",
+        removes=("status:needs-grooming",),
+        already_message="  Status: already groomed",
+        applied_message="  Status: groomed",
+        output=out,
+    )
 
 
 def apply_status_blocked(item: BacklogItem, repo: str = "", output: Output | None = None) -> None:
@@ -1602,29 +1644,19 @@ def apply_status_blocked(item: BacklogItem, repo: str = "", output: Output | Non
         msg = f"Invalid issue ref: {item.issue!r}"
         raise ValueError(msg)
     owner, repo_name = repository.full_name.split("/", 1)
-    issue = _fetch_issue_graphql(repository, owner, repo_name, num)
-    current_names = [lbl["name"] for lbl in issue["labels"]]
-    if "status:blocked" in current_names:
-        out.info("  Status: already blocked")
-        return
-    # Ensure status:blocked label exists — label creation stays REST (ADR-004)
-    try:
-        repository.get_label("status:blocked")
-    except GithubException as e:
-        if e.status != _HTTP_NOT_FOUND:
-            raise
-        repository.create_label(
-            name="status:blocked", color="d93f0b", description="Blocked — missing information or a decision"
-        )
-    # Add blocked without removing other status:* labels (overlay, not a transition)
-    try:
-        desired_names = [*current_names, "status:blocked"]
-        id_map = _resolve_label_ids_graphql(repository, owner, repo_name, desired_names)
-        desired_ids = [id_map[n] for n in desired_names if n in id_map]
-        _update_issue_graphql(repository, issue["id"], label_ids=desired_ids)
-        out.info("  Status: blocked")
-    except BacklogError as e:
-        out.warn(f"  WARNING: Could not set status: {e}")
+    # Blocked is an overlay: no removes — other status:* labels stay in place.
+    _apply_status_label(
+        repository,
+        owner,
+        repo_name,
+        num,
+        label="status:blocked",
+        colour="d93f0b",
+        description="Blocked — missing information or a decision",
+        already_message="  Status: already blocked",
+        applied_message="  Status: blocked",
+        output=out,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -2945,9 +2945,7 @@ def close_item(
     today()
 
     reference = item.reference
-    # Unreachable under BacklogItem's current invariant (see models.py class docstring) —
-    # `reference` self-heals to non-empty at construction and no code path assigns it back
-    # to "" afterward. Kept as defense-in-depth against a future direct assignment.
+    # Unreachable — see BacklogItem class docstring (models.py).
     if not reference:
         msg = "Item has no backend reference"
         raise BacklogError(msg)
@@ -3023,9 +3021,7 @@ def resolve_item(
     today()
 
     reference = item.reference
-    # Unreachable under BacklogItem's current invariant (see models.py class docstring) —
-    # `reference` self-heals to non-empty at construction and no code path assigns it back
-    # to "" afterward. Kept as defense-in-depth against a future direct assignment.
+    # Unreachable — see BacklogItem class docstring (models.py).
     if not reference:
         msg = "Item has no backend reference"
         raise BacklogError(msg)
@@ -3236,9 +3232,7 @@ def _apply_groomed_update(
         BacklogError: If item has no file_path.
         ValidationError: If resolved single-section content is empty.
     """
-    # Unreachable under BacklogItem's current invariant (see models.py class docstring) —
-    # `reference` self-heals to non-empty at construction and no code path assigns it back
-    # to "" afterward. Kept as defense-in-depth against a future direct assignment.
+    # Unreachable — see BacklogItem class docstring (models.py).
     if not item.reference:
         msg = "Item has no backend reference"
         raise BacklogError(msg)
@@ -3498,9 +3492,7 @@ def strike_entry(
     item = find_item(items, selector)
     if not item:
         raise ItemNotFoundError(selector)
-    # Unreachable under BacklogItem's current invariant (see models.py class docstring) —
-    # `reference` self-heals to non-empty at construction and no code path assigns it back
-    # to "" afterward. Kept as defense-in-depth against a future direct assignment.
+    # Unreachable — see BacklogItem class docstring (models.py).
     if not item.reference:
         msg = "Item has no backend reference"
         raise BacklogError(msg)

--- a/tests/test_frustration_analyzer_python_compatibility.py
+++ b/tests/test_frustration_analyzer_python_compatibility.py
@@ -2,24 +2,18 @@
 
 from __future__ import annotations
 
-import tomllib
-from pathlib import Path
 
-ROOT = Path(__file__).parents[1]
-PLUGIN = ROOT / "plugins" / "frustration-analyzer"
+def test_frustration_analyzer_server_imports_on_current_interpreter() -> None:
+    """The MCP server module must import cleanly under the running interpreter.
 
+    Replaces a prior version of this test that asserted the PEP 723
+    ``requires-python`` bound equaled a literal string -- a tautology that
+    proved only that the string was edited, not that the server actually
+    works on the interpreters it claims to support. Reuses the existing
+    ``_server`` loader from the plugin's own test suite (importable here
+    via the shared ``pythonpath`` entry in the root ``pyproject.toml``)
+    instead of duplicating its importlib boilerplate.
+    """
+    import _server
 
-def read_pep_723_metadata(script: Path) -> dict[str, object]:
-    """Parse the inline PEP 723 block without importing the MCP server."""
-    lines = script.read_text(encoding="utf-8").splitlines()
-    start = lines.index("# /// script") + 1
-    end = lines.index("# ///", start)
-    metadata = "\n".join(line.removeprefix("# ") for line in lines[start:end])
-    return tomllib.loads(metadata)
-
-
-def test_frustration_analyzer_declares_python_312_through_314_support() -> None:
-    """The server metadata includes every interpreter the plugin supports."""
-    metadata = read_pep_723_metadata(PLUGIN / "mcp" / "server.py")
-
-    assert metadata["requires-python"] == ">=3.11,<3.15"
+    assert _server.extract_user_messages is not None


### PR DESCRIPTION
## Summary

Dedup/cleanup pass from a ponytail (over-engineering) review of today's merged
Python changes (`.tmp/scratch/reports/ponytail-review-20260817.md`). Addresses
all 5 items in that report's "Worth fixing now" section. Pure refactor —
no behavior changes to items 1-4; item 5 changes what the test asserts,
by design.

- **1.1** `gh_client.py` — extracted `_apply_status_label()`, collapsing four
  ~35-line near-identical `apply_status_*` functions to thin wrappers.
  Each wrapper keeps its exact original guard placement and label-creation
  behavior (in_progress does not auto-create its label or early-return on
  empty issue; verified/groomed/blocked do — preserved as-is).
- **1.2** `sqlite_backend.py` — extracted `_tag_issue()`, collapsing all four
  `apply_status_*` tag writers (the report named three; a fourth,
  `apply_status_in_progress`, has the identical shape and is included for
  consistency) to one-line wrappers.
- **1.3** `operations.py` — collapsed four duplicated 3-line "this guard is
  unreachable" comment blocks to one-line pointers at the model docstring
  that already states the invariant once. The four guards themselves are
  untouched.
- **1.4** `file_cache.py` — `discard_pending()` now returns `None`; its one
  caller never read the `bool`, and the docstring spent four lines
  justifying a return value nothing consumed.
- **1.5** `tests/test_frustration_analyzer_python_compatibility.py` —
  replaced a test that asserted a PEP 723 version-bound string literally
  equals `">=3.11,<3.15"` (asserting the edit was made, not that anything
  works) with a real smoke check: the MCP server module actually imports
  under the running interpreter. Renamed to match.

## Test plan

- [x] `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` on
      every touched file
- [x] Full existing suites covering the touched code (368 tests) —
      `gh_client`, `sqlite_backend`, `operations` status-label guards,
      `file_cache` — all pass unchanged
- [x] `uv run pytest tests/test_frustration_analyzer_python_compatibility.py -v`
      — new test passes and genuinely exercises `server.py` (20% line
      coverage recorded, confirming real import, not a string comparison)
- [x] `uv run prek run --files <touched files>` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)