### PR TITLE
fix(settings): exclude worktree-duplicate CLAUDE.md/rules from memory loading

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,12 @@
   "worktree": {
     "baseRef": "head"
   },
+  "claudeMdExcludes": [
+    "**/.claude/worktrees/**/.claude/CLAUDE.md",
+    "**/.claude/worktrees/**/.claude/rules/**",
+    "**/.claude/worktrees/**/CLAUDE.md",
+    "**/.claude/worktrees/**/CLAUDE.local.md"
+  ],
   "permissions": {
     "allow": [
       "Bash(gh issue list:*)",


### PR DESCRIPTION
## Summary
- `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` (set in `.claude/settings.json`) loads `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/*.md`, and `CLAUDE.local.md` from any directory added via `--add-dir`.
- Every entry under `.claude/worktrees/*/` is a full git checkout carrying a byte-identical copy of `.claude/rules/*.md` — so a worktree added mid-session reloads the entire shared rules set a second time under a different relative path, burning tokens with zero new content.
- Verified against `code.claude.com/docs/en/memory.md`: default nested-subdirectory `CLAUDE.md` discovery is unrelated to this and stays enabled — only the `--add-dir` reload path is affected.
- Adds `claudeMdExcludes` (the documented mechanism for exactly this monorepo-duplication case) to exclude worktree copies of `.claude/CLAUDE.md`, `.claude/rules/**`, `CLAUDE.md`, and `CLAUDE.local.md`.

## Test plan
- [x] `.claude/settings.json` validated as well-formed JSON (`uv run python -c "import json; json.load(open('.claude/settings.json'))"`)
- [x] `prek` commit hooks passed on commit
- [ ] Confirm in a live session: add a worktree via `--add-dir` and verify `.claude/rules/*.md` content is not duplicated in context (requires a session restart to observe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)