### PR TITLE
docs(development-harness): ponytail cleanup batch — trim duplicated prose, drift guard, ceiling comment

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.14",
+  "version": "9.0.15",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/memory_backend.py
+++ b/plugins/development-harness/backlog_core/backends/memory_backend.py
@@ -164,6 +164,8 @@ class InMemoryBackend:
                 the check is scoped to derived references only.
         """
         existing = self._work_items.get(item.reference)
+        # ponytail: description-only equality; compare full model_dump if
+        # same-title/same-description distinct items appear
         if existing is not None and reference_is_title_derived(item) and existing.description != item.description:
             raise ReferenceCollisionError(item.reference, item.title)
         canonical = BacklogItem.model_validate(item.model_dump())

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -240,6 +240,8 @@ class SQLiteBackend:
             ).fetchone()
             if row is not None:
                 existing = BacklogItem.model_validate_json(row["content"])
+                # ponytail: description-only equality; compare full model_dump if
+                # same-title/same-description distinct items appear
                 if existing.description != item.description:
                     raise ReferenceCollisionError(item.reference, item.title)
         self._conn.execute(

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -579,23 +579,10 @@ class DuplicateItemError(BacklogError):
 class ReferenceCollisionError(BacklogError):
     """Raised when a title-derived backend reference already belongs to a different item.
 
-    ``BacklogItem.reference`` self-heals via :func:`_derive_stable_reference` when a
-    caller constructs an item with no backend issue yet and no explicit ``reference``
-    (see the second invariant in :class:`BacklogItem`'s docstring). That fallback is
-    deterministic on ``title`` alone, so it cannot by itself distinguish "the same
-    never-issued item, reconstructed again" from "a different, never-issued item that
-    happens to share a title" — both look identical at derivation time.
-
-    Native backends (:class:`~backlog_core.backends.memory_backend.InMemoryBackend`,
-    :class:`~backlog_core.backends.sqlite_backend.SQLiteBackend`) resolve that ambiguity
-    at write time in ``put_work_item``: a freshly derived reference that collides with an
-    *existing* stored record is treated as the same item only when the record's
-    ``description`` also matches (this is what
-    ``test_backend_put_work_item_reference_is_deterministic_across_reloads`` in
-    ``tests/test_work_item_reference_healing.py`` exercises — reconstructing an
-    all-default item under the same title is expected to collapse to one record). A
-    mismatched ``description`` raises this error instead of silently discarding the
-    record already stored under the colliding reference.
+    Two never-issued items can derive the identical reference from a shared title (see
+    :class:`BacklogItem`'s docstring, second invariant). Native backends raise this
+    instead of silently discarding the record already stored under the colliding
+    reference when the existing record's ``description`` does not also match.
     """
 
     def __init__(self, reference: str, title: str) -> None:
@@ -935,24 +922,8 @@ class BacklogItemMetadata(BaseModel):
 def _derive_stable_reference(issue: str, title: str) -> str:
     """Return the stable backend reference a work item should carry.
 
-    ``BacklogItem.reference`` is the opaque key every backend (GitHub cache
-    records, SQLite primary keys, in-memory dict keys) uses to identify a
-    work item. Unlike ``priority``/``issue`` and the other backward-compatible
-    flat fields, ``reference`` has no metadata counterpart to synchronise
-    with — a raw record can reach construction with ``reference=""`` (a
-    freshly created item with no backend issue yet, or a stale on-disk
-    record written before this field was populated consistently).
-
-    The fallback must be deterministic, not random (e.g. not ``uuid4()``):
-    a stable key ensures the same conceptual item — same title, reloaded or
-    reconstructed independently — always resolves to the same reference. A
-    random fallback would mint a new, unmatched key on every reload of a
-    persisted record, permanently orphaning it from reference-gated
-    operations (groom, resolve) that expect repeated loads of the same
-    record to agree on its key. This is the shared root cause behind a
-    production incident where a GitHub-backend record's cached reference
-    went stale as empty, breaking every subsequent groom/resolve call for
-    that item.
+    Deterministic, not ``uuid4()``: a reloaded record must key the same on every
+    read. See :class:`BacklogItem`'s class docstring for the full rationale.
 
     Args:
         issue: The item's resolved backend issue identifier, if any.
@@ -968,12 +939,10 @@ def _derive_stable_reference(issue: str, title: str) -> str:
 def reference_is_title_derived(item: BacklogItem) -> bool:
     """Return whether ``item.reference`` is exactly the title-hash fallback.
 
-    Pure, stateless re-derivation — not a value cached on ``item`` — so it
-    is correct regardless of *when* or *how* ``item.reference`` came to hold
-    that value (self-healed by ``_sync_metadata`` this construction, carried
-    forward from a reload, or supplied explicitly by a caller that happened
-    to compute the same hash). See :class:`ReferenceCollisionError` and the
-    class docstring's second invariant for why backends need this check.
+    Pure, stateless re-derivation, correct regardless of when or how
+    ``item.reference`` came to hold that value. See
+    :class:`ReferenceCollisionError` and :class:`BacklogItem`'s docstring
+    (second invariant) for why backends need this check.
 
     Args:
         item: The item whose reference to test.

--- a/plugins/development-harness/tests/test_run_pytest.py
+++ b/plugins/development-harness/tests/test_run_pytest.py
@@ -1,0 +1,47 @@
+"""Drift guard for run_pytest.py's standalone test-path duplication.
+
+``run_pytest.py`` re-declares ``_DEFAULT_TEST_PATHS`` because a standalone bundle has no
+parent ``pyproject.toml`` to read ``testpaths`` from (see its module docstring). This test
+catches drift between that duplication and the root ``pyproject.toml`` when both are checked
+out together — it is skipped for a standalone bundle, which has no root ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tomllib
+from pathlib import Path
+
+import pytest
+
+# run_pytest.py is a standalone PEP 723 script, not a package member — load it directly
+# from its sibling path rather than relying on pythonpath registration.
+_RUN_PYTEST_PATH = Path(__file__).parent / "run_pytest.py"
+_spec = importlib.util.spec_from_file_location("run_pytest", _RUN_PYTEST_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+_run_pytest_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_run_pytest_mod)
+
+_DEFAULT_TEST_PATHS = _run_pytest_mod._DEFAULT_TEST_PATHS
+_PLUGIN_ROOT = _run_pytest_mod._PLUGIN_ROOT
+
+_ROOT_PYPROJECT = _PLUGIN_ROOT.parent.parent / "pyproject.toml"
+
+
+@pytest.mark.skipif(not _ROOT_PYPROJECT.exists(), reason="standalone bundle has no root pyproject.toml")
+def test_default_test_paths_match_pyproject_testpaths() -> None:
+    """This plugin's *existing* entries in root ``testpaths`` must equal ``_DEFAULT_TEST_PATHS``.
+
+    A ``testpaths`` entry whose directory does not exist (dead config, unrelated to this
+    guard) is excluded from the comparison rather than forcing a false failure here.
+    """
+    repo_root = _ROOT_PYPROJECT.parent
+    testpaths = tomllib.loads(_ROOT_PYPROJECT.read_text())["tool"]["pytest"]["ini_options"]["testpaths"]
+    plugin_prefix = "plugins/development-harness/"
+    plugin_testpaths = {
+        path.removeprefix(plugin_prefix)
+        for path in testpaths
+        if path.startswith(plugin_prefix) and (repo_root / path).is_dir()
+    }
+    assert set(_DEFAULT_TEST_PATHS) == plugin_testpaths

--- a/plugins/development-harness/tests/test_work_item_reference_healing.py
+++ b/plugins/development-harness/tests/test_work_item_reference_healing.py
@@ -60,10 +60,8 @@ def test_memory_and_sqlite_backends_derive_the_same_reference_for_the_same_title
 def test_backend_put_work_item_reference_is_deterministic_across_reloads() -> None:
     """Reconstructing the same conceptual item twice resolves to the same backend key.
 
-    This is the property the deterministic (SHA-256) fallback exists to guarantee: a
-    stale on-disk or in-database record with no explicit reference must resolve to the
-    same key every time it is reloaded, or reference-gated operations (groom, resolve)
-    permanently orphan it. See backlog item #2900/#2902 for the incident this prevents.
+    See ``models.py::BacklogItem``'s class docstring for why the reference fallback
+    must be deterministic rather than random.
     """
     for backend in _backends():
         first = BacklogItem(title="Reloaded item")
@@ -80,14 +78,11 @@ def test_backend_put_work_item_reference_is_deterministic_across_reloads() -> No
 def test_backend_put_work_item_rejects_distinct_items_that_share_a_title() -> None:
     """Two DIFFERENT never-issued items sharing a title must not silently collide.
 
-    Regression test for the data-loss window the deterministic title-hash fallback
-    introduced: unlike ``test_backend_put_work_item_reference_is_deterministic_across_reloads``
-    above (same title, identical — i.e. reloaded — content, which must still collapse to one
-    record), these two items share a title but carry different ``description`` values, so they
-    are genuinely distinct backlog items. Before the ``ReferenceCollisionError`` check in
-    ``InMemoryBackend``/``SQLiteBackend.put_work_item``, the second ``put_work_item`` call
-    silently discarded the first record (``list_work_items()`` returned 1 item, and
-    ``get_work_item(item_a.reference).description`` read back as ``"Item B"``).
+    Unlike ``test_backend_put_work_item_reference_is_deterministic_across_reloads``
+    above (same title, identical content — a reload, which must collapse to one
+    record), these two items share a title but carry different ``description``
+    values, so they are genuinely distinct. See ``models.py::ReferenceCollisionError``
+    for the data-loss window this guards against.
     """
     for backend in _backends():
         item_a = BacklogItem(title="Duplicate Title", description="Item A")


### PR DESCRIPTION
## Summary

Addresses three "worth flagging, not urgent" items from the ponytail review report (`.tmp/scratch/reports/ponytail-review-20260817.md`, items 2.1, 2.6, 2.7):

- **2.1** — `backlog_core/models.py` carried the same multi-paragraph essay defending the deterministic title-hash reference fallback (not `uuid4()`) in four places: `_derive_stable_reference`, `reference_is_title_derived`, `ReferenceCollisionError`, and `BacklogItem`'s class docstring, plus a further restatement in `tests/test_work_item_reference_healing.py`. Collapsed to one canonical explanation on `BacklogItem`'s docstring, with one-line pointers at the other call sites. No non-duplicated information was removed (the production-incident narrative is preserved in the linked backlog items #2900/#2902 and commit history).
- **2.6** — `plugins/development-harness/tests/run_pytest.py` re-declares `_DEFAULT_TEST_PATHS` with no guard against drifting from the root `pyproject.toml`'s `testpaths`. Added `plugins/development-harness/tests/test_run_pytest.py`, which asserts the two stay in sync (skipped when no root `pyproject.toml` is present, i.e. a standalone bundle). Verified by falsification: temporarily removing an entry from `_DEFAULT_TEST_PATHS` makes the new test fail as expected, then reverted. The comparison excludes `testpaths` entries whose directory doesn't exist on disk — `pyproject.toml` currently lists `plugins/development-harness/skills/implementation-manager/tests`, which has no corresponding directory in the tree; this is a pre-existing, unrelated drift outside this PR's scope, flagged here rather than silently fixed or silently masked.
- **2.7** — Named the ceiling on the reference-collision heuristic in `memory_backend.py`/`sqlite_backend.py` (`put_work_item` treats two never-issued items as the same record when title *and* description both match) with a `ponytail:` comment: `# ponytail: description-only equality; compare full model_dump if same-title/same-description distinct items appear`. Comparison logic itself is unchanged — documentation only.

## Test plan

- [x] `uv run ruff check --fix` / `uv run ruff format` on all touched files
- [x] `uv run ty check` on all touched files — all checks passed
- [x] `uv run pytest plugins/development-harness/tests/test_work_item_reference_healing.py plugins/development-harness/tests/test_run_pytest.py` — 6 passed
- [x] `uv run pytest plugins/development-harness/backlog_core/` (full suite) — 509 passed
- [x] Falsification check on the new drift-guard test (see 2.6 above)
- [x] `uv run prek run --files <touched files>` — all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)