### PR TITLE
docs(agents): clarify compact-JSON rule doesn't cover static repo config

### DIFF
--- a/.claude/rules/frontmatter-requirements.md
+++ b/.claude/rules/frontmatter-requirements.md
@@ -43,8 +43,7 @@ the host (an uninstalled plugin) is a **silent no-op** — no error, agent just 
 content. Never name a skill from an externally-sourced plugin (a marketplace entry whose `source`
 is `github`, `git-subdir`, `url`, or `npm`, not a local path) in `skills:`. Reference such skills
 only in prose (a routing table entry, an inline mention) — a name an agent tries to activate on
-demand fails visibly if the plugin isn't installed, instead of silently starting the agent with no
-fallback and no signal.
+demand fails visibly instead.
 
 ## Multi-Ecosystem Frontmatter Preservation
 

--- a/.claude/rules/frontmatter-requirements.md
+++ b/.claude/rules/frontmatter-requirements.md
@@ -42,8 +42,9 @@ An agent's `skills:` field preloads skill content at subagent startup. A listed 
 the host (an uninstalled plugin) is a **silent no-op** — no error, agent just starts without that
 content. Never name a skill from an externally-sourced plugin (a marketplace entry whose `source`
 is `github`, `git-subdir`, `url`, or `npm`, not a local path) in `skills:`. Reference such skills
-only in prose (a `Skill(skill="...")` call, a routing table), where a dangling name degrades to a
-harmless no-op instead of silently starting an agent with no fallback and no signal.
+only in prose (a routing table entry, an inline mention) — a name an agent tries to activate on
+demand fails visibly if the plugin isn't installed, instead of silently starting the agent with no
+fallback and no signal.
 
 ## Multi-Ecosystem Frontmatter Preservation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,8 +186,10 @@ guess:
   value to its meaning via column *position* (nth value = nth header); JSON binds via an explicit
   *repeated key* at each value — a more direct, unambiguous token-level association for an LLM
   parsing the output, with no risk of misparsing when a cell value contains whitespace. Emit
-  compact JSON (`json.dumps(data)` / `model_dump_json()`, no `indent=`) — see
-  `.claude/CLAUDE.md` "Code Quality Standards" for the JSON-output rule.
+  compact JSON (`json.dumps(data)` / `model_dump_json()`, no `indent=`) for this — output a script
+  or CLI emits for an agent to parse. This does **not** apply to static repo config files
+  (`package.json`, `.claude-plugin/*.json`, `marketplace.json`) — those are read by humans
+  browsing the repo and by non-AI tooling (npm, git), and stay pretty-printed.
 - **`logging` is for debug/trace/forensic output only** — never for primary output a calling agent
   needs to read or parse. Status messages, results, and errors meant to be consumed by the caller
   go through direct stdout/stderr emission (`typer.echo()`, `print()`, structured JSON), not a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,13 +207,34 @@ guess:
   `references/typer-rich-non-tty-patterns.md` for the measure-and-render pattern that keeps it
   data-loss-safe; do not use Rich's TTY-oriented defaults unmodified.
 
+### Writing `.claude/rules/*.md` Files
+
+Rules state the current requirement only — never provenance, citations, or narrative. Extract the
+imperative directive; drop the evidence, the "who verified this and when," the history of how the
+rule came to be. That belongs in the commit message or PR description. A durable architecture
+decision (not an enforcement rule) belongs in `docs/`, not here.
+
+Rules are kept small specifically so they get read — a long rule gets skimmed past, not followed.
+When tightening an existing rule file, rewrite it from scratch as flat directives; don't
+`Edit`-trim words out of the existing structure, which preserves the narrative's overhead and
+saves little.
+
 ### Markdown (Skills/Commands/Agents)
 
-- Skills are **AI-facing documentation**, NOT user documentation
+- Skills are AI-facing documentation, NOT user documentation
 - Use imperative language ("The model MUST...")
+- No decorative `**bold**` — it carries no instruction-priority signal to a model. Use imperative
+  wording for emphasis and backtick code-spans for literal identifiers (tool names, config keys);
+  both cost less than bold and, for an identifier, are also more accurate.
 - Include XML tags for structured sections
-- Cite sources with URLs and access dates
+- Cite sources with URLs and access dates (this file category only — `.claude/rules/*.md` never
+  carries citations; see above)
 - File references use `./` relative prefix
+- Skill handoffs use plain prose (`plugin:skill-name` or `/plugin:skill-name`), not
+  `Skill(skill="...")` call syntax. `Skill(...)` is Claude-Code-specific invocation syntax; this
+  repo ships plugin content meant to run under Codex and OpenCode too, where that syntax means
+  nothing. Existing `Skill(...)` blocks predate this convention and are a known follow-up, not a
+  bug to flag.
 
 Before writing or editing any SKILL.md, load `.claude/rules/skill-substitution.md` — string
 substitution happens at load time, including inside fenced code blocks, and gets the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,10 +229,8 @@ flat directives, not `Edit`-trimming words from its existing structure.
   `Skill(skill="...")` — that syntax is Claude-Code-only and this repo's plugin content also
   targets Codex and OpenCode. Existing `Skill(...)` blocks are pre-convention, not bugs.
 
-Before writing or editing any SKILL.md, load `.claude/rules/skill-substitution.md` — string
-substitution happens at load time, including inside fenced code blocks, and gets the
-`${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_SKILL_DIR}` / `$ARGUMENTS` mechanics wrong in ways that corrupt
-the rendered skill.
+Before writing or editing any SKILL.md, load `.claude/rules/skill-substitution.md` — load-time
+substitution can silently corrupt the rendered skill if unaccounted for.
 
 ### JavaScript/TypeScript
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,32 +209,25 @@ guess:
 
 ### Writing `.claude/rules/*.md` Files
 
-Rules state the current requirement only — never provenance, citations, or narrative. Extract the
-imperative directive; drop the evidence, the "who verified this and when," the history of how the
-rule came to be. That belongs in the commit message or PR description. A durable architecture
-decision (not an enforcement rule) belongs in `docs/`, not here.
+Rules are the current requirement only — never provenance, citations, or narrative. Put those in
+the commit message or PR description; put a durable architecture decision in `docs/` instead.
 
-Rules are kept small specifically so they get read — a long rule gets skimmed past, not followed.
-When tightening an existing rule file, rewrite it from scratch as flat directives; don't
-`Edit`-trim words out of the existing structure, which preserves the narrative's overhead and
-saves little.
+Rules are read only when small. Tightening an existing rule means rewriting it from scratch as
+flat directives, not `Edit`-trimming words from its existing structure.
 
 ### Markdown (Skills/Commands/Agents)
 
 - Skills are AI-facing documentation, NOT user documentation
 - Use imperative language ("The model MUST...")
-- No decorative `**bold**` — it carries no instruction-priority signal to a model. Use imperative
-  wording for emphasis and backtick code-spans for literal identifiers (tool names, config keys);
-  both cost less than bold and, for an identifier, are also more accurate.
+- No decorative `**bold**` — a model reads it as no stronger a signal than plain text. Use
+  imperative wording for emphasis, backtick code-spans for literal identifiers (tool names, config
+  keys)
 - Include XML tags for structured sections
-- Cite sources with URLs and access dates (this file category only — `.claude/rules/*.md` never
-  carries citations; see above)
+- Cite sources with URLs and access dates (not `.claude/rules/*.md` — see above)
 - File references use `./` relative prefix
-- Skill handoffs use plain prose (`plugin:skill-name` or `/plugin:skill-name`), not
-  `Skill(skill="...")` call syntax. `Skill(...)` is Claude-Code-specific invocation syntax; this
-  repo ships plugin content meant to run under Codex and OpenCode too, where that syntax means
-  nothing. Existing `Skill(...)` blocks predate this convention and are a known follow-up, not a
-  bug to flag.
+- Skill handoffs use plain prose (`plugin:skill-name`, `/plugin:skill-name`), not
+  `Skill(skill="...")` — that syntax is Claude-Code-only and this repo's plugin content also
+  targets Codex and OpenCode. Existing `Skill(...)` blocks are pre-convention, not bugs.
 
 Before writing or editing any SKILL.md, load `.claude/rules/skill-substitution.md` — string
 substitution happens at load time, including inside fenced code blocks, and gets the


### PR DESCRIPTION
## Summary

Follow-up to #3035. Greptile flagged the pretty-printed `package.json` added there against AGENTS.md's compact-JSON rule ("CLI and script output — agent-only, never human-facing"). That rule's own section header already scoped it to `plugins/**/scripts/` output, but the bullet itself didn't restate that scope, and cited a "Code Quality Standards" section in `.claude/CLAUDE.md` that no longer exists there (stale pointer).

Made the bullet self-contained: compact JSON is for output a script/CLI emits for an agent to parse — never for static repo config files (`package.json`, `.claude-plugin/*.json`, `marketplace.json`), which are read by humans browsing the repo and by non-AI tooling (npm, git) and stay pretty-printed.

#3035 merged before this landed on its branch, so it's re-applied here against current `main`.

## Test plan
- [x] Reviewed the corrected bullet against the actual rule scope and file examples (`pyproject.toml` correctly excluded — it's TOML, not JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (5): Last reviewed commit: ["docs(agents): fix skill-substitution.md ..."](https://github.com/jamie-bitflight/claude_skills/commit/39ca6f7cbc6144ef981510f410908bb069b5f0bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54673493)</sub>

<!-- /greptile_comment -->