### PR TITLE
docs(development-harness): integrate markdown consumption contract with existing docs

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.0.21",
+  "version": "9.0.22",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -419,6 +419,11 @@ Load these documents based on what you are doing. They contain the system design
 - Load [Backlog Item Lifecycle](./docs/backlog-item-lifecycle.md) — end-to-end issue journey from creation through closure
 - Load [Backend Providers](./docs/backend-providers.md) — pluggable backend abstractions, GitHub/GitLab/Linear capabilities
 
+**Modifying markdown consumption, content pagination, table-of-contents/section addressing, or response sizing:**
+
+- Load [Agent Markdown Consumption — Behaviour Specification](./docs/agent-markdown-consumption-contract.md) — normative requirements R1-R7 for how markdown reaches an agent, across every transport
+- Load [MCP Progressive-Disclosure Contract](./docs/mcp-progressive-disclosure-contract.md) — mechanical reference for ordinal addressing, navigation parameters, and response shapes
+
 **Modifying `backlog_core/` internals — any backend implementation, GitHub content/CAS storage, offline queueing, or collaborator boundaries within `GitHubBackend`:**
 
 - Load [backlog_core/ARCHITECTURE.md](./backlog_core/ARCHITECTURE.md) — the authoritative module design doc: per-collaborator responsibilities, the GitHub writable-records design (CAS-on-blob-SHA, envelope validation, fail-closed semantics, why this replaced an earlier Gist-backed store), offline/replay policy, and the reasoning behind decisions that read as arbitrary without it. Read this BEFORE diagnosing a bug or proposing a fix anywhere in `backlog_core/models.py`, `backlog_core/operations.py`, or `backlog_core/backends/*.py` — this file already answers "why does it work this way" for most of what looks, from the code alone, like an odd or missing design choice. A recurring failure shape across independently-diagnosed bugs (e.g. "a queued mutation never gets acknowledged after the thing it was waiting for already happened," seen 3 times in one session before this doc was read) is itself a signal to stop and read this file rather than keep patching instances.

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -112,8 +112,9 @@ The engine described by R1 exists as the `progressive_markdown` package: `Naviga
 `budget`), `Paginator` (`paginate_blocks`, `paginate_text`), and a `MarkdownContentProvider`
 protocol for arbitrary sources.
 
-Duplicate implementations to delete rather than refactor, in the backlog MCP server and
-`backlog_core`:
+Duplicate implementations to delete rather than refactor, in the backlog server layer
+(`backlog_core/server.py`, `backlog_core/operations.py`) shared by the MCP tool and CLI paths
+that call it:
 
 - the compact manifest, over-budget directory, and section-index builders, which emit a
   bracket-numbered index that neither paginates nor matches the engine's addresses — the
@@ -124,10 +125,12 @@ Duplicate implementations to delete rather than refactor, in the backlog MCP ser
 The address-based navigation path (`disclosure_handler`, `ordinal_mapper`) already routes
 through the engine and is the reference for how the remaining paths should call it.
 
-## Documents this supersedes or unifies
+## Related documents
 
-- The progressive-disclosure contract — documents address-based navigation as an opt-in
-  protocol and does not describe the automatic compact form.
-- The unified section layer brief — defines the cross-provider entry contract and does not
-  reference disclosure or pagination.
-- Neither cross-references the other, and neither states R1.
+- [MCP Progressive-Disclosure Contract](./mcp-progressive-disclosure-contract.md) — mechanical
+  reference for ordinal addressing, navigation parameters, and response shapes on one conforming
+  implementation. Subordinate to this contract for behaviour.
+- [Unified Section Layer Brief](./unified-section-layer-brief.md) — defines the cross-provider
+  entry and ID contract that markdown sources are built from. Complementary, not overlapping:
+  that brief owns entry and ID identity; this contract owns pagination and disclosure of the
+  content built from those entries.

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -1,0 +1,133 @@
+# Agent Markdown Consumption — Behaviour Specification
+
+Every consumer of every operation described here is an AI agent. There is no human reader.
+
+Requirements R1–R7 are normative. The open questions section names decisions not yet made;
+until each is resolved, an implementation satisfying the surrounding requirements is correct.
+
+## Purpose
+
+Define one contract for how markdown reaches an agent. An agent must never receive an
+unbounded dump, must never receive silently truncated content, and must always receive
+enough structure to request exactly the part it needs next.
+
+## Normative requirements
+
+### R1 — One markdown engine, all consumption
+
+A single markdown engine serves every markdown consumption path across the plan/task system
+and the backlog system. It parses content from any source, builds an addressable tree, and
+returns paginated results.
+
+No component may hand-build a table of contents, a section listing, a content excerpt, or a
+bounded response of its own. Where such an implementation exists today it is deleted, not
+maintained in parallel. A second implementation is a defect regardless of whether it works.
+
+Sources include, and are not limited to: issue and item bodies, plan documents, task
+documents, and the reports and artifacts produced during grooming.
+
+### R2 — Everything paginates, including the table of contents
+
+Every response that can exceed the window budget paginates. This applies recursively and
+without exception — a table of contents that exceeds the budget paginates exactly as a
+content body does.
+
+No response may drop, elide, or truncate addressable nodes to fit a budget. Content that
+does not fit the current page is reachable on a subsequent page, never merely implied.
+
+Harnesses commonly cap a single tool response at ~10,000 tokens, adjustable. The engine's
+budget is configurable and must not exceed the harness cap.
+
+### R3 — Threshold triggers the compact form, automatically
+
+When a response would exceed the budget, the compact form is returned instead. This is
+automatic: no opt-in parameter, no prior knowledge required of the caller.
+
+The compact form contains item metadata, the top description, the table of contents, the
+inventory of associated reports and artifacts, and a hint naming the exact next call.
+
+### R4 — One addressing scheme
+
+Addresses in a table of contents are the same addresses accepted by every retrieval
+operation. An agent copies an address from a response and passes it back unchanged. Exactly
+one scheme exists across the whole system.
+
+### R5 — Addresses accepted wherever content is requested
+
+Every operation that returns markdown accepts an address to scope what it returns, and a
+page selector to traverse it.
+
+### R6 — Sections and artifacts are one inventory
+
+An agent viewing an item receives, in one response, both the section table of contents and
+the associated reports and artifacts. Both are requestable by name. Discovering what exists
+never requires a second call to a different tool.
+
+### R7 — Hints must be actionable
+
+A response that withholds content states what the caller must do to obtain it, using
+addresses valid in that same response. A hint must never recommend retrieving everything as
+its first suggestion, never recommend an action the caller has already exhausted, and never
+name a mechanism absent from the response it accompanies.
+
+## Required flow
+
+```mermaid
+flowchart TD
+    Req([Agent requests content<br>from any source]) --> Eng[Markdown engine parses<br>and builds addressable tree<br>R1]
+    Eng --> Measure{Response exceeds<br>window budget?}
+
+    Measure -->|No| Full[Return full content]
+    Measure -->|Yes| Compact["Return compact form R3:<br>metadata + description<br>+ table of contents R4<br>+ artifact inventory R6<br>+ actionable hint R7"]
+
+    Compact --> TocFits{Table of contents<br>itself exceeds budget?}
+    TocFits -->|Yes| TocPage["Paginate the table of contents R2<br>nothing dropped — page selector returned"]
+    TocFits -->|No| Select
+    TocPage --> Select[Agent selects an address<br>or artifact name from the response]
+
+    Select --> Fetch[Request that address]
+    Fetch --> Children{Node has children?}
+    Children -->|Yes| ChildMap[Return child listing<br>agent drills further]
+    ChildMap --> Select
+    Children -->|No| Fits{Content exceeds<br>window budget?}
+
+    Fits -->|No| Deliver[Return full node content]
+    Fits -->|Yes| Window["Return page 1 + page selector R2<br>no content dropped"]
+    Window --> Cont[Agent requests next page]
+    Cont --> Fits
+```
+
+## Open questions requiring a decision
+
+1. Budget value — one configurable constant for all operations, and what default relative to
+   the ~10,000 token harness cap.
+2. Compact-form composition when both the table of contents and the artifact inventory are
+   large — page them together, or independently.
+3. Whether an agent may request an explicit page size, or only accept the configured budget.
+
+## Implementation appendix — shape to code
+
+The engine described by R1 exists as the `progressive_markdown` package: `Navigator`
+(`map`, `view_section`, `view_code`, `links`, `search_sections`, each taking `page` and
+`budget`), `Paginator` (`paginate_blocks`, `paginate_text`), and a `MarkdownContentProvider`
+protocol for arbitrary sources.
+
+Duplicate implementations to delete rather than refactor, in the backlog MCP server and
+`backlog_core`:
+
+- the compact manifest, over-budget directory, and section-index builders, which emit a
+  bracket-numbered index that neither paginates nor matches the engine's addresses — the
+  same index format is hand-built in three separate functions
+- the entry-block pagination and paged-body rendering, which duplicate `Paginator`
+- the section-filter assembly, which duplicates parser-level node extraction
+
+The address-based navigation path (`disclosure_handler`, `ordinal_mapper`) already routes
+through the engine and is the reference for how the remaining paths should call it.
+
+## Documents this supersedes or unifies
+
+- The progressive-disclosure contract — documents address-based navigation as an opt-in
+  protocol and does not describe the automatic compact form.
+- The unified section layer brief — defines the cross-provider entry contract and does not
+  reference disclosure or pagination.
+- Neither cross-references the other, and neither states R1.

--- a/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
+++ b/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
@@ -1,5 +1,13 @@
 # MCP Progressive-Disclosure Contract
 
+Behaviour for how markdown reaches an agent is normative in
+[Agent Markdown Consumption — Behaviour Specification](./agent-markdown-consumption-contract.md)
+(R1–R7), across every transport — MCP and CLI alike. This document is mechanical reference,
+subordinate to that contract: ordinal addressing, navigation parameters, and response shapes
+for one conforming implementation, the `backlog_view` MCP tool. See
+[Backend Providers](./backend-providers.md) "CLI vs MCP Capability Surface" for the CLI
+equivalent's current parameter parity.
+
 The `backlog_view` MCP tool exposes progressive disclosure for backlog items — a two-call
 navigation protocol that lets agents browse large items incrementally, from a token-efficient
 map down to full section, sub-heading, or code-fence content.
@@ -166,20 +174,31 @@ NavigateResponse:
 
 ## Typical Navigation Flow
 
-```text
-1. backlog_view(selector="#2529", map=true)
-   → MapResponse: map_text lists ordinals at sections and entries
+Per R3 in the behaviour contract, the compact form — including the table of contents — returns
+automatically once a plain `backlog_view` call would exceed the token budget; no `map=true`
+call is required to reach it. The steps below assume the agent already holds a table of
+contents (from that automatic compact form, or from an explicit `map=true` call) and is
+drilling into an ordinal:
 
-2. backlog_view(selector="#2529", navigate="4.0")
+```text
+1. backlog_view(selector="#2529", navigate="4.0")
    → NavigateResponse
      if has_children=true  → read child_map, navigate to a child ordinal
      if has_children=false → read content directly
 
-3. backlog_view(selector="#2529", navigate="4.0.1")
+2. backlog_view(selector="#2529", navigate="4.0.1")
    → NavigateResponse: prose with [code:...] tokens for any fences
 
-4. backlog_view(selector="#2529", navigate="4.0.1.code.0")
+3. backlog_view(selector="#2529", navigate="4.0.1.code.0")
    → NavigateResponse: raw code fence body
+```
+
+An explicit `map=true` call remains available to request the table of contents directly,
+without first triggering the budget check:
+
+```text
+backlog_view(selector="#2529", map=true)
+→ MapResponse: map_text lists ordinals at sections and entries
 ```
 
 ---
@@ -190,8 +209,9 @@ The resolution index inside `OrdinalPathMapper` is built eagerly to all depths d
 `build_map()`. `resolve()` and `valid_ordinals()` operate on this complete index.
 
 The `map_text` field in `MapResponse` is bounded by the token budget (from
-`progressive_markdown.list_navigator.TOKEN_BUDGET`). Deep ordinals may be absent from the
-rendered map text but remain resolvable via `navigate=`.
+`progressive_markdown.list_navigator.TOKEN_BUDGET`). See R2 in the behaviour contract for the
+pagination requirement governing what happens when the full index exceeds that budget — no
+addressable ordinal may be dropped or elided.
 
 Source: architecture spec §5.3 and `backlog_core/ordinal_mapper.py`.
 

--- a/plugins/development-harness/docs/unified-section-layer-brief.md
+++ b/plugins/development-harness/docs/unified-section-layer-brief.md
@@ -2,7 +2,9 @@
 
 This contributor brief defines the section-wire contract. Consumer workflows must use the
 configured backlog MCP/CLI operations and must not parse provider bodies, cache files, or wire
-timestamps themselves.
+timestamps themselves. For how the entries and sections defined here are paginated and
+disclosed to an agent, see
+[Agent Markdown Consumption — Behaviour Specification](./agent-markdown-consumption-contract.md).
 
 ## Outcome
 
@@ -72,7 +74,10 @@ Known-input parsing, search, filtering, section addressing, artifact lookup, pla
 progress counting belong in scripts, CLI commands, or MCP tools. Consumer instructions should
 name the operation and interpret its returned evidence; they should not reproduce a grep,
 parser, filter pipeline, or multi-call state update. Keep unique evidence interpretation,
-diagnosis, synthesis, and design decisions in the agent reasoning layer.
+diagnosis, synthesis, and design decisions in the agent reasoning layer. R1 in
+[Agent Markdown Consumption — Behaviour Specification](./agent-markdown-consumption-contract.md)
+states the markdown-engine side of this same boundary — one engine, no duplicate hand-built
+implementations.
 
 ## Contributor acceptance criteria
 


### PR DESCRIPTION
## Summary

Integrates the previously-committed `plugins/development-harness/docs/agent-markdown-consumption-contract.md` (normative R1-R7 behaviour spec) with its two sibling docs, which it referenced but neither cross-referenced nor was discoverable from.

## Conflicts found and how each was resolved

1. **Stale "deep ordinals may be absent from map text" claim in `mcp-progressive-disclosure-contract.md`'s "Resolution Index vs Map Text" section** — directly contradicted R2 ("no response may drop, elide, or truncate addressable nodes to fit a budget"). Removed the claim and replaced it with a pointer to R2.

2. **"Typical Navigation Flow" taught `map=true` as the agent's opt-in first step** — contradicted R3, which makes the compact form (including the table of contents) automatic once a plain call exceeds budget. Reframed the flow to lead with R3's automatic behaviour, kept the `map=true` example as a still-valid explicit-request path (not opt-in-as-entry-point).

3. **MCP-only framing** — the implementation appendix in the new contract said "in the backlog MCP server and `backlog_core`," implying an MCP/CLI split that doesn't reflect the actual shared code (`backlog_core/server.py` + `backlog_core/operations.py`, both reachable by the CLI's `backlog view` command via `sam_schema/backlog.py`). Reworded to name the shared server layer. Similarly added a scope line to the top of `mcp-progressive-disclosure-contract.md` stating the R1-R7 contract binds every transport (MCP and CLI), while pointing to `backend-providers.md`'s "CLI vs MCP Capability Surface" for the CLI's current per-parameter parity rather than overclaiming full parity (a documented pre-existing gap: the CLI's `backlog view` does not yet accept `navigate`/`map`/`head`).

4. **No cross-reference between `unified-section-layer-brief.md` and the new contract** — the brief defines the cross-provider entry/ID contract but never mentioned disclosure or pagination, and the new contract's "Mechanical boundary" section restated content that already belongs to R1. Added a pointer from the brief's intro to the contract, and had its "Mechanical boundary" section point at R1 instead of restating it.

5. **Not discoverable** — `plugins/development-harness/AGENTS.md`'s "Required Reading by Task Type" table had no entry for markdown consumption/pagination/disclosure work. Added one, listing the new contract first and the disclosure reference second, matching the existing entries' wording.

6. **Stale changelog-style section** ("Documents this supersedes or unifies") — not explicitly named in the task, but became self-contradictory the moment the contradictions above were fixed (it asserted the sibling docs "do not reference disclosure or pagination" and "neither cross-references the other," which stopped being true after this PR's edits). Replaced with a "Related documents" section stating the current relationship instead of the historical bug list, per this repo's "current over historical" documentation convention.

No file was renamed — `mcp-progressive-disclosure-contract.md` keeps its name per the task's explicit deferral of that decision.

## Files changed

- `plugins/development-harness/docs/agent-markdown-consumption-contract.md`
- `plugins/development-harness/docs/mcp-progressive-disclosure-contract.md`
- `plugins/development-harness/docs/unified-section-layer-brief.md`
- `plugins/development-harness/AGENTS.md`

## Test plan

- [x] `uv run prek run --files <all four changed files>` — all hooks passed (markdownlint-cli2, manifest sync, symlink checks, etc.)
- [x] Verified the MCP/CLI scope claim against source: `backlog_core/server.py` (`_build_compact_manifest`, `_build_over_budget_view`) and `backlog_core/operations.py` (`_render_section_index`, reachable from both `backlog_view` MCP tool and `sam_schema/backlog.py`'s `view` CLI command via `operations.view_item`)
- [x] Verified the CLI's `backlog view` command (`sam_schema/backlog.py`) does not currently accept `navigate`/`map`/`head` flags, confirming the parity caveat added is accurate rather than aspirational

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into worktree-agent-..."](https://github.com/jamie-bitflight/claude_skills/commit/86eb244033f067609c1421edf8d4d7bf5dff6380) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54999241)</sub>

<!-- /greptile_comment -->