### PR TITLE
fix(development-harness): stop frontend-parity tests making live GitHub calls

### DIFF
--- a/plugins/development-harness/tests/helpers.py
+++ b/plugins/development-harness/tests/helpers.py
@@ -63,9 +63,28 @@ async def call_mcp_tool(
 
 
 def run_cli_subprocess(
-    args: list[str], *, timeout: int = 30, env: dict[str, str] | None = None, cwd: Path | None = None
+    args: list[str],
+    *,
+    timeout: int = 30,
+    env: dict[str, str] | None = None,
+    cwd: Path | None = None,
+    sanitize_env: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Run a CLI subprocess (e.g. ``uv run <script>``) with whole-process-group timeout kill.
+
+    Fail-closed network guard: a subprocess is a fresh interpreter and inherits none of
+    ``conftest.py``'s in-process socket-patching network guard (that guard monkeypatches
+    ``socket.connect``/``connect_ex``/``getaddrinfo`` in the pytest process only). Left
+    unsanitized, a subprocess that inherits the caller's real ``GITHUB_TOKEN``/``GH_TOKEN``
+    resolves the CLI's default ``github`` backlog backend and makes live, authenticated GitHub
+    API calls from inside a test -- a correctness bug (results depend on whether the developer
+    happens to have a token exported), not merely a slowdown (measured ~28x: a real round trip
+    adds ~65-80s versus ~2.5s for the local ``sqlite`` backend). ``sanitize_env=True`` (the
+    default) closes this at the one place every subprocess-spawning test routes through, by
+    blanking both token vars and defaulting ``BACKLOG_BACKEND`` to ``sqlite`` (without
+    overriding a caller-supplied ``BACKLOG_BACKEND``). Pass ``sanitize_env=False`` -- with a
+    comment explaining why -- only for a test that genuinely needs to exercise the live
+    ``github`` backend.
 
     Root cause this works around: ``subprocess.run(timeout=...)`` kills only the
     immediate child on timeout (``Popen.kill()`` signals ``self.pid`` alone — see the
@@ -87,8 +106,11 @@ def run_cli_subprocess(
     Args:
         args: Full argv, e.g. ``["uv", "run", str(cli_path), "plan", "list"]``.
         timeout: Seconds to wait before killing the process group.
-        env: Environment for the subprocess; defaults to the current environment.
+        env: Environment for the subprocess; defaults to a copy of the current environment.
         cwd: Working directory for the subprocess.
+        sanitize_env: When True (default), blank ``GITHUB_TOKEN``/``GH_TOKEN`` and default
+            ``BACKLOG_BACKEND`` to ``sqlite`` in the effective environment before launching.
+            Set False only when a test must exercise the live ``github`` backend.
 
     Returns:
         A ``CompletedProcess`` with captured text stdout/stderr.
@@ -96,6 +118,12 @@ def run_cli_subprocess(
     Raises:
         subprocess.TimeoutExpired: If the process group does not exit within timeout.
     """
+    run_env = dict(env) if env is not None else os.environ.copy()
+    if sanitize_env:
+        run_env.pop("GITHUB_TOKEN", None)
+        run_env.pop("GH_TOKEN", None)
+        run_env.setdefault("BACKLOG_BACKEND", "sqlite")
+
     # POSIX only: os.killpg/os.getpgid have no Windows equivalent, and CI
     # (ubuntu-latest) is the only enforced target for this helper. On Windows
     # start_new_session is a no-op default (False) and the except branch below
@@ -105,7 +133,7 @@ def run_cli_subprocess(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        env=env,
+        env=run_env,
         cwd=cwd,
         start_new_session=os.name != "nt",
     )

--- a/plugins/development-harness/tests/test_frontend_parity.py
+++ b/plugins/development-harness/tests/test_frontend_parity.py
@@ -65,7 +65,14 @@ def run_cli(args: list[str], *, timeout: int = 180, env: dict[str, str] | None =
         json.JSONDecodeError: If stdout is not valid JSON.
         RuntimeError: If the CLI exits with a non-zero code.
     """
+    # Sanitize before applying caller overrides: these tests assert returncode/JSON shape only
+    # and never depend on the live github backend, so a real network round trip here is a
+    # correctness bug (results depend on whether GITHUB_TOKEN happens to be exported), not just
+    # slower (measured ~28x: ~70-85s live vs ~2.5s sqlite). run_cli_subprocess's own
+    # sanitize_env default would also catch this; setting it here too keeps the behavior visible
+    # at the call site, matching the dh_env fixture pattern in test_frontend_parity_ops.py.
     run_env = os.environ.copy()
+    run_env.update({"BACKLOG_BACKEND": "sqlite", "GITHUB_TOKEN": "", "GH_TOKEN": ""})
     if env:
         run_env.update(env)
     result = run_cli_subprocess(["uv", "run", str(_CLI_PATH), *args], timeout=timeout, env=run_env)
@@ -130,11 +137,22 @@ class TestCLIForeignCWD:
         state_home = tmp_path / label / "dh_state"
         plan_dir = state_home / "projects" / _get_project_slug() / "plan"
         plan_dir.mkdir(parents=True, exist_ok=True)
+        # BACKLOG_BACKEND/GITHUB_TOKEN/GH_TOKEN sanitized: this test verifies foreign-CWD and
+        # contaminated-PYTHONPATH behavior, not backend selection -- a live github round trip
+        # here is unrelated to what it asserts and was making the run 28x slower.
         result = run_cli_subprocess(
             ["uv", "run", str(_CLI_PATH), "plan", "list", "--limit", "1"],
             timeout=180,
             cwd=tmp_path,
-            env={**os.environ, **extra_env, "DH_STATE_HOME": str(state_home), "DH_PROJECT_ROOT": str(_REPO_ROOT)},
+            env={
+                **os.environ,
+                **extra_env,
+                "DH_STATE_HOME": str(state_home),
+                "DH_PROJECT_ROOT": str(_REPO_ROOT),
+                "BACKLOG_BACKEND": "sqlite",
+                "GITHUB_TOKEN": "",
+                "GH_TOKEN": "",
+            },
         )
         assert result.returncode == 0, f"label={label} {result.stderr[:500]}"
         json.loads(result.stdout)


### PR DESCRIPTION
## Summary

Fixes a correctness bug found during a pytest timing investigation, not just a
speed issue: `run_cli()` and `TestCLIForeignCWD::test_cli_runs_from_a_foreign_cwd`
in `test_frontend_parity.py` built their subprocess environment as
`os.environ.copy()` plus a couple of state-home overrides — never setting
`BACKLOG_BACKEND` and never blanking `GITHUB_TOKEN`/`GH_TOKEN`. The `uv run cli.py`
subprocess therefore resolved to the default `github` backlog backend and made
live, authenticated GitHub API calls from inside tests whose assertions only
check `returncode == 0` and that stdout parses as JSON — neither depends on the
github backend. Results silently depended on whether the developer happened to
have a token exported.

`conftest.py`'s network guard only monkeypatches `socket.connect`/`connect_ex`/
`getaddrinfo` inside the pytest process itself; a `uv run` child is a fresh
interpreter and inherits none of it, so subprocess-spawning tests are the one
hole in that guard.

- **Option 1** — sanitize the subprocess environment directly in
  `test_frontend_parity.py`'s `run_cli()` and `TestCLIForeignCWD`, matching the
  pattern already established by `test_frontend_parity_ops.py`'s `dh_env`
  fixture (`BACKLOG_BACKEND=sqlite`, `GITHUB_TOKEN=""`, `GH_TOKEN=""`).
- **Option 4** — harden the shared `run_cli_subprocess()` helper
  (`tests/helpers.py`) that every subprocess-spawning test in this suite routes
  through, so it sanitizes the same three vars by default
  (`sanitize_env: bool = True`), closing the hole structurally instead of
  per-caller. A test that genuinely needs the live `github` backend can opt out
  explicitly via `sanitize_env=False`.

Audited all 3 `run_cli_subprocess` call sites in the plugin
(`test_frontend_parity.py` x2, `test_frontend_parity_ops.py` x1) — none rely on
the live github backend, so no opt-out was needed anywhere.

**Deliberately deferred (separate decision, not in this PR):** Option 2 from the
prior investigation — converting the other 103 `_run_cli` subprocess call sites
in `test_frontend_parity_ops.py` to in-process `CliRunner` invocations — and
Option 3 — moving the remaining real-subprocess tests to a slower marker tier.
Both are out of scope here; this PR is the token/backend sanitization fix only.

## Measured before/after

| Test | Before | After (isolated, `--no-cov -n0`) |
|---|---|---|
| `TestParityInfrastructure::test_cli_plan_list_returns_json` | ~70-85s (live GitHub round trip) | 6.86s |
| `TestCLIForeignCWD::test_cli_runs_from_a_foreign_cwd[extra_env0-clean]` | ~70-85s | 6.55s |
| `TestCLIForeignCWD::test_cli_runs_from_a_foreign_cwd[extra_env1-contaminated]` | ~70-85s | 6.00s |

Under the repo's default full-suite `-n auto --dist loadgroup` + coverage run,
absolute numbers are higher (~17-22s call time) due to xdist worker/coverage
overhead and concurrent-agent CPU contention on this machine at test time, but
the key correctness signal is gone: no more 60-85s network-stall outliers.

## Test plan

- [x] `uv run pytest plugins/development-harness/tests/test_frontend_parity.py -v --durations=0` — 6 passed, no live-network stalls
- [x] `uv run pytest plugins/development-harness/tests/ -q` (run twice) — 2569 passed, 39 skipped, 5 xfailed both times; the only 2 failures
      (`test_network_guard.py::test_guard_covers_testpath[tests]` and `[tests_sam]`) are pre-existing flakiness unrelated to this change —
      confirmed by re-running them in isolation (4/4 passed) and by zero code-path overlap with the touched files (that test spawns a full
      `pytest` subprocess directly via `subprocess.run`, not `run_cli_subprocess`)
- [x] `uv run ruff check --fix` / `uv run ruff format` — clean
- [x] `uv run ty check` — clean
- [x] `uv run prek run --files <touched files>` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)