### PR TITLE
fix(rules): scope citation-requirements out of .claude/rules/

### DIFF
--- a/.claude/rules/citation-requirements.md
+++ b/.claude/rules/citation-requirements.md
@@ -3,7 +3,6 @@ paths:
 - '**/SKILL.md'
 - '**/agents/**/*.md'
 - '**/commands/**/*.md'
-- .claude/rules/**/*.md
 - '**/CLAUDE.md'
 ---
 

--- a/.claude/rules/commit-cadence-and-worktrees.md
+++ b/.claude/rules/commit-cadence-and-worktrees.md
@@ -45,16 +45,11 @@ committing.
   the current working tree's uncommitted changes — those are invisible to a new worktree. Before
   spawning a worktree-isolated agent, commit (not necessarily push) whatever the agent needs to
   build on.
-- **Root cause of stale worktree bases (fixed 2026-08-05):** Claude Code's default worktree
-  behavior (`worktree.baseRef: "fresh"`) branches every new worktree — including subagent
-  isolation — from the repository's default branch on the remote (`origin/main`), not from the
-  current local branch or HEAD. On an unmerged feature branch, this guarantees a worktree-isolated
-  agent starts without that branch's commits, no matter how recently the repo was fetched. This
-  repo sets `worktree.baseRef: "head"` in `.claude/settings.json` (commit `82c11e86`) so worktrees
-  branch from current local HEAD instead — verified against a live probe agent whose worktree HEAD
-  matched the main checkout's HEAD exactly. SOURCE:
-  [code.claude.com/docs/en/worktrees.md](https://code.claude.com/docs/en/worktrees.md#choose-the-base-branch)
-  (accessed 2026-08-05), "Choose the base branch" section.
+- **Worktree base is local HEAD, not `origin/main`.** This repo sets `worktree.baseRef: "head"` in
+  `.claude/settings.json` — new worktrees, including subagent isolation, branch from current local
+  HEAD. Without this, Claude Code's default (`worktree.baseRef: "fresh"`) branches from the
+  repository's remote default branch instead, so a worktree-isolated agent on an unmerged feature
+  branch would start without that branch's commits no matter how recently the repo was fetched.
 - Still tell a worktree-isolated agent to verify its HEAD (`git merge-base --is-ancestor <recent
   commit> HEAD`) before starting, as defense-in-depth — `baseRef: "head"` is the repo default, not
   a guarantee for every session (e.g. a session launched with `--settings` overriding it, or a


### PR DESCRIPTION
## Summary

Follow-up to #3030's rule-cleanup sweep. Greptile flagged (correctly) on #3030 that `.claude/rules/citation-requirements.md` still lists `.claude/rules/**/*.md` in its own `paths:` frontmatter — meaning it still technically mandates citations *inside rule files*, directly contradicting the policy established across #3019/#3030 that rule files carry zero provenance/citation content by design. #3030 merged before this fix landed on its branch, so it's re-applied here against current `main`.

- Narrowed `citation-requirements.md`'s scope to the skill/agent-facing docs the requirement is actually for (`SKILL.md`, `agents/**/*.md`, `commands/**/*.md`, `CLAUDE.md`).
- Fixed the same violation in `commit-cadence-and-worktrees.md`, which #3030's 7-file sweep missed — a bullet carrying a `(fixed 2026-08-05)` date, a verification narrative, and a trailing `SOURCE:` citation, rewritten as a flat current-state directive.

## Test plan
- [x] `grep -rn "SOURCE:" .claude/rules/*.md` — no remaining citation lines outside citation-requirements.md's own explanation of the syntax
- [x] Frontmatter YAML parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix(rules): scope citation-requirements ..."](https://github.com/jamie-bitflight/claude_skills/commit/b24dc3da96424725bf7556de2bd1e8afdf2dc753) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54671836)</sub>

<!-- /greptile_comment -->