### PR TITLE
fix(development-harness): resolve backlog_view read-path/section-key visibility bug (#2956)

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.19",
+  "version": "9.0.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     from github.Repository import Repository
 
     from backlog_core.backend_types import IssueCommentNode, IssueNode, MilestoneFullNode
+    from backlog_core.backends._github_work_item_versions import WorkItemVersion
     from backlog_core.file_cache_state import _PendingWorkItemMutation
     from backlog_core.models import (
         BackendStatus,
@@ -546,10 +547,21 @@ class GitHubBackend:
     def view_enrich_from_github(self, result: ViewItemResult, issue_num: str, repo: str = "") -> bool:
         """Enrich a ViewItemResult with live data from the backend.
 
+        Resolves the authoritative agent-managed body (head record + audit comment)
+        via ``self._work_items`` rather than the raw issue body — see
+        ``gh_client.view_enrich_from_github`` for why the two differ.
+
         Returns:
             True if enrichment succeeded, False if the issue was not found.
         """
-        return gh_client.view_enrich_from_github(result, issue_num, repo or self._repo)
+
+        def _resolve_version(repo_obj: Repository, owner: str, repo_name: str, issue: IssueNode) -> WorkItemVersion:
+            version, _head_record, _root = self._work_items.work_item_version(repo_obj, owner, repo_name, issue)
+            return version
+
+        return gh_client.view_enrich_from_github(
+            result, issue_num, repo or self._repo, resolve_version=_resolve_version
+        )
 
     def issue_to_local_fields(self, issue: IssueNode) -> IssueLocalFields:
         """Convert a raw IssueNode to a typed IssueLocalFields model.

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -68,7 +68,6 @@ if TYPE_CHECKING:
     from github.Repository import Repository
 
     from backlog_core.backend_types import IssueCommentNode, IssueNode, MilestoneFullNode
-    from backlog_core.backends._github_work_item_versions import WorkItemVersion
     from backlog_core.file_cache_state import _PendingWorkItemMutation
     from backlog_core.models import (
         BackendStatus,
@@ -554,13 +553,11 @@ class GitHubBackend:
         Returns:
             True if enrichment succeeded, False if the issue was not found.
         """
-
-        def _resolve_version(repo_obj: Repository, owner: str, repo_name: str, issue: IssueNode) -> WorkItemVersion:
-            version, _head_record, _root = self._work_items.work_item_version(repo_obj, owner, repo_name, issue)
-            return version
-
         return gh_client.view_enrich_from_github(
-            result, issue_num, repo or self._repo, resolve_version=_resolve_version
+            result,
+            issue_num,
+            repo or self._repo,
+            resolve_version=lambda r, o, n, i: self._work_items.work_item_version(r, o, n, i)[0],
         )
 
     def issue_to_local_fields(self, issue: IssueNode) -> IssueLocalFields:

--- a/plugins/development-harness/backlog_core/backends/github_work_items.py
+++ b/plugins/development-harness/backlog_core/backends/github_work_items.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from backlog_core import gh_client
+from backlog_core import gh_client, rendering as _rendering
 from backlog_core.backends._github_work_item_versions import (
     WorkItemHead,
     WorkItemVersion,
@@ -534,6 +534,18 @@ class _GitHubReconciliation:
     ) -> list[LogicalCacheRecord]:
         """Merge cached work-item snapshots with queued mutations.
 
+        Queued mutations are read from ``_CacheState`` via plain
+        ``BacklogItem.model_validate`` (``file_cache_state.py``), which never
+        runs ``rendering.normalize_unknown_sections`` — unlike a snapshot,
+        which is always loaded through ``yaml_io.load_item`` and normalized on
+        the way in. A mutation takes precedence over its snapshot for the same
+        reference below, so a reference with a queued mutation would otherwise
+        keep serving un-normalized (duplicate/stale-keyed) sections
+        indefinitely — including while the mutation itself is stuck pending
+        (e.g. the title-mismatch acknowledgement gap tracked in #2963), which
+        is exactly when a caller most needs the healed view. Normalizing here
+        closes that gap without touching the acknowledgement logic itself.
+
         Returns:
             One logical cache record per work-item reference.
         """
@@ -544,8 +556,11 @@ class _GitHubReconciliation:
             pending_work_items if pending_work_items is not None else self._cache._pending_work_item_mutations()
         ):
             snapshot = records_by_reference.get(mutation.item.reference)
+            item = mutation.item
+            if item.sections:
+                item = item.model_copy(update={"sections": _rendering.normalize_unknown_sections(item.sections)})
             records_by_reference[mutation.item.reference] = LogicalCacheRecord(
-                key=snapshot.key if snapshot is not None else mutation.key, item=mutation.item
+                key=snapshot.key if snapshot is not None else mutation.key, item=item
             )
         return list(records_by_reference.values())
 

--- a/plugins/development-harness/backlog_core/gh_client.py
+++ b/plugins/development-harness/backlog_core/gh_client.py
@@ -11,6 +11,7 @@ transport (established in Phase 1, #773).
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import re
@@ -28,6 +29,8 @@ from .models import (
     BackendStatus,
     BacklogError,
     BacklogItem,
+    ContentConflictError,
+    ContentUnavailableError,
     GitHubUnavailableError,
     IssueLocalFields,
     IssueStatus,
@@ -54,6 +57,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from github.Repository import Repository
+
+    from .backends._github_work_item_versions import WorkItemVersion
 
 
 class _GraphQLRequester(Protocol):
@@ -1708,8 +1713,23 @@ def fetch_open_issues_by_title(repo: Repository, issues: list[IssueNode] | None 
 # ---------------------------------------------------------------------------
 
 
-def view_enrich_from_github(result: ViewItemResult, issue_num: str, repo: str = "") -> bool:
+def view_enrich_from_github(
+    result: ViewItemResult,
+    issue_num: str,
+    repo: str = "",
+    resolve_version: Callable[[Repository, str, str, IssueNode], WorkItemVersion] | None = None,
+) -> bool:
     """Enrich view result with live GitHub issue data.
+
+    GitHub carries two body representations for a work item: the raw human-owned
+    ``issue.body``, and (for backends that maintain one) the agent-owned authoritative
+    body tracked via a Contents-API head record and audit comment — see
+    ``backlog_core/ARCHITECTURE.md`` "GitHub writable records". ``backlog_groom``
+    writes land in the second representation. When *resolve_version* is provided,
+    it is used to resolve that authoritative body instead of the raw issue body, so
+    callers see the same content the write path actually targets. A resolution
+    failure (content store unavailable, conflicting/malformed head or comment) falls
+    back to the raw issue body rather than failing the whole view.
 
     Returns:
         True if GitHub data was fetched, False if unavailable or errored.
@@ -1722,10 +1742,14 @@ def view_enrich_from_github(result: ViewItemResult, issue_num: str, repo: str = 
         gh_issue = _fetch_issue_graphql(gh_repo, owner, repo_name, int(issue_num))
     except (BacklogError, GithubException):
         return False
+    body = gh_issue["body"]
+    if resolve_version is not None:
+        with contextlib.suppress(BacklogError, ContentConflictError, ContentUnavailableError):
+            body = resolve_version(gh_repo, owner, repo_name, gh_issue).body
     result.number = gh_issue["number"]
     result.title = gh_issue["title"]
     result.state = gh_issue["state"].lower()  # GraphQL returns "OPEN"/"CLOSED"; callers expect lowercase
-    result.body = gh_issue["body"]
+    result.body = body
     result.labels = [lb["name"] for lb in gh_issue["labels"]]
     ms = gh_issue["milestone"]
     result.milestone = ms["title"] if ms else ""

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -932,8 +932,30 @@ def _normalize_section_key(name: str, *, output: Output | None = None) -> str:
     Returns:
         Canonical storage key, e.g. ``"rt_ica"`` for a canonical section or
         ``"unknown__custom_analysis"`` for a custom one.
+
+    Raises:
+        BacklogError: When *name* is ``"Description"`` (case-insensitive).
+            ``github_sync.parse_issue_body`` special-cases a ``## Description``
+            heading as ``BacklogItem.description``, never as a section — so a
+            section write targeting that name can never be recovered by a
+            GitHub round-trip and instead accumulates as a permanent orphan
+            key. Worse, ``render_issue_body`` still emits it as a second,
+            independent ``## Description`` heading alongside the one built
+            from ``item.description``, and ``github_sync.extract_sections``'
+            last-heading-wins parse then silently discards whichever one
+            rendered first — the exact #2956 failure mode, but for a name a
+            registry entry can never fix, because "Description" is
+            deliberately excluded from :data:`SECTION_HEADING` by design.
+            Found live on #2979/#2984/#2985 (2026-08-20).
     """
     name = name.strip()
+    if name.lower() == "description":
+        msg = (
+            'Section name "Description" is reserved for BacklogItem.description — '
+            "use update_item(description=...) instead of a section write. Writing "
+            "to it as a section produces a permanent, unrenderable orphan key."
+        )
+        raise BacklogError(msg)
     canonical = resolve_section_name(name)
     if canonical is not None:
         return canonical

--- a/plugins/development-harness/backlog_core/rendering.py
+++ b/plugins/development-harness/backlog_core/rendering.py
@@ -163,69 +163,87 @@ def merge_entries(local_entries: list[Entry], remote_entries: list[Entry]) -> li
 
 
 def normalize_unknown_sections(sections: dict[str, Section | GroomedData]) -> dict[str, Section | GroomedData]:
-    """Fold ``unknown__{key}`` entries into ``{key}`` when now canonical.
+    """Fold non-canonical section keys into their registered counterpart.
 
     A local YAML cache written before a name was registered in
-    :data:`SECTION_HEADING` stores it as ``unknown__{key}`` (e.g.
-    ``unknown__story``).  Once that name becomes canonical, a freshly parsed
-    GitHub body produces the same logical section under the plain key
-    (``story``) instead — two different dict keys for one heading, which
-    survive :func:`github_sync.merge_item`'s key-union merge and render as a
-    duplicated ``## Story`` heading (#2956 follow-up). Resolving legacy
-    ``unknown__`` keys against the current registry at load time — before
-    reconciliation ever sees the item — makes both sides collide on one key.
+    :data:`SECTION_HEADING` stores it verbatim — either ``unknown__{key}``
+    (e.g. ``unknown__story``, produced by the current write/parse boundary) or
+    a bare, non-canonical key such as ``"Working Register"`` (produced by an
+    older write path that returned an unresolved caller-supplied name
+    unchanged instead of prefixing it — see #2956's write-path trace). Once
+    that name becomes canonical, a freshly parsed GitHub body or a fresh write
+    produces the same logical section under the plain registered key
+    (``working_register``) instead — two different dict keys for one heading,
+    which survive :func:`github_sync.merge_item`'s key-union merge and render
+    as a duplicated ``## Working Register`` heading, with the newer key's
+    entries silently lost on the next GitHub-body reparse (last-heading-wins
+    in :func:`github_sync.extract_sections`) — #2956's live data-loss defect.
+    Resolving *any* non-canonical key against the current registry at load
+    time — before reconciliation ever sees the item — makes both sides
+    collide on one key, whether the stale key carries the ``unknown__``
+    prefix or not.
 
-    When both ``unknown__{key}`` and ``{key}`` are present in the same
-    ``sections`` dict (e.g. a manually edited cache file), their entries are
+    A key already present in :data:`SECTION_HEADING` is left alone — it is
+    already canonical, and re-resolving it is a no-op at best.
+
+    When both a non-canonical key and its canonical counterpart are present
+    in the same ``sections`` dict (e.g. a manually edited cache file, or a
+    stale bare key alongside a fresh canonical write), their entries are
     merged through :func:`merge_entries` — the same struck-wins /
     longer-content-wins-per-id rule :func:`github_sync.merge_item` applies to
     local/remote reconciliation — rather than a bespoke first-seen-wins dedup
     that would silently drop a struck or longer-content copy sharing an id
-    with the other key's entry. The canonical (non-``unknown__``) key's
-    entries are always passed as :func:`merge_entries`' first (tie-break-
-    winning) argument, regardless of which key ``sections`` happens to
-    iterate first — the dict's key order is an incidental artifact of the
-    caller (YAML load order, dict-literal order in a test), not a documented
-    local/remote distinction, so the exact-tie winner must not depend on it
-    (#3015 Copilot review finding).
+    with the other key's entry. The canonical key's entries are always passed
+    as :func:`merge_entries`' first (tie-break-winning) argument, regardless
+    of which key ``sections`` happens to iterate first — the dict's key order
+    is an incidental artifact of the caller (YAML load order, dict-literal
+    order in a test), not a documented local/remote distinction, so the
+    exact-tie winner must not depend on it (#3015 Copilot review finding).
 
     Recovery is routed through :func:`~.section_registry.resolve_section_name`
     — the same alias-aware resolver the write boundary
     (``operations._normalize_section_key``) and the GitHub-parse boundary
     (``github_sync.parse_issue_body``) both use — rather than a bespoke
-    display-title-only comparison, so a legacy ``unknown__`` key whose
-    reconstructed heading matches a registered *alias* (e.g.
-    ``"unknown__facts_check"`` -> alias ``"facts check"`` -> canonical
-    ``fact_check``), not only an exact :data:`SECTION_HEADING` display title,
-    still folds.
+    display-title-only comparison, so a legacy key whose reconstructed
+    heading matches a registered *alias* (e.g. ``"unknown__facts_check"`` ->
+    alias ``"facts check"`` -> canonical ``fact_check``), not only an exact
+    :data:`SECTION_HEADING` display title, still folds.
 
-    Two forms of the stored key are tried, in order: the raw ``unknown__``-
-    stripped key itself (already ``snake_case`` for keys produced by the
-    current, punctuation-sanitizing :func:`heading_to_unknown_key`), then the
-    reconstructed display heading (:func:`unknown_key_to_heading` output) —
+    Two forms of the stored key are tried, in order: the raw key itself, with
+    any ``unknown__`` prefix stripped (a no-op for a bare non-canonical key;
+    already ``snake_case`` for keys produced by the current,
+    punctuation-sanitizing :func:`heading_to_unknown_key`), then the
+    reconstructed display heading (:func:`unknown_key_to_heading` output,
+    also a no-op-safe title-case pass for a bare key already in that form) —
     the fallback that still supports older, more heavily punctuation-bearing
-    keys (e.g. ``"unknown__output_/_evidence"``, whose raw stripped form
-    never matches a ``SectionKey`` value but whose reconstructed title
-    ``"Output / Evidence"`` does).
+    ``unknown__`` keys (e.g. ``"unknown__output_/_evidence"``, whose raw
+    stripped form never matches a ``SectionKey`` value but whose
+    reconstructed title ``"Output / Evidence"`` does).
+
+    A key that resolves to nothing (e.g. ``"Description"``, which
+    ``github_sync.parse_issue_body`` special-cases as ``item.description``
+    rather than a section, so it can never be a registered ``SectionKey``) is
+    left unchanged — it is orphan data outside this function's recovery
+    scope, not a bug this fold can fix.
 
     Args:
         sections: Raw ``BacklogItem.sections`` mapping as loaded from storage.
 
     Returns:
-        A new mapping with legacy ``unknown__{key}`` keys folded into their
-        now-canonical counterparts. Keys that are not legacy, or whose
-        ``unknown__`` name is still uncanonical, are returned unchanged.
+        A new mapping with legacy non-canonical keys folded into their
+        now-canonical counterparts. Keys that are already canonical, or whose
+        name is still unresolvable, are returned unchanged.
     """
     normalized: dict[str, Section | GroomedData] = {}
     # Tracks, per target key, whether the Section entries currently stored in
     # `normalized` include the canonical key's own entries — so a canonical
-    # key encountered *after* its legacy `unknown__` counterpart still wins
+    # key encountered *after* its legacy counterpart still wins
     # merge_entries' tie-break, instead of losing simply because it folded
     # into `normalized[target]` second.
     canonical_owns: dict[str, bool] = {}
     for key, value in sections.items():
         target = key
-        is_canonical_key = not key.startswith("unknown__")
+        is_canonical_key = key in SECTION_HEADING
         if not is_canonical_key and isinstance(value, Section):
             stripped = key.removeprefix("unknown__")
             canonical = resolve_section_name(stripped) or resolve_section_name(unknown_key_to_heading(key))

--- a/plugins/development-harness/tests/test_backlog_core_github.py
+++ b/plugins/development-harness/tests/test_backlog_core_github.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from backlog_core.backends._github_work_item_versions import WorkItemVersion
 from backlog_core.gh_client import (
     _get_repo_node_id,
     _is_not_found_error,
@@ -40,7 +41,14 @@ from backlog_core.gh_client import (
     try_get_github,
     view_enrich_from_github,
 )
-from backlog_core.models import BacklogError, BacklogItem, Output, ViewItemResult
+from backlog_core.models import (
+    BacklogError,
+    BacklogItem,
+    ContentConflictError,
+    ContentUnavailableError,
+    Output,
+    ViewItemResult,
+)
 
 from tests.graphql_factories import (
     make_create_issue_response,
@@ -1222,6 +1230,59 @@ class TestViewEnrichFromGithub:
 
         # Assert
         assert enriched is False
+
+    def test_uses_resolve_version_body_when_provided(self, mocker: MockerFixture) -> None:
+        """A successful resolve_version callback's body wins over the raw issue body.
+
+        Tests: view_enrich_from_github resolve_version success path (#2956 root cause A)
+        Why: backlog_groom writes land in the agent-owned authoritative body (head
+             record + audit comment), not the raw human-owned issue.body — the two
+             can diverge. resolve_version exists precisely so the view reflects
+             whichever body a caller actually wrote to; a passing resolver must win.
+        """
+        # Arrange
+        issue_node = make_issue_node(number=42, title="Item", state="OPEN", body="Raw human-owned body")
+        mock_repo = _make_mock_repo(mocker)
+        mocker.patch("backlog_core.gh_client.try_get_github", return_value=mock_repo)
+        mocker.patch("backlog_core.gh_client._graphql_request", return_value=make_issue_by_number_response(issue_node))
+        result = ViewItemResult()
+        resolved_version = WorkItemVersion(revision="deadbeef", body="Authoritative agent-managed body")
+
+        # Act
+        enriched = view_enrich_from_github(result, "42", resolve_version=lambda *_args: resolved_version)
+
+        # Assert
+        assert enriched is True
+        assert result.body == "Authoritative agent-managed body"
+
+    @pytest.mark.parametrize(
+        "error", [BacklogError("boom"), ContentConflictError("boom"), ContentUnavailableError("boom")]
+    )
+    def test_falls_back_to_raw_body_when_resolve_version_raises(self, mocker: MockerFixture, error: Exception) -> None:
+        """A raising resolve_version degrades to the raw issue body, not a failed view.
+
+        Tests: view_enrich_from_github resolve_version failure fallback,
+               parametrized over every exception class the call site suppresses.
+        Why: A content-store hiccup (unavailable, conflicting/malformed head or
+             comment) must not break the whole view — it should look exactly like
+             the pre-fix behavior (raw body), not raise past the caller.
+        """
+        # Arrange
+        issue_node = make_issue_node(number=42, title="Item", state="OPEN", body="Raw human-owned body")
+        mock_repo = _make_mock_repo(mocker)
+        mocker.patch("backlog_core.gh_client.try_get_github", return_value=mock_repo)
+        mocker.patch("backlog_core.gh_client._graphql_request", return_value=make_issue_by_number_response(issue_node))
+        result = ViewItemResult()
+
+        def _raising_resolver(*_args: object) -> WorkItemVersion:
+            raise error
+
+        # Act
+        enriched = view_enrich_from_github(result, "42", resolve_version=_raising_resolver)
+
+        # Assert
+        assert enriched is True
+        assert result.body == "Raw human-owned body"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -2831,11 +2831,7 @@ class TestGroomItemMarkGroomed:
 
         out = Output()
         result = ops.groom_item(
-            selector="Mark Groomed Local",
-            section="Description",
-            content="Groomed content.",
-            output=out,
-            mark_groomed=True,
+            selector="Mark Groomed Local", section="Concerns", content="Groomed content.", output=out, mark_groomed=True
         )
 
         assert "error" not in result
@@ -2865,7 +2861,7 @@ class TestGroomItemMarkGroomed:
         out = Output()
         result = ops.groom_item(
             selector="Mark Groomed Github",
-            section="Description",
+            section="Concerns",
             content="Groomed with issue.",
             output=out,
             mark_groomed=True,
@@ -2897,7 +2893,7 @@ class TestGroomItemMarkGroomed:
         out = Output()
         result = ops.groom_item(
             selector="Mark Groomed False",
-            section="Description",
+            section="Concerns",
             content="No status change expected.",
             output=out,
             mark_groomed=False,
@@ -2963,7 +2959,7 @@ class TestGroomItemMarkGroomed:
         out = Output()
         result = ops.groom_item(
             selector="Mark Groomed Error",
-            section="Description",
+            section="Concerns",
             content="This write will fail.",
             output=out,
             mark_groomed=True,

--- a/plugins/development-harness/tests/test_section_registry.py
+++ b/plugins/development-harness/tests/test_section_registry.py
@@ -327,6 +327,77 @@ def test_normalize_unknown_sections_folds_stripped_snake_case_key(canonical: str
     assert canonical in folded
 
 
+def test_normalize_unknown_sections_folds_bare_display_title_key() -> None:
+    """A bare (non-``unknown__``-prefixed) display-title key folds to its canonical key too.
+
+    Tests: rendering.normalize_unknown_sections bare-key fold (#2956 root cause B)
+    Why: A pre-registry write path returned an unresolved name unchanged instead of
+         ``unknown__``-prefixing it, so legacy caches carry bare keys like
+         ``"Working Register"`` with no prefix at all. The fold gate used to check
+         only ``not key.startswith("unknown__")`` to decide "already canonical",
+         so a bare key never reached the resolver even though
+         ``resolve_section_name`` resolves it cleanly — causing
+         ``render_issue_body`` to double-emit the heading and
+         ``extract_sections``' last-heading-wins parse to silently drop whichever
+         copy rendered first.
+    """
+    sections: dict[str, Section | GroomedData] = {
+        "Working Register": Section(entries=[Entry(id="2026-01-01T00:00:00Z", content="Legacy bare-key content.")])
+    }
+
+    folded = rendering.normalize_unknown_sections(sections)
+
+    assert "Working Register" not in folded
+    assert "working_register" in folded
+    folded_section = folded["working_register"]
+    assert isinstance(folded_section, Section)
+    assert folded_section.entries[0].content == "Legacy bare-key content."
+
+
+def test_normalize_unknown_sections_bare_key_alongside_canonical_merges_not_overwrites() -> None:
+    """A bare display-title key and its canonical counterpart merge, not overwrite.
+
+    Tests: rendering.normalize_unknown_sections bare-key + canonical-key collision
+           (#2956 root cause B — mirrors the existing ``unknown__`` + canonical
+           merge tests above, for the bare-key shape instead)
+    Why: The exact #2955 reproduction: a stale bare ``"Working Register"`` key
+         alongside a fresh canonical ``working_register`` write from the same
+         item. Both entries must survive the fold via the same
+         struck-wins/longer-content-wins rule as the ``unknown__`` case — a
+         first-seen-wins dedup would silently drop one entry outright.
+    """
+    canonical = Section(entries=[Entry(id="2026-01-01T00:00:00Z", content="Fresh canonical write.")])
+    legacy_bare = Section(entries=[Entry(id="2026-01-02T00:00:00Z", content="Stale bare-key entry.")])
+    sections: dict[str, Section | GroomedData] = {"working_register": canonical, "Working Register": legacy_bare}
+
+    folded = rendering.normalize_unknown_sections(sections)
+
+    assert "Working Register" not in folded
+    folded_section = folded["working_register"]
+    assert isinstance(folded_section, Section)
+    assert {e.content for e in folded_section.entries} == {"Fresh canonical write.", "Stale bare-key entry."}
+
+
+def test_normalize_unknown_sections_leaves_unresolvable_bare_key_unchanged() -> None:
+    """A bare key that resolves to nothing (e.g. "Description") is left alone, not renamed or dropped.
+
+    Tests: rendering.normalize_unknown_sections orphan-key passthrough
+    Why: ``github_sync.parse_issue_body`` special-cases ``## Description`` as
+         ``BacklogItem.description``, never a section, so ``"Description"`` is
+         deliberately excluded from ``SECTION_HEADING`` and can never resolve.
+         The fold must not invent a fallback key for it — it stays exactly as
+         stored, so callers can still find and migrate it explicitly (see
+         ``operations._normalize_section_key``'s write-side rejection of new
+         writes to this name).
+    """
+    orphan = Section(entries=[Entry(id="2026-01-01T00:00:00Z", content="Orphan description content.")])
+    sections: dict[str, Section | GroomedData] = {"Description": orphan}
+
+    folded = rendering.normalize_unknown_sections(sections)
+
+    assert folded == sections
+
+
 # ---------------------------------------------------------------------------
 # Legacy Markdown parser routes both heading levels through the registry (#2987 finding 3)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the two live root causes behind #2956 — `backlog_groom` writes reporting success but being invisible via `backlog_view`, both immediately after write and via the live GitHub issue body.

- **Root cause A**: `backlog_view`'s GitHub enrichment (`gh_client.view_enrich_from_github`) unconditionally read the raw human-owned `issue.body`, while `backlog_groom` writes land in a separate agent-owned authoritative representation (a Contents-API head record + tagged audit comment). The reconciliation path already resolved this correctly elsewhere in the codebase (`_GitHubWorkItemSync.provider_item_from_issue`); only the view path bypassed it. `view_enrich_from_github` now accepts an optional `resolve_version` callback that `GitHubBackend` wires to the existing correct resolution, falling back to the raw body only on a resolution failure.
- **Root cause B**: `rendering.normalize_unknown_sections` only healed `unknown__`-prefixed legacy keys, not bare non-canonical keys (e.g. a stale `Working Register` key written before the section registry existed). This caused `render_issue_body` to double-emit the section heading, and last-heading-wins parsing on reparse silently dropped whichever copy rendered first — including fresh writes. The healing gate now checks against the actual `SectionKey` registry instead of the `unknown__` prefix. Also fixed: `_GitHubWorkItemSync.load_records()` merges normalized snapshots with pending mutations that were never normalized on load, and a pending mutation wins over its snapshot — so an item with a stuck pending mutation (the separate #2963 title-mismatch class) would keep serving un-normalized data indefinitely regardless of the registry fix. Pending-mutation items are now normalized too.

Root cause C (the ~58 legacy items stuck behind the #2963 title-mismatch pending-mutation guard) and the unrecoverable `Description`/`Notes`/probe-key orphan-data class are explicitly out of scope for this PR — noted as follow-ups in #2956.

## Test plan

- [x] Reproduced the exact failure from #2956's body against live source pre-fix, confirmed `section_filter_miss: True` / "Section not found" and a doubled `## Working Register` heading in the resolved body.
- [x] Re-ran the same reproduction post-fix against live source (direct import, not the installed plugin cache) and the live GitHub backend, on the same item (#2955) that exhibited both the stale-key and stuck-mutation conditions: write is now visible immediately via `backlog_view`, heading count back to 1, marker confirmed present on the live GitHub issue comment.
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` — all pass on every touched file.
- [x] `uv run pytest` — 1079 passed, 9 skipped, no regressions.
- [x] Diagnostic test-residue entries used during tracing/validation were struck from the live items afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg

## Update — additional fix + blast-radius cleanup

Added a third commit: `_normalize_section_key` now rejects `section="Description"` writes outright (found live on `#2979`/`#2984`/`#2985` while auditing this bug's blast radius — same failure shape as root cause B, but for a name no registry entry can ever make resolvable, since `github_sync.parse_issue_body` special-cases `## Description` as `BacklogItem.description`, never a section).

Also cleaned up every item already corrupted by this bug prior to the fix (a one-time data migration against the live GitHub backend, not a code change) — nine items total, full details and per-item resolution in #2956. Re-scanned the entire local cache afterward: zero items with a bare non-canonical section key remain.

<!-- greptile_comment -->

<sub>Reviews (3): Last reviewed commit: ["test(development-harness): cover bare-ke..."](https://github.com/jamie-bitflight/claude_skills/commit/192847c9a9233056cc65abb4653e973d27e5a485) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54781078)</sub>

<!-- /greptile_comment -->