### PR TITLE
fix(scripts): drop --active from uv PEP 723 shebang in 20 scripts

### DIFF
--- a/plugins/dasel/.claude-plugin/plugin.json
+++ b/plugins/dasel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dasel",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Query, transform, and convert structured data files (JSON, YAML, TOML, XML, CSV, HCL, INI) using dasel v3. Provides reference syntax, exploration workflows, transformation patterns, and cross-platform installation.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/dasel/scripts/install_dasel.py
+++ b/plugins/dasel/scripts/install_dasel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.19",
+  "version": "9.0.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/scripts/close_test_issues.py
+++ b/plugins/development-harness/scripts/close_test_issues.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/scripts/dh_migrate.py
+++ b/plugins/development-harness/scripts/dh_migrate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/scripts/enumerate_scope.py
+++ b/plugins/development-harness/scripts/enumerate_scope.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = []

--- a/plugins/development-harness/scripts/manifest_resolver.py
+++ b/plugins/development-harness/scripts/manifest_resolver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = ["ruamel.yaml", "tomlkit", "typer"]

--- a/plugins/development-harness/scripts/migrate_backlog_to_yaml.py
+++ b/plugins/development-harness/scripts/migrate_backlog_to_yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/scripts/migrate_plan_artifacts.py
+++ b/plugins/development-harness/scripts/migrate_plan_artifacts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/scripts/migrate_tasks_to_github.py
+++ b/plugins/development-harness/scripts/migrate_tasks_to_github.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/scripts/run_backlog_server.py
+++ b/plugins/development-harness/scripts/run_backlog_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/scripts/run_sam_cli.py
+++ b/plugins/development-harness/scripts/run_sam_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/scripts/run_sam_server.py
+++ b/plugins/development-harness/scripts/run_sam_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/development-harness/scripts/verify_migration_fidelity.py
+++ b/plugins/development-harness/scripts/verify_migration_fidelity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "14.5.10",
+  "version": "14.5.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/scripts/fix_tool_formats.py
+++ b/plugins/plugin-creator/scripts/fix_tool_formats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 """Fix invalid tool format patterns in Claude Code frontmatter.
 
 Recursively scans:

--- a/plugins/plugin-creator/scripts/normalize_frontmatter.py
+++ b/plugins/plugin-creator/scripts/normalize_frontmatter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/scripts/validate_pep723.py
+++ b/plugins/python3-development/scripts/validate_pep723.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = ["typer>=0.21.0"]

--- a/scripts/audit_branch_transfer.py
+++ b/scripts/audit_branch_transfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # ///

--- a/scripts/markdown_to_task_pool.py
+++ b/scripts/markdown_to_task_pool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/scripts/process-research-integration.py
+++ b/scripts/process-research-integration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/scripts/rename_plan_files.py
+++ b/scripts/rename_plan_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/scripts/session_audit.py
+++ b/scripts/session_audit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --active --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [


### PR DESCRIPTION
## Summary

- This repo's canonical PEP 723 script shebang is `#!/usr/bin/env -S uv run --quiet --script` (`.claude/rules/script-invocation.md`). 20 pre-existing files on `main` instead used `#!/usr/bin/env -S uv --quiet run --active --script` — same flags, wrong order, plus an erroneous `--active`.
- `--active` makes `uv run` reuse and mutate the shared project `.venv` with the script's own PEP 723 dependencies, instead of resolving an isolated ephemeral environment for the standalone script. That defeats the entire point of a self-contained PEP 723 script and risks dependency-version collisions across unrelated scripts sharing the same `.venv`.
- Fixes only line 1 (the shebang) in each of the 20 files — no other shebang content, PEP 723 metadata, or logic touched.
- `plugins/python3-development/scripts/validate_pep723.py` also contains the same buggy string in its `UV_SHEBANG` constant (line 47) and a docstring example (line 330) — i.e. the validator's own canonical-shebang reference is wrong. That is a distinct, more consequential bug (a validator that accepts/teaches the wrong pattern) and is deliberately left untouched here since it's out of this PR's line-1-only scope; flagging for separate follow-up.
- A repo-wide grep for the same buggy pattern also found 41 more instances outside this PR's 20-file list (mostly under `.claude/skills/`, `plugins/*/skills/*/assets/`, `plugins/rtfp`, `plugins/holistic-linting`, and a few plugin `mcp/server.py` / `sam_schema/cli.py` files) — also intentionally out of scope here per explicit instruction, flagged as a separate follow-up.

## Context

Discovered incidentally while reviewing PR #2787: Copilot's automated review repeatedly flagged the same `--active` shebang drift in two files that PR touches (already fixed there). Grepping the rest of `main` turned up these 20 additional, unrelated pre-existing instances of the identical bug. This PR is an independent cleanup — it does not modify PR #2787 or the `codex-plugin-usability-port` branch.

## Test plan

- [x] Verified line 1 of all 20 files matched the expected buggy string before editing
- [x] `uv run ruff check <20 files>` — all checks passed
- [x] `uv run ruff format --check <20 files>` — all 20 already formatted
- [x] `uv run ty check <20 files>` — all checks passed
- [x] `uv run prek run --files <20 files>` — all hooks passed; manifest-sync hook auto-bumped patch versions for the 4 affected plugins (dasel, dh, plugin-creator, python3-development) as an expected side effect, included in this commit
- [x] `git diff --stat` confirmed exactly the 20 intended files each changed by 1 line before commit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>