### PR TITLE
fix(development-harness): sync local item title with the type-prefixed GitHub issue title

### DIFF
--- a/plugins/development-harness/backlog_core/gh_client.py
+++ b/plugins/development-harness/backlog_core/gh_client.py
@@ -1244,6 +1244,22 @@ def create_issue_for_item(
 
     Uses GraphQL createIssue mutation with resolved label IDs.
 
+    Mutates ``item.title`` in place to the type-prefixed title actually sent to
+    GitHub (e.g. ``"refactor: {title}"``) once creation succeeds. Without this,
+    the local record keeps the caller-supplied, unprefixed title forever while
+    the live GitHub issue carries the prefixed one — the two titles never
+    converge on any subsequent reconcile. `_GitHubReconciliation.reconcile()`
+    only acknowledges (dequeues) a locally-queued work-item mutation once the
+    live snapshot's title exactly matches the queued item's title, as a guard
+    against acknowledging stale intent against a since-renamed issue; a
+    permanent title mismatch introduced at creation time defeats that guard
+    every time, so the mutation queue for every GitHub-backend item never
+    drains and every reconcile re-applies the same "still pending" content,
+    producing new duplicate provider-comment "patches" on each subsequent
+    reconcile (#2963). Mutating here — the single place the prefixed title is
+    computed — keeps the local record and the live issue title identical from
+    the moment of creation, for every caller, with no signature change.
+
     Returns:
         Issue number if created, None otherwise.
     """
@@ -1265,6 +1281,7 @@ def create_issue_for_item(
         if name not in label_id_map:
             out.warn(f"  WARNING: label '{name}' not found")
     created = _create_issue_graphql(repo, _get_repo_node_id(repo), issue_title, body, list(label_id_map.values()))
+    item.title = issue_title
     out.info(f"  Created #{created['number']}: {issue_title[:60]}...")
     return created["number"]
 

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -695,7 +695,14 @@ def _create_issue_and_update_item(item: BacklogItem, repo: str, output: Output |
             return None
         reference = item.reference
         if reference:
-            update_item_metadata(reference, {"metadata": {"issue": f"#{issue_num}"}}, output=out)
+            # create_issue_for_item mutates item.title in place to the type-prefixed
+            # title actually sent to GitHub (e.g. "refactor: {title}"). Persist that
+            # here too ("name" -> item.title, see _apply_updates_to_item), not just the
+            # issue number — otherwise the local record keeps the pre-prefix title
+            # forever while the live issue carries the prefixed one, and every
+            # subsequent reconcile's title-equality acknowledge check fails, so this
+            # item's pending mutations never drain (#2963).
+            update_item_metadata(reference, {"name": item.title, "metadata": {"issue": f"#{issue_num}"}}, output=out)
         return issue_num
 
 
@@ -1359,9 +1366,15 @@ def add_item(
     issue_ref = _try_create_backend_issue_ref(item_data, repo, out)
     item_reference = issue_ref or _resolve_reference(priority, slug)
 
-    # Build and persist the backend-owned work item
+    # Build and persist the backend-owned work item. Reuse item_data.title, not the
+    # raw title argument: gh_client.create_issue_for_item mutates item_data.title in
+    # place to the type-prefixed title actually sent to GitHub (e.g. "refactor: {title}")
+    # when a real GitHub issue was created. Persisting the unprefixed title here instead
+    # would permanently diverge the local record from the live issue title, breaking the
+    # title-equality guard _GitHubReconciliation.reconcile() uses to acknowledge (dequeue)
+    # this item's pending mutations on every subsequent reconcile (#2963).
     item_to_write = BacklogItem(
-        title=title,
+        title=item_data.title,
         description=description,
         source=source,
         added=today_str,
@@ -2847,10 +2860,15 @@ def sync_create_missing_issues(
         new_normalized = normalize_issue_title(item.title)
         if new_normalized not in existing_issues:
             existing_issues[new_normalized] = issue_num
-        # Update backend-owned metadata with issue number
+        # Update backend-owned metadata with issue number. item.title has already
+        # been mutated in place by create_issue_for_item (via find_or_create_issue)
+        # to the type-prefixed title actually sent to GitHub when a NEW issue was
+        # created here -- persist it under "name" too, not just the issue number,
+        # or the local record permanently diverges from the live issue title and
+        # this item's pending mutations never drain on later reconciles (#2963).
         reference = item.reference
         if reference:
-            update_item_metadata(reference, {"metadata": {"issue": f"#{issue_num}"}}, output=out)
+            update_item_metadata(reference, {"name": item.title, "metadata": {"issue": f"#{issue_num}"}}, output=out)
 
     return {"created": created, **out.to_dict()}
 

--- a/plugins/development-harness/tests/test_backlog_core_github.py
+++ b/plugins/development-harness/tests/test_backlog_core_github.py
@@ -765,6 +765,53 @@ class TestCreateIssueForItem:
         assert len(captured_vars) == 1
         assert captured_vars[0]["title"].startswith("fix: Fix null crash")
 
+    def test_create_issue_mutates_item_title_to_match_created_issue(self, mocker: MockerFixture) -> None:
+        """create_issue_for_item mutates item.title to the type-prefixed title sent to GitHub.
+
+        Tests: item.title in-place mutation on successful creation (#2963).
+        How: Create an item with an unprefixed title; call create_issue_for_item;
+             assert item.title now carries the same prefix sent to the GraphQL mutation.
+        Why: Without this, the local record keeps the unprefixed title forever while the
+             live GitHub issue carries the prefixed one. _GitHubReconciliation.reconcile()
+             only acknowledges (dequeues) a queued work-item mutation once the live
+             snapshot's title exactly matches the local item's title -- a permanent
+             mismatch introduced here means every reconcile re-applies the same "still
+             pending" content forever, producing duplicate provider comments each time.
+        """
+        # Arrange
+        repo = _make_mock_repo(mocker)
+        repo.requester.graphql_query.return_value = ({}, {"data": {"repository": {}}})
+        mocker.patch(
+            "backlog_core.gh_client._graphql_request",
+            return_value=make_create_issue_response(make_created_issue_node(number=99)),
+        )
+        item = BacklogItem(title="Refactor the parser", item_type="refactor", priority="P1")
+
+        # Act
+        result = create_issue_for_item(repo, item)
+
+        # Assert
+        assert result == 99
+        assert item.title == "refactor: Refactor the parser"
+
+    def test_create_issue_does_not_mutate_item_title_on_dry_run(self, mocker: MockerFixture) -> None:
+        """create_issue_for_item leaves item.title untouched when dry_run=True.
+
+        Tests: no title mutation on the dry-run early-return path.
+        How: Call with dry_run=True; assert item.title is unchanged.
+        Why: A dry-run must not have any observable side effect, including on the
+             passed-in item, since no issue was actually created to match against.
+        """
+        # Arrange
+        repo = _make_mock_repo(mocker)
+        item = BacklogItem(title="Preview only", item_type="feature", priority="P1")
+
+        # Act
+        create_issue_for_item(repo, item, dry_run=True)
+
+        # Assert
+        assert item.title == "Preview only"
+
 
 # ---------------------------------------------------------------------------
 # batch_fetch_statuses — GraphQL list query (Requirement: replaces N+1 REST)

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -254,6 +254,105 @@ class TestAddItemCreatesLocalFile:
 
         assert _stored_item(str(result["file_path"])).title == "Frontmatter Title Test"
 
+    def test_add_item_persists_type_prefixed_title_from_github_creation(self, mocker: MockerFixture) -> None:
+        """Verify add_item persists the type-prefixed title create_issue_for_item sends to GitHub.
+
+        Tests: item_to_write.title reuses item_data.title after GitHub issue creation (#2963).
+        How: Mock create_issue_for_item with a side_effect that mutates item.title in place
+             (matching gh_client.create_issue_for_item's real post-fix behavior) and returns
+             an issue number; assert the persisted item's title carries that same prefix.
+        Why: Before the fix, the persisted title was built from the raw, unprefixed local
+             `title` argument, permanently diverging from the live GitHub issue title (which
+             always carries a "{type}: " prefix). That divergence breaks the title-equality
+             check `_GitHubReconciliation.reconcile()` uses to acknowledge (dequeue) this
+             item's pending mutations, so they never drain on any later reconcile.
+        """
+        mock_repo = mocker.Mock()
+        mocker.patch("backlog_core.operations.try_get_github", return_value=mock_repo)
+
+        def fake_create_issue_for_item(
+            repository: object, item: BacklogItem, dry_run: bool = False, output: object = None
+        ) -> int:
+            item.title = f"refactor: {item.title}"
+            return 314
+
+        mocker.patch("backlog_core.operations.create_issue_for_item", side_effect=fake_create_issue_for_item)
+
+        result = add_item(title="Split the parser module", description="desc", priority="P1", type_="Refactor")
+
+        stored = _stored_item(str(result["file_path"]))
+        assert stored.title == "refactor: Split the parser module"
+
+    def test_backfill_issue_creation_persists_type_prefixed_title(self, mocker: MockerFixture) -> None:
+        """Verify _create_issue_and_update_item persists the type-prefixed title too (#2963).
+
+        Tests: the "backfill a missing GitHub issue for an existing local-only item" path
+               (update_item's _create_issue_and_update_item, distinct from add_item's
+               creation path) also keeps the local title in sync with the live issue title.
+        How: Create a local-only item (no GitHub), then call _create_issue_and_update_item
+             directly with create_issue_for_item mocked to mutate item.title in place
+             (matching the real post-fix behavior) and return an issue number.
+        Why: update_item_metadata only received {"metadata": {"issue": ...}} before the fix
+             -- the title mutation on the in-memory item was silently discarded because
+             _apply_updates_to_item reloads a fresh copy from the backend by reference,
+             never seeing the caller's in-memory item.title change.
+        """
+        from backlog_core.operations import _create_issue_and_update_item
+
+        mocker.patch("backlog_core.operations.try_get_github", return_value=None)
+        add_result = add_item(title="Backfill target item", description="desc", priority="P1", type_="Bug")
+        reference = str(add_result["reference"])
+        item = _stored_item(reference)
+
+        def fake_create_issue_for_item(
+            repository: object, target: BacklogItem, dry_run: bool = False, output: object = None
+        ) -> int:
+            target.title = f"fix: {target.title}"
+            return 271
+
+        mock_repo = mocker.Mock()
+        mocker.patch("backlog_core.operations.try_get_github", return_value=mock_repo)
+        mocker.patch("backlog_core.operations.create_issue_for_item", side_effect=fake_create_issue_for_item)
+
+        issue_num = _create_issue_and_update_item(item, repo="owner/repo")
+
+        assert issue_num == 271
+        assert _stored_item(reference).title == "fix: Backfill target item"
+
+    def test_sync_create_missing_issues_persists_type_prefixed_title(self, mocker: MockerFixture) -> None:
+        """Verify sync_create_missing_issues persists the type-prefixed title too (#2963).
+
+        Tests: the bulk "create GitHub issues for all items missing them" sync path
+               (sync_create_missing_issues -> find_or_create_issue) also keeps the
+               local title in sync with the live issue title after creation.
+        How: Create a local-only item (no GitHub), then call sync_create_missing_issues
+             directly with create_issue_for_item mocked to mutate item.title in place.
+        Why: The persistence call here only carried {"metadata": {"issue": ...}} before
+             the fix, same defect class as add_item and _create_issue_and_update_item.
+        """
+        from backlog_core.operations import sync_create_missing_issues
+
+        mocker.patch("backlog_core.operations.try_get_github", return_value=None)
+        add_result = add_item(title="Sync backfill item", description="desc", priority="P1", type_="Docs")
+        reference = str(add_result["reference"])
+        item = _stored_item(reference)
+
+        def fake_create_issue_for_item(
+            repository: object, target: BacklogItem, dry_run: bool = False, output: object = None
+        ) -> int:
+            target.title = f"docs: {target.title}"
+            return 512
+
+        mock_repo = mocker.Mock()
+        mocker.patch("backlog_core.operations.create_issue_for_item", side_effect=fake_create_issue_for_item)
+
+        result = sync_create_missing_issues(
+            [item], repo="owner/repo", dry_run=False, repository=mock_repo, existing_issues={}
+        )
+
+        assert result["created"] == 1
+        assert _stored_item(reference).title == "docs: Sync backfill item"
+
     def test_add_item_always_calls_github(self, mocker: MockerFixture) -> None:
         """Verify add_item always attempts GitHub issue creation via try_get_github.
 


### PR DESCRIPTION
## Summary
- `gh_client.create_issue_for_item` computes a type-prefixed issue title (`"refactor: {title}"`, `"fix: {title}"`, etc.) for the GitHub GraphQL `createIssue` mutation, but never persisted that title back to the local record — the caller kept storing the raw, unprefixed title forever, permanently diverging the local `BacklogItem.title` from the live GitHub issue title from the moment of creation.
- `_GitHubReconciliation.reconcile()` (`backends/github_work_items.py`) only acknowledges (dequeues) a locally-queued work-item mutation once the freshly-fetched snapshot's title exactly matches the queued item's title — a guard against acknowledging stale intent against a since-renamed issue. The permanent title mismatch broke this guard on every single reconcile, for every GitHub-backend item, so pending work-item mutations never drained.
- Fix: mutate `item.title` in place inside `create_issue_for_item` once the issue is actually created (single source of truth for the prefix computation), and update the three callers that persist a `BacklogItem` after calling it (`add_item`, `_create_issue_and_update_item`, `sync_create_missing_issues`) to persist that same title instead of the raw pre-prefix one.

## Important correction during investigation
My initial hypothesis (and an earlier draft finding I did **not** post) was "groomed content never reaches GitHub." That was wrong — I was checking the issue **body** only. Per `ARCHITECTURE.md`'s "GitHub writable records" section, issue bodies are deliberately never overwritten; groomed content is posted as **issue comments** (the documented "human projection record"). Verified directly against GitHub (`gh api .../issues/2953/comments`): #2953's full groomed content (Fact-Check, RT-ICA, Impact Radius, etc.) is present — as 20 growing/duplicate comments, not lost. The actual bug is narrower: the stuck mutation queue causes every reconcile to re-apply the same "still pending" content and post another comment, which is what produced those 20 duplicates and the "pending mutation(s) never decreases" symptom.

## Test plan
- [x] Live reproduction against a real (throwaway, closed after use) GitHub issue: before the fix, its pending work-item mutation survived a groom + reconcile cycle unacknowledged (confirmed via direct inspection of `FileCache._pending_work_item_mutations()`), while the local title (`"SCRATCH..."`) and live GitHub title (`"chore: SCRATCH..."`) diverged
- [x] Isolated the exact failing condition with a targeted diagnostic re-running the reconcile internals: `cond2 title_matches: False`
- [x] Applied the fix, re-ran the exact same reproduction: pending mutation now drains to 0 after each of two consecutive groom + reconcile cycles, with exactly one GitHub comment posted per groom call (no duplication)
- [x] Added permanent regression tests: `TestCreateIssueForItem` (2 new: title mutation on success, no mutation on dry-run) and `TestAddItemCreatesLocalFile` (3 new: `add_item`, `_create_issue_and_update_item`, `sync_create_missing_issues` all persist the prefixed title)
- [x] Full suite: `uv run pytest plugins/development-harness/tests plugins/development-harness/backlog_core/tests plugins/development-harness/tests_backlog` — 3604 passed, 1 pre-existing unrelated failure (`test_github_content_provider_replay_preserves_concurrent_remote_revision`, backlog #2922)
- [x] `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` clean on touched files

Fixes #2963

🤖 Generated with [Claude Code](https://claude.com/claude-code)