### PR TITLE
fix(astral-adoption): restore knowledge-explorer ANN401 ignore, pin create-pull-request

### DIFF
--- a/.github/workflows/sync-astral-corpus.yml
+++ b/.github/workflows/sync-astral-corpus.yml
@@ -51,7 +51,7 @@ jobs:
             plugins/python-engineering/skills/python3-tools/scripts/sync_uv_releases.py
 
       - name: Open PR if the archive changed
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(python3-tools): sync uv changelog"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -506,6 +506,8 @@ max-complexity = 12
 "plugins/scientific-method/mcp/experiment-registry/__init__.py" = [
     "invalid-module-name",
 ]
+# ruamel.yaml returns dynamically typed values; Any is the correct annotation here
+"research/knowledge-explorer.py" = ["any-type"]
 # Third-party type stubs authored here to keep typing consistent for packages that ship none.
 # A (builtin-shadowing) and N (naming) often must mirror the external module's real names
 # verbatim; ANN softening (e.g. Any) reflects that the systems below the stub aren't ours to


### PR DESCRIPTION
## Summary
- Restores the `research/knowledge-explorer.py` per-file ruff ignore (`any-type`) that was silently dropped by the `typings/**` block added in #3019 — this was failing the `Quality Gate` on `main` since #3019 merged.
- Pins `peter-evans/create-pull-request` in `sync-astral-corpus.yml` to a reviewed commit SHA instead of the mutable `@v7` tag, since that step runs with a `contents: write` / `pull-requests: write` token.

Both were flagged by Copilot/Greptile review on #3019 and left as explicit follow-ups after merge.

## Test plan
- [x] `uv run ruff check .` passes clean
- [x] pre-commit hooks (pypfmt, yaml/toml checks, conventional-commit) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix(astral-adoption): restore knowledge-..."](https://github.com/jamie-bitflight/claude_skills/commit/7457b2c097bd192f2b2408896f94486625600c18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54657312)</sub>

<!-- /greptile_comment -->