### PR TITLE
fix(development-harness): batch FileCache writes to fix O(n^2) list_content refresh

### DIFF
--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -22,6 +22,7 @@ together and remains the seam callers substitute.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Protocol, assert_never
 
 from backlog_core.backends._github_work_item_versions import is_work_item_head_ref
@@ -53,6 +54,8 @@ if TYPE_CHECKING:
 
     from backlog_core.artifact_provider import ArtifactBackend
     from backlog_core.file_cache import FileCache
+
+_log = logging.getLogger(__name__)
 
 
 class _PlanPersistence(Protocol):
@@ -257,8 +260,14 @@ class _GitHubContentCache:
             except (BacklogError, ContentUnavailableError, OSError):
                 online = False
             else:
-                for record in records:
-                    self._cache.cache_content(record)
+                stored = self._cache.cache_content_many(records)
+                if stored != len(records):
+                    _log.info(
+                        "list_content refresh stored %d/%d records (%d skipped -- pending mutation owns those references)",
+                        stored,
+                        len(records),
+                        len(records) - stored,
+                    )
                 return records[query.offset : query.offset + query.limit]
         records = [
             record.model_copy(update={"stale": not online})

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -8,6 +8,7 @@ import json
 import os
 import tempfile
 import warnings
+from collections.abc import Iterable
 from io import StringIO
 from pathlib import Path
 
@@ -73,6 +74,44 @@ class FileCache:
             return state.model_copy(update={"records": self._replace_record(state.records, record)}), None
 
         self._state.transaction(replace)
+
+    def cache_content_many(self, records: Iterable[ContentRecord], *, acknowledge_pending: bool = False) -> int:
+        """Durably replace many provider-observed content records in one transaction.
+
+        Applies the same per-record pending-guard invariant as :meth:`cache_content`
+        to every record, but performs a single locked read-modify-write for the
+        whole batch instead of one transaction per record. A caller looping over
+        ``cache_content`` pays a full state load, validate, and durable dump on
+        every call -- O(n) work repeated n times. Folding the batch into one
+        transaction collapses that to a single O(n) load/dump/fsync, and is
+        strictly more durable than the loop it replaces: the batch either lands
+        in full or not at all, where a mid-loop process death previously left a
+        partially-refreshed cache.
+
+        Args:
+            records: Provider-observed content records to store.
+            acknowledge_pending: Pass ``True`` only when this batch itself is
+                landing the authoritative write for every reference in it.
+                Defaults to ``False`` so a routine cache-refresh read never
+                overwrites a still-pending reference.
+
+        Returns:
+            The count of records actually stored -- excludes records skipped
+            because a pending mutation still owns that reference.
+        """
+
+        def replace(state: _CacheState) -> tuple[_CacheState, int]:
+            current = state.records
+            stored = 0
+            for record in records:
+                existing = next((entry for entry in current if entry.reference == record.reference), None)
+                if existing is not None and existing.pending and not acknowledge_pending:
+                    continue
+                current = self._replace_record(current, record)
+                stored += 1
+            return state.model_copy(update={"records": current}), stored
+
+        return self._state.transaction(replace)
 
     def queue_write(self, record: ContentRecord, write: ContentWrite) -> PendingMutation:
         """Atomically cache an offline write and append its deduplicated mutation.

--- a/plugins/development-harness/tests/test_github_contents.py
+++ b/plugins/development-harness/tests/test_github_contents.py
@@ -331,6 +331,7 @@ def test_malformed_native_content_does_not_fall_back_to_legacy(
     cache.cache_content(ContentRecord(reference=reference, content="cached"))
     backend = GitHubBackend(cache=cache, artifact_provider=MagicMock(), plan_persistence=legacy, contents=store)
     backend._cache.cache_content = MagicMock()
+    backend._cache.cache_content_many = MagicMock()
     backend.try_get_github = MagicMock(return_value=MagicMock())
 
     with pytest.raises(ContentUnavailableError, match="envelope"):
@@ -633,7 +634,7 @@ def _paged_backend(tmp_path: Path, native: list[ContentRecord], legacy: list[Con
         plan_persistence=_PagedContent(legacy),
         contents=_PagedContent(native),
     )
-    backend._cache.cache_content = MagicMock()
+    backend._cache.cache_content_many = MagicMock(return_value=0)
     backend.try_get_github = MagicMock(return_value=MagicMock())
     return backend
 


### PR DESCRIPTION
## Summary

- `_GitHubContentCache.list_content` called `FileCache.cache_content()` once per returned record. Each call is a full lock + YAML load + Pydantic validate + YAML dump + `fsync` of the entire cache state file, making a single `list_content()` call O(n^2) in the number of records returned — 101 records cost 79s of pure local serialization work in the test, with zero network involved.
- Adds `FileCache.cache_content_many(records, *, acknowledge_pending=False) -> int`: folds a whole batch into **one** durable transaction, applying the existing per-record `pending`-write guard (PR #2906) to every record inside the fold, and returns the count of records actually stored (vs. skipped because a pending mutation still owns that reference).
- Switches the one affected loop caller (`github_content_migration.py`'s `list_content`) to a single `cache_content_many(records)` call. `get_content`/`put_content`'s single-record call sites are untouched — out of scope, per the vetted options analysis.
- Closes a pre-existing Silent Failure Prevention gap on this same path: the loop now logs (`_log.info`) when any records are skipped by the pending guard, instead of discarding that information.

**Durability: strict improvement, not a trade-off.** The batch is a single atomic transaction with the same lock, same `fsync`, same atomic rename as today's per-record transaction — just done once instead of n times. It is strictly *stronger* than the current behavior, which can leave a partially-refreshed cache if the process dies mid-loop; a single batch transaction cannot leave a partial state. Verified against `backlog_core/ARCHITECTURE.md`'s stated guarantee (per-transaction atomicity, not per-record fsync granularity) and the commit that introduced the transaction machinery (`326ffe24`).

Backlog: #2931. Full options analysis (Option A implemented here; B/C/D explicitly rejected) is in `.tmp/scratch/reports/pytest-fix-options-filecache-on2.md`.

## Measured before/after

`test_backend_native_pagination_fetches_each_blob_once` (101 in-memory-mocked records folded into one transaction):

- Before: 79s (serial) / 185s (parallel via xdist)
- After: **~1.3s** (`call` phase, `--durations=0`)

## Test plan

- [x] `uv run pytest plugins/development-harness/tests/test_github_contents.py -v --durations=0` — 33 passed; target test's `call` phase dropped to 1.38s
- [x] `uv run pytest plugins/development-harness/tests/test_github_content_safety.py -v` — 17 passed (pending-guard regression suite, unchanged)
- [x] `uv run pytest plugins/development-harness/tests_backlog/test_file_cache.py plugins/development-harness/tests_backlog/test_github_sync_provider.py -v` — 47 passed, 1 pre-existing failure (`test_github_content_provider_replay_preserves_concurrent_remote_revision`) confirmed unrelated: reproduces identically on `main` with this branch's changes stashed out
- [x] `uv run ruff check --fix`, `uv run ruff format`, `uv run ty check` on touched files — all clean
- [x] `uv run prek run --files <touched files>` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)