### PR TITLE
refactor(development-harness): canonical StatusLabel registry

### DIFF
--- a/.github/workflows/quality-gate-audit.yml
+++ b/.github/workflows/quality-gate-audit.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            // Must equal StatusLabel.VERIFIED.value in
+            // plugins/development-harness/backlog_core/status_registry.py — a mismatch
+            // here is caught by test_status_label_registry_drift.py (#3004).
             const VERIFIED_LABEL = 'status:verified';
             const FLAG_LABEL = 'needs-verification';
             const PLAN_PATTERN = /\*\*Plan\*\*:/i;

--- a/plugins/development-harness/backlog_core/gh_client.py
+++ b/plugins/development-harness/backlog_core/gh_client.py
@@ -48,6 +48,7 @@ from .parsing import (
     parse_sam_task_metadata,
     today,
 )
+from .status_registry import STATUS_LABEL_PREFIX, StatusLabel
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -95,9 +96,9 @@ DH_LABELS: dict[str, str] = {
     "type:refactor": "2563eb",
     "type:chore": "6b7280",
     "type:docs": "0891b2",
-    "status:needs-grooming": "f59e0b",
-    "status:in-progress": "3b82f6",
-    "status:verified": "10b981",
+    StatusLabel.NEEDS_GROOMING: "f59e0b",
+    StatusLabel.IN_PROGRESS: "3b82f6",
+    StatusLabel.VERIFIED: "10b981",
 }
 
 
@@ -1273,7 +1274,7 @@ def create_issue_for_item(
     if dry_run:
         out.info(f"  [dry-run] Would create: {issue_title}")
         return None
-    labels = ["status:needs-grooming", f"priority:{(item.priority or 'P1').lower()}", type_gh]
+    labels = [StatusLabel.NEEDS_GROOMING, f"priority:{(item.priority or 'P1').lower()}", type_gh]
     owner, repo_name = repo.full_name.split("/", 1)
     ensure_dh_labels(repo, out)
     label_id_map = _resolve_label_ids_graphql(repo, owner, repo_name, labels)
@@ -1409,7 +1410,7 @@ def batch_fetch_statuses(items: list[BacklogItem], repo: str = "") -> dict[int, 
             continue
         if num in issue_map:
             gh_issue = issue_map[num]
-            status_labels = [lbl["name"] for lbl in gh_issue["labels"] if lbl["name"].startswith("status:")]
+            status_labels = [lbl["name"] for lbl in gh_issue["labels"] if lbl["name"].startswith(STATUS_LABEL_PREFIX)]
             ms = gh_issue["milestone"]
             result[num] = IssueStatus(
                 status=_pick_primary_status_label(status_labels), milestone=ms["title"] if ms else ""
@@ -1429,8 +1430,8 @@ def _pick_primary_status_label(status_labels: list[str]) -> str:
         ``"status:blocked"`` if present, else the first label in ``status_labels``,
         else ``""``.
     """
-    if "status:blocked" in status_labels:
-        return "status:blocked"
+    if StatusLabel.BLOCKED in status_labels:
+        return StatusLabel.BLOCKED
     return status_labels[0] if status_labels else ""
 
 
@@ -1451,7 +1452,7 @@ def fetch_item_status(item: BacklogItem, repo: str = "", output: Output | None =
             raise ValueError(msg)
         owner, repo_name = repository.full_name.split("/", 1)
         gh_issue = _fetch_issue_graphql(repository, owner, repo_name, num)
-        labels = [lb["name"] for lb in gh_issue["labels"] if lb["name"].startswith("status:")]
+        labels = [lb["name"] for lb in gh_issue["labels"] if lb["name"].startswith(STATUS_LABEL_PREFIX)]
         return _pick_primary_status_label(labels)
     except (BacklogError, GithubException):
         return ""
@@ -1537,8 +1538,8 @@ def apply_status_in_progress(item: BacklogItem, repo: str = "", output: Output |
             owner,
             repo_name,
             num,
-            label="status:in-progress",
-            removes=("status:needs-grooming",),
+            label=StatusLabel.IN_PROGRESS,
+            removes=(StatusLabel.NEEDS_GROOMING,),
             create_if_missing=False,
             already_message="  Status: already in-progress",
             applied_message="  Status: in-progress",
@@ -1580,10 +1581,10 @@ def apply_status_verified(item: BacklogItem, repo: str = "", output: Output | No
         owner,
         repo_name,
         num,
-        label="status:verified",
+        label=StatusLabel.VERIFIED,
         colour="0e8a16",
         description="Quality gates passed via /complete-implementation",
-        removes=("status:in-progress",),
+        removes=(StatusLabel.IN_PROGRESS,),
         already_message="  Status: already verified",
         applied_message="  Status: verified",
         output=out,
@@ -1623,10 +1624,10 @@ def apply_status_groomed(item: BacklogItem, repo: str = "", output: Output | Non
         owner,
         repo_name,
         num,
-        label="status:groomed",
+        label=StatusLabel.GROOMED,
         colour="0075ca",
         description="Grooming complete — all sections written and approved",
-        removes=("status:needs-grooming",),
+        removes=(StatusLabel.NEEDS_GROOMING,),
         already_message="  Status: already groomed",
         applied_message="  Status: groomed",
         output=out,
@@ -1667,7 +1668,7 @@ def apply_status_blocked(item: BacklogItem, repo: str = "", output: Output | Non
         owner,
         repo_name,
         num,
-        label="status:blocked",
+        label=StatusLabel.BLOCKED,
         colour="d93f0b",
         description="Blocked — missing information or a decision",
         already_message="  Status: already blocked",
@@ -1732,7 +1733,7 @@ def view_enrich_from_github(result: ViewItemResult, issue_num: str, repo: str = 
         if lb.startswith("priority:"):
             result.priority = lb.split(":", 1)[1].upper()
             break
-    status_labels = [lb for lb in result.labels if lb.startswith("status:")]
+    status_labels = [lb for lb in result.labels if lb.startswith(STATUS_LABEL_PREFIX)]
     if primary_status := _pick_primary_status_label(status_labels):
         result.status = primary_status.split(":", 1)[1]
     return True
@@ -1773,7 +1774,7 @@ def issue_to_local_fields(issue: IssueNode) -> IssueLocalFields:
     else:
         status = "open"
         for lbl in labels:
-            if lbl.startswith("status:"):
+            if lbl.startswith(STATUS_LABEL_PREFIX):
                 status = lbl.split(":")[1]
                 break
     ms = issue["milestone"]

--- a/plugins/development-harness/backlog_core/gh_client.py
+++ b/plugins/development-harness/backlog_core/gh_client.py
@@ -96,9 +96,9 @@ DH_LABELS: dict[str, str] = {
     "type:refactor": "2563eb",
     "type:chore": "6b7280",
     "type:docs": "0891b2",
-    StatusLabel.NEEDS_GROOMING: "f59e0b",
-    StatusLabel.IN_PROGRESS: "3b82f6",
-    StatusLabel.VERIFIED: "10b981",
+    StatusLabel.NEEDS_GROOMING.value: "f59e0b",
+    StatusLabel.IN_PROGRESS.value: "3b82f6",
+    StatusLabel.VERIFIED.value: "10b981",
 }
 
 
@@ -1430,8 +1430,8 @@ def _pick_primary_status_label(status_labels: list[str]) -> str:
         ``"status:blocked"`` if present, else the first label in ``status_labels``,
         else ``""``.
     """
-    if StatusLabel.BLOCKED in status_labels:
-        return StatusLabel.BLOCKED
+    if StatusLabel.BLOCKED.value in status_labels:
+        return StatusLabel.BLOCKED.value
     return status_labels[0] if status_labels else ""
 
 

--- a/plugins/development-harness/backlog_core/status_registry.py
+++ b/plugins/development-harness/backlog_core/status_registry.py
@@ -1,0 +1,52 @@
+"""Canonical status-label registry -- single source of truth for GitHub ``status:*`` labels.
+
+``gh_client.py`` previously scattered ~19 raw ``"status:X"`` string literals across its
+label-management functions (``apply_status_in_progress``, ``apply_status_verified``,
+``apply_status_groomed``, ``apply_status_blocked``, ``_pick_primary_status_label``, ...)
+with no shared source of truth, and a second independent copy of ``status:verified`` was
+hardcoded in ``.github/workflows/quality-gate-audit.yml``'s inline JS. This module exists
+to prevent a renamed or added status label from drifting silently across any of them (#3004).
+
+Dependency direction (must remain acyclic):
+    status_registry <- gh_client (and any other consumer)
+
+This module imports nothing from the rest of ``backlog_core`` — it is a leaf, so any
+module may import from it without risking a cycle. Mirrors the shape of
+``section_registry.py`` (canonical enum + drift-detection test), simplified because
+status labels have no display-heading or alias-recovery concerns of their own — the
+enum value IS the literal GitHub label name.
+
+How to add a new canonical status label
+-----------------------------------------
+1. Append a member to :class:`StatusLabel` — the value is the literal GitHub label
+   name (e.g. ``ARCHIVED = "status:archived"``).
+2. Use the new member everywhere the label is referenced instead of a raw string.
+   ``plugins/development-harness/tests/test_status_label_registry_drift.py`` fails
+   the build if a raw ``"status:X"`` literal appears in ``gh_client.py`` or the
+   quality-gate-audit workflow that is not a registered member.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final
+
+__all__ = ["STATUS_LABEL_PREFIX", "StatusLabel"]
+
+# Shared namespace prefix for every status label — used by callers that filter an
+# issue's labels down to "any status label" rather than checking a specific one.
+STATUS_LABEL_PREFIX: Final[str] = "status:"
+
+
+class StatusLabel(StrEnum):
+    """Canonical ``status:*`` GitHub label values used across the backlog lifecycle.
+
+    Append new members here when registering a new status label — see the module
+    docstring's "How to add a new canonical status label" steps.
+    """
+
+    NEEDS_GROOMING = "status:needs-grooming"
+    IN_PROGRESS = "status:in-progress"
+    GROOMED = "status:groomed"
+    VERIFIED = "status:verified"
+    BLOCKED = "status:blocked"

--- a/plugins/development-harness/tests/test_status_label_registry_drift.py
+++ b/plugins/development-harness/tests/test_status_label_registry_drift.py
@@ -6,14 +6,25 @@
 ``apply_status_blocked``, ``_pick_primary_status_label``, ...), with no canonical
 source of truth. A second, independent copy of one of those labels
 (``VERIFIED_LABEL = 'status:verified'``) is hardcoded in
-``.github/workflows/quality-gate-audit.yml``'s inline JS. Nothing kept these in sync —
-a renamed or added status label could drift silently across any of them.
+``.github/workflows/quality-gate-audit.yml``'s inline JS. ``backlog_core/server.py``
+and ``backlog_core/operations.py`` also reference concrete ``status:X`` labels in
+their MCP tool/CLI descriptions and docstrings (e.g. "Filter by status value e.g.
+'status:in-progress'") — an agent reads these strings to decide what to pass back
+in, so a rename that only touches ``StatusLabel`` would silently mislead callers.
+Nothing kept any of these in sync — a renamed or added status label could drift
+silently across any of them.
 
-This test parses ``gh_client.py`` and the workflow file for every ``status:X``-shaped
-literal and fails if any is not a member of ``backlog_core.status_registry.StatusLabel``
-(mirrors the grep-based drift-detection pattern in
-``test_section_name_registry_drift.py``, not a general duplicate-literal linter — see
-issue #3004 for why a general linter was rejected).
+This test parses ``gh_client.py``, ``server.py``, ``operations.py``, and the workflow
+file for every ``status:X``-shaped literal and fails if any is not a member of
+``backlog_core.status_registry.StatusLabel`` (mirrors the grep-based drift-detection
+pattern in ``test_section_name_registry_drift.py``, not a general duplicate-literal
+linter — see issue #3004 for why a general linter was rejected). The regex requires a
+lowercase word immediately after the colon, so generic GitHub-state mentions like
+``status:open``/``status:closed`` (issue open/closed state, not a ``StatusLabel``
+member) match the pattern shape but are exercised the same as any other literal: they
+must also be registered in ``StatusLabel`` or the test fails, prompting a deliberate
+decision (register it, or reword the doc to not look like a label) rather than a
+silent scope gap.
 """
 
 from __future__ import annotations
@@ -30,26 +41,37 @@ _STATUS_LABEL_RE = re.compile(r"\bstatus:[a-z][a-z-]*\b")
 
 _CANONICAL_LABELS = {label.value for label in StatusLabel}
 
+# Every backlog_core module known to reference concrete status:X label literals —
+# in label-management code (gh_client.py) or in agent-facing tool/CLI descriptions
+# and docstrings (server.py, operations.py). Extend this tuple, not the regex, when
+# a new module starts mentioning status:X literals.
+_SCANNED_MODULES = ("gh_client.py", "server.py", "operations.py")
+
 
 def _scan(path: Path) -> set[str]:
     return set(_STATUS_LABEL_RE.findall(path.read_text(encoding="utf-8")))
 
 
-def test_gh_client_status_literals_are_canonical() -> None:
-    """Every ``status:X`` literal in gh_client.py must be a registered StatusLabel member.
+def test_backlog_core_status_literals_are_canonical() -> None:
+    """Every ``status:X`` literal in backlog_core must be a registered StatusLabel member.
 
     Tests: backlog_core.status_registry.StatusLabel completeness against real usage
-    How: Regex-scan gh_client.py for ``status:X``-shaped substrings, diff against the
-         canonical StatusLabel value set.
-    Why: A status label used in code but never registered in StatusLabel is exactly
-         the drift #3004 describes — this fails loudly instead of silently.
+    How: Regex-scan gh_client.py, server.py, and operations.py for ``status:X``-shaped
+         substrings, diff against the canonical StatusLabel value set.
+    Why: A status label used in code, an MCP tool description, or a docstring but
+         never registered in StatusLabel is exactly the drift #3004 describes — this
+         fails loudly instead of silently. server.py and operations.py are in scope
+         because their ``status:X`` mentions are user/agent-facing documentation an
+         agent reads to decide what value to pass back — a stale copy there is as
+         misleading as a stale literal in gh_client.py itself.
     """
-    found = _scan(_PLUGIN_ROOT / "backlog_core" / "gh_client.py")
-    unknown = found - _CANONICAL_LABELS
-    assert not unknown, (
-        f"gh_client.py references status label(s) not registered in StatusLabel: {sorted(unknown)}. "
-        "Register them in backlog_core/status_registry.py or fix the typo."
-    )
+    for module in _SCANNED_MODULES:
+        found = _scan(_PLUGIN_ROOT / "backlog_core" / module)
+        unknown = found - _CANONICAL_LABELS
+        assert not unknown, (
+            f"{module} references status label(s) not registered in StatusLabel: {sorted(unknown)}. "
+            "Register them in backlog_core/status_registry.py or fix the typo."
+        )
 
 
 def test_quality_gate_audit_workflow_verified_label_matches_registry() -> None:

--- a/plugins/development-harness/tests/test_status_label_registry_drift.py
+++ b/plugins/development-harness/tests/test_status_label_registry_drift.py
@@ -1,0 +1,69 @@
+"""Guards against status-label drift between raw string literals and StatusLabel (#3004).
+
+``backlog_core/gh_client.py`` previously defined an under-used ``DH_LABELS`` dict plus
+~19 raw ``"status:X"`` string literals scattered through label-management functions
+(``apply_status_in_progress``, ``apply_status_verified``, ``apply_status_groomed``,
+``apply_status_blocked``, ``_pick_primary_status_label``, ...), with no canonical
+source of truth. A second, independent copy of one of those labels
+(``VERIFIED_LABEL = 'status:verified'``) is hardcoded in
+``.github/workflows/quality-gate-audit.yml``'s inline JS. Nothing kept these in sync —
+a renamed or added status label could drift silently across any of them.
+
+This test parses ``gh_client.py`` and the workflow file for every ``status:X``-shaped
+literal and fails if any is not a member of ``backlog_core.status_registry.StatusLabel``
+(mirrors the grep-based drift-detection pattern in
+``test_section_name_registry_drift.py``, not a general duplicate-literal linter — see
+issue #3004 for why a general linter was rejected).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from backlog_core.status_registry import StatusLabel
+
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _PLUGIN_ROOT.parent.parent
+
+_STATUS_LABEL_RE = re.compile(r"\bstatus:[a-z][a-z-]*\b")
+
+_CANONICAL_LABELS = {label.value for label in StatusLabel}
+
+
+def _scan(path: Path) -> set[str]:
+    return set(_STATUS_LABEL_RE.findall(path.read_text(encoding="utf-8")))
+
+
+def test_gh_client_status_literals_are_canonical() -> None:
+    """Every ``status:X`` literal in gh_client.py must be a registered StatusLabel member.
+
+    Tests: backlog_core.status_registry.StatusLabel completeness against real usage
+    How: Regex-scan gh_client.py for ``status:X``-shaped substrings, diff against the
+         canonical StatusLabel value set.
+    Why: A status label used in code but never registered in StatusLabel is exactly
+         the drift #3004 describes — this fails loudly instead of silently.
+    """
+    found = _scan(_PLUGIN_ROOT / "backlog_core" / "gh_client.py")
+    unknown = found - _CANONICAL_LABELS
+    assert not unknown, (
+        f"gh_client.py references status label(s) not registered in StatusLabel: {sorted(unknown)}. "
+        "Register them in backlog_core/status_registry.py or fix the typo."
+    )
+
+
+def test_quality_gate_audit_workflow_verified_label_matches_registry() -> None:
+    """The workflow's hardcoded VERIFIED_LABEL JS constant must match StatusLabel.VERIFIED.
+
+    Tests: .github/workflows/quality-gate-audit.yml's ``VERIFIED_LABEL`` constant
+    How: Regex-scan the workflow YAML for ``status:X``-shaped substrings, assert
+         ``StatusLabel.VERIFIED.value`` is present and every match is canonical.
+    Why: This is the cross-language duplicate #3004 flags — a Python-only registry
+         does not catch a JS-side rename on its own; this test is the catch.
+    """
+    found = _scan(_REPO_ROOT / ".github" / "workflows" / "quality-gate-audit.yml")
+    assert StatusLabel.VERIFIED.value in found, (
+        f"Expected quality-gate-audit.yml to reference {StatusLabel.VERIFIED.value!r}, found {sorted(found)}"
+    )
+    unknown = found - _CANONICAL_LABELS
+    assert not unknown, f"quality-gate-audit.yml references status label(s) not in StatusLabel: {sorted(unknown)}"


### PR DESCRIPTION
## Summary
- Adds `backlog_core/status_registry.py` — a `StatusLabel` `StrEnum` (+ `STATUS_LABEL_PREFIX`) mirroring the shape of `section_registry.py` (PR #2987) — as the single source of truth for GitHub `status:*` labels.
- Replaces `gh_client.py`'s under-used `DH_LABELS` dict entries and ~19 raw `"status:X"` literals across `apply_status_in_progress`/`apply_status_verified`/`apply_status_groomed`/`apply_status_blocked`/`_pick_primary_status_label`/etc. with references to `StatusLabel`.
- Adds `test_status_label_registry_drift.py` (grep-based, extending the pattern in `test_section_name_registry_drift.py` — not a general duplicate-literal linter) that fails CI if any `status:X`-shaped literal in `gh_client.py` **or** `.github/workflows/quality-gate-audit.yml` is not a registered `StatusLabel` member.
- Comments `quality-gate-audit.yml`'s hardcoded `VERIFIED_LABEL = 'status:verified'` JS constant with a pointer to the canonical Python source and the drift test that now catches a mismatch.

## Test plan
- [x] `test_status_label_registry_drift.py` written first against current code and confirmed failing (`ModuleNotFoundError: No module named 'backlog_core.status_registry'`) before implementation
- [x] Registry + `gh_client.py` refactor implemented; both drift tests pass
- [x] `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` clean on all touched files
- [x] `plugins/development-harness/tests/run_pytest.py` full suite: 4859 passed, 42 skipped, 5 xfailed, 2 failed — both pre-existing on `main` and unrelated (`ruff` binary not on PATH in one sandboxed test; `test_github_content_provider_replay_preserves_concurrent_remote_revision`, a previously-tracked pre-existing failure)
- [x] `uv run prek run --files <touched files>` — all hooks pass

Fixes #3004

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20jamie-bitflight%2Fclaude_skills%20PR%20%233013%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=jamie-bitflight%2Fclaude_skills&pr=3013&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aplugins%2Fdevelopment-harness%2Ftests%2Ftest_status_label_registry_drift.py%3A87-90%0A**Workflow%20assignment%20is%20not%20validated**%0A%0AThe%20test%20scans%20every%20status%20literal%20in%20the%20workflow%20rather%20than%20checking%20the%20%60VERIFIED_LABEL%60%20assignment.%20Changing%20that%20constant%20to%20another%20registered%20status%20still%20passes%20because%20independent%20%60status%3Averified%60%20references%20satisfy%20the%20presence%20assertion%2C%20leaving%20the%20audit%20to%20skip%20the%20wrong%20issues%20and%20flag%20verified%20ones.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jamie-bitflight%2Fclaude_skills&pr=3013&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22jamie-bitflight%2Fclaude_skills%22%20on%20the%20existing%20branch%20%22fix%2Fstatus-label-registry-3004%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstatus-label-registry-3004%22.%0A%0A%23%23%23%20Issue%201%0Aplugins%2Fdevelopment-harness%2Ftests%2Ftest_status_label_registry_drift.py%3A87-90%0A**Workflow%20assignment%20is%20not%20validated**%0A%0AThe%20test%20scans%20every%20status%20literal%20in%20the%20workflow%20rather%20than%20checking%20the%20%60VERIFIED_LABEL%60%20assignment.%20Changing%20that%20constant%20to%20another%20registered%20status%20still%20passes%20because%20independent%20%60status%3Averified%60%20references%20satisfy%20the%20presence%20assertion%2C%20leaving%20the%20audit%20to%20skip%20the%20wrong%20issues%20and%20flag%20verified%20ones.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jamie-bitflight%2Fclaude_skills&pr=3013&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
plugins/development-harness/tests/test_status_label_registry_drift.py:87-90
**Workflow assignment is not validated**

The test scans every status literal in the workflow rather than checking the `VERIFIED_LABEL` assignment. Changing that constant to another registered status still passes because independent `status:verified` references satisfy the presence assertion, leaving the audit to skip the wrong issues and flag verified ones.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(development-harness): address PR #30..."](https://github.com/jamie-bitflight/claude_skills/commit/48ff6e73c27284f4a66e3ef7a647d4dd72e9a08f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54618916)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->