### PR TITLE
fix(development-harness): add_item() honest item_ref/issue_created signal

### DIFF
--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1372,6 +1372,14 @@ def add_item(
     Raises:
         ValidationError: If priority or type_ is not a recognized value. No
             item is stored and no backend issue is created when raised.
+        ContentUnavailableError: On a string-ID backend (beads), when the
+            backend issue could not be created. ``_try_create_backend_issue_ref``
+            treats creation failure as non-fatal and returns ``""``, but the
+            subsequent ``backend.put_work_item()`` call retries creation for a
+            still-issueless item and raises instead of falling back to a
+            local-only item a second time (see ``BeadsBackend.put_work_item``).
+            Integer-ID backends (GitHub, sqlite, memory) do not raise this —
+            their local-only fallback is unconditional.
     """
     _validate_add_item_priority(priority)
     _validate_add_item_type(type_)

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1361,7 +1361,14 @@ def add_item(
       nanoid (e.g. ``"bd-a3f8"``).
 
     Returns:
-        Dict with title, priority, logical reference, compatibility ``file_path``, and optionally item_ref.
+        Dict with title, priority, logical reference, compatibility ``file_path``,
+        ``item_ref`` (the backend issue ref, or ``""`` when creation failed or was
+        skipped), and ``issue_created`` (``True`` only when a backend issue —
+        GitHub or beads — now backs this item). ``item_ref`` is always present:
+        its emptiness, not its absence, is the local-only-create signal, matching
+        the already-persisted ``BacklogItem.issue`` field and the ``issue`` key
+        that ``list_items``/``view_item`` return for this same item on every
+        later read (see ``_build_list_entry`` and ``view_result_from_local_item``).
 
     Raises:
         ValidationError: If priority or type_ is not a recognized value. No
@@ -1428,9 +1435,12 @@ def add_item(
         "priority": priority,
         "reference": item_reference,
         "file_path": item_reference,
+        # item_ref is always present — "" (not absence) is the local-only-create
+        # signal, so a caller checking `if result["item_ref"]` behaves correctly
+        # even if it never learns about issue_created. See #2999.
+        "item_ref": issue_ref,
+        "issue_created": bool(issue_ref),
     }
-    if issue_ref:
-        result["item_ref"] = issue_ref
     return {**result, **out.to_dict()}
 
 

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1362,13 +1362,12 @@ def add_item(
 
     Returns:
         Dict with title, priority, logical reference, compatibility ``file_path``,
-        ``item_ref`` (the backend issue ref, or ``""`` when creation failed or was
-        skipped), and ``issue_created`` (``True`` only when a backend issue —
-        GitHub or beads — now backs this item). ``item_ref`` is always present:
-        its emptiness, not its absence, is the local-only-create signal, matching
-        the already-persisted ``BacklogItem.issue`` field and the ``issue`` key
-        that ``list_items``/``view_item`` return for this same item on every
-        later read (see ``_build_list_entry`` and ``view_result_from_local_item``).
+        and ``item_ref`` (the backend issue ref, or ``""`` when creation failed or
+        was skipped). ``item_ref`` is always present: its emptiness, not its
+        absence, is the local-only-create signal, matching the already-persisted
+        ``BacklogItem.issue`` field and the ``issue`` key that ``list_items``/
+        ``view_item`` return for this same item on every later read (see
+        ``_build_list_entry`` and ``view_result_from_local_item``).
 
     Raises:
         ValidationError: If priority or type_ is not a recognized value. No
@@ -1436,10 +1435,9 @@ def add_item(
         "reference": item_reference,
         "file_path": item_reference,
         # item_ref is always present — "" (not absence) is the local-only-create
-        # signal, so a caller checking `if result["item_ref"]` behaves correctly
-        # even if it never learns about issue_created. See #2999.
+        # signal, so a caller checking `if result["item_ref"]` behaves correctly.
+        # See #2999.
         "item_ref": issue_ref,
-        "issue_created": bool(issue_ref),
     }
     return {**result, **out.to_dict()}
 

--- a/plugins/development-harness/scripts/close_test_issues.py
+++ b/plugins/development-harness/scripts/close_test_issues.py
@@ -10,6 +10,7 @@
 #   "marko>=2.0.0",
 #   "typer>=0.21.2",
 #   "python-dotenv>=1.0.0",
+#   "httpx>=0.28.1",
 # ]
 # ///
 """Close orphaned [MCP-TEST-*] GitHub issues left by failed e2e test teardown.

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -429,29 +429,6 @@ class TestAddItemCreatesLocalFile:
 
         assert result["item_ref"] == ""
 
-    def test_add_item_issue_created_signals_github_backed_vs_local_only(self, mocker: MockerFixture) -> None:
-        """Verify issue_created distinguishes a GitHub-backed create from a local-only one.
-
-        Tests: add_item's explicit success signal (#2999) — the field a caller checks
-            instead of inferring state from item_ref truthiness alone.
-        How: Run add_item once with GitHub issue creation succeeding and once with it
-             unavailable; compare issue_created on both results.
-        Why: Before this fix, a failed/skipped GitHub create returned a response with
-             no error field and no boolean signal — shape-identical to success except
-             for the presence of one optional key, so no caller not specifically
-             checking for item_ref could tell the two outcomes apart.
-        """
-        mock_repo = mocker.Mock()
-        mocker.patch("backlog_core.operations.try_get_github", return_value=mock_repo)
-        mocker.patch("backlog_core.operations.create_issue_for_item", return_value=7)
-        created = add_item(title="GitHub Backed Item", description="desc", priority="P1")
-
-        mocker.patch("backlog_core.operations.try_get_github", return_value=None)
-        local_only = add_item(title="Local Only Item Signal", description="desc", priority="P2")
-
-        assert created["issue_created"] is True
-        assert local_only["issue_created"] is False
-
     def test_add_item_local_only_pending_state_visible_via_list_and_view(self, mocker: MockerFixture) -> None:
         """Verify a local-only create's pending state is visible on later reads, not just at creation.
 

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -413,19 +413,70 @@ class TestAddItemCreatesLocalFile:
 
         assert result["item_ref"] == "#1632"
 
-    def test_add_item_item_ref_absent_when_no_github_issue(self, mocker: MockerFixture) -> None:
-        """Verify item_ref is absent from result when GitHub issue creation fails.
+    def test_add_item_item_ref_empty_when_no_github_issue(self, mocker: MockerFixture) -> None:
+        """Verify item_ref is present but empty when GitHub issue creation fails.
 
-        Tests: add_item item_ref absent on no-issue path.
+        Tests: add_item item_ref contract on the local-only-create path (#2999).
         How: Mock try_get_github to return None (no GitHub available).
-        Why: item_ref must not be present with a falsy value — absence is the
-             correct signal that no issue was created.
+        Why: item_ref must always be present — its emptiness, not its absence, is
+             the local-only signal. A dict with no distinguishing key at all is
+             indistinguishable from a successful create by any caller that does
+             not specifically probe for the key's presence (the original #2999 bug).
         """
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
 
         result = add_item(title="Local Only No Ref", description="desc", priority="P2")
 
-        assert "item_ref" not in result
+        assert result["item_ref"] == ""
+
+    def test_add_item_issue_created_signals_github_backed_vs_local_only(self, mocker: MockerFixture) -> None:
+        """Verify issue_created distinguishes a GitHub-backed create from a local-only one.
+
+        Tests: add_item's explicit success signal (#2999) — the field a caller checks
+            instead of inferring state from item_ref truthiness alone.
+        How: Run add_item once with GitHub issue creation succeeding and once with it
+             unavailable; compare issue_created on both results.
+        Why: Before this fix, a failed/skipped GitHub create returned a response with
+             no error field and no boolean signal — shape-identical to success except
+             for the presence of one optional key, so no caller not specifically
+             checking for item_ref could tell the two outcomes apart.
+        """
+        mock_repo = mocker.Mock()
+        mocker.patch("backlog_core.operations.try_get_github", return_value=mock_repo)
+        mocker.patch("backlog_core.operations.create_issue_for_item", return_value=7)
+        created = add_item(title="GitHub Backed Item", description="desc", priority="P1")
+
+        mocker.patch("backlog_core.operations.try_get_github", return_value=None)
+        local_only = add_item(title="Local Only Item Signal", description="desc", priority="P2")
+
+        assert created["issue_created"] is True
+        assert local_only["issue_created"] is False
+
+    def test_add_item_local_only_pending_state_visible_via_list_and_view(self, mocker: MockerFixture) -> None:
+        """Verify a local-only create's pending state is visible on later reads, not just at creation.
+
+        Tests: item 2 of #2999's fix — a caller reading the item later (grooming,
+            RT-ICA, dispatch) via list_items/view_item, not the add_item() return
+            value itself, must still be able to tell the item has no backend issue.
+        How: Create a local-only item (GitHub unavailable), then read it back through
+             both list_items and view_item; assert the empty "issue" field is present
+             on both, exactly mirroring add_item's own item_ref=="" signal.
+        Why: _build_list_entry and view_result_from_local_item already emit "issue"
+             unconditionally (BacklogItem.issue defaults to ""), so this test locks in
+             that the read paths already carry the signal add_item now also returns —
+             no separate mechanism was needed for requirement 2.
+        """
+        mocker.patch("backlog_core.operations.try_get_github", return_value=None)
+        mocker.patch("backlog_core.operations.batch_fetch_statuses", return_value={})
+        add_item(title="Pending Local Only Item", description="desc", priority="P2")
+
+        listed = list_items(from_github=False)
+        list_entries = cast("list[dict[str, str | bool]]", listed["items"])
+        entry = next(it for it in list_entries if it["title"] == "Pending Local Only Item")
+        assert entry["issue"] == ""
+
+        viewed = view_item("Pending Local Only Item")
+        assert viewed.issue == ""
 
 
 class TestAddItemValidatesPriorityAndType:


### PR DESCRIPTION
## Summary

- `add_item()` (`plugins/development-harness/backlog_core/operations.py`) only set `result["item_ref"]` inside `if issue_ref:`, so a failed or skipped backend issue create returned a success-shaped dict with no distinguishing key — indistinguishable from a real GitHub/beads-backed create to any caller not specifically checking for `item_ref`'s presence.
- `item_ref` is now always present (`""` sentinel for local-only, matching the already-persisted `BacklogItem.issue` convention `_build_list_entry`/`view_result_from_local_item` already expose on every later read).
- Confirmed the read-time visibility requirement (pending state visible via `backlog_list`/`backlog_view`, not just at creation) was already satisfied by `_build_list_entry`/`view_result_from_local_item` emitting `issue` unconditionally — added a test locking this in end-to-end rather than a second signaling mechanism.
- Fixed `close_test_issues.py`'s PEP 723 metadata gap (missing `httpx`, a transitive import pulled in via `backlog_core/__init__.py` → `gitlab_client.py`) per this issue's second acceptance criterion.

Fixes #2999

## Test plan

- [x] Reproduced the bug: `test_add_item_item_ref_absent_when_no_github_issue` (pre-existing) passed against unmodified HEAD, codifying the silent-failure contract.
- [x] Fixed `add_item()`; updated that test to `test_add_item_item_ref_empty_when_no_github_issue` asserting `item_ref == ""`.
- [x] Added `test_add_item_local_only_pending_state_visible_via_list_and_view` — end-to-end: create local-only, read back via `list_items`/`view_item`, assert `issue == ""` is visible on both.
- [x] Reproduced and fixed the `close_test_issues.py` `httpx` `ModuleNotFoundError` by running it via `uv run` with its own PEP 723 metadata.
- [x] `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` clean on all touched files.
- [x] `uv run pytest plugins/development-harness/tests/ -k "add_item or sync or reconcile"` — 540 passed, 20 skipped.
- [x] `uv run pytest plugins/development-harness/tests/` (full plugin suite) — 2651 passed, 39 skipped, 5 xfailed, no regressions.
- [x] `uv run prek run --files <changed files>` — all hooks passed.

Follow-up (review): removed a redundant `result["issue_created"] = bool(issue_ref)` field — it
expressed no state beyond `bool(result["item_ref"])`, which callers can already check directly.
Its dedicated test was removed with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["docs(development-harness): document Cont..."](https://github.com/jamie-bitflight/claude_skills/commit/0cb18b4d7453a25646cdccb3a058624aadd93db0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54618918)</sub>

<!-- /greptile_comment -->