### PR TITLE
docs(development-harness): correct the rationale for github_contents.py's Protocol shims

### DIFF
--- a/plugins/development-harness/backlog_core/backends/github_contents.py
+++ b/plugins/development-harness/backlog_core/backends/github_contents.py
@@ -58,6 +58,24 @@ class _GitHubContentIntegrityError(ContentUnavailableError):
     pass
 
 
+# PyGithub (>=2.9.0) is PEP 561-compliant and ships real, correctly-typed
+# classes for every one of these -- github.ContentFile.ContentFile,
+# github.Commit.Commit, github.Branch.Branch, github.GitTree.GitTree, and
+# github.GitTreeElement.GitTreeElement each declare concrete typed
+# properties (verified via inspect.signature against the installed
+# package). These five Protocols do NOT exist to compensate for missing
+# PyGithub stubs. They exist because the real classes have private,
+# requester-bound constructors that only PyGithub itself can call, so the
+# lightweight fakes in tests/test_github_contents.py (_File, _FakeCommit,
+# _FakeBranch, _TreeEntry, _Tree -- plain Pydantic models) cannot subclass
+# or otherwise become nominal instances of them. `ty` proves this: swapping
+# any one of these Protocols for its real-class equivalent makes
+# `_GitHubContentsStore(lambda: repository)` in the test fixture fail
+# `invalid-argument-type` because the fake's return value is not
+# assignable to the concrete class. `_ContentsFile` is additionally
+# `@runtime_checkable` because `put()` isinstance-checks the write
+# response against it -- a real `isinstance(x, ContentFile)` check would
+# also reject every test double at runtime, not just at type-check time.
 @runtime_checkable
 class _ContentsFile(Protocol):
     @property


### PR DESCRIPTION
## Summary

This PR corrects a prior investigation's wrong premise. It does **not** change any runtime behavior — `github_contents.py` is functionally identical before and after.

**The false premise (from the prior investigation):** `_ContentsFile`, `_Commit`, `_Branch`, `_GitTreeEntry`, `_GitTree` exist because "PyGithub ships no usable type stubs."

**Verified false**, directly against this repo's installed `PyGithub==2.9.0`:

- `importlib.resources.files('github').joinpath('py.typed').exists()` → `True`
- Real classes have correct, concrete typed properties (via `inspect.signature`):
  - `github.Branch.Branch.commit` → `-> 'Commit'`
  - `github.Commit.Commit.sha` → `-> 'str'`
  - `github.GitTree.GitTree.tree` → `-> 'list[GitTreeElement]'`
  - `github.GitTreeElement.GitTreeElement.path` / `.type` / `.sha` → each `-> 'str'`
  - `github.ContentFile.ContentFile.sha` / `.content` / `.decoded_content` / `.path` → each correctly typed
- `github/py.typed` exists in PyGithub's source repo at the installed tag (confirmed via the GitHub API), so this is genuine PEP 561 compliance, not a repo-local packaging fluke.

## What I attempted, and what `ty` proved

I replaced all five Protocols with PyGithub's real classes (`github.ContentFile.ContentFile`, `github.Commit.Commit`, `github.Branch.Branch`, `github.GitTree.GitTree`, `github.GitTreeElement.GitTreeElement`), imported directly, and deleted the Protocol definitions.

`uv run ty check` on `plugins/development-harness/backlog_core/backends/github_contents.py` alone passed. But `uv run ty check` on `plugins/development-harness/tests/test_github_contents.py` failed with `invalid-argument-type` on the `store` fixture (`_GitHubContentsStore(lambda: repository)`).

I reverted one Protocol at a time and re-ran `ty check` after each, which surfaced a cascade — each revert unmasked the *next* incompatible member:

1. `get_branch: Branch` → fails because `_FakeBranch` (a plain Pydantic model in the test double) is not assignable to the real `Branch` class.
2. After restoring `_Branch`/`_Commit`: `get_contents: ContentFile` → fails because `_File` is not assignable to `ContentFile`.
3. After restoring `_ContentsFile`: `get_git_tree: GitTree` → fails because `_Tree` is not assignable to `GitTree`.

Restoring `_GitTree`/`_GitTreeEntry` last made `ty check` on both files pass clean again.

**Root cause of why all five are load-bearing:** PyGithub's real classes (`ContentFile`, `Commit`, `Branch`, `GitTree`, `GitTreeElement`) have private, requester-bound constructors — only PyGithub itself can construct them from a live API response. The test suite's fakes (`_File`, `_FakeCommit`, `_FakeBranch`, `_TreeEntry`, `_Tree` in `tests/test_github_contents.py`) are lightweight, unrelated Pydantic models that satisfy the *structural* shape these Protocols declare, but cannot become *nominal* instances of the concrete classes. Protocols are the correct mechanism here — not because PyGithub lacks stubs, but because structural typing is what lets a simple test double stand in for an object PyGithub alone can construct.

`_ContentsFile` additionally needs `@runtime_checkable`, because `put()` does `isinstance(written, _ContentsFile)` at runtime to validate the write response — a real `isinstance(x, ContentFile)` check would also reject every test double at runtime (not just fail static type-checking), breaking every write-path test.

## Which Protocols were removed vs. retained

**All five retained** — `_ContentsFile`, `_Commit`, `_Branch`, `_GitTreeEntry`, `_GitTree`. None were removed. `ty` forced this outcome empirically for every one of them (see cascade above); this was verified, not assumed.

The only change is a new explanatory comment above the Protocol block, replacing the false "no usable type stubs" reasoning with the real, verified reason (test-double structural compatibility with PyGithub's private-constructor concrete classes).

## Test plan

- [x] `uv run ruff check` / `uv run ruff format` on the touched file — clean
- [x] `uv run ty check` on `github_contents.py` and `tests/test_github_contents.py` together — passes clean
- [x] `uv run pytest plugins/development-harness/tests/test_github_contents.py -v` — 33 passed
- [x] `uv run prek run --files plugins/development-harness/backlog_core/backends/github_contents.py` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)