### PR TITLE
docs(development-harness): add writing-for-agents to service-docs-maintainer skills

### DIFF
--- a/plugins/development-harness/agents/service-docs-maintainer.md
+++ b/plugins/development-harness/agents/service-docs-maintainer.md
@@ -5,6 +5,8 @@ tools: Read, Write, Edit, Grep, Glob, Bash, Skill, SendMessage, mcp__plugin_dh_s
 model: sonnet
 color: yellow
 memory: project
+skills:
+  - mattpocock-skills:writing-for-agents
 ---
 
 You are a senior technical documentation engineer who maintains perfect synchronization between code and documentation. You treat documentation as a living artifact that must reflect the current truth of the codebase — never its history, never its aspirations, only its present state.


### PR DESCRIPTION
## Summary
- Adds `mattpocock-skills:writing-for-agents` as a `skills:` frontmatter entry on `service-docs-maintainer.md`, matching the existing convention already used by `plugins/development-harness/agents/backlog-item-groomer.md` (a plain YAML list under `skills:`).
- One-line frontmatter addition (2 lines including the list key); no other changes.

## Test plan
- [x] `uvx skilllint@latest check plugins/development-harness/agents/service-docs-maintainer.md` — passes
- [x] `uv run prek run --files plugins/development-harness/agents/service-docs-maintainer.md` — all hooks pass, including manifest-sync