### PR TITLE
fix(development-harness): scope startup-sync gate fixture to whole plugin subtree

### DIFF
--- a/plugins/development-harness/backlog_core/tests/test_startup_sync.py
+++ b/plugins/development-harness/backlog_core/tests/test_startup_sync.py
@@ -121,6 +121,7 @@ class TestSingletonSyncLaunch:
     call, which would start multiple concurrent sync loops.
     """
 
+    @pytest.mark.allow_startup_sync
     async def test_startup_sync_loop_called_exactly_once_on_lifespan_start(self, mocker: MockerFixture) -> None:
         """Background sync starts exactly once when the lifespan initialises.
 
@@ -128,6 +129,10 @@ class TestSingletonSyncLaunch:
         its lifespan context.  The sync function is patched to count calls.
         Requires backlog_core.server.mcp to have lifespan=_backlog_lifespan
         configured -- this will fail with AttributeError until implemented.
+
+        Marked ``allow_startup_sync`` because it depends on the real
+        ``_startup_sync_enabled`` gate returning True; the plugin-root
+        autouse fixture disables it by default for every other test.
         """
         reset_sync_state()
 
@@ -166,12 +171,17 @@ class TestSingletonSyncLaunch:
 class TestInFlightSyncGuard:
     """A sync_now call while a sync is running must not start a second sync."""
 
+    @pytest.mark.allow_startup_sync
     async def test_second_sync_now_while_running_returns_progress_not_new_sync(self, mocker: MockerFixture) -> None:
         """sync_now while RUNNING: triggered=False, progress fields present, no second start.
 
         Arrange: patch _startup_sync_loop so it holds state=RUNNING without completing.
         Act: call sync_now twice while the lock is held.
         Assert: second call returns triggered=False with percent/started_at fields.
+
+        Marked ``allow_startup_sync`` because it depends on the real
+        ``_startup_sync_enabled`` gate returning True; the plugin-root
+        autouse fixture disables it by default for every other test.
         """
         reset_sync_state()
 
@@ -654,8 +664,14 @@ class TestSyncStatusTool:
         data = response.data if hasattr(response, "data") else response
         assert data["status"] == "idle", f"After successful sync, status must be 'idle'. Got {data['status']!r}."
 
+    @pytest.mark.allow_startup_sync
     async def test_sync_status_offline_after_non_retryable_error(self, mocker: MockerFixture) -> None:
-        """After a non-retryable error, sync_status returns status='offline'."""
+        """After a non-retryable error, sync_status returns status='offline'.
+
+        Marked ``allow_startup_sync`` because it depends on the real
+        ``_startup_sync_enabled`` gate returning True; the plugin-root
+        autouse fixture disables it by default for every other test.
+        """
         reset_sync_state()
 
         from backlog_core.models import GitHubUnavailableError
@@ -794,6 +810,7 @@ class TestSyncTaskDoneCallback:
     callback must call the module logger when the task raises an unexpected error.
     """
 
+    @pytest.mark.allow_startup_sync
     async def test_unexpected_exception_from_sync_task_is_logged(self, mocker: MockerFixture) -> None:
         """An unexpected exception escaping the sync task triggers logger.error.
 
@@ -802,6 +819,10 @@ class TestSyncTaskDoneCallback:
         Act: enter the server lifespan so the background task is launched.
         Assert: the module-level logger in server.py receives an error() call
         containing the exception message.
+
+        Marked ``allow_startup_sync`` because it depends on the real
+        ``_startup_sync_enabled`` gate returning True; the plugin-root
+        autouse fixture disables it by default for every other test.
         """
         reset_sync_state()
 

--- a/plugins/development-harness/conftest.py
+++ b/plugins/development-harness/conftest.py
@@ -185,6 +185,44 @@ def pytest_unconfigure(config: pytest.Config) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _disable_startup_sync(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    """Disable the background startup sync loop for all non-e2e tests.
+
+    Patches ``backlog_core.server._startup_sync_enabled`` to return ``False``
+    so that ``_backlog_lifespan`` never calls ``asyncio.create_task`` during
+    in-process MCP test invocations.  Without this fixture every tool call that
+    exercises the MCP server starts a live GitHub sync task, which dominates
+    wall-clock time and causes the CI timeout.
+
+    Lives at the pytest rootdir (rather than ``tests/conftest.py``) so it
+    applies to every sibling test directory in the plugin subtree --
+    ``tests``, ``tests_sam``, ``sam_schema/tests``, ``backlog_core/tests``,
+    and any directory added later (e.g. ``tests_backlog``, once it joins
+    ``testpaths``) -- not just ``tests/``. A test that needs the real gate
+    opts back in with ``@pytest.mark.allow_startup_sync``.
+
+    Skips for tests marked ``@pytest.mark.e2e`` so that live end-to-end tests
+    exercise the real startup path, and for tests marked
+    ``@pytest.mark.allow_startup_sync`` (e.g. the startup-sync behaviour
+    tests themselves, which assert on the real gate).
+
+    TODO: remove when #2573 lands (permanent backend-level gating in the
+    in-memory and SQLite backends).
+    """
+    if request.node.get_closest_marker("e2e") or request.node.get_closest_marker("allow_startup_sync"):
+        return
+    # Deliberately lazy: backlog_core.server pulls in FastMCP and the full tool
+    # surface, a multi-second import. A module-level import here would pay that
+    # cost for every pytest process that merely collects this rootdir conftest --
+    # including the lightweight nested pytest subprocesses that
+    # tests/test_network_guard.py spawns to probe guard behaviour in isolation,
+    # which run with tight wall-clock timeouts. See per-file-ignore below.
+    import backlog_core.server as _server
+
+    monkeypatch.setattr(_server, "_startup_sync_enabled", lambda: False)
+
+
+@pytest.fixture(autouse=True)
 def _network_policy(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Compute the per-test network policy from the e2e marker + env var.
 

--- a/plugins/development-harness/tests/conftest.py
+++ b/plugins/development-harness/tests/conftest.py
@@ -217,29 +217,6 @@ def gate_token() -> str:
     return TEST_GATE_TOKEN
 
 
-@pytest.fixture(autouse=True)
-def _disable_startup_sync(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
-    """Disable the background startup sync loop for all non-e2e tests.
-
-    Patches ``backlog_core.server._startup_sync_enabled`` to return ``False``
-    so that ``_backlog_lifespan`` never calls ``asyncio.create_task`` during
-    in-process MCP test invocations.  Without this fixture every tool call that
-    exercises the MCP server starts a live GitHub sync task, which dominates
-    wall-clock time and causes the CI timeout.
-
-    Skips for tests marked ``@pytest.mark.e2e`` so that live end-to-end tests
-    exercise the real startup path.
-
-    TODO: remove when #2573 lands (permanent backend-level gating in the
-    in-memory and SQLite backends).
-    """
-    if request.node.get_closest_marker("e2e"):
-        return
-    import backlog_core.server as _server
-
-    monkeypatch.setattr(_server, "_startup_sync_enabled", lambda: False)
-
-
 # ---------------------------------------------------------------------------
 # Quality gate fixtures
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ addopts = [
 ]
 asyncio_mode = "auto"
 markers = [
+    "allow_startup_sync: marks tests that must exercise the real backlog_core.server._startup_sync_enabled gate instead of the autouse override",
     "critical: marks tests covering critical-path code requiring stronger correctness guarantees (e.g. round-trip property tests)",
     "cross_backend: marks tests that run only in the test-cross-backend CI matrix job",
     "demos: marks tests as demonstration tests",
@@ -477,6 +478,10 @@ max-complexity = 12
     "PLR", # Complexity flags from intentional god-object patterns
     "SLF", # Private-access patterns seeded intentionally
 ]
+# Lazy import of backlog_core.server (pulls in FastMCP + full tool surface) so
+# collecting this rootdir conftest stays cheap for nested pytest subprocesses
+# spawned by test_network_guard.py's guard probes, which run under tight timeouts
+"plugins/development-harness/conftest.py" = ["import-outside-top-level"]
 # live_validation_step: S105 false-positive (enum value "PASS" ≠ password),
 # S602 shell=True intentional (command run verbatim as manifest declares),
 # PLR0911 exceeds 6-return limit — early-return guard clauses are intentional


### PR DESCRIPTION
## Summary

- `_disable_startup_sync` (the autouse fixture that patches `backlog_core.server._startup_sync_enabled` to `False`) only lived in `plugins/development-harness/tests/conftest.py`, so it never applied to sibling test directories such as `tests_backlog/`. Tests there entered the real `_backlog_lifespan` and paid a ~90-109s teardown cost per test waiting on the live GitHub sync task.
- Moves the fixture to the plugin-root `plugins/development-harness/conftest.py` so it covers every test directory in the subtree (`tests`, `tests_sam`, `sam_schema/tests`, `backlog_core/tests`, and any future directory such as `tests_backlog`).
- Adds a new `allow_startup_sync` marker (registered in `pyproject.toml`) as an opt-out for tests that must exercise the real gate, and applies it to the four `backlog_core/tests/test_startup_sync.py` tests that assert on real sync behaviour (two identified in the original options analysis, plus two more discovered during verification: `TestSyncStatusTool::test_sync_status_offline_after_non_retryable_error` and `TestSyncTaskDoneCallback::test_unexpected_exception_from_sync_task_is_logged`).
- Keeps the `backlog_core.server` import lazy (inside the fixture body, not module-level) to avoid making the FastMCP tool-surface import a mandatory cost for every nested pytest subprocess that collects this rootdir conftest — this matters for `test_network_guard.py`'s guard-probe tests, which spawn nested pytest subprocesses under tight wall-clock timeouts. Added the corresponding `ruff` per-file-ignore for `import-outside-top-level`, matching the existing pattern already used for `assets/version.py`.

## Follow-up (deliberately out of scope)

Backlog item #2930 tracks adding `tests_backlog/` to `testpaths` now that the teardown-cost fix has landed — that is a separate change with its own CI-cost implications and must land only after this fix is confirmed working.

## Test plan

- [x] `uv run pytest plugins/development-harness/backlog_core/tests/test_startup_sync.py -v` — 61 passed (all four `allow_startup_sync`-marked tests still exercise the real gate correctly)
- [x] `uv run pytest plugins/development-harness/tests_backlog/test_artifact_provider.py --durations=0` — before (baseline worktree, isolated run): 347.36s, with the 12 previously-slow tests each paying 90-109s teardown; after: 13.17s total, with none of those 12 tests appearing above the 0.005s duration-hiding threshold
- [x] `uv run pytest plugins/development-harness/tests/ -q` — 2571 passed, 39 skipped, 5 xfailed, 0 failed
- [x] `uv run ruff check --fix`, `uv run ruff format`, `uv run ty check`, `uv run prek run --files <touched files>` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)