### PR TITLE
docs(development-harness): document backlog_view progressive-disclosure navigation

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.21",
+  "version": "9.1.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/backlog/SKILL.md
+++ b/plugins/development-harness/skills/backlog/SKILL.md
@@ -93,7 +93,7 @@ View a single backlog item in detail. Supports pagination for long bodies.
 | `include_content` | `bool` | `True` | When True (default), returns full body and section entries. When False, returns metadata and section inventory only (section names with entry counts, no body or entry content). |
 | `offset` | `int` | `0` | Skip N entry blocks from body start (for pagination) |
 | `limit` | `int` | `0` | Show at most N entry blocks (`0` = all, no truncation) |
-| `map` | `bool` | `False` | Return a flat ordinal dot-path map of the item's structure instead of content. Bounded under 2,000 tokens regardless of item size. Mutually exclusive with `navigate`. |
+| `map` | `bool` | `False` | Return a flat ordinal dot-path map of the item's structure instead of content. Not token-bounded — `map_text` returns in full regardless of size; `over_budget=true` flags large items without truncating or paginating. Mutually exclusive with `navigate`. |
 | `navigate` | `str \| None` | `None` | Dot-path ordinal to fetch: `"4.0"`, `"4.0.1"`, `"4.0.code.0"`. Must match `^\d+(\.\d+)*(\.code\.\d+)?$`. An unknown ordinal returns an error listing every valid ordinal. |
 | `head` | `int \| None` | `None` | Cap tokens returned from the navigated ordinal (1–25,000). Requires `navigate`. |
 | `skip_tokens` | `int` | `0` | Token offset within the navigated content, for continuation. Requires `navigate` and `head`. Distinct from `offset`, which counts entry blocks. |

--- a/plugins/development-harness/skills/backlog/SKILL.md
+++ b/plugins/development-harness/skills/backlog/SKILL.md
@@ -93,11 +93,24 @@ View a single backlog item in detail. Supports pagination for long bodies.
 | `include_content` | `bool` | `True` | When True (default), returns full body and section entries. When False, returns metadata and section inventory only (section names with entry counts, no body or entry content). |
 | `offset` | `int` | `0` | Skip N entry blocks from body start (for pagination) |
 | `limit` | `int` | `0` | Show at most N entry blocks (`0` = all, no truncation) |
+| `map` | `bool` | `False` | Return a flat ordinal dot-path map of the item's structure instead of content. Bounded under 2,000 tokens regardless of item size. Mutually exclusive with `navigate`. |
+| `navigate` | `str \| None` | `None` | Dot-path ordinal to fetch: `"4.0"`, `"4.0.1"`, `"4.0.code.0"`. Must match `^\d+(\.\d+)*(\.code\.\d+)?$`. An unknown ordinal returns an error listing every valid ordinal. |
+| `head` | `int \| None` | `None` | Cap tokens returned from the navigated ordinal (1–25,000). Requires `navigate`. |
+| `skip_tokens` | `int` | `0` | Token offset within the navigated content, for continuation. Requires `navigate` and `head`. Distinct from `offset`, which counts entry blocks. |
 
 Returns `{title, priority, issue, plan, file_path, body, groomed, messages, warnings}` when
 `include_content=True` (default). When `include_content=False`, returns compact metadata:
 `{title, priority, issue, plan, file_path, groomed, sections_metadata, messages, warnings}` where
 `sections_metadata` is a list of `{name, num_entries, num_struck}` dicts — no `body` or `sections` keys.
+
+With `map=True`, returns `{selector, total_sections, total_est_tokens, map_text, over_budget}`.
+With `navigate` alone, returns `{ordinal, title, content, total_tokens, truncated, child_map, has_children}`.
+With `navigate` plus `head`, returns `{ordinal, title, content, total_tokens, returned_tokens, truncated, next_call}`.
+
+Before fetching a large item to read one part of it — one acceptance-criteria block, one code
+fence, one sub-heading — read
+[progressive-disclosure.md](./references/progressive-disclosure.md) for the map-then-navigate
+drill-down, ordinal syntax, and the parent-versus-leaf `child_map` contract.
 
 ### `backlog_sync`
 

--- a/plugins/development-harness/skills/backlog/references/progressive-disclosure.md
+++ b/plugins/development-harness/skills/backlog/references/progressive-disclosure.md
@@ -1,0 +1,50 @@
+# Navigating Inside a Backlog Item
+
+`backlog_view` addresses any node of an item by dot-path ordinal. Use `map` to discover ordinals,
+`navigate` to fetch one, `head` and `skip_tokens` to bound and page a large one.
+
+## When to navigate instead of fetching the item
+
+Reach for `map` plus `navigate` whenever the target is one part of a large item — a single
+acceptance-criteria block, one code fence, one sub-heading. `section` filtering returns a whole
+named section; `navigate` reaches inside one, at any nesting depth.
+
+Fetch the whole item only when every section will be read.
+
+## Ordinal syntax
+
+Ordinals must match `^\d+(\.\d+)*(\.code\.\d+)?$`.
+
+- `4` — top-level section
+- `4.0` — first entry within that section
+- `4.0.1` — second sub-heading inside that entry; nesting depth is unbounded
+- `4.0.code.0` — first code fence in that entry's direct body
+
+An ordinal that matches no node returns an error listing every valid ordinal in the item.
+
+## Parent versus leaf (ADR-7)
+
+A node with sub-heading children returns `content=""`, `has_children=true`, and a `child_map`
+listing the child ordinals. Drill into a child ordinal to reach prose.
+
+A leaf node returns full `content`, `child_map=null`, and `has_children=false`. A node holding
+prose and code fences but no sub-headings is a leaf.
+
+## Drill-down sequence
+
+1. Call `backlog_view(selector="#2969", map=True)`. The response is bounded under 2,000 tokens
+   regardless of item size. Each `map_text` line reads
+   `{ordinal} {title} ({est_tokens}t) — "{first content line}"`. Select the ordinal whose title and
+   preview match the target.
+2. Call `backlog_view(selector="#2969", navigate="4.0")`. When `has_children=true`, read `child_map`
+   and repeat this step with a child ordinal such as `4.0.1`. When `has_children=false`, `content`
+   holds the full node.
+3. When the node is larger than needed, bound it:
+   `backlog_view(selector="#2969", navigate="4.0", head=4000)`. While `truncated=true`, repeat using
+   the `skip_tokens` value from the response's `next_call` hint until `truncated=false`.
+
+## Parameter interactions
+
+`map=True` is mutually exclusive with `navigate`. `head` and `skip_tokens` each require `navigate`.
+`skip_tokens` counts tokens within the navigated node; `offset` counts entry blocks in the item
+body. They address different concerns — do not substitute one for the other.

--- a/plugins/development-harness/skills/backlog/references/progressive-disclosure.md
+++ b/plugins/development-harness/skills/backlog/references/progressive-disclosure.md
@@ -32,10 +32,13 @@ prose and code fences but no sub-headings is a leaf.
 
 ## Drill-down sequence
 
-1. Call `backlog_view(selector="#2969", map=True)`. The response is bounded under 2,000 tokens
-   regardless of item size. Each `map_text` line reads
-   `{ordinal} {title} ({est_tokens}t) — "{first content line}"`. Select the ordinal whose title and
-   preview match the target.
+1. Call `backlog_view(selector="#2969", map=True)`. The response is not currently token-bounded —
+   for a large item `map_text` returns every entry in one response; `over_budget=true` flags that
+   case without truncating or paginating it. (Intended behavior is R2 in
+   [agent-markdown-consumption-contract.md](../../../docs/agent-markdown-consumption-contract.md);
+   the gap is tracked in [#3059](https://github.com/Jamie-BitFlight/claude_skills/issues/3059).)
+   Each `map_text` line reads `{ordinal} {title} ({est_tokens}t) — "{first content line}"`. Select
+   the ordinal whose title and preview match the target.
 2. Call `backlog_view(selector="#2969", navigate="4.0")`. When `has_children=true`, read `child_map`
    and repeat this step with a child ordinal such as `4.0.1`. When `has_children=false`, `content`
    holds the full node.


### PR DESCRIPTION
## Motivating finding

`backlog_view`'s progressive-disclosure navigation is fully implemented and covered by unit and integration tests (`backlog_core/disclosure_handler.py`, `disclosure_types.py`, `ordinal_mapper.py`), yet **zero** consuming agents use it. A grep for `navigate`, `child_map`, `skip_tokens`, or `ordinal` across `plugins/development-harness/skills/` and `plugins/development-harness/agents/` returns no hits related to this feature. Every consumer calls `backlog_view` with flat `section=` filtering, or fetches a whole item and filters it in-context — burning context on exactly the problem this feature was built to solve.

Root cause: the feature was never documented in the agent-facing skill files. The parameters exist only in the MCP tool schema's `Field(description=...)` strings, which give an agent the mechanics but never the "reach for this instead of fetching the item" decision.

## Change

- `skills/backlog/SKILL.md` — added `map`, `navigate`, `head`, and `skip_tokens` rows to the `backlog_view` parameter table, plus the three disclosure-mode return shapes, plus a pointer to the new reference.
- `skills/backlog/references/progressive-disclosure.md` (new) — when to navigate rather than fetch the item, ordinal syntax including the `.code.N` form, the ADR-7 parent-versus-leaf contract (parent → `content=""` plus `child_map`; leaf → full `content`), the worked map → navigate → head drill-down, and the `skip_tokens` versus `offset` distinction.

The narrative lives behind a pointer rather than inline because inlining it pushed the SKILL.md body past the skilllint `SK006`/`AS005` token threshold (4693 > 4400). With the split, both files pass clean.

## Validation

- `uvx skilllint@latest check plugins/development-harness/skills/backlog/SKILL.md` — no findings
- `uv run prek run --files <both paths>` — all hooks pass

## Related

Relates to the backlog-integrity issue cluster, #2969 and #2974. No closing keywords — this addresses the documentation gap only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg

<!-- greptile_comment -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into docs/backlog-vi..."](https://github.com/jamie-bitflight/claude_skills/commit/8d3cdb535758ee0c4f2a05064b9091548a6f0bd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54983092)</sub>

**Context used:**

- Context used - .claude/rules/markdown-file-references.md ([source](https://github.com/jamie-bitflight/claude_skills/blob/main/.claude/rules/markdown-file-references.md))

<!-- /greptile_comment -->