### PR TITLE
fix: remove stale testpaths entry for deleted implementation-manager tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ testpaths = [
     "plugins/development-harness/backlog_core/tests",
     "plugins/frustration-analyzer/tests",
     "plugins/plugin-creator/tests",
-    "plugins/development-harness/skills/implementation-manager/tests",
     "plugins/summarizer/tests",
     "tests",
     "examples/solid-review-ab/tests",


### PR DESCRIPTION
## Summary
- pyproject.toml's testpaths listed plugins/development-harness/skills/implementation-manager/tests, which doesn't exist -- its two test files were deleted outright in 3282a3c2 during a backend-support refactor, not moved, so there's nothing to restore.
- Removed the stale entry. test_run_pytest.py's drift-guard test filters by .is_dir(), so it self-adjusts with no further change.

Closes #2943

## Test plan
- [x] git log --diff-filter=D confirms deletion, not a rename
- [x] uv run pytest plugins/development-harness/tests/test_run_pytest.py passes
- [x] prek clean

Generated with Claude Code