### PR TITLE
refactor(development-harness): trim _apply_non_in_progress_status to 5 params

### DIFF
--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -3058,13 +3058,7 @@ def resolve_item(
 
 
 def _apply_non_in_progress_status(
-    item: BacklogItem,
-    status: str,
-    is_string_id_backend: bool,
-    has_integer_issue: bool,
-    repo: str,
-    result: dict[str, str | int | bool | list[str]],
-    output: Output,
+    item: BacklogItem, status: str, repo: str, result: dict[str, str | int | bool | list[str]], output: Output
 ) -> None:
     """Handle every status value other than "in-progress" for _apply_issue_status_labels.
 
@@ -3077,12 +3071,13 @@ def _apply_non_in_progress_status(
     Args:
         item: Resolved BacklogItem.
         status: Status string to set (non-empty, not "in-progress").
-        is_string_id_backend: Whether the active backend uses string issue IDs (e.g. beads).
-        has_integer_issue: Whether ``item.issue`` parses as a numeric GitHub-style issue.
         repo: GitHub repo slug (e.g. ``"owner/repo"``).
         result: Partial result dict mutated in place with ``"status"`` / ``"error"`` keys.
         output: Output aggregator for info/warning messages.
     """
+    is_string_id_backend = get_config().backend.issue_id_type == "string"
+    has_integer_issue = parse_issue_number(item.issue) is not None
+
     if status == "blocked":
         if is_string_id_backend:
             # item.reference self-heals to a title-hash placeholder at construction
@@ -3171,8 +3166,10 @@ def _apply_issue_status_labels(
         # Unlike "in-progress" above, these outcomes don't all require a
         # backend target — terminal-status/unrecognized-value rejection is
         # pure validation, so run it even when no_backend_target is True.
-        _apply_non_in_progress_status(item, status, is_string_id_backend, has_integer_issue, repo, result, output)
+        _apply_non_in_progress_status(item, status, repo, result, output)
     elif no_backend_target:
+        # No status change requested and nothing to write to: skip the
+        # verified check below too, rather than reporting a no-op "verified".
         return
 
     if verified:


### PR DESCRIPTION
## Summary

Addresses item 2.5 from the ponytail over-engineering review
(`.tmp/scratch/reports/ponytail-review-20260817.md`, section "2.5
`_apply_non_in_progress_status` — seven parameters to satisfy a complexity
linter").

`_apply_non_in_progress_status` was extracted from `_apply_issue_status_labels`
to keep the latter's cyclomatic complexity within limit. The extraction took
7 positional parameters, two of which (`is_string_id_backend`,
`has_integer_issue`) are one-line derivations from `item` / `get_config()`
rather than genuine caller state that only the caller knows.

**Shape chosen: (a) tighten the existing extraction, not (b) a dispatch-dict
restructure.** The review explicitly left this open — either the linter
threshold is right (tighten) or wrong (restructure). The function body is a
flat `if/elif/elif/else` where the `"blocked"` branch does meaningfully more
work than the other two (nested backend-type/issue-type branching with
distinct error messages); a dispatch dict keyed on status would need to
either pass the same derived state in through closures/partials (no
simplification) or split `"blocked"` out anyway (no complexity reduction).
Recomputing two cheap, pure values inside the function is the smaller, more
direct fix and follows the ponytail ladder's "already-minimal, just tighten"
rung.

- Recompute `is_string_id_backend` / `has_integer_issue` inside
  `_apply_non_in_progress_status` from `item` and `get_config()` instead of
  threading them through the call site — signature drops from 7 to 5
  parameters.
- The caller (`_apply_issue_status_labels`) still computes both values
  locally, since it independently needs them for its own `"in-progress"` and
  `"verified"` branches — no behavior change there.
- Added a one-line comment on the caller's trailing
  `elif no_backend_target: return`, which the review called out as reading
  like leftover code. It's intentional: when no status change is requested
  and there's no backend target, it also skips the `verified` check below
  rather than reporting a no-op `verified: true`. Confirmed this exact
  short-circuit is pinned by
  `test_status_rejection_reached_even_with_no_backend_target` (kept
  unchanged — no reproduction command needed since it's a comment-only
  addition on that branch).

Pure refactor — no behavior change for any status value or backend
combination. The "blocked" branch's `reference_is_title_derived()` check
(landed today in #2916/#2908) is untouched.

## Test plan

- [x] `uv run ruff check --fix` / `uv run ruff format` — clean
- [x] `uv run ty check plugins/development-harness/backlog_core/operations.py` — clean
- [x] `uv run pytest plugins/development-harness/tests/test_backlog_core_operations.py -k "TestApplyIssueStatusLabelsBeads or status_label"` — 12/12 passed, covering in-progress (beads native/claim/nanoid/github), blocked (github/beads/no-reference/no-issue/GithubException), done-rejection, unrecognized-status, and the no-backend-target short-circuit
- [x] `uv run prek run --files plugins/development-harness/backlog_core/operations.py` — all hooks passed