### PR TITLE
fix(development-harness): distinguish absent from mis-keyed sections in view filter

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.21",
+  "version": "9.0.22",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1330,6 +1330,25 @@ def _build_section_miss_error(filter_expr: str, valid_names: list[str], out: Out
     ``suggestion`` key only when difflib finds a close match in ``valid_names``
     (SequenceMatcher ratio >= 0.6, equivalent to Levenshtein-adjacent proximity).
 
+    Adds an ``unresolved_sections`` key (issue #2974) when *valid_names* contains
+    a raw ``unknown__``-prefixed storage key — the signature left by content
+    stored under a mis-keyed, unrecognized heading (#2956) that
+    :func:`~.section_registry.resolve_section_name` could not resolve at write
+    time.  The ``unknown__`` prefix is checked literally (not via
+    ``resolve_section_name`` here) because many legitimate, non-canonical
+    headings exist in real item bodies (e.g. ``"Description"``) that are not
+    registered in :mod:`.section_registry` yet were never mis-keyed — flagging
+    every unregistered name would produce false positives on ordinary items.
+    Both the singular ``section=`` path (``_apply_body_section_filter`` /
+    ``_assemble_view_compact``) and the plural ``sections=[...]`` path
+    (``_filter_view_sections``) populate *valid_names* from the item's actual
+    section inventory, so this single check distinguishes "the requested name
+    genuinely has no match, and nothing about this item is unresolved" (key
+    absent) from "no match, but this item also has unresolved mis-keyed
+    content the caller should investigate rather than assume absent" (key
+    present, non-empty) — previously both cases produced an identical
+    ``section_filter_miss: True`` with no way to tell them apart.
+
     Args:
         filter_expr: The section filter string the caller supplied.
         valid_names: Known section names at the time of the miss.
@@ -1344,6 +1363,9 @@ def _build_section_miss_error(filter_expr: str, valid_names: list[str], out: Out
         "section_filter_miss": True,
         **out.to_dict(),
     }
+    unresolved_names = [name for name in valid_names if name.startswith("unknown__")]
+    if unresolved_names:
+        error_dict["unresolved_sections"] = unresolved_names
     if valid_names and filter_expr:
         matches = _difflib.get_close_matches(filter_expr, valid_names, n=1, cutoff=0.6)
         if matches:

--- a/plugins/development-harness/backlog_core/tests/test_section_filter_error_dict.py
+++ b/plugins/development-harness/backlog_core/tests/test_section_filter_error_dict.py
@@ -514,3 +514,92 @@ class TestSectionHitRegressionGuard:
             f"section_filter_miss must not be True when sections=[{_VALID_SECTION!r}] "
             f"successfully matches.  Got: {resp.get('section_filter_miss')!r}."
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2974 — distinguish "genuinely absent" from "mis-keyed content exists"
+# ---------------------------------------------------------------------------
+
+# A body with one recognized section ("Story") and one heading literally
+# carrying the raw ``unknown__``-prefixed storage key — the signature #2956
+# leaves on content whose write-time heading never resolved through
+# section_registry.resolve_section_name() and fell back to
+# heading_to_unknown_key().  Neither singular nor plural filters below
+# request this heading; its mere presence in the item is what must be
+# surfaced.  The literal ``unknown__`` prefix (rather than an unregistered
+# display title like "Description", which is legitimately non-canonical by
+# design — see operations._normalize_section_key's reserved-name docstring)
+# is the unambiguous, false-positive-free signal the fix keys off of.
+_UNRESOLVED_HEADING = "unknown__zorbulon_frobnication_ledger"
+_MISKEYED_BODY = f"## Story\n\nReal content.\n\n## {_UNRESOLVED_HEADING}\n\nMis-keyed content.\n"
+
+# A body with only recognized sections (plus "Description", a legitimate,
+# deliberately unregistered heading — see the comment above) — no
+# unknown__-prefixed heading anywhere.
+_CLEAN_BODY = "## Story\n\nReal content.\n\n## Description\n\nAlso real.\n"
+
+
+class TestSectionMissErrorDictUnresolvedSections:
+    """A section-filter miss reports whether unresolved (mis-keyed) content exists.
+
+    Before the #2974 fix, ``section_filter_miss: True`` was identical whether the
+    requested section was genuinely absent or merely unreachable under an
+    unrecognized heading — a caller could not distinguish "nothing here" from
+    "something's here but mis-keyed."  ``unresolved_sections`` closes that gap.
+    """
+
+    def test_miss_with_unresolved_heading_reports_unresolved_sections_singular(self, mocker: MockerFixture) -> None:
+        """section=<miss> reports 'unresolved_sections' when a mis-keyed heading exists.
+
+        Arrange: body has 'Story' (recognized) and a raw ``unknown__``-prefixed
+                 heading (mis-keyed, never resolved at write time).
+        Act: call backlog_view(summary=False, section=<nonexistent>).
+        Assert: 'unresolved_sections' is present and names the unresolved heading.
+        """
+        _patch_github_body(mocker, issue_num=2974, body=_MISKEYED_BODY)
+
+        resp = asyncio.run(server.backlog_view(selector="2974", summary=False, section=_NONEXISTENT_FILTER))
+
+        assert "unresolved_sections" in resp, (
+            f"Miss response must report 'unresolved_sections' when the item has a "
+            f"mis-keyed heading. Got keys: {sorted(resp.keys())}."
+        )
+        unresolved = resp["unresolved_sections"]
+        assert isinstance(unresolved, list)
+        assert _UNRESOLVED_HEADING in unresolved, f"Expected {_UNRESOLVED_HEADING!r} in {unresolved!r}."
+
+    def test_miss_with_unresolved_heading_reports_unresolved_sections_plural(self, mocker: MockerFixture) -> None:
+        """sections=[<miss>] reports 'unresolved_sections' when a mis-keyed heading exists.
+
+        Mirrors the singular-path test above but exercises the plural
+        ``sections=[...]`` filter (``_filter_view_sections``), confirming both
+        miss paths funnel through the same fixed signal.
+        """
+        _patch_github_body(mocker, issue_num=2974, body=_MISKEYED_BODY)
+
+        resp = asyncio.run(server.backlog_view(selector="2974", summary=False, sections=[_NONEXISTENT_FILTER]))
+
+        assert "unresolved_sections" in resp, (
+            f"Plural miss response must report 'unresolved_sections' when the item has a "
+            f"mis-keyed heading. Got keys: {sorted(resp.keys())}."
+        )
+        unresolved = resp["unresolved_sections"]
+        assert isinstance(unresolved, list)
+        assert _UNRESOLVED_HEADING in unresolved, f"Expected {_UNRESOLVED_HEADING!r} in {unresolved!r}."
+
+    def test_miss_without_unresolved_heading_omits_unresolved_sections(self, mocker: MockerFixture) -> None:
+        """section=<miss> omits 'unresolved_sections' when nothing is mis-keyed.
+
+        Arrange: body has only recognized sections ('Story', 'Description').
+        Act: call backlog_view(summary=False, section=<nonexistent>).
+        Assert: 'unresolved_sections' key is absent — the miss is genuinely
+                "nothing here," not "something's here but mis-keyed."
+        """
+        _patch_github_body(mocker, issue_num=2974, body=_CLEAN_BODY)
+
+        resp = asyncio.run(server.backlog_view(selector="2974", summary=False, section=_NONEXISTENT_FILTER))
+
+        assert "unresolved_sections" not in resp, (
+            f"Miss response must NOT report 'unresolved_sections' when every section "
+            f"in the item is recognized. Got: {resp.get('unresolved_sections')!r}."
+        )


### PR DESCRIPTION
## Summary

- `_build_section_miss_error()` in `backlog_core/server.py` collapsed two distinct outcomes into an identical `section_filter_miss: True` signal: a requested section genuinely absent from an item, and a requested section absent but the item also holding content under an unresolved `unknown__`-prefixed heading (the write-time key-mismatch defect from #2956). A caller had no way to distinguish "nothing here" from "something's here but mis-keyed."
- Both the singular `section=` path (`_apply_body_section_filter` / `_assemble_view_compact` in `operations.py`) and the plural `sections=[...]` path (`_filter_view_sections` in `server.py`) already funnel their `valid_names` list through this single function — confirmed by reading the call site, which documents both paths converging there. The fix therefore lives in one place: partition `valid_names` for a literal `unknown__` prefix and add an `unresolved_sections` key to the error dict only when such a name exists.
- The classifier is a literal `unknown__` prefix check, not `resolve_section_name(name) is None` — several legitimate, deliberately unregistered headings exist in real item bodies (e.g. `"Description"`, reserved per `operations._normalize_section_key`'s docstring) that would otherwise false-positive as "unresolved."

Relates to #2974

## Investigation

- Reproduced the collapsed signal directly against `_filter_view_sections()` with two constructed `view_item`-shaped payloads (absent vs. mis-keyed-content-present) before making any change — both cases returned identical `section_filter_miss: True` with no distinguishing field, matching the issue's confirmed reproduction.
- Verified `operations.py::_apply_body_section_filter` (the singular `section=` filter) independently rather than assuming it shared the fix automatically: it funnels into the exact same `_build_section_miss_error` call site as the plural path (confirmed by the existing code comment at that call site and by grepping all callers of `_build_section_miss_error` — there is exactly one). No separate change to `operations.py` was needed or made.
- Re-ran the reproduction after the fix: the two cases are now distinguishable via the presence/absence of `unresolved_sections`.

## Test plan

- [x] Added `TestSectionMissErrorDictUnresolvedSections` to the existing ADR-3 suite (`backlog_core/tests/test_section_filter_error_dict.py`) covering: singular `section=` miss with an unresolved heading present, plural `sections=[...]` miss with an unresolved heading present, and a miss with only recognized headings (no `unresolved_sections` key).
- [x] `uv run pytest plugins/development-harness/backlog_core/tests/test_section_filter_error_dict.py -q` — 17 passed (14 pre-existing + 3 new).
- [x] `uv run plugins/development-harness/tests/run_pytest.py backlog_core/tests tests` — 3366 passed, 1 pre-existing unrelated failure (`progressive_markdown` PLR complexity lint gate, untouched by this change).
- [x] `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` on both changed files — all pass.
- [x] `uv run prek run --files` on both changed files — all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg