### PR TITLE
fix(development-harness): stop shell-metacharacter breakage in work-backlog-item arg parsing

### DIFF
--- a/plugins/development-harness/skills/work-backlog-item/SKILL.md
+++ b/plugins/development-harness/skills/work-backlog-item/SKILL.md
@@ -3,13 +3,16 @@ name: work-backlog-item
 description: "Use when working, planning, grooming, or closing a backlog item. Bridges backlog items to SAM planning with GitHub Issue, Project, and Milestone tracking. Activates on interactive browsing with no args, loading an item from a GitHub issue reference like #N, matching by title substring to run auto-grooming plus RT-ICA gate plus GitHub sync plus SAM planning, autonomous --auto {title} mode that skips AskUserQuestion and derives data from research files while logging decisions, close {title} to dismiss an item without completion with a required reason (duplicate, out_of_scope, superseded, wontfix, blocked) per ADR-9, resolve {title} to mark DONE with an evidence trail and required summary per ADR-9, setup-github to initialize labels, project, and milestone, and --language or --stack flags that select the Layer 1 or Layer 2 profile. Stops when the item already has a Plan field or when RT-ICA returns BLOCKED."
 argument-hint: '[#N | --auto {title} | --language {lang} | --stack {stack} | item-title-substring | close {title} | resolve {title} [--force] | setup-github | --quick {title} | progress | resume [{title}]]'
 user-invocable: true
+shell: bash
 ---
 <gate_token>
 !`node "${CLAUDE_SKILL_DIR}/scripts/get-gate-token.mjs"`
 </gate_token>
 
 <input>
-!`node "${CLAUDE_SKILL_DIR}/scripts/parser/parse.mjs" "$ARGUMENTS"`
+!`node "${CLAUDE_SKILL_DIR}/scripts/parser/parse.mjs" <<'WORK_BACKLOG_ITEM_ARGS_EOF'
+$ARGUMENTS
+WORK_BACKLOG_ITEM_ARGS_EOF`
 </input>
 
 Execute the command in <input/> and parse its stdout as JSON. Treat that JSON as the normalized user input for this workflow.

--- a/plugins/development-harness/skills/work-backlog-item/SKILL.md
+++ b/plugins/development-harness/skills/work-backlog-item/SKILL.md
@@ -117,7 +117,7 @@ When invoked with no arguments, shows an interactive browser. When invoked with 
 
 ## Arguments
 
-**Agent Preflight:** `<input/>` already has the parsed JSON — use it, don't re-derive. If you must re-run `parse.mjs` yourself, pipe via stdin, never a shell-quoted positional arg (see parser-guide.md). Pipeline, output shape, and extension steps: [parser-guide.md](./scripts/parser/parser-guide.md).
+**Agent Preflight:** `<input/>` already carries the parsed JSON — treat it as source of truth. Re-running `parse.mjs` yourself: pipe via stdin, not a shell-quoted positional arg. Pipeline, output shape, extension steps: [parser-guide.md](./scripts/parser/parser-guide.md).
 
 Parser `route` is `none` only when argv is empty (no flags, no positionals, no freetext suffix): follow **Step 1.1 — Interactive Browser** below. It is not the same as `mode: "interactive"` (which only means `--auto` was not passed).
 

--- a/plugins/development-harness/skills/work-backlog-item/SKILL.md
+++ b/plugins/development-harness/skills/work-backlog-item/SKILL.md
@@ -117,7 +117,7 @@ When invoked with no arguments, shows an interactive browser. When invoked with 
 
 ## Arguments
 
-**Agent Preflight:** The `<input/>` block above already ran this parser automatically against the raw invocation — its JSON output is the `mode`/`route`/`flags`/`item_ref`/`user_text` to follow; do not re-derive them by manually parsing the rules below. Only re-run `parse.mjs` yourself if `<input/>` is genuinely unavailable (e.g. shell execution disabled) — if so, pipe the raw text through stdin (`node .../parse.mjs <<'EOF' ... EOF`), never as a shell-quoted positional argument: free text containing quotes, `#`, or backticks is not safe to splice into a quoted shell string. Pipeline, output shape, and extension steps: [parser-guide.md](./scripts/parser/parser-guide.md).
+**Agent Preflight:** `<input/>` already has the parsed JSON — use it, don't re-derive. If you must re-run `parse.mjs` yourself, pipe via stdin, never a shell-quoted positional arg (see parser-guide.md). Pipeline, output shape, and extension steps: [parser-guide.md](./scripts/parser/parser-guide.md).
 
 Parser `route` is `none` only when argv is empty (no flags, no positionals, no freetext suffix): follow **Step 1.1 — Interactive Browser** below. It is not the same as `mode: "interactive"` (which only means `--auto` was not passed).
 

--- a/plugins/development-harness/skills/work-backlog-item/SKILL.md
+++ b/plugins/development-harness/skills/work-backlog-item/SKILL.md
@@ -117,7 +117,7 @@ When invoked with no arguments, shows an interactive browser. When invoked with 
 
 ## Arguments
 
-**Agent Preflight:** Run `node plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs "<invocation_args/>"` to receive a structured JSON payload with the exact `mode`, `route`, `flags`, `item_ref`, and `user_text` to follow, rather than manually parsing the rules below. Pipeline, output shape, and extension steps: [parser-guide.md](./scripts/parser/parser-guide.md).
+**Agent Preflight:** The `<input/>` block above already ran this parser automatically against the raw invocation — its JSON output is the `mode`/`route`/`flags`/`item_ref`/`user_text` to follow; do not re-derive them by manually parsing the rules below. Only re-run `parse.mjs` yourself if `<input/>` is genuinely unavailable (e.g. shell execution disabled) — if so, pipe the raw text through stdin (`node .../parse.mjs <<'EOF' ... EOF`), never as a shell-quoted positional argument: free text containing quotes, `#`, or backticks is not safe to splice into a quoted shell string. Pipeline, output shape, and extension steps: [parser-guide.md](./scripts/parser/parser-guide.md).
 
 Parser `route` is `none` only when argv is empty (no flags, no positionals, no freetext suffix): follow **Step 1.1 — Interactive Browser** below. It is not the same as `mode: "interactive"` (which only means `--auto` was not passed).
 

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs
@@ -4,10 +4,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// SKILL.md's bang-exec line pipes $ARGUMENTS in via a quoted-delimiter heredoc (<<'EOF') rather
-// than as a shell-quoted positional arg, so arbitrary free text (embedded quotes, apostrophes,
-// #, parens, backticks, $()) reaches us as inert literal bytes instead of being parsed as shell
-// syntax. A TTY means we're invoked interactively with no piped input — don't block on stdin.
+// Falls back to stdin when invoked with no argv, unless stdin is a TTY (avoids blocking on a
+// bare interactive invocation).
 function readStdinArg() {
   if (process.stdin.isTTY) return null;
   try {

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs
@@ -4,6 +4,20 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// SKILL.md's bang-exec line pipes $ARGUMENTS in via a quoted-delimiter heredoc (<<'EOF') rather
+// than as a shell-quoted positional arg, so arbitrary free text (embedded quotes, parens,
+// backticks, $()) reaches us as inert literal bytes instead of being parsed as shell syntax.
+// A TTY means we're invoked interactively with no piped input — don't block waiting on stdin.
+function readStdinArg() {
+  if (process.stdin.isTTY) return null;
+  try {
+    const text = readFileSync(0, 'utf-8').replace(/\n$/, '');
+    return text.length > 0 ? text : null;
+  } catch {
+    return null;
+  }
+}
+
 function printErrorAndExit(message) {
   console.error(message);
   process.exit(1);
@@ -27,6 +41,10 @@ try {
   // If the user passes the entire invocation as a single quoted string (e.g., to prevent bash from treating # as a comment),
   // we need to split it back into an array of arguments, respecting quotes.
   let rawArgv = process.argv.slice(2);
+  if (rawArgv.length === 0) {
+    const stdinArg = readStdinArg();
+    if (stdinArg !== null) rawArgv = [stdinArg];
+  }
   if (rawArgv.length === 1) {
     // Basic split by space, but this doesn't handle internal quotes well.
     // However, for this specific CLI, we mostly care about splitting by spaces.

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs
@@ -5,9 +5,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // SKILL.md's bang-exec line pipes $ARGUMENTS in via a quoted-delimiter heredoc (<<'EOF') rather
-// than as a shell-quoted positional arg, so arbitrary free text (embedded quotes, parens,
-// backticks, $()) reaches us as inert literal bytes instead of being parsed as shell syntax.
-// A TTY means we're invoked interactively with no piped input — don't block waiting on stdin.
+// than as a shell-quoted positional arg, so arbitrary free text (embedded quotes, apostrophes,
+// #, parens, backticks, $()) reaches us as inert literal bytes instead of being parsed as shell
+// syntax. A TTY means we're invoked interactively with no piped input — don't block on stdin.
 function readStdinArg() {
   if (process.stdin.isTTY) return null;
   try {

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
@@ -1,12 +1,12 @@
 # Work-backlog invocation parser
 
-Guide to **`parse.mjs`** in this directory: how it turns skill arguments into machine-readable JSON, and how to extend routes, flags, item-ref token shapes, and schemas.
+Architecture doc for **`parse.mjs`**: internals, and how to extend routes, flags, item-ref token shapes, and schemas. Not for routine skill invocation — `SKILL.md`'s `<input/>` block already runs this parser automatically; use its output.
 
 Co-located files: **`parse.mjs`**, **`command-routes.json`**, **`command-routes.schema.json`**, **`parse.schema.json`**, and this guide.
 
 ## Why this exists
 
-Claude (or any agent) receives `<invocation_args/>` as unstructured text. The parser normalizes that string into a single JSON object on stdout: `mode`, `route`, optional `reference`, `flags`, `item_ref`, and `user_text`. Agents MUST treat that object as the source of truth for which workflow file to load and what parameters apply.
+`<input/>` pipes the raw invocation through this parser and treats its stdout JSON (`mode`, `route`, optional `reference`, `flags`, `item_ref`, `user_text`) as the source of truth for routing. This doc covers how that JSON gets built, for extending or debugging it.
 
 ## Files
 

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
@@ -21,11 +21,20 @@ Paths in `command-routes.json` are relative to the **skill root** (parent of `sc
 
 ## Invocation: argv shape
 
-The shell often passes multiple argv tokens. For skill preflight, the typical pattern is a **single quoted argument** so `#` is not treated as a comment:
+The shell often passes multiple argv tokens. When you're typing a command yourself in a terminal
+(manual/dev testing, both shown below), a **single quoted argument** so `#` is not treated as a
+comment is fine — you author both the quotes and the content together:
 
 ```bash
 node plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs "groom #50 --auto extra words"
 ```
+
+**Do not construct this same form programmatically from text you didn't author** (agent-supplied
+free text, a backlog item description, anything from `$ARGUMENTS`). `SKILL.md`'s own `<input/>`
+block used to splice `$ARGUMENTS` into exactly this quoted-positional-arg shape and broke on any
+embedded `"`, `#`, or backtick — see the `<input/>` bang-exec line for the fix (a quoted-delimiter
+heredoc piped via stdin). When argv is empty, `parse.mjs` reads stdin instead (unless stdin is a
+TTY), reusing the same quote-aware splitting logic described below.
 
 When `process.argv.slice(2).length === 1`, the script **re-splits** that string on whitespace using a regex that preserves quoted segments (`"..."`, `'...'`). This is a deliberate tradeoff: good enough for agent-provided strings; it is not a full POSIX shell lexer.
 

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
@@ -1,6 +1,6 @@
 # Work-backlog invocation parser
 
-Architecture doc for **`parse.mjs`**: internals, and how to extend routes, flags, item-ref token shapes, and schemas. Not for routine skill invocation — `SKILL.md`'s `<input/>` block already runs this parser automatically; use its output.
+Architecture doc for **`parse.mjs`**: internals, and how to extend routes, flags, item-ref token shapes, and schemas. Invoking the skill never needs this doc — `SKILL.md`'s `<input/>` block already runs the parser and gives you its JSON. Read this only to extend or debug `parse.mjs` itself.
 
 Co-located files: **`parse.mjs`**, **`command-routes.json`**, **`command-routes.schema.json`**, **`parse.schema.json`**, and this guide.
 

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
@@ -21,20 +21,13 @@ Paths in `command-routes.json` are relative to the **skill root** (parent of `sc
 
 ## Invocation: argv shape
 
-The shell often passes multiple argv tokens. When you're typing a command yourself in a terminal
-(manual/dev testing, both shown below), a **single quoted argument** so `#` is not treated as a
-comment is fine — you author both the quotes and the content together:
+Manual terminal use (you author both quotes and content) — a single quoted argument, so `#` isn't a comment:
 
 ```bash
 node plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs "groom #50 --auto extra words"
 ```
 
-**Do not construct this same form programmatically from text you didn't author** (agent-supplied
-free text, a backlog item description, anything from `$ARGUMENTS`). `SKILL.md`'s own `<input/>`
-block used to splice `$ARGUMENTS` into exactly this quoted-positional-arg shape and broke on any
-embedded `"`, `#`, or backtick — see the `<input/>` bang-exec line for the fix (a quoted-delimiter
-heredoc piped via stdin). When argv is empty, `parse.mjs` reads stdin instead (unless stdin is a
-TTY), reusing the same quote-aware splitting logic described below.
+Don't build this same quoted-positional shape from text you didn't author (agent-supplied free text, `$ARGUMENTS`) — pipe it via stdin instead; `parse.mjs` reads stdin when argv is empty and it isn't a TTY.
 
 When `process.argv.slice(2).length === 1`, the script **re-splits** that string on whitespace using a regex that preserves quoted segments (`"..."`, `'...'`). This is a deliberate tradeoff: good enough for agent-provided strings; it is not a full POSIX shell lexer.
 

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
@@ -29,8 +29,6 @@ node plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.m
 
 Don't build this shape from unauthored, caller-supplied text — pipe via stdin instead; `parse.mjs` reads stdin when argv is empty and it isn't a TTY.
 
-When `process.argv.slice(2).length === 1`, the script **re-splits** that string on whitespace using a regex that preserves quoted segments (`"..."`, `'...'`) — see Limitations below.
-
 ## Pipeline (order matters)
 
 The implementation follows these phases in order.

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
@@ -29,7 +29,7 @@ node plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.m
 
 Don't build this shape from unauthored, caller-supplied text — pipe via stdin instead; `parse.mjs` reads stdin when argv is empty and it isn't a TTY.
 
-When `process.argv.slice(2).length === 1`, the script **re-splits** that string on whitespace using a regex that preserves quoted segments (`"..."`, `'...'`). This is a deliberate tradeoff: good enough for agent-provided strings; it is not a full POSIX shell lexer.
+When `process.argv.slice(2).length === 1`, the script **re-splits** that string on whitespace using a regex that preserves quoted segments (`"..."`, `'...'`) — see Limitations below.
 
 ## Pipeline (order matters)
 

--- a/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
+++ b/plugins/development-harness/skills/work-backlog-item/scripts/parser/parser-guide.md
@@ -27,7 +27,7 @@ Manual terminal use (you author both quotes and content) — a single quoted arg
 node plugins/development-harness/skills/work-backlog-item/scripts/parser/parse.mjs "groom #50 --auto extra words"
 ```
 
-Don't build this same quoted-positional shape from text you didn't author (agent-supplied free text, `$ARGUMENTS`) — pipe it via stdin instead; `parse.mjs` reads stdin when argv is empty and it isn't a TTY.
+Don't build this shape from unauthored, caller-supplied text — pipe via stdin instead; `parse.mjs` reads stdin when argv is empty and it isn't a TTY.
 
 When `process.argv.slice(2).length === 1`, the script **re-splits** that string on whitespace using a regex that preserves quoted segments (`"..."`, `'...'`). This is a deliberate tradeoff: good enough for agent-provided strings; it is not a full POSIX shell lexer.
 


### PR DESCRIPTION
## Summary
- $ARGUMENTS was spliced verbatim into a double-quoted bang-exec shell string, so free text containing a double quote -- including the skill's own documented `create -- "<text>"` invocation form -- broke out of the outer quoting; embedded parens/backticks then hit bash's own parser.
- Two narrower fixes were tried and rejected: single-quoting the wrapper breaks on any embedded apostrophe (very common in prose); dropping the wrapper's quotes entirely fixes the crash but reintroduces two real regressions -- an unquoted leading `#` (e.g. `#2943`, a core documented invocation form) gets eaten as a bash comment, and embedded backticks/$() still execute even inside the caller's own quotes.
- Route $ARGUMENTS through a quoted-delimiter heredoc instead -- content between quoted heredoc delimiters is never subject to shell expansion, comment-stripping, or parsing. parse.mjs reads stdin when argv is empty and stdin isn't a TTY, reusing its existing quote-aware splitting logic unchanged.
- Pinned `shell: bash` since heredocs are bash-only syntax -- converts a silent PowerShell-fallback mis-parse on Windows-without-Git-Bash into Claude Code's documented explicit "requires bash" error.

## Test plan
- [x] Reproduced the original failure with the exact text that broke live; confirmed the fix parses it correctly
- [x] Confirmed a `#N` issue ref (`#2943`) still routes correctly and isn't eaten as a bash comment
- [x] Confirmed a backtick/$() injection payload reaches parser output as inert literal text, not executed
- [x] Regression-checked empty args (route:none, no hang) and --quick flag parsing
- [x] prek clean

Generated with Claude Code