### PR TITLE
fix(dh): bump version to 9.0.17 — three merges landed after the last bump

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.16",
+  "version": "9.0.17",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"


### PR DESCRIPTION
## Summary
Confirmed via `check_plugin_version_bump.py --audit` (from #3022, merged just before this) that `development-harness` drifted again live: #3020 set the version to 9.0.16, but #3012, #3009, and #3013 all subsequently merged via GitHub squash-merge and changed plugin content without bumping — the exact pattern #3021/#3022 exist to prevent, caught here retroactively before the new CI gate had a chance to apply going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix(dh): bump version to 9.0.17 — three ..."](https://github.com/jamie-bitflight/claude_skills/commit/8a82e90596c13ab785aa217b57129beab61ff3f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54630039)</sub>

<!-- /greptile_comment -->