### PR TITLE
feat(ci): scheduled check surfaces red main CI via tracking issue

### DIFF
--- a/.github/workflows/main-ci-health-check.yml
+++ b/.github/workflows/main-ci-health-check.yml
@@ -1,0 +1,133 @@
+name: Main CI Health Check
+
+on:
+  schedule:
+    # Hourly — cheap read-only check, catches a red main quickly
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+# Minimal permissions by default — job-level override grants issues:write, actions:read
+permissions: {}
+
+jobs:
+  check-main-ci-health:
+    name: Check latest main push CI conclusion
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+    steps:
+      - name: Surface red main CI via tracking issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const WORKFLOW_FILE = 'code-quality.yml';
+            const BRANCH = 'main';
+            const TRACKING_LABEL = 'ci-main-broken';
+            const ISSUE_TITLE = 'CI: main branch quality gate is red';
+
+            // Ensure tracking label exists
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: TRACKING_LABEL,
+              });
+            } catch (err) {
+              if (err.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: TRACKING_LABEL,
+                  color: 'b60205',
+                  description: 'Latest push to main did not pass the Code quality workflow',
+                });
+                console.log(`Created label: ${TRACKING_LABEL}`);
+              } else {
+                throw err;
+              }
+            }
+
+            // Latest completed push-triggered run of the Code quality workflow on main
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: WORKFLOW_FILE,
+              branch: BRANCH,
+              event: 'push',
+              status: 'completed',
+              per_page: 1,
+            });
+
+            const latestRun = runs.data.workflow_runs[0];
+            if (!latestRun) {
+              console.log(`No completed push runs of ${WORKFLOW_FILE} found on ${BRANCH} yet.`);
+              return;
+            }
+
+            console.log(`Latest ${WORKFLOW_FILE} push run on ${BRANCH}: #${latestRun.run_number} — ${latestRun.conclusion} (${latestRun.html_url})`);
+
+            const openTrackingIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: TRACKING_LABEL,
+                per_page: 100,
+              }
+            );
+            const trackingIssue = openTrackingIssues.find(issue => !issue.pull_request);
+
+            if (latestRun.conclusion === 'failure') {
+              const body = [
+                `The most recent push to \`${BRANCH}\` did not pass the \`${WORKFLOW_FILE}\` quality gate.`,
+                '',
+                `- Run: ${latestRun.html_url}`,
+                `- Commit: ${latestRun.head_sha}`,
+                `- Observed: ${new Date().toISOString()}`,
+                '',
+                'This issue is reused across scheduled checks — it will be closed automatically once a push to',
+                `\`${BRANCH}\` passes ${WORKFLOW_FILE} again.`,
+              ].join('\n');
+
+              if (!trackingIssue) {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: ISSUE_TITLE,
+                  body,
+                  labels: [TRACKING_LABEL],
+                });
+                console.log(`Opened tracking issue #${created.data.number}`);
+              } else {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: trackingIssue.number,
+                  body,
+                });
+                console.log(`Updated existing tracking issue #${trackingIssue.number} — still red, no new issue opened.`);
+              }
+              return;
+            }
+
+            // Latest run is green (or at least not 'failure') — close out any open tracking issue.
+            if (trackingIssue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: trackingIssue.number,
+                body: `:white_check_mark: Latest push to \`${BRANCH}\` passed \`${WORKFLOW_FILE}\` (${latestRun.html_url}). Closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: trackingIssue.number,
+                state: 'closed',
+              });
+              console.log(`Closed tracking issue #${trackingIssue.number} — main is green again.`);
+            } else {
+              console.log(`${BRANCH} is green — nothing to do.`);
+            }

--- a/.github/workflows/main-ci-health-check.yml
+++ b/.github/workflows/main-ci-health-check.yml
@@ -113,21 +113,41 @@ jobs:
               return;
             }
 
-            // Latest run is green (or at least not 'failure') — close out any open tracking issue.
+            if (latestRun.conclusion === 'success') {
+              // Latest run genuinely passed — close out any open tracking issue.
+              if (trackingIssue) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: trackingIssue.number,
+                  body: `:white_check_mark: Latest push to \`${BRANCH}\` passed \`${WORKFLOW_FILE}\` (${latestRun.html_url}). Closing.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: trackingIssue.number,
+                  state: 'closed',
+                });
+                console.log(`Closed tracking issue #${trackingIssue.number} — main is green again.`);
+              } else {
+                console.log(`${BRANCH} is green — nothing to do.`);
+              }
+              return;
+            }
+
+            // Ambiguous conclusion (neutral, cancelled, timed_out, action_required, skipped, stale, ...) —
+            // this is neither a confirmed red nor a confirmed green, so do not open, close, or claim an
+            // all-clear. Leave any existing tracking issue exactly as-is and just surface the ambiguity.
+            console.log(
+              `Latest ${WORKFLOW_FILE} push run on ${BRANCH} concluded '${latestRun.conclusion}' — ` +
+              'not a definitive pass or fail, leaving tracking issue state unchanged.'
+            );
             if (trackingIssue) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: trackingIssue.number,
-                body: `:white_check_mark: Latest push to \`${BRANCH}\` passed \`${WORKFLOW_FILE}\` (${latestRun.html_url}). Closing.`,
+                body: `:warning: Latest push to \`${BRANCH}\` concluded \`${latestRun.conclusion}\` (${latestRun.html_url}) — ` +
+                  'ambiguous result, not treated as pass or fail. Leaving this issue open.',
               });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: trackingIssue.number,
-                state: 'closed',
-              });
-              console.log(`Closed tracking issue #${trackingIssue.number} — main is green again.`);
-            } else {
-              console.log(`${BRANCH} is green — nothing to do.`);
             }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/main-ci-health-check.yml`, a new scheduled + `workflow_dispatch` workflow that checks the conclusion of the latest completed push-triggered `code-quality.yml` run on `main`.
- When that run's conclusion is `failure`, opens (or updates, without spamming) one persistent tracking issue labeled `ci-main-broken`. When that run's conclusion is `success`, the tracking issue is commented on and auto-closed. Any other conclusion (`neutral`, `cancelled`, `timed_out`, `action_required`, `skipped`, `stale`) is ambiguous — the workflow leaves the tracking issue untouched (adding a comment noting the ambiguity if one is open) rather than treating it as either red or green. No new issue is opened per run — the always-red-nobody-looks failure mode this item exists to prevent.
- Read-only: makes no change to branch protection, required status checks, or `code-quality.yml`'s own gating logic. Follows the existing `quality-gate-audit.yml` shape (scheduled + `workflow_dispatch`, minimal top-level `permissions: {}` with job-level override, `actions/github-script@v7`, self-creating label).

Fixes #3001

## Test plan
- [x] `uv run prek run --files .github/workflows/main-ci-health-check.yml` — actionlint + YAML checks pass
- [x] Conclusion-routing logic (open/update-red vs close/all-clear vs leave-untouched) validated with a standalone Node harness that runs the actual `github-script` body from the workflow YAML against a mocked `github` API for all 8 documented `conclusion` values (`success`, `failure`, `neutral`, `cancelled`, `timed_out`, `action_required`, `skipped`, `stale`), each checked both with and without an existing open tracking issue. Harness lives at `.tmp/scratch/tests/validate_main_ci_health_check.py` (not committed — throwaway per repo convention) and was falsification-tested against the pre-fix script to confirm it actually catches the bug it's checking for.
- [x] Confirmed the existing `code-quality.yml` quality gate is unaffected and green on this PR
- [ ] **Not yet verified**: live `workflow_dispatch` execution against the real GitHub API. This workflow file is not yet on the default branch (`gh api repos/.../actions/workflows/main-ci-health-check.yml` returns 404 until merge), so `workflow_dispatch` cannot be triggered pre-merge — the actual issue open/update/close REST calls have not executed against the live repo. Verify this post-merge by dispatching the workflow once on `main` and confirming it opens/updates/closes the tracking issue as expected before relying on it unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
