### PR TITLE
fix(development-harness): route unregistered legacy-md headings through unknown__ prefix

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.21",
+  "version": "9.0.22",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/parsing.py
+++ b/plugins/development-harness/backlog_core/parsing.py
@@ -43,6 +43,7 @@ from .models import (
     ViewItemResult,
     parse_issue_number,
 )
+from .rendering import heading_to_unknown_key
 from .section_registry import resolve_section_name, resolve_subsection_name
 
 # ---------------------------------------------------------------------------
@@ -1250,17 +1251,17 @@ def parse_md_body_sections(body_text: str, added_date: str = "0000-00-00") -> di
             else:
                 result[key] = parsed
         else:
-            raw_key = heading_name.lower()
             # Route through the canonical registry resolver — the same
             # write-boundary lookup operations._normalize_section_key uses —
             # so a display heading like "Impact Radius" resolves to its
             # registered snake_case key ("impact_radius"), not the raw
             # lowercased heading text. A name the registry does not recognise
             # (e.g. "Description", an ad hoc heading a caller invented) falls
-            # through to the raw lowercased key unchanged — this legacy .md
-            # path has never unknown__-prefixed unrecognised names, and
-            # changing that is out of scope for this canonicalization fix.
-            key = resolve_section_name(heading_name) or raw_key
+            # through to heading_to_unknown_key(), matching operations.py and
+            # github_sync.py so the same unregistered heading round-trips to
+            # the same storage key regardless of which of the three parse
+            # paths handled it (see #2978).
+            key = resolve_section_name(heading_name) or heading_to_unknown_key(heading_name)
             parsed_section = _parse_section_entries(content, added_date)
             existing_section = result.get(key)
             if isinstance(existing_section, Section):

--- a/plugins/development-harness/tests/test_md_migration.py
+++ b/plugins/development-harness/tests/test_md_migration.py
@@ -160,11 +160,17 @@ Real content after fence.
 
 
 def test_parse_md_body_sections_plain_sections_present() -> None:
-    """Plain ## sections without entry blocks produce Section objects."""
+    """Plain ## sections without entry blocks produce Section objects.
+
+    "Description" is not a registered SECTION_HEADING (see operations.py's
+    reserved-name guard), so it falls through to the unknown__ prefix like
+    any other unrecognised heading — matching the write and GitHub-parse
+    paths (#2978).
+    """
     result = parse_md_body_sections(_PLAIN_SECTIONS_BODY)
 
     assert "story" in result
-    assert "description" in result
+    assert "unknown__description" in result
     assert "context" in result
 
 
@@ -190,7 +196,7 @@ def test_parse_md_body_sections_plain_section_content_preserved() -> None:
     """Section content is captured verbatim in the entry."""
     result = parse_md_body_sections(_PLAIN_SECTIONS_BODY)
 
-    description = result["description"]
+    description = result["unknown__description"]
     assert isinstance(description, Section)
     assert "This is the description paragraph." in description.entries[0].content
 
@@ -351,8 +357,8 @@ def test_parse_md_body_sections_fenced_code_block_not_split() -> None:
     """## inside a fenced code block is not treated as a heading."""
     result = parse_md_body_sections(_FENCED_CODE_BODY)
 
-    # Only "description" should be present; the ## inside the fence is not a section
-    assert "description" in result
+    # Only "unknown__description" should be present; the ## inside the fence is not a section
+    assert "unknown__description" in result
     # The heading-looking line inside the fence must NOT appear as a key
     assert "this looks like a heading but is inside a fence" not in result
 
@@ -361,7 +367,7 @@ def test_parse_md_body_sections_fenced_code_content_preserved() -> None:
     """Content after a fenced block is captured in the section entry."""
     result = parse_md_body_sections(_FENCED_CODE_BODY)
 
-    description = result["description"]
+    description = result["unknown__description"]
     assert isinstance(description, Section)
     assert "Real content after fence." in description.entries[0].content
 

--- a/plugins/development-harness/tests/test_section_registry.py
+++ b/plugins/development-harness/tests/test_section_registry.py
@@ -428,19 +428,42 @@ def test_parse_md_body_sections_canonicalizes_every_registered_display_heading(d
         )
 
 
-def test_parse_md_body_sections_unregistered_heading_falls_back_to_raw_lowercase() -> None:
-    """A genuinely unregistered '## ' heading keeps the legacy raw-lowercased fallback.
+def test_parse_md_body_sections_unregistered_heading_routes_through_unknown_prefix() -> None:
+    """A genuinely unregistered '## ' heading routes through heading_to_unknown_key (#2978).
 
-    Tests: parsing.parse_md_body_sections unregistered-name passthrough —
-           falsification check proving the fix does not unknown__-prefix
-           names this legacy path has never prefixed.
+    Tests: parsing.parse_md_body_sections unregistered-name fallback now matches
+           operations._normalize_section_key and github_sync.parse_issue_body,
+           which both fall through to heading_to_unknown_key for the same case.
+           Previously this legacy .md path used the raw lowercased heading text
+           instead, producing a different storage key than the other two parse
+           paths for the identical unregistered heading.
     """
     from backlog_core.parsing import parse_md_body_sections
 
-    result = parse_md_body_sections("## Zzyx Quantum Analysis 9000\n\nContent.\n")
+    heading = "Zzyx Quantum Analysis 9000"
+    result = parse_md_body_sections(f"## {heading}\n\nContent.\n")
 
-    assert "zzyx quantum analysis 9000" in result
-    assert not any(k.startswith("unknown__") for k in result)
+    assert rendering.heading_to_unknown_key(heading) in result
+    assert "zzyx quantum analysis 9000" not in result
+
+
+def test_parse_md_body_sections_unregistered_heading_matches_write_and_github_paths() -> None:
+    """The three section-key derivation paths agree for an unregistered heading (#2978).
+
+    Tests: parsing.parse_md_body_sections vs operations._normalize_section_key
+           vs github_sync.parse_issue_body — same unregistered heading must
+           produce the same storage key on all three paths.
+    """
+    from backlog_core.parsing import parse_md_body_sections
+
+    heading = "Custom Analysis"
+    md_key = next(iter(parse_md_body_sections(f"## {heading}\n\nContent.\n")))
+    write_key = ops._normalize_section_key(heading)
+    gh_item = github_sync.parse_issue_body(f"## {heading}\n\nContent.\n")
+    gh_keys = [k for k in gh_item.sections if k != "preamble"]
+
+    assert md_key == write_key
+    assert gh_keys == [write_key]
 
 
 @pytest.mark.parametrize("subsection_name", sorted(section_registry.SubsectionKey))


### PR DESCRIPTION
## Summary

- `parse_md_body_sections` (`backlog_core/parsing.py`) fell back to the raw lowercased heading text when a `## Heading` did not resolve via `resolve_section_name`.
- `operations._normalize_section_key` and `github_sync.parse_issue_body`/`heading_to_section_key` both fall back to `heading_to_unknown_key(heading_name)` for the same unrecognized-heading case.
- Result: the same unregistered heading produced a different storage key depending on which of the three parse paths handled it — e.g. `"Custom Analysis"` became `custom analysis` via the legacy `.md` path but `unknown__custom_analysis` via the write path and the GitHub-parse path.

## Fix

Route the `.md` fallback through `heading_to_unknown_key(heading_name)`, matching `operations.py` and `github_sync.py` exactly. One function, one fallback branch.

## Reproduction

Before fix:

```
md path key: custom analysis
write path key: unknown__custom_analysis
github path keys: ['unknown__custom_analysis']
```

After fix:

```
md path key: unknown__custom_analysis
write path key: unknown__custom_analysis
github path keys: ['unknown__custom_analysis']
```

## Tests

- Updated `test_parse_md_body_sections_unregistered_heading_falls_back_to_raw_lowercase` (renamed to `..._routes_through_unknown_prefix`) — it previously asserted the buggy raw-lowercase behavior as a "falsification check"; now asserts the corrected `unknown__`-prefixed behavior.
- Added `test_parse_md_body_sections_unregistered_heading_matches_write_and_github_paths` — asserts all three key-derivation paths agree for the same unregistered heading.
- Updated 4 pre-existing `test_md_migration.py` assertions that incidentally used `"## Description"` as a generic unregistered-heading fixture (`"description"` is not a registered `SECTION_HEADING`) — they now expect `unknown__description`.
- `uv run plugins/development-harness/tests/run_pytest.py tests/test_section_registry.py tests/test_md_migration.py` — 230 passed.
- `uv run ruff check --fix`, `uv run ruff format`, `uv run ty check` — all clean on the changed files.

## Pre-existing failure found, not fixed here

While running a broader sweep (`-k "parsing or parse_md or section"`), `tests/test_github_sync.py::TestSectionRoundTripProperty::test_write_render_parse_round_trip_is_lossless` fails for a Hypothesis-shrunk `section_name=':PRIORITY'` — `render_issue_body`/`parse_issue_body`/`merge_item` produces a duplicate `priority` key alongside `unknown__priority`. Confirmed via `git stash` that this fails identically on `main` without this PR's changes — unrelated code path (not `parsing.py`), same class of key-derivation defect as the already-filed underscore issue `#2968` referenced in that test file, but for punctuation (`:`) instead of `_`. Not fixed here; flagging for a follow-up backlog item since a same-session backlog-item creation attempt hit a worktree sandbox restriction.

Relates to #2978