### PR TITLE
fix(development-harness): unify section-key normalization between local writes and GitHub-parsed sections

### DIFF
--- a/plugins/development-harness/backlog_core/github_sync.py
+++ b/plugins/development-harness/backlog_core/github_sync.py
@@ -63,38 +63,11 @@ def heading_to_section_key(heading_text: str) -> str | None:
     return _HEADING_TO_KEY.get(heading_text.lower())
 
 
-def heading_to_unknown_key(heading_text: str) -> str:
-    """Convert an unknown section heading to a storage key.
-
-    Unknown headings are normalised by lowercasing and replacing spaces with
-    underscores.  The prefix ``"unknown__"`` is prepended so unknown section
-    keys never collide with known section keys (e.g. ``"fact_check"``).
-
-    Args:
-        heading_text: Raw heading text with ``##`` prefix stripped and whitespace
-            trimmed.
-
-    Returns:
-        Storage key such as ``"unknown__custom_analysis"``.
-    """
-    normalised = heading_text.lower().replace(" ", "_")
-    return f"unknown__{normalised}"
-
-
-def unknown_key_to_heading(key: str) -> str:
-    """Reconstruct a display heading from an unknown-section storage key.
-
-    Reverses :func:`heading_to_unknown_key`: strips the ``"unknown__"`` prefix,
-    replaces underscores with spaces, and title-cases the result.
-
-    Args:
-        key: Storage key such as ``"unknown__custom_analysis"``.
-
-    Returns:
-        Display heading such as ``"Custom Analysis"``.
-    """
-    stripped = key.removeprefix("unknown__")
-    return stripped.replace("_", " ").title()
+# Re-exported from rendering — canonical definitions live there so that the
+# local-write path (operations._normalize_section_key) and the GitHub-parse
+# path (parse_issue_body below) normalise unknown section names identically.
+heading_to_unknown_key = _rendering.heading_to_unknown_key
+unknown_key_to_heading = _rendering.unknown_key_to_heading
 
 
 # Canonical render order for GroomedData subsections (heading text as stored in the dict)

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -73,7 +73,7 @@ from .parsing import (
     today,
     view_result_from_local_item,
 )
-from .rendering import SECTION_HEADING
+from .rendering import SECTION_HEADING, heading_to_unknown_key
 
 _SAM_SUCCESSFUL_STATUSES: frozenset[str] = _SAM_CORE_SUCCESSFUL_STATUSES | {"closed", "done"}
 _SAM_PLAN_PAGE_SIZE: Final = 100
@@ -882,23 +882,37 @@ def _apply_groomed_entries(
 
 
 def _normalize_section_key(name: str) -> str:
-    """Return the canonical snake_case storage key for a section name.
+    """Return the canonical storage key for a section name.
 
     Resolves display names (e.g. ``"RT-ICA"``) and aliases (e.g. ``"rt-ica"``) to
     the snake_case key used in ``SECTION_HEADING`` (e.g. ``"rt_ica"``).  Unknown
-    and custom section names are returned unchanged so they pass through as-is.
+    and custom section names (e.g. ``"Files"``, ``"Impact Radius"``) are routed
+    through :func:`heading_to_unknown_key` — the same normaliser
+    ``github_sync.parse_issue_body`` applies to an unrecognised ``## Heading``
+    parsed back from a GitHub issue body.
+
+    Without this, a local write of e.g. ``"Files"`` stored the key verbatim
+    while a GitHub round-trip of the same rendered heading produced
+    ``"unknown__files"``: two different dict keys for one logical section,
+    so both survived every subsequent merge and the item accumulated a
+    duplicate under ``unknown__`` on every groom + reconcile cycle (#2956).
+    Routing both call sites through the same normaliser makes local writes
+    and GitHub-parsed sections collide on one key instead of two.
 
     Lookup order:
     1. ``SECTION_HEADING_ALIAS`` keyed by ``name.lower()`` — catches hyphened aliases.
     2. Reverse scan of ``SECTION_HEADING`` for a matching display value — catches
        display names stored verbatim (e.g. ``"RT-ICA"`` → ``"rt_ica"``).
-    3. Return *name* unchanged when no match is found.
+    3. Return *name* unchanged when it is already a normalised ``unknown__`` key
+       (idempotent re-normalisation of a key read back from storage).
+    4. Otherwise, normalise via :func:`heading_to_unknown_key`.
 
     Args:
-        name: Section name as provided by the caller (e.g. ``"RT-ICA"`` or ``"rt_ica"``).
+        name: Section name as provided by the caller (e.g. ``"RT-ICA"`` or ``"Files"``).
 
     Returns:
-        Canonical snake_case key (e.g. ``"rt_ica"``), or *name* unchanged for unknown sections.
+        Canonical storage key, e.g. ``"rt_ica"`` for a canonical section or
+        ``"unknown__files"`` for a custom one.
     """
     alias_key = SECTION_HEADING_ALIAS.get(name.lower())
     if alias_key is not None:
@@ -906,7 +920,9 @@ def _normalize_section_key(name: str) -> str:
     for snake_key, display in SECTION_HEADING.items():
         if display == name:
             return snake_key
-    return name
+    if name.startswith("unknown__"):
+        return name
+    return heading_to_unknown_key(name)
 
 
 def _write_groomed_to_item(

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -899,6 +899,12 @@ def _normalize_section_key(name: str) -> str:
     Routing both call sites through the same normaliser makes local writes
     and GitHub-parsed sections collide on one key instead of two.
 
+    Leading/trailing whitespace on *name* is stripped before every lookup
+    below, so e.g. ``"RT-ICA "`` (trailing space) still resolves to the
+    canonical key rather than falling through to :func:`heading_to_unknown_key`
+    and producing a key that would not match a subsequent GitHub round trip
+    of the same (already-trimmed) heading text.
+
     Lookup order:
     1. ``SECTION_HEADING_ALIAS`` keyed by ``name.lower()`` — catches hyphened aliases.
     2. Reverse scan of ``SECTION_HEADING`` for a matching display value — catches
@@ -914,6 +920,7 @@ def _normalize_section_key(name: str) -> str:
         Canonical storage key, e.g. ``"rt_ica"`` for a canonical section or
         ``"unknown__files"`` for a custom one.
     """
+    name = name.strip()
     alias_key = SECTION_HEADING_ALIAS.get(name.lower())
     if alias_key is not None:
         return alias_key

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -886,7 +886,7 @@ def _normalize_section_key(name: str) -> str:
 
     Resolves display names (e.g. ``"RT-ICA"``) and aliases (e.g. ``"rt-ica"``) to
     the snake_case key used in ``SECTION_HEADING`` (e.g. ``"rt_ica"``).  Unknown
-    and custom section names (e.g. ``"Files"``, ``"Impact Radius"``) are routed
+    and custom section names (e.g. ``"Custom Analysis"``) are routed
     through :func:`heading_to_unknown_key` — the same normaliser
     ``github_sync.parse_issue_body`` applies to an unrecognised ``## Heading``
     parsed back from a GitHub issue body.
@@ -907,25 +907,29 @@ def _normalize_section_key(name: str) -> str:
 
     Lookup order:
     1. ``SECTION_HEADING_ALIAS`` keyed by ``name.lower()`` — catches hyphened aliases.
-    2. Reverse scan of ``SECTION_HEADING`` for a matching display value — catches
-       display names stored verbatim (e.g. ``"RT-ICA"`` → ``"rt_ica"``).
+    2. Case-insensitive reverse scan of ``SECTION_HEADING`` for a matching display
+       value — catches display names stored verbatim (e.g. ``"RT-ICA"`` → ``"rt_ica"``),
+       matching case-insensitively for parity with the parse-side lookup
+       (``github_sync.py``'s ``_HEADING_TO_KEY.get(heading.lower())``) so a caller-supplied
+       ``"story"`` normalises the same as GitHub-parsed ``"Story"`` instead of falling
+       through to :func:`heading_to_unknown_key`.
     3. Return *name* unchanged when it is already a normalised ``unknown__`` key
        (idempotent re-normalisation of a key read back from storage).
     4. Otherwise, normalise via :func:`heading_to_unknown_key`.
 
     Args:
-        name: Section name as provided by the caller (e.g. ``"RT-ICA"`` or ``"Files"``).
+        name: Section name as provided by the caller (e.g. ``"RT-ICA"`` or ``"Custom Analysis"``).
 
     Returns:
         Canonical storage key, e.g. ``"rt_ica"`` for a canonical section or
-        ``"unknown__files"`` for a custom one.
+        ``"unknown__custom_analysis"`` for a custom one.
     """
     name = name.strip()
     alias_key = SECTION_HEADING_ALIAS.get(name.lower())
     if alias_key is not None:
         return alias_key
     for snake_key, display in SECTION_HEADING.items():
-        if display == name:
+        if display.lower() == name.lower():
             return snake_key
     if name.startswith("unknown__"):
         return name

--- a/plugins/development-harness/backlog_core/parsing.py
+++ b/plugins/development-harness/backlog_core/parsing.py
@@ -741,39 +741,24 @@ def extract_description_from_issue_body(body: str) -> str:
 def extract_sections(text: str) -> dict[str, str]:
     """Extract '## Section' content blocks from markdown text.
 
-    A ``## `` line is only treated as a section boundary while scanning is
-    outside every ``<div>...</div>`` entry block. Entry content (see
-    ``entry_blocks.py``) is free-form and may legitimately contain its own
-    ``## `` headings (e.g. a fact-checker verdict quoting one claim per
-    heading) — without this guard those embedded headings are indistinguishable
-    from real section boundaries and shatter one section into many spurious
-    ones on the next parse.
+    Delegates the actual boundary detection to :func:`_split_body_h2`, the
+    marko-AST-based splitter already used by the legacy ``.md`` body-parsing
+    path (see the "Legacy .md body section parsing" section of this module).
+    Both callers now share one structural section boundary decision instead
+    of independently maintaining their own hand-rolled line scanners that can
+    silently disagree — see :class:`_EntryDivBlock` for why a naive line-based
+    ``## `` scan (this function's previous implementation) misidentifies a
+    heading-shaped line inside entry-block content as a real section boundary.
 
     Args:
         text: Markdown body text.
 
     Returns:
         Dict mapping section heading (e.g. '## Story') to its content (not including heading).
+        When the same heading text appears more than once, the last occurrence wins —
+        matching this function's pre-existing (dict-based) contract.
     """
-    sections: dict[str, str] = {}
-    current_heading: str | None = None
-    current_lines: list[str] = []
-    div_depth = 0
-
-    for line in text.splitlines():
-        if div_depth == 0 and line.startswith("## "):
-            if current_heading is not None:
-                sections[current_heading] = "\n".join(current_lines).strip()
-            current_heading = line.strip()
-            current_lines = []
-        elif current_heading is not None:
-            current_lines.append(line)
-        div_depth = max(0, div_depth + line.count("<div>") - line.count("</div>"))
-
-    if current_heading is not None:
-        sections[current_heading] = "\n".join(current_lines).strip()
-
-    return sections
+    return {f"## {name}": content for name, content in _split_body_h2(text)}
 
 
 def merge_sections(local_body: str, github_body: str) -> tuple[str, bool]:
@@ -829,7 +814,11 @@ def merge_sections(local_body: str, github_body: str) -> tuple[str, bool]:
 # ---------------------------------------------------------------------------
 
 import marko
-from marko.block import Heading as _MarkoHeading
+from marko.block import BlockElement as _MarkoBlockElement, Heading as _MarkoHeading
+from marko.helpers import MarkoExtension as _MarkoExtension
+
+if TYPE_CHECKING:
+    from marko.source import Source as _MarkoSource
 
 # Heading levels used for body section splitting.
 _H2_LEVEL = 2
@@ -840,6 +829,84 @@ _GROOMED_DATE_RE = re.compile(r"^Groomed(?:\s*\((\d{4}-\d{2}-\d{2})\))?$", re.IG
 
 # ATX heading detector used when mapping AST positions back to source lines.
 _ATX_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)")
+
+# Entry-block wrapper markers. Must match entry_blocks.wrap_entry()'s
+# "<div><sub>{ts}</sub>\n\n{content}\n</div>" format (see ENTRY_RE in
+# entry_blocks.py for the canonical parse-side pattern this mirrors).
+_ENTRY_DIV_OPEN = "<div><sub>"
+_ENTRY_DIV_CLOSE = "</div>"
+_ENTRY_DIV_OPEN_RE = re.compile(r" {0,3}" + re.escape(_ENTRY_DIV_OPEN))
+
+
+class _EntryDivBlock(_MarkoBlockElement):
+    """Marko block element matching this codebase's ``<div><sub>...</sub>...</div>`` entry wrapper.
+
+    CommonMark's HTML-block rules end a generic ``<div>`` block at the first
+    blank line. ``entry_blocks.wrap_entry()`` always emits a blank line right
+    after the opening ``<div><sub>{ts}</sub>`` tag (to separate the timestamp
+    from multi-paragraph content), so marko's built-in ``HTMLBlock`` element
+    would otherwise stop treating the entry as opaque at that first blank line
+    and reparse everything after it as ordinary markdown — including any
+    ``## ``/``### ``-looking line inside the entry's own content (e.g. a
+    fact-checker verdict quoting one claim per heading) as a real section
+    boundary (#2956).
+
+    This element is registered with higher priority than ``Heading``,
+    ``HTMLBlock``, and ``Paragraph`` (see :data:`_ENTRY_AWARE_MARKDOWN`), so
+    once a line opens an entry block the parser hands the *entire* block —
+    every line up to the point ``<div>``/``</div>`` nesting returns to zero,
+    regardless of blank lines, code fences, or heading-shaped text inside — to
+    this element instead of descending into it looking for block-level
+    structure. Depth is tracked (not "stop at the first ``</div>``") because
+    entry content may itself contain further, unrelated ``<div>``/``</div>``
+    text; a first-match stop would end the opaque region early and let a
+    heading-lookalike line *after* that inner close fragment the section
+    again. That makes "a heading-lookalike line inside entry content is
+    mistaken for a section boundary" structurally impossible rather than
+    special-cased: no line inside an entry block is ever offered to the
+    block-level parser as a heading candidate in the first place, at any
+    nesting depth.
+    """
+
+    priority = 9  # Above ThematicBreak(8)/FencedCode(7)/Heading(6)/HTMLBlock(5)/Paragraph(1).
+
+    def __init__(self, lines: str) -> None:
+        self.body = lines
+
+    @classmethod
+    def match(cls, source: _MarkoSource) -> bool:
+        """Return whether the current line opens an entry block.
+
+        Returns:
+            ``True`` when the line matches the entry-block open marker.
+        """
+        return bool(source.expect_re(_ENTRY_DIV_OPEN_RE))
+
+    @classmethod
+    def parse(cls, source: _MarkoSource) -> str:
+        """Consume every line until ``<div>``/``</div`` nesting returns to zero.
+
+        Returns:
+            The raw, verbatim source text of the entry block.
+        """
+        lines: list[str] = []
+        depth = 0
+        while not source.exhausted:
+            line = source.next_line()
+            if line is None:
+                break
+            lines.append(line)
+            source.consume()
+            depth += line.count("<div>") - line.count("</div>")
+            if depth <= 0:
+                break
+        return "".join(lines)
+
+
+# Single shared marko instance used by every AST-based split in this module so
+# entry-block opacity is enforced identically everywhere, rather than each
+# caller independently re-deciding what counts as a section boundary.
+_ENTRY_AWARE_MARKDOWN = marko.Markdown(extensions=[_MarkoExtension(elements=[_EntryDivBlock])])
 
 
 def _extract_heading_text(node: _MarkoHeading) -> str:
@@ -861,7 +928,8 @@ def _extract_heading_text(node: _MarkoHeading) -> str:
 def _ast_h2_headings(text: str) -> list[str]:
     """Return level-2 heading texts from the marko AST in document order.
 
-    marko correctly ignores ``##`` lines inside fenced code blocks.
+    Uses :data:`_ENTRY_AWARE_MARKDOWN` so ``##`` lines inside fenced code
+    blocks or entry-block content are never misidentified as headings.
 
     Args:
         text: Raw markdown body text.
@@ -869,7 +937,7 @@ def _ast_h2_headings(text: str) -> list[str]:
     Returns:
         Ordered list of heading text strings (after ``## ``).
     """
-    doc = marko.parse(text)
+    doc = _ENTRY_AWARE_MARKDOWN.parse(text)
     return [
         _extract_heading_text(child)
         for child in doc.children
@@ -886,7 +954,7 @@ def _ast_h3_headings(text: str) -> list[str]:
     Returns:
         Ordered list of heading text strings (after ``### ``).
     """
-    doc = marko.parse(text)
+    doc = _ENTRY_AWARE_MARKDOWN.parse(text)
     return [
         _extract_heading_text(child)
         for child in doc.children
@@ -897,9 +965,13 @@ def _ast_h3_headings(text: str) -> list[str]:
 def _map_headings_to_lines(ast_headings: list[str], raw_lines: list[str], target_level: int) -> list[tuple[int, str]]:
     """Map AST heading texts to their 0-indexed source line numbers.
 
-    Uses a code-fence state tracker to skip ``#`` lines inside fenced code
-    blocks, then matches AST heading entries in document order by level.  Line
-    numbers are 0-indexed (offsets into ``raw_lines``).
+    The AST decides *which* lines are real headings; this function only
+    locates *where* each one lives in the original source so its exact
+    verbatim content (including entry-block HTML) can be sliced out. Its
+    state tracking must therefore recognise the same block boundaries the
+    AST does — code fences and entry blocks — or it can misalign a heading
+    text with the wrong source line once any ``#``-prefixed text appears
+    inside one of those opaque regions.
 
     Args:
         ast_headings: Heading texts extracted from the marko AST, in order.
@@ -909,15 +981,21 @@ def _map_headings_to_lines(ast_headings: list[str], raw_lines: list[str], target
     Returns:
         List of ``(line_index, heading_text_from_source)`` tuples.
     """
-    "#" * target_level + " "
     result: list[tuple[int, str]] = []
     ast_idx = 0
     in_fence = False
+    entry_depth = 0
 
     for idx, line in enumerate(raw_lines):
         if ast_idx >= len(ast_headings):
             break
         stripped = line.lstrip()
+        if entry_depth > 0:
+            entry_depth += line.count("<div>") - line.count("</div>")
+            continue
+        if _ENTRY_DIV_OPEN_RE.match(line):
+            entry_depth = line.count("<div>") - line.count("</div>")
+            continue
         if stripped.startswith(("```", "~~~")):
             in_fence = not in_fence
             continue

--- a/plugins/development-harness/backlog_core/parsing.py
+++ b/plugins/development-harness/backlog_core/parsing.py
@@ -834,7 +834,6 @@ _ATX_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)")
 # "<div><sub>{ts}</sub>\n\n{content}\n</div>" format (see ENTRY_RE in
 # entry_blocks.py for the canonical parse-side pattern this mirrors).
 _ENTRY_DIV_OPEN = "<div><sub>"
-_ENTRY_DIV_CLOSE = "</div>"
 _ENTRY_DIV_OPEN_RE = re.compile(r" {0,3}" + re.escape(_ENTRY_DIV_OPEN))
 
 # Tag-boundary matchers for div-nesting depth tracking. A literal-substring count

--- a/plugins/development-harness/backlog_core/parsing.py
+++ b/plugins/development-harness/backlog_core/parsing.py
@@ -741,6 +741,14 @@ def extract_description_from_issue_body(body: str) -> str:
 def extract_sections(text: str) -> dict[str, str]:
     """Extract '## Section' content blocks from markdown text.
 
+    A ``## `` line is only treated as a section boundary while scanning is
+    outside every ``<div>...</div>`` entry block. Entry content (see
+    ``entry_blocks.py``) is free-form and may legitimately contain its own
+    ``## `` headings (e.g. a fact-checker verdict quoting one claim per
+    heading) — without this guard those embedded headings are indistinguishable
+    from real section boundaries and shatter one section into many spurious
+    ones on the next parse.
+
     Args:
         text: Markdown body text.
 
@@ -750,15 +758,17 @@ def extract_sections(text: str) -> dict[str, str]:
     sections: dict[str, str] = {}
     current_heading: str | None = None
     current_lines: list[str] = []
+    div_depth = 0
 
     for line in text.splitlines():
-        if line.startswith("## "):
+        if div_depth == 0 and line.startswith("## "):
             if current_heading is not None:
                 sections[current_heading] = "\n".join(current_lines).strip()
             current_heading = line.strip()
             current_lines = []
         elif current_heading is not None:
             current_lines.append(line)
+        div_depth = max(0, div_depth + line.count("<div>") - line.count("</div>"))
 
     if current_heading is not None:
         sections[current_heading] = "\n".join(current_lines).strip()

--- a/plugins/development-harness/backlog_core/parsing.py
+++ b/plugins/development-harness/backlog_core/parsing.py
@@ -837,6 +837,28 @@ _ENTRY_DIV_OPEN = "<div><sub>"
 _ENTRY_DIV_CLOSE = "</div>"
 _ENTRY_DIV_OPEN_RE = re.compile(r" {0,3}" + re.escape(_ENTRY_DIV_OPEN))
 
+# Tag-boundary matchers for div-nesting depth tracking. A literal-substring count
+# (``line.count("<div>")``) misses an attributed opening tag like
+# ``<div class="note">`` while ``line.count("</div>")`` still matches its close
+# unconditionally — that asymmetry drives depth negative and ends entry-block
+# opacity early, letting a heading-lookalike line further down escape as a
+# spurious section (#2964 follow-up). Matching tag boundaries via regex keeps
+# opens and closes counted symmetrically regardless of attributes.
+_DIV_OPEN_TAG_RE = re.compile(r"<div\b")
+_DIV_CLOSE_TAG_RE = re.compile(r"</div\s*>")
+
+
+def _div_depth_delta(line: str) -> int:
+    """Return the net change in ``<div>``/``</div>`` nesting depth for one line.
+
+    Args:
+        line: Source line to scan.
+
+    Returns:
+        Count of opening ``<div`` tags minus closing ``</div>`` tags on this line.
+    """
+    return len(_DIV_OPEN_TAG_RE.findall(line)) - len(_DIV_CLOSE_TAG_RE.findall(line))
+
 
 class _EntryDivBlock(_MarkoBlockElement):
     """Marko block element matching this codebase's ``<div><sub>...</sub>...</div>`` entry wrapper.
@@ -897,7 +919,7 @@ class _EntryDivBlock(_MarkoBlockElement):
                 break
             lines.append(line)
             source.consume()
-            depth += line.count("<div>") - line.count("</div>")
+            depth += _div_depth_delta(line)
             if depth <= 0:
                 break
         return "".join(lines)
@@ -991,10 +1013,10 @@ def _map_headings_to_lines(ast_headings: list[str], raw_lines: list[str], target
             break
         stripped = line.lstrip()
         if entry_depth > 0:
-            entry_depth += line.count("<div>") - line.count("</div>")
+            entry_depth += _div_depth_delta(line)
             continue
         if _ENTRY_DIV_OPEN_RE.match(line):
-            entry_depth = line.count("<div>") - line.count("</div>")
+            entry_depth = _div_depth_delta(line)
             continue
         if stripped.startswith(("```", "~~~")):
             in_fence = not in_fence

--- a/plugins/development-harness/backlog_core/rendering.py
+++ b/plugins/development-harness/backlog_core/rendering.py
@@ -36,46 +36,23 @@ __all__ = [
 
 # Section key (used in BacklogItem.sections) -> markdown heading text.
 #
-# The first three entries (fact_check, rt_ica, issue_classification) need an
-# explicit mapping because their correct display form cannot be derived by
-# the generic unknown-section fallback (title-casing "rt_ica" produces "Rt
-# Ica", not the acronym-cased "RT-ICA"; "fact_check" needs a hyphen, not a
-# space). Every entry below this point DOES already round-trip correctly
-# through the generic unknown__ fallback (#2956's write-path/parse-path fix
-# makes that true for ANY section name, registered or not) — registering
-# them here is a display-quality improvement only, not a correctness fix:
-# it gives grooming's most commonly observed sections a clean canonical
-# storage key (e.g. "files") instead of the "unknown__" prefix. Sourced from
-# a full grep of the real corrupted local cache for #2953/#2955 (the
-# ground-truth evidence for #2956) plus every literal `section=` value found
-# across plugins/development-harness/agents/*.md and skill references
-# (2026-08-18) — not a guessed or partial list.
+# These three need an explicit mapping because their correct display form
+# cannot be derived by the generic unknown-section fallback (title-casing
+# "rt_ica" produces "Rt Ica", not the acronym-cased "RT-ICA"; "fact_check"
+# needs a hyphen, not a space). Any OTHER section name already round-trips
+# correctly through the generic unknown__ fallback (#2956's write-path/
+# parse-path fix makes that true for ANY section name, registered or not) —
+# adding a name here is a display-quality improvement only (a clean
+# canonical key instead of an "unknown__" prefix), never a correctness
+# requirement. Extending this registry with more commonly-observed section
+# names belongs to #2970's normalize-on-read design (see
+# rendering.normalize_unknown_sections), not to this file in isolation —
+# see #2964 review discussion for why a broad batch of new entries here was
+# split out.
 SECTION_HEADING: dict[str, str] = {
     "fact_check": "Fact-Check",
     "rt_ica": "RT-ICA",
     "issue_classification": "Issue Classification",
-    "files": "Files",
-    "resources": "Resources",
-    "impact": "Impact",
-    "impact_radius": "Impact Radius",
-    "dependencies": "Dependencies",
-    "priority": "Priority",
-    "benefits": "Benefits",
-    "research": "Research",
-    "design_intent_alignment": "Design Intent Alignment",
-    "acceptance_criteria": "Acceptance Criteria",
-    "expected_behavior": "Expected Behavior",
-    "effort": "Effort",
-    "reproducibility": "Reproducibility",
-    "story": "Story",
-    "context": "Context",
-    "working_register": "Working Register",
-    "suggested_location": "Suggested Location",
-    "concerns": "Concerns",
-    "divergence_notes": "Divergence Notes",
-    "execution_results": "Execution Results",
-    "grooming_notes": "Grooming Notes",
-    "root_cause_analysis": "Root-Cause Analysis",
 }
 
 # Frozenset of the display values in SECTION_HEADING.
@@ -154,13 +131,15 @@ def normalize_unknown_sections(sections: dict[str, Section | GroomedData]) -> di
 
     A local YAML cache written before a name was registered in
     :data:`SECTION_HEADING` stores it as ``unknown__{key}`` (e.g.
-    ``unknown__story``).  Once that name becomes canonical, a freshly parsed
-    GitHub body produces the same logical section under the plain key
-    (``story``) instead — two different dict keys for one heading, which
-    survive :func:`github_sync.merge_item`'s key-union merge and render as a
-    duplicated ``## Story`` heading (#2956 follow-up). Resolving legacy
-    ``unknown__`` keys against the current registry at load time — before
-    reconciliation ever sees the item — makes both sides collide on one key.
+    ``unknown__issue_classification``). Once that name becomes canonical, a
+    freshly parsed GitHub body produces the same logical section under the
+    plain key (``issue_classification``) instead — two different dict keys
+    for one heading, which survive :func:`github_sync.merge_item`'s
+    key-union merge and render as a duplicated heading (#2956 follow-up).
+    Resolving legacy ``unknown__`` keys against the current registry at load
+    time — before reconciliation ever sees the item — makes both sides
+    collide on one key. This same mechanism is what #2970's normalize-on-read
+    design needs when the registry is later extended.
 
     When both ``unknown__{key}`` and ``{key}`` are present in the same
     ``sections`` dict (e.g. a manually edited cache file), their entries are

--- a/plugins/development-harness/backlog_core/rendering.py
+++ b/plugins/development-harness/backlog_core/rendering.py
@@ -31,11 +31,48 @@ __all__ = [
 # Constants
 # ---------------------------------------------------------------------------
 
-# Section key (used in BacklogItem.sections) -> markdown heading text
+# Section key (used in BacklogItem.sections) -> markdown heading text.
+#
+# The first three entries (fact_check, rt_ica, issue_classification) need an
+# explicit mapping because their correct display form cannot be derived by
+# the generic unknown-section fallback (title-casing "rt_ica" produces "Rt
+# Ica", not the acronym-cased "RT-ICA"; "fact_check" needs a hyphen, not a
+# space). Every entry below this point DOES already round-trip correctly
+# through the generic unknown__ fallback (#2956's write-path/parse-path fix
+# makes that true for ANY section name, registered or not) — registering
+# them here is a display-quality improvement only, not a correctness fix:
+# it gives grooming's most commonly observed sections a clean canonical
+# storage key (e.g. "files") instead of the "unknown__" prefix. Sourced from
+# a full grep of the real corrupted local cache for #2953/#2955 (the
+# ground-truth evidence for #2956) plus every literal `section=` value found
+# across plugins/development-harness/agents/*.md and skill references
+# (2026-08-18) — not a guessed or partial list.
 SECTION_HEADING: dict[str, str] = {
     "fact_check": "Fact-Check",
     "rt_ica": "RT-ICA",
     "issue_classification": "Issue Classification",
+    "files": "Files",
+    "resources": "Resources",
+    "impact": "Impact",
+    "impact_radius": "Impact Radius",
+    "dependencies": "Dependencies",
+    "priority": "Priority",
+    "benefits": "Benefits",
+    "research": "Research",
+    "design_intent_alignment": "Design Intent Alignment",
+    "acceptance_criteria": "Acceptance Criteria",
+    "expected_behavior": "Expected Behavior",
+    "effort": "Effort",
+    "reproducibility": "Reproducibility",
+    "story": "Story",
+    "context": "Context",
+    "working_register": "Working Register",
+    "suggested_location": "Suggested Location",
+    "concerns": "Concerns",
+    "divergence_notes": "Divergence Notes",
+    "execution_results": "Execution Results",
+    "grooming_notes": "Grooming Notes",
+    "root_cause_analysis": "Root-Cause Analysis",
 }
 
 # Frozenset of the display values in SECTION_HEADING.

--- a/plugins/development-harness/backlog_core/rendering.py
+++ b/plugins/development-harness/backlog_core/rendering.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 __all__ = [
     "GROOMED_SUBSECTION_ORDER",
     "SECTION_HEADING",
+    "heading_to_unknown_key",
     "render_groomed_section",
     "section_display_title",
     "unknown_key_to_heading",
@@ -74,6 +75,31 @@ def unknown_key_to_heading(key: str) -> str:
     """
     stripped = key.removeprefix("unknown__")
     return stripped.replace("_", " ").title()
+
+
+def heading_to_unknown_key(heading_text: str) -> str:
+    """Convert an arbitrary section heading/name to its canonical storage key.
+
+    Inverse of :func:`unknown_key_to_heading`. Normalises by lowercasing and
+    replacing spaces with underscores, then prepends the ``"unknown__"``
+    prefix so unknown section keys never collide with :data:`SECTION_HEADING`
+    keys (e.g. ``"fact_check"``).
+
+    This is the single normalisation used on both sides of the local-write /
+    GitHub-parse boundary: :mod:`operations` calls it when storing a section
+    under a caller-supplied display name, and :mod:`github_sync` calls it when
+    parsing an unrecognised ``## Heading`` from an issue body. Keeping both
+    call sites on one function is what makes the two round-trip to the same
+    key — see ``ARCHITECTURE.md`` for the incident this closed.
+
+    Args:
+        heading_text: Raw heading or section display name, whitespace trimmed.
+
+    Returns:
+        Storage key such as ``"unknown__custom_analysis"``.
+    """
+    normalised = heading_text.lower().replace(" ", "_")
+    return f"unknown__{normalised}"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/backlog_core/rendering.py
+++ b/plugins/development-harness/backlog_core/rendering.py
@@ -92,13 +92,20 @@ def heading_to_unknown_key(heading_text: str) -> str:
     call sites on one function is what makes the two round-trip to the same
     key — see ``ARCHITECTURE.md`` for the incident this closed.
 
+    Strips leading/trailing whitespace before normalising, defensively —
+    :mod:`github_sync`'s caller already strips its extracted heading text
+    before calling this function, but a local write's caller-supplied name
+    was not guaranteed to be pre-trimmed; a trailing space surviving into the
+    key (``"unknown__files_"`` vs. ``"unknown__files"``) reproduces the exact
+    write-path/parse-path key divergence this function exists to prevent.
+
     Args:
-        heading_text: Raw heading or section display name, whitespace trimmed.
+        heading_text: Raw heading or section display name.
 
     Returns:
         Storage key such as ``"unknown__custom_analysis"``.
     """
-    normalised = heading_text.lower().replace(" ", "_")
+    normalised = heading_text.strip().lower().replace(" ", "_")
     return f"unknown__{normalised}"
 
 

--- a/plugins/development-harness/backlog_core/rendering.py
+++ b/plugins/development-harness/backlog_core/rendering.py
@@ -36,23 +36,46 @@ __all__ = [
 
 # Section key (used in BacklogItem.sections) -> markdown heading text.
 #
-# These three need an explicit mapping because their correct display form
-# cannot be derived by the generic unknown-section fallback (title-casing
-# "rt_ica" produces "Rt Ica", not the acronym-cased "RT-ICA"; "fact_check"
-# needs a hyphen, not a space). Any OTHER section name already round-trips
-# correctly through the generic unknown__ fallback (#2956's write-path/
-# parse-path fix makes that true for ANY section name, registered or not) —
-# adding a name here is a display-quality improvement only (a clean
-# canonical key instead of an "unknown__" prefix), never a correctness
-# requirement. Extending this registry with more commonly-observed section
-# names belongs to #2970's normalize-on-read design (see
-# rendering.normalize_unknown_sections), not to this file in isolation —
-# see #2964 review discussion for why a broad batch of new entries here was
-# split out.
+# The first three entries (fact_check, rt_ica, issue_classification) need an
+# explicit mapping because their correct display form cannot be derived by
+# the generic unknown-section fallback (title-casing "rt_ica" produces "Rt
+# Ica", not the acronym-cased "RT-ICA"; "fact_check" needs a hyphen, not a
+# space). Every entry below this point DOES already round-trip correctly
+# through the generic unknown__ fallback (#2956's write-path/parse-path fix
+# makes that true for ANY section name, registered or not) — registering
+# them here is a display-quality improvement only, not a correctness fix:
+# it gives grooming's most commonly observed sections a clean canonical
+# storage key (e.g. "files") instead of the "unknown__" prefix. Sourced from
+# a full grep of the real corrupted local cache for #2953/#2955 (the
+# ground-truth evidence for #2956) plus every literal `section=` value found
+# across plugins/development-harness/agents/*.md and skill references
+# (2026-08-18) — not a guessed or partial list.
 SECTION_HEADING: dict[str, str] = {
     "fact_check": "Fact-Check",
     "rt_ica": "RT-ICA",
     "issue_classification": "Issue Classification",
+    "files": "Files",
+    "resources": "Resources",
+    "impact": "Impact",
+    "impact_radius": "Impact Radius",
+    "dependencies": "Dependencies",
+    "priority": "Priority",
+    "benefits": "Benefits",
+    "research": "Research",
+    "design_intent_alignment": "Design Intent Alignment",
+    "acceptance_criteria": "Acceptance Criteria",
+    "expected_behavior": "Expected Behavior",
+    "effort": "Effort",
+    "reproducibility": "Reproducibility",
+    "story": "Story",
+    "context": "Context",
+    "working_register": "Working Register",
+    "suggested_location": "Suggested Location",
+    "concerns": "Concerns",
+    "divergence_notes": "Divergence Notes",
+    "execution_results": "Execution Results",
+    "grooming_notes": "Grooming Notes",
+    "root_cause_analysis": "Root-Cause Analysis",
 }
 
 # Frozenset of the display values in SECTION_HEADING.
@@ -131,15 +154,13 @@ def normalize_unknown_sections(sections: dict[str, Section | GroomedData]) -> di
 
     A local YAML cache written before a name was registered in
     :data:`SECTION_HEADING` stores it as ``unknown__{key}`` (e.g.
-    ``unknown__issue_classification``). Once that name becomes canonical, a
-    freshly parsed GitHub body produces the same logical section under the
-    plain key (``issue_classification``) instead — two different dict keys
-    for one heading, which survive :func:`github_sync.merge_item`'s
-    key-union merge and render as a duplicated heading (#2956 follow-up).
-    Resolving legacy ``unknown__`` keys against the current registry at load
-    time — before reconciliation ever sees the item — makes both sides
-    collide on one key. This same mechanism is what #2970's normalize-on-read
-    design needs when the registry is later extended.
+    ``unknown__story``).  Once that name becomes canonical, a freshly parsed
+    GitHub body produces the same logical section under the plain key
+    (``story``) instead — two different dict keys for one heading, which
+    survive :func:`github_sync.merge_item`'s key-union merge and render as a
+    duplicated ``## Story`` heading (#2956 follow-up). Resolving legacy
+    ``unknown__`` keys against the current registry at load time — before
+    reconciliation ever sees the item — makes both sides collide on one key.
 
     When both ``unknown__{key}`` and ``{key}`` are present in the same
     ``sections`` dict (e.g. a manually edited cache file), their entries are

--- a/plugins/development-harness/backlog_core/rendering.py
+++ b/plugins/development-harness/backlog_core/rendering.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .models import Section
+
 if TYPE_CHECKING:
     from .models import GroomedData
 
@@ -22,6 +24,7 @@ __all__ = [
     "GROOMED_SUBSECTION_ORDER",
     "SECTION_HEADING",
     "heading_to_unknown_key",
+    "normalize_unknown_sections",
     "render_groomed_section",
     "section_display_title",
     "unknown_key_to_heading",
@@ -144,6 +147,48 @@ def heading_to_unknown_key(heading_text: str) -> str:
     """
     normalised = heading_text.strip().lower().replace(" ", "_")
     return f"unknown__{normalised}"
+
+
+def normalize_unknown_sections(sections: dict[str, Section | GroomedData]) -> dict[str, Section | GroomedData]:
+    """Fold ``unknown__{key}`` entries into ``{key}`` when now canonical.
+
+    A local YAML cache written before a name was registered in
+    :data:`SECTION_HEADING` stores it as ``unknown__{key}`` (e.g.
+    ``unknown__story``).  Once that name becomes canonical, a freshly parsed
+    GitHub body produces the same logical section under the plain key
+    (``story``) instead — two different dict keys for one heading, which
+    survive :func:`github_sync.merge_item`'s key-union merge and render as a
+    duplicated ``## Story`` heading (#2956 follow-up). Resolving legacy
+    ``unknown__`` keys against the current registry at load time — before
+    reconciliation ever sees the item — makes both sides collide on one key.
+
+    When both ``unknown__{key}`` and ``{key}`` are present in the same
+    ``sections`` dict (e.g. a manually edited cache file), their entries are
+    concatenated, deduplicating by entry ``id``.
+
+    Args:
+        sections: Raw ``BacklogItem.sections`` mapping as loaded from storage.
+
+    Returns:
+        A new mapping with legacy ``unknown__{key}`` keys folded into their
+        now-canonical counterparts. Keys that are not legacy, or whose
+        ``unknown__`` name is still uncanonical, are returned unchanged.
+    """
+    normalized: dict[str, Section | GroomedData] = {}
+    for key, value in sections.items():
+        target = key
+        if key.startswith("unknown__") and isinstance(value, Section):
+            candidate = key.removeprefix("unknown__")
+            if candidate in SECTION_HEADING:
+                target = candidate
+        existing = normalized.get(target)
+        if isinstance(existing, Section) and isinstance(value, Section):
+            seen_ids = {e.id for e in existing.entries}
+            merged_entries = [*existing.entries, *(e for e in value.entries if e.id not in seen_ids)]
+            normalized[target] = Section(entries=merged_entries)
+        else:
+            normalized[target] = value
+    return normalized
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/backlog_core/yaml_io.py
+++ b/plugins/development-harness/backlog_core/yaml_io.py
@@ -18,6 +18,7 @@ from ruamel.yaml import YAML
 
 from .models import BacklogItem
 from .parsing import parse_item_file
+from .rendering import normalize_unknown_sections
 
 _log = logging.getLogger(__name__)
 
@@ -65,6 +66,7 @@ def load_item(path: Path) -> BacklogItem:
         with path.open(encoding="utf-8") as fh:
             data = yaml.load(fh)
         item = BacklogItem.model_validate(data)
+        item.sections = normalize_unknown_sections(item.sections)
         item.file_path = str(path.resolve())
         return item
     # fmt == "legacy_md"
@@ -152,6 +154,7 @@ def load_item_text(text: str, path: Path) -> BacklogItem:
         yaml = YAML(typ="safe")
         data = yaml.load(StringIO(text))
         item = BacklogItem.model_validate(data)
+        item.sections = normalize_unknown_sections(item.sections)
         item.file_path = str(path)
         return item
     # fmt == "legacy_md"

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -1238,9 +1238,13 @@ class TestViewItem:
 
         sections = result.sections
         assert isinstance(sections, dict), "sections must be a dict"
-        assert "Decision" in sections, f"Expected 'Decision' in sections, got: {list(sections.keys())}"
+        # "Decision" is not a canonical section name (see rendering.SECTION_HEADING), so it is
+        # stored under its normalised unknown-section key — see operations._normalize_section_key.
+        assert "unknown__decision" in sections, (
+            f"Expected 'unknown__decision' in sections, got: {list(sections.keys())}"
+        )
         # groom_item creates entry-block sections (SectionEntryMetadata shape).
-        decision = cast("SectionEntryMetadata", sections["Decision"])
+        decision = cast("SectionEntryMetadata", sections["unknown__decision"])
         assert decision["num_entries"] == 2
         assert len(decision["entries"]) == 2
 

--- a/plugins/development-harness/tests/test_batch_section_writes.py
+++ b/plugins/development-harness/tests/test_batch_section_writes.py
@@ -140,9 +140,9 @@ class TestHandleBatchGroomedLocalWrites:
 
         result = ops._handle_batch_groomed(item, {"Plan": "Content A.", "Research": "Content B."}, repo="owner/repo")
 
-        # "Plan" is not a canonical section name (see rendering.SECTION_HEADING), so it is
-        # stored under its normalised unknown-section key. "Research" IS canonical.
-        assert result == ["unknown__plan", "research"]
+        # "Plan"/"Research" are not canonical section names (see rendering.SECTION_HEADING), so
+        # they are stored under their normalised unknown-section keys.
+        assert result == ["unknown__plan", "unknown__research"]
 
     def test_single_section_written_to_file_body(self, tmp_path: Path, mocker: MockerFixture) -> None:
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
@@ -278,9 +278,8 @@ class TestUpdateItemSectionsRouting:
             selector="Written Sections", sections={"Plan": "The plan.", "Research": "The research."}, repo="owner/repo"
         )
 
-        # "Plan" is not a canonical section name, so it normalises to an unknown__ key.
-        # "Research" IS canonical (see rendering.SECTION_HEADING).
-        assert result["sections_written"] == ["unknown__plan", "research"]
+        # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
+        assert result["sections_written"] == ["unknown__plan", "unknown__research"]
 
     def test_sections_with_content_returns_groomed_updated_true(self, mocker: MockerFixture) -> None:
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
@@ -305,10 +304,9 @@ class TestUpdateItemSectionsRouting:
         ("sections", "expected_written", "expected_groomed"),
         [
             ({}, [], False),
-            # "Plan" is not a canonical section name, so it normalises to an unknown__ key.
-            # "Research" IS canonical (see rendering.SECTION_HEADING).
+            # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
             ({"Plan": "Plan content."}, ["unknown__plan"], True),
-            ({"Plan": "P.", "Research": "R."}, ["unknown__plan", "research"], True),
+            ({"Plan": "P.", "Research": "R."}, ["unknown__plan", "unknown__research"], True),
         ],
     )
     def test_sections_routing_parametrized(

--- a/plugins/development-harness/tests/test_batch_section_writes.py
+++ b/plugins/development-harness/tests/test_batch_section_writes.py
@@ -140,7 +140,9 @@ class TestHandleBatchGroomedLocalWrites:
 
         result = ops._handle_batch_groomed(item, {"Plan": "Content A.", "Research": "Content B."}, repo="owner/repo")
 
-        assert result == ["Plan", "Research"]
+        # "Plan"/"Research" are not canonical section names (see rendering.SECTION_HEADING), so
+        # they are stored under their normalised unknown-section keys.
+        assert result == ["unknown__plan", "unknown__research"]
 
     def test_single_section_written_to_file_body(self, tmp_path: Path, mocker: MockerFixture) -> None:
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
@@ -276,7 +278,8 @@ class TestUpdateItemSectionsRouting:
             selector="Written Sections", sections={"Plan": "The plan.", "Research": "The research."}, repo="owner/repo"
         )
 
-        assert result["sections_written"] == ["Plan", "Research"]
+        # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
+        assert result["sections_written"] == ["unknown__plan", "unknown__research"]
 
     def test_sections_with_content_returns_groomed_updated_true(self, mocker: MockerFixture) -> None:
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
@@ -301,8 +304,9 @@ class TestUpdateItemSectionsRouting:
         ("sections", "expected_written", "expected_groomed"),
         [
             ({}, [], False),
-            ({"Plan": "Plan content."}, ["Plan"], True),
-            ({"Plan": "P.", "Research": "R."}, ["Plan", "Research"], True),
+            # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
+            ({"Plan": "Plan content."}, ["unknown__plan"], True),
+            ({"Plan": "P.", "Research": "R."}, ["unknown__plan", "unknown__research"], True),
         ],
     )
     def test_sections_routing_parametrized(
@@ -344,7 +348,8 @@ class TestGroomItemWithSections:
             repo="owner/repo",
         )
 
-        assert result["sections_written"] == ["Plan", "Decision"]
+        # "Plan"/"Decision" are not canonical section names, so they normalise to unknown__ keys.
+        assert result["sections_written"] == ["unknown__plan", "unknown__decision"]
         assert result["groomed_updated"] is True
 
     def test_empty_sections_is_noop_with_no_file_changes(self, mocker: MockerFixture) -> None:

--- a/plugins/development-harness/tests/test_batch_section_writes.py
+++ b/plugins/development-harness/tests/test_batch_section_writes.py
@@ -140,9 +140,9 @@ class TestHandleBatchGroomedLocalWrites:
 
         result = ops._handle_batch_groomed(item, {"Plan": "Content A.", "Research": "Content B."}, repo="owner/repo")
 
-        # "Plan"/"Research" are not canonical section names (see rendering.SECTION_HEADING), so
-        # they are stored under their normalised unknown-section keys.
-        assert result == ["unknown__plan", "unknown__research"]
+        # "Plan" is not a canonical section name (see rendering.SECTION_HEADING), so it is
+        # stored under its normalised unknown-section key. "Research" IS canonical.
+        assert result == ["unknown__plan", "research"]
 
     def test_single_section_written_to_file_body(self, tmp_path: Path, mocker: MockerFixture) -> None:
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
@@ -278,8 +278,9 @@ class TestUpdateItemSectionsRouting:
             selector="Written Sections", sections={"Plan": "The plan.", "Research": "The research."}, repo="owner/repo"
         )
 
-        # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
-        assert result["sections_written"] == ["unknown__plan", "unknown__research"]
+        # "Plan" is not a canonical section name, so it normalises to an unknown__ key.
+        # "Research" IS canonical (see rendering.SECTION_HEADING).
+        assert result["sections_written"] == ["unknown__plan", "research"]
 
     def test_sections_with_content_returns_groomed_updated_true(self, mocker: MockerFixture) -> None:
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
@@ -304,9 +305,10 @@ class TestUpdateItemSectionsRouting:
         ("sections", "expected_written", "expected_groomed"),
         [
             ({}, [], False),
-            # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
+            # "Plan" is not a canonical section name, so it normalises to an unknown__ key.
+            # "Research" IS canonical (see rendering.SECTION_HEADING).
             ({"Plan": "Plan content."}, ["unknown__plan"], True),
-            ({"Plan": "P.", "Research": "R."}, ["unknown__plan", "unknown__research"], True),
+            ({"Plan": "P.", "Research": "R."}, ["unknown__plan", "research"], True),
         ],
     )
     def test_sections_routing_parametrized(

--- a/plugins/development-harness/tests/test_entry_blocks_integration.py
+++ b/plugins/development-harness/tests/test_entry_blocks_integration.py
@@ -26,8 +26,10 @@ def test_full_entry_lifecycle(backlog_dir, mock_github):
     result = operations.view_item(selector="Lifecycle Test", output=out)
     sections = result.sections
     assert isinstance(sections, dict), f"sections should be dict, got {type(sections)}"
-    assert "Decision" in sections, f"Expected 'Decision' in sections, got: {list(sections.keys())}"
-    decision = cast("SectionEntryMetadata", sections["Decision"])
+    # "Decision" is not a canonical section name (see rendering.SECTION_HEADING), so it is
+    # stored under its normalised unknown-section key — see operations._normalize_section_key.
+    assert "unknown__decision" in sections, f"Expected 'unknown__decision' in sections, got: {list(sections.keys())}"
+    decision = cast("SectionEntryMetadata", sections["unknown__decision"])
     assert decision["num_entries"] == 2, f"Expected 2 active entries, got {decision['num_entries']}"
 
     # Strike the first entry
@@ -39,7 +41,7 @@ def test_full_entry_lifecycle(backlog_dir, mock_github):
     result = operations.view_item(selector="Lifecycle Test", output=out)
     sections = result.sections
     assert isinstance(sections, dict)
-    decision = cast("SectionEntryMetadata", sections["Decision"])
+    decision = cast("SectionEntryMetadata", sections["unknown__decision"])
     assert decision["num_entries"] == 1, f"Expected 1 active entry, got {decision['num_entries']}"
     assert decision["num_struck"] == 1, f"Expected 1 struck entry, got {decision['num_struck']}"
 
@@ -60,7 +62,7 @@ def test_full_entry_lifecycle(backlog_dir, mock_github):
     result = operations.view_item(selector="Lifecycle Test", output=out)
     sections = result.sections
     assert isinstance(sections, dict)
-    entries3 = list(cast("SectionEntryMetadata", sections["Decision"])["entries"])
+    entries3 = list(cast("SectionEntryMetadata", sections["unknown__decision"])["entries"])
     active = [e for e in entries3 if not e.get("struck")]
     assert len(active) == 1
     assert "Updated second decision." in active[0]["content"]

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -878,19 +878,16 @@ class TestSectionKeyRoundTripRegression:
     def test_normalize_section_key_resolves_registered_display_names(self) -> None:
         """Sections registered in SECTION_HEADING resolve to their clean canonical key.
 
-        Canonical sections (the original 3, plus the commonly-observed set
-        added for #2956/#2964 — see rendering.SECTION_HEADING) resolve to a
-        clean snake_case key instead of falling through to the unknown__
-        fallback. This is a display-quality property (storage key cleanliness),
-        not the correctness fix — see the previous test for the property that
-        actually prevents data loss, which holds regardless of registration.
+        Canonical sections (the original 3 — see rendering.SECTION_HEADING)
+        resolve to a clean snake_case key instead of falling through to the
+        unknown__ fallback. This is a display-quality property (storage key
+        cleanliness), not the correctness fix — see the previous test for the
+        property that actually prevents data loss, which holds regardless of
+        registration.
         """
         assert _normalize_section_key("RT-ICA") == "rt_ica"
         assert _normalize_section_key("Fact-Check") == "fact_check"
         assert _normalize_section_key("Issue Classification") == "issue_classification"
-        assert _normalize_section_key("Files") == "files"
-        assert _normalize_section_key("Impact Radius") == "impact_radius"
-        assert _normalize_section_key("Design Intent Alignment") == "design_intent_alignment"
 
     def test_normalize_section_key_display_lookup_is_case_insensitive(self) -> None:
         """The reverse display-value scan matches case-insensitively.
@@ -898,15 +895,17 @@ class TestSectionKeyRoundTripRegression:
         Regression guard: the parse-side lookup (github_sync._HEADING_TO_KEY,
         keyed by ``heading.lower()``) is case-insensitive in both directions,
         but the write-side reverse scan previously compared ``display == name``
-        exactly — so ``_normalize_section_key("Story")`` resolved to ``"story"``
-        while ``_normalize_section_key("story")`` fell through to
-        ``"unknown__story"``. Both casings of a registered display name must
-        resolve to the same canonical key.
+        exactly — so ``_normalize_section_key("Issue Classification")``
+        resolved to ``"issue_classification"`` while
+        ``_normalize_section_key("issue classification")`` fell through to
+        ``"unknown__issue_classification"``. "Issue Classification" (unlike
+        "RT-ICA"/"Fact-Check") has no entry in SECTION_HEADING_ALIAS, so this
+        exercises the reverse-scan branch specifically, not the alias-table
+        lookup that already normalises case via ``.lower()``.
         """
-        assert _normalize_section_key("Story") == "story"
-        assert _normalize_section_key("story") == "story"
-        assert _normalize_section_key("STORY") == "story"
-        assert _normalize_section_key("rt-ica") == "rt_ica"
+        assert _normalize_section_key("Issue Classification") == "issue_classification"
+        assert _normalize_section_key("issue classification") == "issue_classification"
+        assert _normalize_section_key("ISSUE CLASSIFICATION") == "issue_classification"
 
     def test_custom_section_write_then_github_round_trip_does_not_duplicate(self) -> None:
         """A locally-written custom section survives render+parse+merge under one key.

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -14,6 +14,7 @@ from backlog_core.github_sync import merge_item, parse_issue_body, render_issue_
 from backlog_core.models import BacklogItem, Entry, GroomedData, Section
 from backlog_core.operations import _normalize_section_key
 from backlog_core.parsing import extract_sections
+from hypothesis import HealthCheck, given, settings, strategies as st
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -941,3 +942,115 @@ class TestExtractSectionsEntryBoundary:
         )
         sections = extract_sections(body)
         assert set(sections.keys()) == {"## Fact-Check", "## Resources"}
+
+    def test_embedded_heading_after_nested_unrelated_div_stays_in_same_section(self) -> None:
+        """A '## ' line is not a boundary even after a nested, unrelated <div>...</div> closes.
+
+        Regression for a depth-tracking gap: stopping entry-block opacity at the
+        *first* bare '</div>' line (rather than tracking balanced <div>/</div>
+        nesting) would let this fake heading — which appears after an inner,
+        unrelated div fragment closes — escape back into ordinary markdown
+        parsing and fragment the section a second, different way.
+        """
+        body = (
+            "## Fact-Check\n\n"
+            "<div><sub>2026-01-01T00:00:00Z</sub>\n\n"
+            "before\n<div>\nnested\n</div>\n\n"
+            "## Claim 1: fake heading after inner div closes\n\nVERDICT: VERIFIED\n"
+            "</div>\n"
+        )
+        sections = extract_sections(body)
+        assert list(sections.keys()) == ["## Fact-Check"]
+        assert "fake heading after inner div closes" in sections["## Fact-Check"]
+
+
+# ---------------------------------------------------------------------------
+# Property-based round trip: write -> render -> parse -> merge is lossless
+# ---------------------------------------------------------------------------
+
+# Balanced, individually well-formed adversarial fragments -- deliberately including
+# heading-lookalike lines, nested <div> content, and code fences (the exact bug
+# classes #2956 fixed). Each fragment keeps its own <div>/</div> tags balanced so a
+# generated example never trips the separate, out-of-scope entry_blocks.ENTRY_RE
+# greedy-match behavior on an unmatched tag -- this property targets section-boundary
+# detection, not entry-content regex matching. A "<div><sub>...</sub>...</div>"-shaped
+# fragment (mimicking a literal nested entry marker) is deliberately excluded: it
+# surfaced a real but distinct bug in entry_blocks.parse_entries's own ENTRY_RE
+# matching (filed as #2967), not in the section-boundary logic #2956 fixed.
+_ADVERSARIAL_FRAGMENTS = st.sampled_from([
+    "## Fake Heading Inside Content",
+    "### Fake Subheading",
+    "#### Even deeper fake heading",
+    "<div>\nnested content\n</div>",
+    "```python\nprint('fenced code fence lookalike')\n```",
+    "~~~\nfenced with tildes\n~~~",
+    "plain prose line",
+])
+
+_content_strategy = (
+    st.lists(_ADVERSARIAL_FRAGMENTS, min_size=1, max_size=8).map("\n\n".join).map(str.strip).filter(lambda s: s != "")
+)
+
+_section_name_strategy = st.text(
+    # Scoped to the realistic domain: printable ASCII letters/digits/punctuation,
+    # matching how agents and humans actually name sections ("Files", "Fact-Check",
+    # "Impact Radius"). Full-Unicode section names surfaced a real but narrow and
+    # unrelated defect during development of this test: rendering.py's display-title
+    # round trip (str.lower() / str.title()) is not idempotent for a handful of
+    # Unicode characters with special-case title mappings (e.g. MICRO SIGN U+00B5 ->
+    # title-cases to GREEK CAPITAL MU, a different codepoint) — filed separately as
+    # #2966 rather than fixed here, since it is a distinct bug class (a Unicode
+    # casing quirk) from what #2956 fixed (write-path vs. parse-path key mismatch).
+    # Requiring at least one alphanumeric character, and excluding literal
+    # underscores entirely, excludes another real but narrow and unrelated
+    # defect this test surfaced: any name containing a literal underscore
+    # (e.g. "_", "0_") round-trips through a different key each time, because
+    # heading_to_unknown_key's space<->underscore substitution cannot distinguish
+    # a literal underscore in the name from one it introduced itself — filed as
+    # #2968 rather than fixed here (a real display name is always a readable
+    # phrase and never contains a raw underscore, so this class of input is
+    # unrealistic for what this function is actually used for).
+    alphabet=st.characters(min_codepoint=32, max_codepoint=126, blacklist_characters="\n\r_"),
+    min_size=1,
+    max_size=40,
+).filter(lambda s: any(c.isalnum() for c in s))
+
+
+class TestSectionRoundTripProperty:
+    """Property: write -> render -> parse -> merge is lossless for arbitrary section names/content.
+
+    This is the guardrail #2956 exposed the absence of: nothing previously
+    enforced that the local-write key derivation (``_normalize_section_key``)
+    and the GitHub-parse key derivation (``parse_issue_body`` /
+    ``extract_sections``) actually agree — they were two independently
+    written functions that merely happened to be *expected* to match.
+    Adversarial content deliberately includes ``## ``-prefixed lines, nested
+    ``<div>`` fragments, and code fences so the property covers the exact bug
+    classes #2956 fixed, not just the originally reported symptom.
+    """
+
+    @given(section_name=_section_name_strategy, content=_content_strategy)
+    @settings(max_examples=200, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_write_render_parse_round_trip_is_lossless(self, section_name: str, content: str) -> None:
+        """A section written locally survives a GitHub render -> parse -> merge cycle intact.
+
+        For any section name and any content (including adversarial content
+        that looks like markdown structure), the derived storage key must be
+        identical before and after the round trip, under one key only (no
+        ``unknown__`` duplicate), and the entry content must be preserved.
+        """
+        key = _normalize_section_key(section_name)
+        item = _make_item(sections={key: Section(entries=[Entry(id="2026-01-01T00:00:00Z", content=content)])})
+
+        rendered = render_issue_body(item)
+        remote = parse_issue_body(rendered, item)
+        merged = merge_item(item, remote)
+
+        assert list(merged.sections.keys()) == [key], (
+            f"Key did not round-trip for section_name={section_name!r}: "
+            f"expected [{key!r}], got {list(merged.sections.keys())!r}"
+        )
+        sec = merged.sections[key]
+        assert isinstance(sec, Section)
+        assert len(sec.entries) == 1
+        assert sec.entries[0].content == content

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -1010,6 +1010,27 @@ class TestExtractSectionsEntryBoundary:
         assert list(sections.keys()) == ["## Fact-Check"]
         assert "fake heading after inner div closes" in sections["## Fact-Check"]
 
+    def test_embedded_heading_after_attributed_nested_div_stays_in_same_section(self) -> None:
+        """A nested div with attributes (e.g. ``<div class="note">``) does not escape opacity.
+
+        Regression for a literal-substring counting bug: ``line.count("<div>")``
+        does not match an attributed opening tag like ``<div class="note">``,
+        while ``line.count("</div>")`` still matches its close unconditionally.
+        That asymmetry drove the nesting-depth counter negative and ended entry
+        opacity one line early, letting a heading-lookalike line further down
+        escape as a spurious section (#2964 follow-up).
+        """
+        body = (
+            "## Fact-Check\n\n"
+            "<div><sub>2026-01-01T00:00:00Z</sub>\n\n"
+            'before\n<div class="note">inner note</div>\n\n'
+            "## Claim 1: fake heading after attributed div closes\n\nVERDICT: VERIFIED\n"
+            "</div>\n"
+        )
+        sections = extract_sections(body)
+        assert list(sections.keys()) == ["## Fact-Check"]
+        assert "fake heading after attributed div closes" in sections["## Fact-Check"]
+
 
 # ---------------------------------------------------------------------------
 # Property-based round trip: write -> render -> parse -> merge is lossless

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -878,16 +878,19 @@ class TestSectionKeyRoundTripRegression:
     def test_normalize_section_key_resolves_registered_display_names(self) -> None:
         """Sections registered in SECTION_HEADING resolve to their clean canonical key.
 
-        Canonical sections (the original 3 — see rendering.SECTION_HEADING)
-        resolve to a clean snake_case key instead of falling through to the
-        unknown__ fallback. This is a display-quality property (storage key
-        cleanliness), not the correctness fix — see the previous test for the
-        property that actually prevents data loss, which holds regardless of
-        registration.
+        Canonical sections (the original 3, plus the commonly-observed set
+        added for #2956/#2964 — see rendering.SECTION_HEADING) resolve to a
+        clean snake_case key instead of falling through to the unknown__
+        fallback. This is a display-quality property (storage key cleanliness),
+        not the correctness fix — see the previous test for the property that
+        actually prevents data loss, which holds regardless of registration.
         """
         assert _normalize_section_key("RT-ICA") == "rt_ica"
         assert _normalize_section_key("Fact-Check") == "fact_check"
         assert _normalize_section_key("Issue Classification") == "issue_classification"
+        assert _normalize_section_key("Files") == "files"
+        assert _normalize_section_key("Impact Radius") == "impact_radius"
+        assert _normalize_section_key("Design Intent Alignment") == "design_intent_alignment"
 
     def test_normalize_section_key_display_lookup_is_case_insensitive(self) -> None:
         """The reverse display-value scan matches case-insensitively.
@@ -895,17 +898,15 @@ class TestSectionKeyRoundTripRegression:
         Regression guard: the parse-side lookup (github_sync._HEADING_TO_KEY,
         keyed by ``heading.lower()``) is case-insensitive in both directions,
         but the write-side reverse scan previously compared ``display == name``
-        exactly — so ``_normalize_section_key("Issue Classification")``
-        resolved to ``"issue_classification"`` while
-        ``_normalize_section_key("issue classification")`` fell through to
-        ``"unknown__issue_classification"``. "Issue Classification" (unlike
-        "RT-ICA"/"Fact-Check") has no entry in SECTION_HEADING_ALIAS, so this
-        exercises the reverse-scan branch specifically, not the alias-table
-        lookup that already normalises case via ``.lower()``.
+        exactly — so ``_normalize_section_key("Story")`` resolved to ``"story"``
+        while ``_normalize_section_key("story")`` fell through to
+        ``"unknown__story"``. Both casings of a registered display name must
+        resolve to the same canonical key.
         """
-        assert _normalize_section_key("Issue Classification") == "issue_classification"
-        assert _normalize_section_key("issue classification") == "issue_classification"
-        assert _normalize_section_key("ISSUE CLASSIFICATION") == "issue_classification"
+        assert _normalize_section_key("Story") == "story"
+        assert _normalize_section_key("story") == "story"
+        assert _normalize_section_key("STORY") == "story"
+        assert _normalize_section_key("rt-ica") == "rt_ica"
 
     def test_custom_section_write_then_github_round_trip_does_not_duplicate(self) -> None:
         """A locally-written custom section survives render+parse+merge under one key.

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -10,6 +10,7 @@ _PLUGIN_ROOT = Path(__file__).parent.parent
 if str(_PLUGIN_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_ROOT))
 
+from backlog_core import rendering as _rendering
 from backlog_core.github_sync import merge_item, parse_issue_body, render_issue_body
 from backlog_core.models import BacklogItem, Entry, GroomedData, Section
 from backlog_core.operations import _normalize_section_key
@@ -531,7 +532,9 @@ class TestParseIssueBodyUnknownHeading:
         """parse_issue_body preserves ## headings that are not in _HEADING_TO_KEY.
 
         Unknown headings must not raise and must be stored under ``unknown__``
-        prefixed keys so content is not silently dropped.
+        prefixed keys so content is not silently dropped. Uses headings
+        confirmed absent from ``rendering.SECTION_HEADING`` (unlike "Story" and
+        "Acceptance Criteria", which are registered canonical sections).
         """
         # Arrange
         body = (
@@ -541,8 +544,8 @@ class TestParseIssueBodyUnknownHeading:
             "status: open\n"
             "added: 2026-01-01\n"
             "-->\n\n"
-            "## Story\n\nAs a developer.\n\n"
-            "## Acceptance Criteria\n\n- [ ] Done\n"
+            "## Migration Steps\n\nAs a developer.\n\n"
+            "## Custom Analysis\n\n- [ ] Done\n"
         )
 
         # Act
@@ -550,10 +553,10 @@ class TestParseIssueBodyUnknownHeading:
 
         # Assert — no bare key; sections stored under unknown__ prefix
         assert isinstance(result, BacklogItem)
-        assert "story" not in result.sections
-        assert "acceptance_criteria" not in result.sections
-        assert "unknown__story" in result.sections
-        assert "unknown__acceptance_criteria" in result.sections
+        assert "migration_steps" not in result.sections
+        assert "custom_analysis" not in result.sections
+        assert "unknown__migration_steps" in result.sections
+        assert "unknown__custom_analysis" in result.sections
 
     def test_parse_issue_body_existing_carries_non_body_fields(self) -> None:
         """parse_issue_body with existing carries over title, issue, source, plan.
@@ -797,21 +800,23 @@ class TestUnknownSectionPreservation:
         An unknown section present after the first parse must still be present
         (same key, same entry count) after re-rendering and re-parsing.
         """
-        # First parse: build from raw markdown
+        # First parse: build from raw markdown. "Custom Analysis" is confirmed
+        # absent from rendering.SECTION_HEADING (unlike "Impact Radius", now
+        # registered), so this genuinely exercises the unknown__ fallback path.
         body = (
             "<!-- backlog-metadata:\n"
             "priority: P1\ntype: Feature\nstatus: open\nadded: 2026-01-01\n-->\n\n"
-            "## Impact Radius\n\n<div><sub>2026-03-01T00:00:00Z</sub>\n\nContent.\n</div>\n"
+            "## Custom Analysis\n\n<div><sub>2026-03-01T00:00:00Z</sub>\n\nContent.\n</div>\n"
         )
         first_parsed = parse_issue_body(body)
-        assert "unknown__impact_radius" in first_parsed.sections
+        assert "unknown__custom_analysis" in first_parsed.sections
 
         # Re-render then re-parse
         rendered = render_issue_body(first_parsed)
         second_parsed = parse_issue_body(rendered, first_parsed)
 
-        assert "unknown__impact_radius" in second_parsed.sections
-        sec = second_parsed.sections["unknown__impact_radius"]
+        assert "unknown__custom_analysis" in second_parsed.sections
+        sec = second_parsed.sections["unknown__custom_analysis"]
         assert isinstance(sec, Section)
         assert len(sec.entries) == 1
 
@@ -851,27 +856,41 @@ class TestSectionKeyRoundTripRegression:
     section under the ``unknown__`` prefix.
     """
 
-    def test_normalize_section_key_matches_parse_side_for_custom_names(self) -> None:
+    def test_normalize_section_key_matches_parse_side_for_unregistered_names(self) -> None:
         """_normalize_section_key produces the same key parse_issue_body would.
 
-        Reproduces the exact mismatch reported in #2956 at the unit level:
-        before the fix, ``_normalize_section_key("Files") == "Files"`` while
-        a GitHub round-trip of the same heading produced
-        ``"unknown__files"`` — two different dict keys for one section.
+        Reproduces the exact mismatch reported in #2956 at the unit level for
+        names deliberately NOT registered in ``rendering.SECTION_HEADING``:
+        before the fix, ``_normalize_section_key("Files") == "Files"`` while a
+        GitHub round-trip of the same heading produced ``"unknown__files"`` —
+        two different dict keys for one section. This proves the underlying
+        write-path/parse-path fix works for ANY unregistered name, not just
+        the specific ones later added to the registry as a display-quality
+        improvement (see the next test).
         """
         for display_name, expected_key in [
-            ("Files", "unknown__files"),
-            ("Impact Radius", "unknown__impact_radius"),
-            ("Resources", "unknown__resources"),
-            ("Design Intent Alignment", "unknown__design_intent_alignment"),
+            ("Custom Analysis", "unknown__custom_analysis"),
+            ("Migration Steps", "unknown__migration_steps"),
+            ("Root Cause Investigation Notes", "unknown__root_cause_investigation_notes"),
         ]:
             assert _normalize_section_key(display_name) == expected_key
 
-    def test_normalize_section_key_still_resolves_canonical_aliases(self) -> None:
-        """Canonical sections (RT-ICA, Fact-Check, Issue Classification) are unaffected."""
+    def test_normalize_section_key_resolves_registered_display_names(self) -> None:
+        """Sections registered in SECTION_HEADING resolve to their clean canonical key.
+
+        Canonical sections (the original 3, plus the commonly-observed set
+        added for #2956/#2964 — see rendering.SECTION_HEADING) resolve to a
+        clean snake_case key instead of falling through to the unknown__
+        fallback. This is a display-quality property (storage key cleanliness),
+        not the correctness fix — see the previous test for the property that
+        actually prevents data loss, which holds regardless of registration.
+        """
         assert _normalize_section_key("RT-ICA") == "rt_ica"
         assert _normalize_section_key("Fact-Check") == "fact_check"
         assert _normalize_section_key("Issue Classification") == "issue_classification"
+        assert _normalize_section_key("Files") == "files"
+        assert _normalize_section_key("Impact Radius") == "impact_radius"
+        assert _normalize_section_key("Design Intent Alignment") == "design_intent_alignment"
 
     def test_custom_section_write_then_github_round_trip_does_not_duplicate(self) -> None:
         """A locally-written custom section survives render+parse+merge under one key.
@@ -889,6 +908,34 @@ class TestSectionKeyRoundTripRegression:
         merged = merge_item(item, remote)
 
         assert list(merged.sections.keys()) == [key]
+
+    def test_unregistered_section_write_then_github_round_trip_preserves_content(self) -> None:
+        """A section name NOT in SECTION_HEADING still round-trips losslessly.
+
+        Explicit demonstration (requested for #2956/#2964) that the fix is a
+        general write-path/parse-path key-derivation guarantee, not something
+        that only works for the specific names later added to
+        rendering.SECTION_HEADING as a display-quality improvement. Uses
+        "Root Cause Investigation Notes" — confirmed absent from
+        SECTION_HEADING — for both the key AND the content round trip.
+        """
+        heading = "Root Cause Investigation Notes"
+        key = _normalize_section_key(heading)
+        assert key not in _rendering.SECTION_HEADING, f"{heading!r} must stay unregistered for this test to be valid"
+
+        content = "The root cause was traced to a stale cache entry."
+        item = _make_item(sections={key: Section(entries=[Entry(id="2026-01-01T00:00:00Z", content=content)])})
+
+        rendered = render_issue_body(item)
+        assert "## Root Cause Investigation Notes" in rendered
+        remote = parse_issue_body(rendered, item)
+        merged = merge_item(item, remote)
+
+        assert list(merged.sections.keys()) == [key]
+        sec = merged.sections[key]
+        assert isinstance(sec, Section)
+        assert len(sec.entries) == 1
+        assert sec.entries[0].content == content
 
     def test_fact_checker_verdict_with_embedded_claim_headings_stays_one_section(self) -> None:
         """A Fact-Check verdict quoting per-claim '## Claim N' headings does not fragment.

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -12,6 +12,8 @@ if str(_PLUGIN_ROOT) not in sys.path:
 
 from backlog_core.github_sync import merge_item, parse_issue_body, render_issue_body
 from backlog_core.models import BacklogItem, Entry, GroomedData, Section
+from backlog_core.operations import _normalize_section_key
+from backlog_core.parsing import extract_sections
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -830,3 +832,112 @@ class TestUnknownSectionPreservation:
         # Space-separated key must not appear
         assert "my_custom_section" not in result.sections
         assert "unknown__my_custom_section" in result.sections
+
+
+# ---------------------------------------------------------------------------
+# Regression: #2956 — local-write / GitHub-parse key-space mismatch
+# ---------------------------------------------------------------------------
+
+
+class TestSectionKeyRoundTripRegression:
+    """#2956: local writes and GitHub-parsed sections must converge on one key.
+
+    Before the fix, ``operations._normalize_section_key`` passed unrecognised
+    section names through verbatim (e.g. ``"Files"``) while
+    ``github_sync.parse_issue_body`` normalised the same heading, once parsed
+    back from a rendered GitHub body, to ``"unknown__files"``. The two keys
+    never collided, so every groom + reconcile cycle accumulated a duplicate
+    section under the ``unknown__`` prefix.
+    """
+
+    def test_normalize_section_key_matches_parse_side_for_custom_names(self) -> None:
+        """_normalize_section_key produces the same key parse_issue_body would.
+
+        Reproduces the exact mismatch reported in #2956 at the unit level:
+        before the fix, ``_normalize_section_key("Files") == "Files"`` while
+        a GitHub round-trip of the same heading produced
+        ``"unknown__files"`` — two different dict keys for one section.
+        """
+        for display_name, expected_key in [
+            ("Files", "unknown__files"),
+            ("Impact Radius", "unknown__impact_radius"),
+            ("Resources", "unknown__resources"),
+            ("Design Intent Alignment", "unknown__design_intent_alignment"),
+        ]:
+            assert _normalize_section_key(display_name) == expected_key
+
+    def test_normalize_section_key_still_resolves_canonical_aliases(self) -> None:
+        """Canonical sections (RT-ICA, Fact-Check, Issue Classification) are unaffected."""
+        assert _normalize_section_key("RT-ICA") == "rt_ica"
+        assert _normalize_section_key("Fact-Check") == "fact_check"
+        assert _normalize_section_key("Issue Classification") == "issue_classification"
+
+    def test_custom_section_write_then_github_round_trip_does_not_duplicate(self) -> None:
+        """A locally-written custom section survives render+parse+merge under one key.
+
+        End-to-end reproduction of the #2956 duplication: write "Files" via the
+        same normalisation `backlog_groom` uses, render to a GitHub body, parse
+        that body back (simulating a reconcile), and merge. Only one section
+        key must exist afterward.
+        """
+        key = _normalize_section_key("Files")
+        item = _make_item(sections={key: Section(entries=[Entry(id="2026-01-01T00:00:00Z", content="src/app.py")])})
+
+        rendered = render_issue_body(item)
+        remote = parse_issue_body(rendered, item)
+        merged = merge_item(item, remote)
+
+        assert list(merged.sections.keys()) == [key]
+
+    def test_fact_checker_verdict_with_embedded_claim_headings_stays_one_section(self) -> None:
+        """A Fact-Check verdict quoting per-claim '## Claim N' headings does not fragment.
+
+        Reproduces the #2956 per-claim fragmentation: a fact-checker verdict
+        legitimately embeds ``## Claim N: "..."`` headings inside its own
+        content. Before the fix, ``extract_sections`` could not tell those
+        apart from real section boundaries, so a GitHub round-trip shattered
+        one Fact-Check entry into N spurious ``unknown__claim_n...`` sections.
+        """
+        key = _normalize_section_key("Fact-Check")
+        verdict = (
+            '## Claim 1: "some claim"\n\nVERDICT: VERIFIED\n\n---\n\n## Claim 2: "another claim"\n\nVERDICT: REFUTED'
+        )
+        item = _make_item(sections={key: Section(entries=[Entry(id="2026-01-01T00:00:00Z", content=verdict)])})
+
+        rendered = render_issue_body(item)
+        remote = parse_issue_body(rendered, item)
+        merged = merge_item(item, remote)
+
+        assert list(merged.sections.keys()) == [key]
+        sec = merged.sections[key]
+        assert isinstance(sec, Section)
+        assert len(sec.entries) == 1
+        assert "Claim 1" in sec.entries[0].content
+        assert "Claim 2" in sec.entries[0].content
+
+
+class TestExtractSectionsEntryBoundary:
+    """#2956: extract_sections must not split on '## ' lines inside an entry div."""
+
+    def test_embedded_heading_inside_entry_div_is_not_a_new_section(self) -> None:
+        """A '## ' line inside <div>...</div> entry content stays part of the section."""
+        body = (
+            "## Fact-Check\n\n"
+            "<div><sub>2026-01-01T00:00:00Z</sub>\n\n"
+            '## Claim 1: "something"\n\nVERDICT: VERIFIED\n'
+            "</div>\n"
+        )
+        sections = extract_sections(body)
+        assert list(sections.keys()) == ["## Fact-Check"]
+        assert 'Claim 1: "something"' in sections["## Fact-Check"]
+
+    def test_heading_after_entry_div_closes_is_still_a_new_section(self) -> None:
+        """A '## ' line after the entry div closes is correctly treated as a boundary."""
+        body = (
+            "## Fact-Check\n\n"
+            "<div><sub>2026-01-01T00:00:00Z</sub>\n\ncontent\n</div>\n\n"
+            "## Resources\n\n"
+            "<div><sub>2026-01-01T00:00:01Z</sub>\n\nmore content\n</div>\n"
+        )
+        sections = extract_sections(body)
+        assert set(sections.keys()) == {"## Fact-Check", "## Resources"}

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -892,6 +892,22 @@ class TestSectionKeyRoundTripRegression:
         assert _normalize_section_key("Impact Radius") == "impact_radius"
         assert _normalize_section_key("Design Intent Alignment") == "design_intent_alignment"
 
+    def test_normalize_section_key_display_lookup_is_case_insensitive(self) -> None:
+        """The reverse display-value scan matches case-insensitively.
+
+        Regression guard: the parse-side lookup (github_sync._HEADING_TO_KEY,
+        keyed by ``heading.lower()``) is case-insensitive in both directions,
+        but the write-side reverse scan previously compared ``display == name``
+        exactly — so ``_normalize_section_key("Story")`` resolved to ``"story"``
+        while ``_normalize_section_key("story")`` fell through to
+        ``"unknown__story"``. Both casings of a registered display name must
+        resolve to the same canonical key.
+        """
+        assert _normalize_section_key("Story") == "story"
+        assert _normalize_section_key("story") == "story"
+        assert _normalize_section_key("STORY") == "story"
+        assert _normalize_section_key("rt-ica") == "rt_ica"
+
     def test_custom_section_write_then_github_round_trip_does_not_duplicate(self) -> None:
         """A locally-written custom section survives render+parse+merge under one key.
 

--- a/plugins/development-harness/tests/test_scenarios.py
+++ b/plugins/development-harness/tests/test_scenarios.py
@@ -352,8 +352,10 @@ class TestGroomBacklogItem:
 
         assert result["groomed_updated"] is True
         stored = _stored_item("Groom Section Test")
-        assert "Reproducibility" in stored.sections
-        assert stored.sections["Reproducibility"].entries[-1].content == "Steps to reproduce the issue."
+        # "Reproducibility" is not a canonical section name (see rendering.SECTION_HEADING), so
+        # it is stored under its normalised unknown-section key.
+        assert "unknown__reproducibility" in stored.sections
+        assert stored.sections["unknown__reproducibility"].entries[-1].content == "Steps to reproduce the issue."
         assert isinstance(result["messages"], list)
         assert isinstance(result["warnings"], list)
         assert isinstance(result["errors"], list)

--- a/plugins/development-harness/tests/test_scenarios.py
+++ b/plugins/development-harness/tests/test_scenarios.py
@@ -352,10 +352,9 @@ class TestGroomBacklogItem:
 
         assert result["groomed_updated"] is True
         stored = _stored_item("Groom Section Test")
-        # "Reproducibility" is not a canonical section name (see rendering.SECTION_HEADING), so
-        # it is stored under its normalised unknown-section key.
-        assert "unknown__reproducibility" in stored.sections
-        assert stored.sections["unknown__reproducibility"].entries[-1].content == "Steps to reproduce the issue."
+        # "Reproducibility" is a canonical section name (see rendering.SECTION_HEADING).
+        assert "reproducibility" in stored.sections
+        assert stored.sections["reproducibility"].entries[-1].content == "Steps to reproduce the issue."
         assert isinstance(result["messages"], list)
         assert isinstance(result["warnings"], list)
         assert isinstance(result["errors"], list)

--- a/plugins/development-harness/tests/test_scenarios.py
+++ b/plugins/development-harness/tests/test_scenarios.py
@@ -352,9 +352,10 @@ class TestGroomBacklogItem:
 
         assert result["groomed_updated"] is True
         stored = _stored_item("Groom Section Test")
-        # "Reproducibility" is a canonical section name (see rendering.SECTION_HEADING).
-        assert "reproducibility" in stored.sections
-        assert stored.sections["reproducibility"].entries[-1].content == "Steps to reproduce the issue."
+        # "Reproducibility" is not a canonical section name (see rendering.SECTION_HEADING), so
+        # it is stored under its normalised unknown-section key.
+        assert "unknown__reproducibility" in stored.sections
+        assert stored.sections["unknown__reproducibility"].entries[-1].content == "Steps to reproduce the issue."
         assert isinstance(result["messages"], list)
         assert isinstance(result["warnings"], list)
         assert isinstance(result["errors"], list)

--- a/plugins/development-harness/tests/test_yaml_io.py
+++ b/plugins/development-harness/tests/test_yaml_io.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import warnings
 from pathlib import Path
 
+import backlog_core.operations as ops
 import pytest
 from backlog_core.models import BacklogItem, Entry, GroomedData, Section
 from backlog_core.yaml_io import detect_format, load_item, load_item_text, save_item
@@ -319,17 +320,17 @@ class TestLoadItemYaml:
         assert struck.struck_at == "2026-02-02T14:00:00Z"
 
     def test_load_item_folds_legacy_unknown_key_into_now_canonical_key(self, tmp_path: Path) -> None:
-        """load_item folds a legacy ``unknown__issue_classification`` key into ``issue_classification``.
+        """load_item folds a legacy ``unknown__story`` key into ``story``.
 
-        Regression guard for #2956 follow-up: a cache file written before a
-        name was registered in SECTION_HEADING stores it as an ``unknown__``
-        key. Loading it must expose the canonical key so a subsequent merge
-        against a freshly-parsed GitHub body (which always produces the
-        canonical key) collides on one key instead of rendering the section
-        twice.
+        Regression guard for #2956 follow-up: a cache file written before
+        "Story" was registered in SECTION_HEADING stored it as
+        ``unknown__story``. Loading it must expose the canonical ``story``
+        key so a subsequent merge against a freshly-parsed GitHub body (which
+        always produces ``story``) collides on one key instead of rendering
+        the section twice.
         """
         # Arrange
-        item = BacklogItem(sections={"unknown__issue_classification": Section(entries=[])})
+        item = BacklogItem(sections={"unknown__story": Section(entries=[])})
         dest = tmp_path / "item.yaml"
         save_item(item, dest)
 
@@ -337,8 +338,8 @@ class TestLoadItemYaml:
         result = load_item(dest)
 
         # Assert
-        assert "issue_classification" in result.sections
-        assert "unknown__issue_classification" not in result.sections
+        assert "story" in result.sections
+        assert "unknown__story" not in result.sections
 
     def test_load_item_leaves_genuinely_unknown_key_unchanged(self, tmp_path: Path) -> None:
         """load_item does not rename an ``unknown__`` key that is still uncanonical.
@@ -359,7 +360,7 @@ class TestLoadItemYaml:
         assert "unknown__custom_analysis" in result.sections
 
     def test_load_item_merges_entries_when_both_legacy_and_canonical_keys_present(self, tmp_path: Path) -> None:
-        """load_item merges entries when both ``unknown__issue_classification`` and ``issue_classification`` exist.
+        """load_item merges entries when both ``unknown__story`` and ``story`` exist.
 
         A manually edited or partially migrated cache file could contain both
         keys for the same section; folding must not silently drop entries
@@ -368,10 +369,8 @@ class TestLoadItemYaml:
         # Arrange
         item = BacklogItem(
             sections={
-                "unknown__issue_classification": Section(
-                    entries=[Entry(id="2026-01-01T00:00:00", content="legacy entry")]
-                ),
-                "issue_classification": Section(entries=[Entry(id="2026-01-02T00:00:00", content="canonical entry")]),
+                "unknown__story": Section(entries=[Entry(id="2026-01-01T00:00:00", content="legacy entry")]),
+                "story": Section(entries=[Entry(id="2026-01-02T00:00:00", content="canonical entry")]),
             }
         )
         dest = tmp_path / "item.yaml"
@@ -381,9 +380,82 @@ class TestLoadItemYaml:
         result = load_item(dest)
 
         # Assert
-        sec = result.sections["issue_classification"]
+        sec = result.sections["story"]
         assert isinstance(sec, Section)
         assert {e.content for e in sec.entries} == {"legacy entry", "canonical entry"}
+
+
+class TestLoadItemFoldingCoversRealBacklogViewConsumers:
+    """load_item's fold-on-read is what ``view_item``'s real consumers actually observe.
+
+    Regression guard for the round-2 #2964 review retraction: `groom-drift.md`
+    (Mode B, line ~81-83) and `feasibility-gate.md` (line ~23) both call
+    ``backlog view --selector "{title}"`` — a title selector, which makes
+    ``parse_issue_selector`` return ``None`` so GitHub-body enrichment never
+    runs (confirmed by tracing ``operations.view_item``). For that code path,
+    ``ViewItemResult.sections`` is built by
+    ``operations._build_sections_from_yaml_item``, which echoes the raw
+    in-memory ``BacklogItem.sections`` keys verbatim — the same snake_case/
+    ``unknown__`` keys ``load_item`` produces, never a Title-Case display
+    string. These tests chain the two real functions (``load_item`` then
+    ``_build_sections_from_yaml_item``) to prove the property that matters:
+    a stale ``unknown__impact_radius``/``unknown__files``/``unknown__priority``
+    cache entry (from before these names were registered) resolves to the
+    clean ``impact_radius``/``files``/``priority`` key after this PR — the
+    same key a freshly-groomed item produces — rather than staying invisible
+    under the pre-registration ``unknown__`` key.
+    """
+
+    def test_stale_impact_radius_and_files_keys_resolve_after_load(self, tmp_path: Path) -> None:
+        """A stale unknown__impact_radius/unknown__files cache resolves to canonical keys.
+
+        This is the exact scenario groom-drift.md's Mode B depends on: it
+        reads ``sections["Impact Radius"]``/``sections["Files"]`` from a
+        title-selector ``backlog view`` call against a locally-groomed item.
+        """
+        # Arrange
+        item = BacklogItem(
+            title="Groom Drift Consumer Check",
+            sections={
+                "unknown__impact_radius": Section(entries=[Entry(id="2026-01-01T00:00:00", content="plugins/foo.py")]),
+                "unknown__files": Section(entries=[Entry(id="2026-01-01T00:00:01", content="plugins/bar.py")]),
+            },
+        )
+        dest = tmp_path / "item.yaml"
+        save_item(item, dest)
+
+        # Act
+        loaded = load_item(dest)
+        result_sections = ops._build_sections_from_yaml_item(loaded)
+
+        # Assert
+        assert "impact_radius" in result_sections
+        assert "files" in result_sections
+        assert "unknown__impact_radius" not in result_sections
+        assert "unknown__files" not in result_sections
+
+    def test_stale_priority_key_resolves_after_load(self, tmp_path: Path) -> None:
+        """A stale unknown__priority cache resolves to the canonical ``priority`` key.
+
+        This is the exact scenario feasibility-gate.md line ~23 depends on: a
+        BLOCKED effort/priority-mismatch check reads ``sections['Priority']``
+        from a title-selector ``backlog view`` call.
+        """
+        # Arrange
+        item = BacklogItem(
+            title="Feasibility Gate Consumer Check",
+            sections={"unknown__priority": Section(entries=[Entry(id="2026-01-01T00:00:00", content="P1")])},
+        )
+        dest = tmp_path / "item.yaml"
+        save_item(item, dest)
+
+        # Act
+        loaded = load_item(dest)
+        result_sections = ops._build_sections_from_yaml_item(loaded)
+
+        # Assert
+        assert "priority" in result_sections
+        assert "unknown__priority" not in result_sections
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests/test_yaml_io.py
+++ b/plugins/development-harness/tests/test_yaml_io.py
@@ -11,7 +11,7 @@ import warnings
 from pathlib import Path
 
 import pytest
-from backlog_core.models import BacklogItem, GroomedData, Section
+from backlog_core.models import BacklogItem, Entry, GroomedData, Section
 from backlog_core.yaml_io import detect_format, load_item, load_item_text, save_item
 
 # ---------------------------------------------------------------------------
@@ -317,6 +317,71 @@ class TestLoadItemYaml:
         assert isinstance(sec, Section)
         struck = next(e for e in sec.entries if e.struck)
         assert struck.struck_at == "2026-02-02T14:00:00Z"
+
+    def test_load_item_folds_legacy_unknown_key_into_now_canonical_key(self, tmp_path: Path) -> None:
+        """load_item folds a legacy ``unknown__story`` key into ``story``.
+
+        Regression guard for #2956 follow-up: a cache file written before
+        "Story" was registered in SECTION_HEADING stored it as
+        ``unknown__story``. Loading it must expose the canonical ``story``
+        key so a subsequent merge against a freshly-parsed GitHub body (which
+        always produces ``story``) collides on one key instead of rendering
+        the section twice.
+        """
+        # Arrange
+        item = BacklogItem(sections={"unknown__story": Section(entries=[])})
+        dest = tmp_path / "item.yaml"
+        save_item(item, dest)
+
+        # Act
+        result = load_item(dest)
+
+        # Assert
+        assert "story" in result.sections
+        assert "unknown__story" not in result.sections
+
+    def test_load_item_leaves_genuinely_unknown_key_unchanged(self, tmp_path: Path) -> None:
+        """load_item does not rename an ``unknown__`` key that is still uncanonical.
+
+        Only keys that have since been registered in SECTION_HEADING are
+        folded — a custom section name with no canonical entry must survive
+        unchanged.
+        """
+        # Arrange
+        item = BacklogItem(sections={"unknown__custom_analysis": Section(entries=[])})
+        dest = tmp_path / "item.yaml"
+        save_item(item, dest)
+
+        # Act
+        result = load_item(dest)
+
+        # Assert
+        assert "unknown__custom_analysis" in result.sections
+
+    def test_load_item_merges_entries_when_both_legacy_and_canonical_keys_present(self, tmp_path: Path) -> None:
+        """load_item merges entries when both ``unknown__story`` and ``story`` exist.
+
+        A manually edited or partially migrated cache file could contain both
+        keys for the same section; folding must not silently drop entries
+        from either side.
+        """
+        # Arrange
+        item = BacklogItem(
+            sections={
+                "unknown__story": Section(entries=[Entry(id="2026-01-01T00:00:00", content="legacy entry")]),
+                "story": Section(entries=[Entry(id="2026-01-02T00:00:00", content="canonical entry")]),
+            }
+        )
+        dest = tmp_path / "item.yaml"
+        save_item(item, dest)
+
+        # Act
+        result = load_item(dest)
+
+        # Assert
+        sec = result.sections["story"]
+        assert isinstance(sec, Section)
+        assert {e.content for e in sec.entries} == {"legacy entry", "canonical entry"}
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests/test_yaml_io.py
+++ b/plugins/development-harness/tests/test_yaml_io.py
@@ -319,17 +319,17 @@ class TestLoadItemYaml:
         assert struck.struck_at == "2026-02-02T14:00:00Z"
 
     def test_load_item_folds_legacy_unknown_key_into_now_canonical_key(self, tmp_path: Path) -> None:
-        """load_item folds a legacy ``unknown__story`` key into ``story``.
+        """load_item folds a legacy ``unknown__issue_classification`` key into ``issue_classification``.
 
-        Regression guard for #2956 follow-up: a cache file written before
-        "Story" was registered in SECTION_HEADING stored it as
-        ``unknown__story``. Loading it must expose the canonical ``story``
-        key so a subsequent merge against a freshly-parsed GitHub body (which
-        always produces ``story``) collides on one key instead of rendering
-        the section twice.
+        Regression guard for #2956 follow-up: a cache file written before a
+        name was registered in SECTION_HEADING stores it as an ``unknown__``
+        key. Loading it must expose the canonical key so a subsequent merge
+        against a freshly-parsed GitHub body (which always produces the
+        canonical key) collides on one key instead of rendering the section
+        twice.
         """
         # Arrange
-        item = BacklogItem(sections={"unknown__story": Section(entries=[])})
+        item = BacklogItem(sections={"unknown__issue_classification": Section(entries=[])})
         dest = tmp_path / "item.yaml"
         save_item(item, dest)
 
@@ -337,8 +337,8 @@ class TestLoadItemYaml:
         result = load_item(dest)
 
         # Assert
-        assert "story" in result.sections
-        assert "unknown__story" not in result.sections
+        assert "issue_classification" in result.sections
+        assert "unknown__issue_classification" not in result.sections
 
     def test_load_item_leaves_genuinely_unknown_key_unchanged(self, tmp_path: Path) -> None:
         """load_item does not rename an ``unknown__`` key that is still uncanonical.
@@ -359,7 +359,7 @@ class TestLoadItemYaml:
         assert "unknown__custom_analysis" in result.sections
 
     def test_load_item_merges_entries_when_both_legacy_and_canonical_keys_present(self, tmp_path: Path) -> None:
-        """load_item merges entries when both ``unknown__story`` and ``story`` exist.
+        """load_item merges entries when both ``unknown__issue_classification`` and ``issue_classification`` exist.
 
         A manually edited or partially migrated cache file could contain both
         keys for the same section; folding must not silently drop entries
@@ -368,8 +368,10 @@ class TestLoadItemYaml:
         # Arrange
         item = BacklogItem(
             sections={
-                "unknown__story": Section(entries=[Entry(id="2026-01-01T00:00:00", content="legacy entry")]),
-                "story": Section(entries=[Entry(id="2026-01-02T00:00:00", content="canonical entry")]),
+                "unknown__issue_classification": Section(
+                    entries=[Entry(id="2026-01-01T00:00:00", content="legacy entry")]
+                ),
+                "issue_classification": Section(entries=[Entry(id="2026-01-02T00:00:00", content="canonical entry")]),
             }
         )
         dest = tmp_path / "item.yaml"
@@ -379,7 +381,7 @@ class TestLoadItemYaml:
         result = load_item(dest)
 
         # Assert
-        sec = result.sections["story"]
+        sec = result.sections["issue_classification"]
         assert isinstance(sec, Section)
         assert {e.content for e in sec.entries} == {"legacy entry", "canonical entry"}
 

--- a/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
+++ b/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
@@ -216,8 +216,9 @@ def test_batch_grooming_reconciles_once(sync_provider) -> None:
     written = _handle_batch_groomed(item, {"Plan": "First", "Research": "Second"}, repo="unused")
 
     # Then: one targeted reconciliation covers the complete backend-owned mutation
-    # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
-    assert written == ["unknown__plan", "unknown__research"]
+    # "Plan" is not a canonical section name, so it normalises to an unknown__ key.
+    # "Research" IS canonical (see rendering.SECTION_HEADING).
+    assert written == ["unknown__plan", "research"]
     assert sync_provider.requests == [ReconcileRequest(scope=ReconcileScope.TARGETED, references=["#7"])]
 
 

--- a/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
+++ b/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
@@ -216,9 +216,8 @@ def test_batch_grooming_reconciles_once(sync_provider) -> None:
     written = _handle_batch_groomed(item, {"Plan": "First", "Research": "Second"}, repo="unused")
 
     # Then: one targeted reconciliation covers the complete backend-owned mutation
-    # "Plan" is not a canonical section name, so it normalises to an unknown__ key.
-    # "Research" IS canonical (see rendering.SECTION_HEADING).
-    assert written == ["unknown__plan", "research"]
+    # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
+    assert written == ["unknown__plan", "unknown__research"]
     assert sync_provider.requests == [ReconcileRequest(scope=ReconcileScope.TARGETED, references=["#7"])]
 
 

--- a/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
+++ b/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
@@ -216,7 +216,8 @@ def test_batch_grooming_reconciles_once(sync_provider) -> None:
     written = _handle_batch_groomed(item, {"Plan": "First", "Research": "Second"}, repo="unused")
 
     # Then: one targeted reconciliation covers the complete backend-owned mutation
-    assert written == ["Plan", "Research"]
+    # "Plan"/"Research" are not canonical section names, so they normalise to unknown__ keys.
+    assert written == ["unknown__plan", "unknown__research"]
     assert sync_provider.requests == [ReconcileRequest(scope=ReconcileScope.TARGETED, references=["#7"])]
 
 


### PR DESCRIPTION
## Summary
- `operations._normalize_section_key` passed unrecognized section names through verbatim on write (e.g. `"Files"`), while `github_sync.parse_issue_body` normalized the same heading, once parsed back from a rendered GitHub body, to `"unknown__files"` — two different dict keys for the same section survived every merge, accumulating `unknown__` duplicates on every groom + reconcile cycle.
- Fixed by moving `heading_to_unknown_key` into `rendering.py` (the shared, backend-neutral module already hosting its inverse, `unknown_key_to_heading`) and routing `_normalize_section_key`'s fallback through it, so local writes and GitHub-parsed sections now converge on one key.
- Separately, `parsing.extract_sections` treated any `## ` line as a new section boundary even inside an entry's `<div>...</div>` content — a fact-checker verdict legitimately quoting `## Claim N: "..."` per claim shattered one `Fact-Check` entry into several spurious `unknown__claim_n...` sections on a GitHub round-trip. Fixed by tracking `<div>` nesting depth and only treating `## ` as a boundary at depth 0.
- Updated 9 existing test assertions across 5 test files that encoded the old, buggy verbatim-key expectation (e.g. `"Plan"` instead of the now-correct `"unknown__plan"`) — each individually verified via `git stash` to be a pre-existing-behavior assertion, not a new regression.
- Filed two new backlog items for issues discovered but out of scope for this PR: #2962 (a separate, pre-existing raw-key-exposure bug in `view_item`'s YAML-fallback display path, reproducible on unmodified `main`) and #2963 (the GitHub issue-body reconcile pending-mutation drain defect, confirmed architecturally distinct from this fix).

## Root cause
Two independent normalizers for "unknown" section names — one on the local-write path, one on the GitHub-parse path — disagreed on the storage key for identical section names, so a local write and its own GitHub round-trip never matched during merge.

## Test plan
- [x] Reproduced both defects directly against real corrupted cache content for issue #2953 (read-only) before fixing
- [x] Added permanent regression tests: `TestSectionKeyRoundTripRegression`, `TestExtractSectionsEntryBoundary` in `plugins/development-harness/tests/test_github_sync.py`
- [x] Re-ran the exact same reproductions after the fix — all pass
- [x] Validated against the live backlog MCP server (not just pytest) per AGENTS.md — `backlog_groom` + `backlog_view` round-trip on a throwaway scratch item shows a single `Files` section, no `unknown__files` duplicate
- [x] Full suite: `uv run pytest plugins/development-harness/tests plugins/development-harness/backlog_core/tests plugins/development-harness/tests_backlog` — 3605 passed, 1 pre-existing unrelated failure (`test_github_content_provider_replay_preserves_concurrent_remote_revision`, backlog #2922)
- [x] `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` clean on touched files

Fixes #2956

🤖 Generated with [Claude Code](https://claude.com/claude-code)