### PR TITLE
fix(development-harness): view_item YAML-fallback shows display titles, not raw section keys

### DIFF
--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1996,6 +1996,12 @@ def _build_sections_from_yaml_item(item: BacklogItem) -> dict[str, SectionEntryM
     for sec_name, sec_data in item.sections.items():
         if isinstance(sec_data, GroomedData):
             title = _section_display_title(sec_name, sec_data.date)
+            if title in result:
+                msg = (
+                    f"_build_sections_from_yaml_item collision: display title {title!r} already "
+                    f"holds a non-groomed section; cannot merge GroomedData into it"
+                )
+                raise TypeError(msg)
             result[title] = GroomedSectionMetadata(type="groomed", date=sec_data.date, subsections=sec_data.subsections)
         elif isinstance(sec_data, Section):
             entries = sec_data.entries
@@ -2005,7 +2011,17 @@ def _build_sections_from_yaml_item(item: BacklogItem) -> dict[str, SectionEntryM
             active_count = sum(1 for e in entries if not e.struck)
             struck_count = sum(1 for e in entries if e.struck)
             title = _section_display_title(sec_name)
-            result[title] = _SectionMetadata(num_entries=active_count, num_struck=struck_count, entries=entry_dicts)
+            if title in result:
+                existing = result[title]
+                if not _is_section_entry_metadata(existing):
+                    msg = (
+                        f"_build_sections_from_yaml_item collision: display title {title!r} already "
+                        f"holds a GroomedData section; cannot merge a Section into it"
+                    )
+                    raise TypeError(msg)
+                result[title] = _merge_section_entries(existing, entry_dicts)
+            else:
+                result[title] = _SectionMetadata(num_entries=active_count, num_struck=struck_count, entries=entry_dicts)
     return result
 
 

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1977,20 +1977,26 @@ def _build_sections_from_yaml_item(item: BacklogItem) -> dict[str, SectionEntryM
     Used when the item has no raw markdown body (i.e. it was created as a ``.yaml``
     file) but its ``sections`` field carries structured ``Section`` objects.
 
+    Keys are display titles (via :func:`_section_display_title`), not the raw
+    storage keys in ``item.sections`` — a canonical section is stored under a
+    snake_case key (e.g. ``"rt_ica"``) and a custom one under an ``unknown__``
+    key (e.g. ``"unknown__decision"``); callers of this function (``view_item``'s
+    YAML-only fallback path) expect the same human-readable names that the
+    GitHub-body and ``## Sections`` index paths already show (#2962).
+
     Args:
         item: The BacklogItem whose sections to convert.
 
     Returns:
-        Mapping of section name to entry metadata.  ``Section`` entries follow the
+        Mapping of display title to entry metadata.  ``Section`` entries follow the
         :class:`SectionEntryMetadata` shape.  ``GroomedData`` entries follow the
         :class:`GroomedSectionMetadata` shape (``"type": "groomed"`` discriminator).
     """
     result: dict[str, SectionEntryMetadata | GroomedSectionMetadata] = {}
     for sec_name, sec_data in item.sections.items():
         if isinstance(sec_data, GroomedData):
-            result[sec_name] = GroomedSectionMetadata(
-                type="groomed", date=sec_data.date, subsections=sec_data.subsections
-            )
+            title = _section_display_title(sec_name, sec_data.date)
+            result[title] = GroomedSectionMetadata(type="groomed", date=sec_data.date, subsections=sec_data.subsections)
         elif isinstance(sec_data, Section):
             entries = sec_data.entries
             entry_dicts: list[SectionEntryDict] = [
@@ -1998,7 +2004,8 @@ def _build_sections_from_yaml_item(item: BacklogItem) -> dict[str, SectionEntryM
             ]
             active_count = sum(1 for e in entries if not e.struck)
             struck_count = sum(1 for e in entries if e.struck)
-            result[sec_name] = _SectionMetadata(num_entries=active_count, num_struck=struck_count, entries=entry_dicts)
+            title = _section_display_title(sec_name)
+            result[title] = _SectionMetadata(num_entries=active_count, num_struck=struck_count, entries=entry_dicts)
     return result
 
 

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -3157,6 +3157,61 @@ class TestViewItemUnknownSections:
         assert unknown_meta["num_entries"] == 2
         assert len(unknown_meta["entries"]) == 2
 
+    def test_display_title_collision_merges_instead_of_overwriting(self, mocker: MockerFixture) -> None:
+        """Two raw storage keys that display-title-collide are merged, not silently dropped.
+
+        Tests: _build_sections_from_yaml_item merges same-titled sections (mirroring
+               _build_sections_metadata's collision handling) instead of the second
+               entry overwriting the first in the result dict.
+        How: Write a YAML item with "unknown__issue_classification" (a custom section
+             that title-cases to "Issue Classification") and "issue_classification"
+             (the canonical section, same display title) as two distinct raw storage
+             keys. Both are guaranteed-unique storage keys but collide once passed
+             through _section_display_title. Call view_item and assert both sections'
+             entries are present under the single "Issue Classification" key.
+        Why: Before this fix, the second section silently overwrote the first in the
+             result dict — no error, no warning, entries from one section vanished.
+        """
+        import backlog_core.models as _m
+        from backlog_core.models import Entry, Section
+
+        mocker.patch("backlog_core.operations.view_enrich_from_github", return_value=False)
+
+        backlog_dir = _m.get_backlog_dir()
+        filepath = backlog_dir / "p1-collision-item.yaml"
+
+        metadata = _m.BacklogItemMetadata(
+            source="test", added="2026-01-01", priority="P1", status="open", topic="collision-item"
+        )
+        item = _m.BacklogItem(
+            title="Collision Item",
+            description="Test display-title collision between distinct storage keys",
+            metadata=metadata,
+            file_path=str(filepath),
+            sections={
+                "unknown__issue_classification": Section(
+                    entries=[Entry(id="20260101T180000", content="Custom classification note")]
+                ),
+                "issue_classification": Section(
+                    entries=[Entry(id="20260101T180001", content="Canonical classification note")]
+                ),
+            },
+        )
+        _seed_items([item])
+
+        # Act
+        result = view_item("Collision Item")
+
+        # Assert: both sections' entries survive under the single collided display title
+        assert "Issue Classification" in result.sections
+        merged = cast("SectionEntryMetadata", result.sections["Issue Classification"])
+        contents = [e["content"] for e in merged["entries"]]
+        assert "Custom classification note" in contents, f"First section's content lost to overwrite, got: {contents}"
+        assert "Canonical classification note" in contents, (
+            f"Second section's content lost to overwrite, got: {contents}"
+        )
+        assert merged["num_entries"] == 2
+
 
 # ---------------------------------------------------------------------------
 # _rename_item_title — beads nanoid safe-skip (issue #2665)

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -1244,6 +1244,35 @@ class TestViewItem:
         assert decision["num_entries"] == 2
         assert len(decision["entries"]) == 2
 
+    def test_view_item_yaml_fallback_shows_display_title_for_canonical_section(self, mocker: MockerFixture) -> None:
+        """view_item's YAML-only fallback shows the display title, not the raw storage key (#2962).
+
+        Tests: _build_sections_from_yaml_item keys its result by display title.
+        How: add_item then groom_item into the canonical "RT-ICA" section (no GitHub body
+             available, so view_item takes the YAML-only fallback path); call view_item.
+        Why: Before the fix, a canonical section groomed with no linked GitHub body was
+             stored under its snake_case key ("rt_ica") and view_item returned that raw
+             key verbatim instead of the documented display title ("RT-ICA") — confirmed
+             reproducible on unmodified main. Callers should never see internal storage
+             keys; every other section-display path (`## Sections` index,
+             `_render_section_index`) already resolves through the same
+             `_section_display_title` helper.
+        """
+        from backlog_core.models import Output
+
+        mocker.patch("backlog_core.operations.view_enrich_from_github", return_value=False)
+        mocker.patch("backlog_core.operations.try_get_github", return_value=None)
+
+        out = Output()
+        ops.add_item(title="RT-ICA Display Title Test", priority="P1", description="Test", output=out)
+        ops.groom_item(selector="RT-ICA Display Title Test", section="RT-ICA", content="Verdict text.", output=out)
+        result = view_item(selector="RT-ICA Display Title Test", output=out)
+
+        sections = result.sections
+        assert isinstance(sections, dict), "sections must be a dict"
+        assert "rt_ica" not in sections, f"Raw storage key leaked into sections: {list(sections.keys())}"
+        assert "RT-ICA" in sections, f"Expected 'RT-ICA' in sections, got: {list(sections.keys())}"
+
 
 # ---------------------------------------------------------------------------
 # close_item
@@ -2823,21 +2852,29 @@ class TestGroomItemMarkGroomed:
 
 
 class TestViewItemUnknownSections:
-    """Unknown section keys (unknown__ prefix) survive through view_item into ViewItemResult.sections.
+    """Unknown-section content survives through view_item into ViewItemResult.sections,
+    keyed by display title rather than by its raw internal storage key.
 
-    These tests prove that `_build_sections_from_yaml_item` preserves freeform
-    `unknown__` prefixed keys — produced by `parse_issue_body` from GitHub issue
-    body headings not in `_HEADING_TO_KEY` — when assembling `ViewItemResult.sections`.
+    These tests prove that `_build_sections_from_yaml_item` preserves the content of
+    freeform `unknown__` prefixed keys — produced by `parse_issue_body` from GitHub
+    issue body headings not in `_HEADING_TO_KEY` — while presenting them to callers
+    under the same human-readable title `_section_display_title` produces for every
+    other section-display path (`## Sections` index, `_render_section_index`). Before
+    #2962, `_build_sections_from_yaml_item` returned the raw storage key verbatim
+    (e.g. ``"unknown__story"``, or ``"rt_ica"`` for a canonical section groomed with
+    no linked GitHub body) instead of the display title.
     """
 
     def test_unknown_section_key_present_in_view_result_sections(self, mocker: MockerFixture) -> None:
-        """Unknown-prefixed section key survives through view_item into ViewItemResult.sections.
+        """Unknown section's display title is present in ViewItemResult.sections.
 
-        Tests: _build_sections_from_yaml_item does not filter out unknown__ keys.
+        Tests: _build_sections_from_yaml_item does not filter out unknown__ keys, and
+               presents them under their display title, not the raw storage key.
         How: Write a YAML item with an unknown__impact_radius section; call view_item;
-             assert the key is present in result.sections.
-        Why: MCP clients receive result.sections as JSON — unknown section keys must
-             appear in the output or downstream consumers silently lose issue body content.
+             assert the display title "Impact Radius" is present in result.sections.
+        Why: MCP clients receive result.sections as JSON — unknown section content must
+             appear in the output, under a human-readable title, or downstream consumers
+             silently lose issue body content or see an internal storage key.
         """
         import backlog_core.models as _m
         from backlog_core.models import Entry, Section
@@ -2871,18 +2908,22 @@ class TestViewItemUnknownSections:
 
         # Assert
         assert isinstance(result, ViewItemResult)
-        assert "unknown__impact_radius" in result.sections, (
-            f"Expected 'unknown__impact_radius' in sections, got: {list(result.sections.keys())}"
+        assert "unknown__impact_radius" not in result.sections, (
+            f"Raw storage key leaked into sections: {list(result.sections.keys())}"
+        )
+        assert "Impact Radius" in result.sections, (
+            f"Expected 'Impact Radius' in sections, got: {list(result.sections.keys())}"
         )
         # Confirm value shape is SectionEntryMetadata (not groomed)
-        section_meta = cast("SectionEntryMetadata", result.sections["unknown__impact_radius"])
+        section_meta = cast("SectionEntryMetadata", result.sections["Impact Radius"])
         assert "num_entries" in section_meta
 
     def test_unknown_section_has_correct_section_entry_metadata_shape(self, mocker: MockerFixture) -> None:
         """Unknown section value has SectionEntryMetadata shape with num_entries, num_struck, entries.
 
         Tests: _build_sections_from_yaml_item wraps Section objects in SectionEntryMetadata.
-        How: Write YAML item with unknown__ section; call view_item; assert TypedDict shape.
+        How: Write YAML item with unknown__ section; call view_item; assert TypedDict shape
+             under the section's display title.
         Why: MCP clients read num_entries and entries — wrong shape breaks consumers.
         """
         import backlog_core.models as _m
@@ -2911,7 +2952,7 @@ class TestViewItemUnknownSections:
         result = view_item("Unknown Shape Item")
 
         # Assert
-        section_meta = cast("SectionEntryMetadata", result.sections["unknown__story"])
+        section_meta = cast("SectionEntryMetadata", result.sections["Story"])
         assert "num_entries" in section_meta
         assert "num_struck" in section_meta
         assert "entries" in section_meta
@@ -2922,7 +2963,7 @@ class TestViewItemUnknownSections:
 
         Tests: Entry content round-trips from BacklogItem.sections into ViewItemResult.sections.
         How: Write YAML item with known entry content in unknown__ section; call view_item;
-             assert entry content matches.
+             assert entry content matches under the section's display title.
         Why: Silent content loss would cause MCP clients to display empty section entries.
         """
         import backlog_core.models as _m
@@ -2957,7 +2998,7 @@ class TestViewItemUnknownSections:
         result = view_item("Unknown Content Item")
 
         # Assert
-        section_meta = cast("SectionEntryMetadata", result.sections["unknown__acceptance_criteria"])
+        section_meta = cast("SectionEntryMetadata", result.sections["Acceptance Criteria"])
         section_entries = section_meta["entries"]
         contents = [e["content"] for e in section_entries]
         assert expected_content in contents, f"Expected '{expected_content}' in entry contents, got: {contents}"
@@ -2967,7 +3008,8 @@ class TestViewItemUnknownSections:
         """num_entries in unknown section metadata equals the count of non-struck entries.
 
         Tests: active/struck entry counting for unknown__ prefixed keys.
-        How: Write item with 3 entries, 1 struck; assert num_entries=2, num_struck=1.
+        How: Write item with 3 entries, 1 struck; assert num_entries=2, num_struck=1
+             under the section's display title.
         Why: MCP clients display entry counts — must be accurate regardless of key prefix.
         """
         import backlog_core.models as _m
@@ -3004,16 +3046,17 @@ class TestViewItemUnknownSections:
         result = view_item("Unknown Count Item")
 
         # Assert
-        section_meta = cast("SectionEntryMetadata", result.sections["unknown__notes"])
+        section_meta = cast("SectionEntryMetadata", result.sections["Notes"])
         assert section_meta["num_entries"] == 2
         assert section_meta["num_struck"] == 1
 
     def test_unknown_section_coexists_with_known_section(self, mocker: MockerFixture) -> None:
         """Unknown and known sections coexist in ViewItemResult.sections with correct shapes.
 
-        Tests: _build_sections_from_yaml_item preserves both known and unknown__ keys simultaneously.
+        Tests: _build_sections_from_yaml_item preserves both known and unknown__ keys simultaneously,
+               presenting both under their display titles.
         How: Write YAML item with rt_ica (known) and unknown__story sections; call view_item;
-             assert both keys present with correct SectionEntryMetadata shapes.
+             assert both display titles are present with correct SectionEntryMetadata shapes.
         Why: Real GitHub issues have mixed headings — known and unknown must both survive.
         """
         import backlog_core.models as _m
@@ -3043,24 +3086,24 @@ class TestViewItemUnknownSections:
         result = view_item("Mixed Sections Item")
 
         # Assert
-        assert "rt_ica" in result.sections, f"Expected 'rt_ica' in sections, got: {list(result.sections.keys())}"
-        assert "unknown__story" in result.sections, (
-            f"Expected 'unknown__story' in sections, got: {list(result.sections.keys())}"
-        )
-        rt_ica_meta = cast("SectionEntryMetadata", result.sections["rt_ica"])
+        assert "RT-ICA" in result.sections, f"Expected 'RT-ICA' in sections, got: {list(result.sections.keys())}"
+        assert "Story" in result.sections, f"Expected 'Story' in sections, got: {list(result.sections.keys())}"
+        rt_ica_meta = cast("SectionEntryMetadata", result.sections["RT-ICA"])
         assert rt_ica_meta["num_entries"] == 1
         assert rt_ica_meta["entries"][0]["content"] == "Risk: breaking change in public API"
 
-        story_meta = cast("SectionEntryMetadata", result.sections["unknown__story"])
+        story_meta = cast("SectionEntryMetadata", result.sections["Story"])
         assert story_meta["num_entries"] == 1
         assert story_meta["entries"][0]["content"] == "As a user I want feature X"
 
     def test_unknown_section_coexists_with_groomed_section(self, mocker: MockerFixture) -> None:
         """Unknown section and groomed section coexist with their respective metadata shapes.
 
-        Tests: SectionEntryMetadata and GroomedSectionMetadata shapes both appear in sections.
+        Tests: SectionEntryMetadata and GroomedSectionMetadata shapes both appear in sections,
+               each keyed by its display title.
         How: Write YAML item with groomed (GroomedData) and unknown__ (Section) keys; call view_item;
-             assert groomed key has type=groomed and unknown key has num_entries shape.
+             assert the groomed display title has type=groomed and the unknown section's display
+             title has num_entries shape.
         Why: GroomedSectionMetadata and SectionEntryMetadata are discriminated by presence of
              the "type" key — MCP clients must receive both shapes correctly.
         """
@@ -3095,18 +3138,21 @@ class TestViewItemUnknownSections:
         # Act
         result = view_item("Groomed Unknown Item")
 
-        # Assert: groomed section has GroomedSectionMetadata shape
-        assert "groomed" in result.sections, f"Expected 'groomed' in sections, got: {list(result.sections.keys())}"
-        groomed_meta = cast("GroomedSectionMetadata", result.sections["groomed"])
+        # Assert: groomed section has GroomedSectionMetadata shape, keyed by its display title
+        groomed_title = "Groomed — 2026-01-15"
+        assert groomed_title in result.sections, (
+            f"Expected {groomed_title!r} in sections, got: {list(result.sections.keys())}"
+        )
+        groomed_meta = cast("GroomedSectionMetadata", result.sections[groomed_title])
         assert groomed_meta.get("type") == "groomed"
         assert "subsections" in groomed_meta
         assert groomed_meta["subsections"]["summary"] == "Feature is ready for review"
 
-        # Assert: unknown section has SectionEntryMetadata shape
-        assert "unknown__implementation_notes" in result.sections, (
-            f"Expected 'unknown__implementation_notes' in sections, got: {list(result.sections.keys())}"
+        # Assert: unknown section has SectionEntryMetadata shape, keyed by its display title
+        assert "Implementation Notes" in result.sections, (
+            f"Expected 'Implementation Notes' in sections, got: {list(result.sections.keys())}"
         )
-        unknown_meta = cast("SectionEntryMetadata", result.sections["unknown__implementation_notes"])
+        unknown_meta = cast("SectionEntryMetadata", result.sections["Implementation Notes"])
         assert "num_entries" in unknown_meta
         assert unknown_meta["num_entries"] == 2
         assert len(unknown_meta["entries"]) == 2


### PR DESCRIPTION
## Summary
- `_build_sections_from_yaml_item` (used by `view_item`'s YAML-only fallback path, when an item has no rendered GitHub body) returned section metadata keyed by the raw internal storage key (e.g. `"rt_ica"`, `"unknown__decision"`) instead of the human-readable display title (`"RT-ICA"`, `"Decision"`) that every other section-display path (`## Sections` index, `_render_section_index`) already produces via `rendering.section_display_title()`.
- Root cause: `_build_sections_from_yaml_item` used `item.sections`' storage keys directly as its own output keys instead of routing them through the display-title resolver already used elsewhere in this module.
- Fix: key the returned dict by `_section_display_title(sec_name, groomed_date)` instead of the raw `sec_name`, for both `Section` and `GroomedData` branches.

## Root cause
Reproducible on unmodified `main`: groom an item into section `"RT-ICA"` with no linked GitHub issue/body, then call `view_item` — `result.sections` shows key `"rt_ica"`, not `"RT-ICA"`. Discovered while fixing #2956 (`backlog_groom` section-key duplication bug); that fix corrected `_normalize_section_key` to route custom section names through the same normalizer GitHub-body parsing uses, which surfaced this same pre-existing raw-key exposure for custom/unknown sections too (e.g. `"unknown__decision"` instead of `"Decision"`).

## Test plan
- [x] Reproduced directly against real function calls (`add_item` + `groom_item` + `view_item`, memory backend, no GitHub) on unmodified `main` before fixing
- [x] Added a permanent regression test: `test_view_item_yaml_fallback_shows_display_title_for_canonical_section` in `tests/test_backlog_core_operations.py`
- [x] Updated the existing `TestViewItemUnknownSections` class (6 tests) — these tests previously asserted the *old, buggy* contract (raw `unknown__`/canonical keys surfacing verbatim); individually inspected and confirmed each was pre-existing-behavior encoding, not a masked regression, before updating to expect display titles
- [x] Re-ran the exact reproduction after the fix — confirmed passing
- [x] Validated against the live backlog MCP server (not just pytest) per AGENTS.md — `backlog_groom` "RT-ICA" then `backlog_view` shows `"RT-ICA"`, not `"rt_ica"`
- [x] Full suite: `uv run pytest plugins/development-harness/tests plugins/development-harness/backlog_core/tests plugins/development-harness/tests_backlog` — 3600 passed, 1 pre-existing unrelated failure (`test_github_content_provider_replay_preserves_concurrent_remote_revision`, backlog #2922)
- [x] `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` clean on touched files

Fixes #2962

🤖 Generated with [Claude Code](https://claude.com/claude-code)