### PR TITLE
fix(development-harness): un-categoricalize HIGH severity in impact-analyst's workflow-continuity lens

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.17",
+  "version": "9.0.18",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/agents/impact-analyst.md
+++ b/plugins/development-harness/agents/impact-analyst.md
@@ -53,7 +53,9 @@ dispatch → sync → verification pipeline hands data forward through the confi
 every step. Judge severity by whether the specific next step that needs this data can still read
 and act on it — not by whether stored bytes are literally deleted or corrupted. Data that exists
 on disk but is never consulted by the step that needs it is functionally lost to the workflow,
-even with zero bytes deleted; that is the failure to rate HIGH, not "will anything be erased."
+even with zero bytes deleted — that is the failure pattern to scale severity against (LOW/MEDIUM/HIGH
+by actual scope, coverage, and recoverability), not "will anything be erased." A recoverable,
+narrow-window gap is not automatically HIGH just because it fits this pattern.
 This lens produces a hypothesis, not a verdict — verify it against the actual consuming code path
 before writing a Risk level. Worked examples:
 [Workflow-Continuity Risk Lens — Case Studies](../docs/severity-workflow-continuity-lens.md).


### PR DESCRIPTION
## Summary
A Greptile P1 finding landed on merged PR #3009 (`impact-analyst.md:56-57`) *after* the fix agent's replies but *before* merge, and was missed at merge time — caught in a post-merge review sweep. "that is the failure to rate HIGH" read as categorical: any workflow-continuity gap gets rated HIGH regardless of scope, coverage, or recoverability, contradicting the file's own LOW/MEDIUM/HIGH scaled risk-level guidance elsewhere in the same document (and the actual lesson from this session's own worked examples, where a recoverable narrow-window gap was correctly scored 'soon,' not 'now').

## Fix
Reworded so the described pattern (data unreachable to the next consuming step) is what severity should be *scaled against* — not an automatic HIGH verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["fix(dh): bump version to 9.0.18 for impa..."](https://github.com/jamie-bitflight/claude_skills/commit/31fd6423dd73ca6b9796b13db905bea1b3fd83f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54630780)</sub>

<!-- /greptile_comment -->