### PR TITLE
test(development-harness): mark residual real-subprocess tests as integration tier

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -243,6 +243,30 @@ jobs:
         run: uv run -q pytest plugins/development-harness/tests/test_cross_backend.py -v -m cross_backend
 
   # =============================================================================
+  # Python: Integration tests (real-subprocess CLI/network-guard behavior)
+  # Deselected from the default `test-python` addopts filter because each test
+  # spawns a real `uv run` or `pytest` subprocess (~2-30s each vs sub-second
+  # in-process tests) — see -m "not e2e and not cross_backend and not
+  # integration" in pyproject.toml. No live external credentials required
+  # (network-guard probes are self-contained; CLI subprocess tests sanitize
+  # BACKLOG_BACKEND/GITHUB_TOKEN), so unlike test-e2e this runs as a required
+  # quality-gate job rather than advisory.
+  # =============================================================================
+  test-integration:
+    name: Python / Integration tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-python
+
+      - name: Run integration tests
+        run: uv run -q pytest -m integration -v plugins/development-harness/tests/
+
+  # =============================================================================
   # Python: End-to-end live validation tests
   # Runs only on main push and manual dispatch — not on PRs.
   # Creates real GitHub issues in a test sandbox repo and cleans up after.
@@ -294,6 +318,7 @@ jobs:
       - file-hygiene
       - test-python
       - test-cross-backend
+      - test-integration
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed

--- a/plugins/development-harness/tests/test_frontend_parity.py
+++ b/plugins/development-harness/tests/test_frontend_parity.py
@@ -122,6 +122,7 @@ class TestParityInfrastructure:
         assert TaskBackend is not None
 
 
+@pytest.mark.integration
 class TestCLIForeignCWD:
     """Regression: the plugin folder is never the CWD in real use."""
 

--- a/plugins/development-harness/tests/test_frontend_parity_ops.py
+++ b/plugins/development-harness/tests/test_frontend_parity_ops.py
@@ -91,6 +91,7 @@ def dh_env(tmp_path: Path, request: pytest.FixtureRequest):
     _reset_bp_config()
 
 
+@pytest.mark.integration
 async def test_memory_provider_is_process_local(dh_env: dict[str, str]) -> None:
     """A memory-backed CLI item is absent from the fresh MCP provider."""
     memory_env = {**dh_env, "BACKLOG_BACKEND": "memory"}
@@ -117,6 +118,7 @@ def test_sqlite_round_trip_restores_section_from_priority(tmp_path: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 async def test_backlog_list_parity(dh_env: dict[str, str]) -> None:
     """A backlog item added via CLI is visible through both list transports."""
     _run_cli(["backlog", "add", "--title", "Parity Item", "--description", "test", "--priority", "P1"], env=dh_env)

--- a/plugins/development-harness/tests/test_network_guard.py
+++ b/plugins/development-harness/tests/test_network_guard.py
@@ -207,6 +207,7 @@ def test_guard_restores_sockets_after_session() -> None:
         server.close()
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("testpath", ["tests", "tests_sam", "tests_backlog", "sam_schema/tests"])
 def test_guard_covers_testpath(testpath: str) -> None:
     """The root conftest guard applies to every configured testpath.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ addopts = [
     "--dist",
     "loadgroup",
     "-m",
-    "not e2e and not cross_backend",
+    "not e2e and not cross_backend and not integration",
 ]
 asyncio_mode = "auto"
 markers = [


### PR DESCRIPTION
## Summary

Option 3 of the pytest-timing options analysis (`.tmp/scratch/reports/pytest-fix-options-frontend-parity-subprocess.md`). Follow-up to two concurrent PRs that eliminate most subprocess-spawning cost:

- #2938 `fix/frontend-parity-token-leak` (Option 1+4) — sanitizes `BACKLOG_BACKEND`/`GITHUB_TOKEN`/`GH_TOKEN` in `run_cli()`/`run_cli_subprocess()`
- `perf/frontend-parity-clirunner-conversion` (Option 2, in flight) — converts most `test_frontend_parity_ops.py` subprocess calls to in-process `CliRunner`

This PR marks the tests that remain **real-subprocess by design** even after both land, as `@pytest.mark.integration`, and excludes that marker from the default local/PR run — mirroring the existing `-m "not e2e and not cross_backend"` precedent already in `pyproject.toml`.

**Marked (8 tests, verified against a merge of this branch + #2938):**

- `test_network_guard.py::test_guard_covers_testpath` (4 params) — each spawns a full `pytest` subprocess to prove the network guard covers every testpath; can't be proven any other way.
- `test_frontend_parity.py::TestCLIForeignCWD` (2 params) — exists specifically to prove foreign-CWD / contaminated-`PYTHONPATH` behavior, which requires a real subprocess.
- `test_frontend_parity_ops.py::test_memory_provider_is_process_local` and `test_backlog_list_parity` — the two subprocess smoke tests the CliRunner-conversion PR is retaining (confirmed directly with that agent since it hadn't pushed yet at the time of this change — proves `BACKLOG_BACKEND` env selection in a fresh interpreter, and that the CLI is invocable via `uv run` with PEP 723 deps resolving and single-line compact JSON on a real pipe).

**CI coverage:** added a `test-integration` job to `.github/workflows/code-quality.yml`, mirroring the existing `test-cross-backend` job pattern (not the advisory `test-e2e` pattern) — these tests need no live external credentials, so they're wired into `quality-gate` as a required job, not advisory. CI continues to exercise this coverage; it just moves out of the default `test-python` job's fast path.

**Scope:** marking only. No test assertions, invocations, timeouts, or helper behavior (`run_cli_subprocess`, `_probe_command`, `dh_env`) were changed.

## Timing (plugins/development-harness/tests/, this repo's `pyproject.toml` default `--no-cov` addopts otherwise unchanged)

| Run | Tests | Time |
|---|---|---|
| Before (integration included, `-m "not e2e and not cross_backend"`) | 69 passed | 145.61s (2:25) |
| After (integration excluded, default addopts) | 61 passed | 96.97s (1:37) |

**~49s saved (~33%) on the default local/PR run** for this file set. Measured on a shared, heavily-loaded dev host (load average swung 40-155 during this session from ~20 concurrent sibling agents) — the relative before/after delta is the reliable signal; absolute numbers will be lower and more consistent on an uncontended CI runner.

## Test plan

- [x] `uv run pytest plugins/development-harness/tests/ -q` (default addopts) — 61 passed, 8 deselected (network_guard 4 + TestCLIForeignCWD 2 + ops 2), confirmed via `--collect-only` (61/69 collected) and a full run
- [x] `uv run pytest plugins/development-harness/tests/ -m integration -v` — all 8 marked tests pass (verified in two batches: network_guard + ops 6/6 passed; TestCLIForeignCWD 2/2 passed against a temporary merge with #2938's token-leak fix, confirming ~24s total for both params instead of the pre-fix 60-85s each)
- [x] `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` on all touched files — clean
- [x] `uv run prek run --files <touched files>` — all hooks pass
- [x] Structural validation of `.github/workflows/code-quality.yml` and `pyproject.toml` — both valid, `quality-gate.needs` includes the new `test-integration` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)
