### PR TITLE
docs(development-harness): component architecture map and contract scope binding

### DIFF
--- a/.claude/agent-memory/dh-service-docs-maintainer/MEMORY.md
+++ b/.claude/agent-memory/dh-service-docs-maintainer/MEMORY.md
@@ -3,3 +3,8 @@
 - [DH MCP-vs-CLI Documentation Structure](dh-mcp-cli-docs.md) — canonical CLI-mapping source, which
   dh docs already pair MCP-reference sections with a dedicated CLI section, and the drift patterns
   found there (stale tool names, overstated parity, extraction-rule blind spots).
+- [Unenforced map guarantee](unenforced-map-guarantee.md) — backlog_view map mode's "under 2,000
+  tokens" claim is not enforced by disclosure_handler.py; other locations asserting the same false
+  bound; tracking issue #3059.
+- [skilllint token threshold](skilllint-token-threshold.md) — prek passing does not mean
+  skilllint's 4400-token SKILL.md ceiling still passes; re-run skilllint directly after edits.

--- a/.claude/agent-memory/dh-service-docs-maintainer/skilllint-token-threshold.md
+++ b/.claude/agent-memory/dh-service-docs-maintainer/skilllint-token-threshold.md
@@ -1,0 +1,22 @@
+---
+name: skilllint-token-threshold
+description: prek passing on a SKILL.md edit does not mean skilllint's 4400-token AS005/SK006 threshold still passes — re-run skilllint after every SKILL.md edit, not just once at the end
+metadata:
+  type: feedback
+---
+
+`uv run prek run --files <SKILL.md>` does not check the skilllint token-count thresholds (AS005
+"body exceeds 4400 tokens", SK006 "skill body is large") — the plugin-validator hook it runs is a
+separate, narrower check. A `SKILL.md` already sitting close to the 4400-token ceiling can cross it
+from a single added sentence in a table cell, and prek will still report green.
+
+**Why**: discovered while fixing a doc claim in `plugins/development-harness/skills/backlog/
+SKILL.md` — a one-sentence correction pushed the file from clean to 4408 tokens (AS005 + SK006
+both fired), even though prek passed throughout.
+
+**How to apply**: after editing any `SKILL.md`, run `uvx skilllint@latest check <path>` directly
+(not just prek) and treat AS005/SK006 warnings as a signal to tighten wording, not as acceptable
+noise — they are warnings (exit 0) but still real regressions worth trimming for, especially when
+the edit is a correction rather than new required content. Re-run after each trim; token count
+does not shrink linearly with word count in an obvious way (chained edits took two trim passes
+to clear the threshold in this case).

--- a/.claude/agent-memory/dh-service-docs-maintainer/unenforced-map-guarantee.md
+++ b/.claude/agent-memory/dh-service-docs-maintainer/unenforced-map-guarantee.md
@@ -1,0 +1,25 @@
+---
+name: unenforced-map-guarantee
+description: backlog_view map mode's "under 2,000 tokens" claim is not enforced by disclosure_handler.py — where the false claim lives, and the tracking issue
+metadata:
+  type: project
+---
+
+`BacklogViewDisclosureHandler._handle_map` in
+`plugins/development-harness/backlog_core/disclosure_handler.py` joins every ordinal entry into
+`map_text` unconditionally (`"\n".join(mapper.format_map_line(e) for e in entries)`) with no
+truncation or pagination. `over_budget` is computed (`total_est_tokens > TOKEN_BUDGET`) but never
+acts on the text — a large item's map response is returned in full regardless of size.
+
+**Why**: R2 of `plugins/development-harness/docs/agent-markdown-consumption-contract.md` (as of
+2026-08-20, only on the unmerged `docs/component-architecture-map` branch, not yet on `main`)
+requires everything to paginate, nothing to drop. The map handler predates that contract and was
+never updated to match it.
+
+**How to apply**: Do not describe the map response as bounded/capped in any doc without checking
+this handler first — several places asserted the false bound independently: `SKILL.md` and
+`references/progressive-disclosure.md` in the `backlog` skill (fixed PR #3051), plus (still
+unfixed as of this writing) `disclosure_types.py`'s `MapResponse`/docstrings and
+`docs/mcp-progressive-disclosure-contract.md` line ~192 — all tracked under issue #3059, whose
+acceptance criteria now also require "no docstring or document asserts a bound the implementation
+does not enforce." Check #3059's current state before re-fixing these — it may already be closed.

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -421,7 +421,8 @@ Load these documents based on what you are doing. They contain the system design
 
 **Modifying markdown consumption, content pagination, table-of-contents/section addressing, or response sizing:**
 
-- Load [Agent Markdown Consumption — Behaviour Specification](./docs/agent-markdown-consumption-contract.md) — normative requirements R1-R7 for how markdown reaches an agent, across every transport
+- Load [Component Architecture](./docs/component-architecture.md) — which package owns what, and the points where two components resemble each other and are not the same. Read this before working in any package in this plugin
+- Load [Agent Markdown Consumption — Behaviour Specification](./docs/agent-markdown-consumption-contract.md) — normative requirements R1-R8 for how markdown reaches an agent, across every transport
 - Load [MCP Progressive-Disclosure Contract](./docs/mcp-progressive-disclosure-contract.md) — mechanical reference for ordinal addressing, navigation parameters, and response shapes
 
 **Modifying `backlog_core/` internals — any backend implementation, GitHub content/CAS storage, offline queueing, or collaborator boundaries within `GitHubBackend`:**

--- a/plugins/development-harness/backlog_core/ARCHITECTURE.md
+++ b/plugins/development-harness/backlog_core/ARCHITECTURE.md
@@ -985,7 +985,16 @@ These are CLI-specific display concerns that don't belong in core logic.
 **Responsibility**: Deliver backlog item content progressively. Large items are navigated
 via a token-efficient ordinal map rather than returned in a single call.
 
-Contract reference: `docs/mcp-progressive-disclosure-contract.md`.
+**Ownership**: navigation and pagination belong to the `progressive_markdown` package, which
+provides them for markdown from any source. The modules described here predate that
+consolidation and reimplement navigation on top of the engine's parser and indexer. They are
+a transitional implementation, not the owner of this concern — see
+[Component Architecture](../docs/component-architecture.md) for the boundary and
+[Agent Markdown Consumption](../docs/agent-markdown-consumption-contract.md) for the
+behaviour they must converge on. Do not extend them; add capability to the engine instead.
+
+Contract reference: `docs/mcp-progressive-disclosure-contract.md` for ordinal addressing and
+response shapes.
 
 ### MarkdownIndexer Integration
 

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -2,7 +2,7 @@
 
 Every consumer of every operation described here is an AI agent. There is no human reader.
 
-Requirements R1–R7 are normative. The open questions section names decisions not yet made;
+Requirements R1–R8 are normative. The open questions section names decisions not yet made;
 until each is resolved, an implementation satisfying the surrounding requirements is correct.
 
 ## Purpose
@@ -10,6 +10,19 @@ until each is resolved, an implementation satisfying the surrounding requirement
 Define one contract for how markdown reaches an agent. An agent must never receive an
 unbounded dump, must never receive silently truncated content, and must always receive
 enough structure to request exactly the part it needs next.
+
+## Scope — operations bound by this contract
+
+Every operation that returns markdown to an agent is bound, on every transport. This
+includes, and is not limited to:
+
+- reading an item and any filtered view of one
+- reading a plan or a task
+- reading an artifact's content
+- any listing operation whose result embeds content rather than only metadata
+
+An operation is not exempt because its content is usually small. Requirements apply to the
+operation, not to a size class of its typical payload.
 
 ## Normative requirements
 
@@ -63,12 +76,29 @@ An agent viewing an item receives, in one response, both the section table of co
 the associated reports and artifacts. Both are requestable by name. Discovering what exists
 never requires a second call to a different tool.
 
+This requirement changes the response shape of the item-view operation on every transport,
+and supersedes the current arrangement in which artifacts are discovered through a separate
+lookup. It states intended behaviour, not current behaviour.
+
 ### R7 — Hints must be actionable
 
 A response that withholds content states what the caller must do to obtain it, using
 addresses valid in that same response. A hint must never recommend retrieving everything as
 its first suggestion, never recommend an action the caller has already exhausted, and never
 name a mechanism absent from the response it accompanies.
+
+### R8 — Paginated content is addressed by content identity
+
+A response that paginates returns a stable identifier derived from the content it paginates,
+alongside the page position. Subsequent pages are requested with that identifier plus a page
+selector or an address, never by re-describing the source.
+
+The identifier resolves against cached parsed content. Serving a later page does not
+re-collect from the provider and does not re-parse.
+
+A request whose identifier no longer matches current content is reported as stale. Pages
+from two different versions of a document are never returned as though they were one
+document.
 
 ## Required flow
 
@@ -104,6 +134,10 @@ flowchart TD
 2. Compact-form composition when both the table of contents and the artifact inventory are
    large — page them together, or independently.
 3. Whether an agent may request an explicit page size, or only accept the configured budget.
+4. Cache lifetime and scope for R8 — held for the duration of a session, or persisted across
+   sessions.
+5. Whether R8's identifier is derived from the raw markdown or from the parsed tree. Raw
+   detects every change; parsed would keep pagination stable across cosmetic edits.
 
 ## Implementation appendix — shape to code
 

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -129,15 +129,24 @@ flowchart TD
 
 ## Open questions requiring a decision
 
+Each open question is tracked as an issue so a decision made here is discoverable and enforced
+against the work it blocks, rather than existing only as prose in this section.
+
 1. Budget value — one configurable constant for all operations, and what default relative to
-   the ~10,000 token harness cap.
+   the ~10,000 token harness cap. Tracked in #3072.
 2. Compact-form composition when both the table of contents and the artifact inventory are
-   large — page them together, or independently.
+   large — page them together, or independently. Tracked in #3073.
 3. Whether an agent may request an explicit page size, or only accept the configured budget.
+   Tracked in #3074.
 4. Cache lifetime and scope for R8 — held for the duration of a session, or persisted across
-   sessions.
+   sessions. Tracked in #3075. Blocks #3062.
 5. Whether R8's identifier is derived from the raw markdown or from the parsed tree. Raw
-   detects every change; parsed would keep pagination stable across cosmetic edits.
+   detects every change; parsed would keep pagination stable across cosmetic edits. Tracked in
+   #3076. Blocks #3062.
+
+When an issue above closes, remove its list item here and fold the decision into the relevant
+requirement (R2, R5, R6, or R8) as normative text — this section holds undecided questions
+only, not a permanent record of resolved ones.
 
 ## Implementation appendix — shape to code
 

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -141,10 +141,14 @@ flowchart TD
 
 ## Implementation appendix — shape to code
 
-The engine described by R1 exists as the `progressive_markdown` package: `Navigator`
-(`map`, `view_section`, `view_code`, `links`, `search_sections`, each taking `page` and
-`budget`), `Paginator` (`paginate_blocks`, `paginate_text`), and a `MarkdownContentProvider`
-protocol for arbitrary sources.
+The engine described by R1 exists as the `progressive_markdown` package:
+`ProgressiveMarkdownNavigator` (`map`, `view_section`, `view_code`, `links`,
+`search_sections`, each taking `page` and `budget`), `Paginator` (`paginate_blocks`,
+`paginate_text`), and a `MarkdownContentProvider` protocol for arbitrary sources.
+
+`ProgressiveMarkdownNavigator` and `Paginator` currently have no consumers. The engine's
+parser and indexer are imported by the address-navigation path; its navigation and
+pagination layer is not used by anything.
 
 Duplicate implementations to delete rather than refactor, in the backlog server layer
 (`backlog_core/server.py`, `backlog_core/operations.py`) shared by the MCP tool and CLI paths

--- a/plugins/development-harness/docs/component-architecture.md
+++ b/plugins/development-harness/docs/component-architecture.md
@@ -1,0 +1,168 @@
+# Development Harness — Component Architecture
+
+Read this before working in any package in this plugin. It maps every code package to its
+role, states which package owns which responsibility, and names the places where two
+components look alike and are not.
+
+This document states the intended architecture. Where the implementation differs, the
+difference is a tracked gap, not a description of how things should stay. Gaps are recorded
+as backlog items rather than as caveats here.
+
+Behavioural requirements for markdown consumption live in
+[Agent Markdown Consumption](./agent-markdown-consumption-contract.md). This document does
+not restate them; it says which package is responsible for satisfying them.
+
+## Transports
+
+The harness exposes the same operations through two transports: MCP servers and a CLI. Both
+are thin. Neither owns behaviour.
+
+`dh_core` is the unified operations layer both transports call. A behavioural requirement
+binds every transport, and a capability added to one transport without the other is a gap.
+Never describe a behaviour as belonging to MCP or to the CLI.
+
+## Package map
+
+### `progressive_markdown`
+
+Role: the markdown engine. The single path through which markdown reaches an agent.
+
+Owns: parsing markdown into an addressable tree, assigning addresses, pagination of every
+result including a table of contents, token budgeting, and the content-provider protocol
+that lets markdown arrive from any source.
+
+Consumed by: `backlog_core`, `sam_schema`.
+
+Do not confuse with: the navigation and pagination logic currently living inside
+`backlog_core`. That logic duplicates this package's `Navigator` and `Paginator` and is
+scheduled for deletion, not maintenance. A second implementation of addressing or pagination
+is a defect regardless of whether it works.
+
+Two numbering schemes exist today and they are not the same thing. The engine's dot-path
+addresses reach sections, sub-headings, and code fences at any depth; they are the surviving
+scheme. The bracket-numbered index emitted by the hand-built section directory addresses only
+top-level sections, does not paginate, and is removed with the code that produces it. When a
+document refers to an address, it means the dot-path form.
+
+### `backlog_core`
+
+Role: the backlog domain — items, their sections and entries, provider adapters, and
+synchronisation.
+
+Owns: item lifecycle, the canonical section-name registry, entry identity and timestamps,
+provider adapters, and reconciliation between local and remote state.
+
+Consumes: `progressive_markdown` for all markdown handling.
+
+Detail: [backlog_core/ARCHITECTURE.md](../backlog_core/ARCHITECTURE.md).
+
+Do not confuse with: two distinct concerns live here and a finding in one does not
+generalise to the other.
+
+- Storage keying decides which canonical key a heading maps to, so the same logical section
+  is addressed consistently across providers.
+- Navigation indexing decides how an agent walks a document's tree.
+
+These answer different questions. Navigation belongs to `progressive_markdown`; where
+`backlog_core` implements it, that is a gap.
+
+### `sam_schema`
+
+Role: the plan and task domain, plus the CLI application.
+
+Owns: plan and task models, plan lifecycle, and the CLI entry point.
+
+Consumes: `progressive_markdown` for all markdown handling; `dh_core` for shared operations.
+
+Constraint: plan mutation is single-writer. Operations that append a task or finalise a plan
+must not be performed concurrently by more than one writer. See
+[ADR-1770-1](./adrs/ADR-1770-1-single-writer-task-backend.md) — this constraint is easy to
+violate silently when adding a new mutation path.
+
+Do not confuse with: `dispatch_schema`. Plans describe work; dispatch plans describe how
+work is distributed to agents.
+
+### `dh_core`
+
+Role: the unified operations layer shared by the CLI and the MCP servers.
+
+Owns: operations both transports invoke, and the protocols defining them.
+
+Do not confuse with: transport modules. An operation implemented in a transport rather than
+here is reachable from one transport only, which violates the transport rule above.
+
+### `dispatch_schema`
+
+Role: dispatch plan models, their serialisation, validation, and gates.
+
+Do not confuse with: `sam_schema`'s plans and tasks. See the distinction above.
+
+### `agent_profile`
+
+Role: an MCP package exposing agent profile discovery and loading.
+
+### `hooks`
+
+Role: Claude Code hook scripts bound to harness events.
+
+### `scripts`
+
+Role: entry-point wrappers that let packages run standalone, including the self-resolving
+server and CLI launchers.
+
+## Content model
+
+An item carries two kinds of associated content, and an agent discovers both from one
+response rather than by querying separate tools.
+
+- Sections: the item's own body content, addressed by the engine's addressing scheme.
+- Artifacts: reports and assets produced during grooming, associated with the item and
+  requestable by name.
+
+Artifact identity and retrieval are provider-independent: the same name resolves the same
+artifact regardless of which provider stores it.
+
+Ownership divides as follows, because three packages each touch artifacts and only one owns
+each concern:
+
+- `backlog_core` owns artifact registration, identity, and the association between an
+  artifact and its item — artifact discovery is part of item state.
+- The storage provider owns durability of artifact content.
+- `progressive_markdown` owns delivery of artifact content to an agent, on the same terms as
+  any other markdown.
+
+Discovery is not a provider concern and not an engine concern. An artifact listed as
+registered whose content cannot be retrieved is a defect in the boundary between the first
+two, not an expected outcome.
+
+## Provider independence
+
+Items may be stored by any supported provider. Provider-specific serialisation stays inside
+its adapter. A read, write, or navigation operation returns the same logical result
+regardless of provider, or reports an explicit unavailable or stale outcome when a provider
+cannot supply it.
+
+Detail: [Backend Providers](./backend-providers.md),
+[Unified Section Layer](./unified-section-layer-brief.md).
+
+## Test layout
+
+Tests live with the subsystem they cover, inside that subsystem's directory. The plugin-level
+test directory is for plugin-level concerns only. Before adding a test file, search the whole
+plugin for an existing suite covering that module and extend it rather than creating a
+second file.
+
+## Where workflow is described
+
+This document maps packages and their responsibilities. It does not describe the workflows
+that run across them — grooming phases, gate sequencing, agent dispatch, or status
+transitions. Those live in the lifecycle and pipeline documents indexed by the Required
+Reading table. Adding workflow description here would recreate the everything-document
+problem this map exists to avoid.
+
+## Documentation layout
+
+Documents live in this directory and are indexed by the Required Reading table in the
+plugin's `AGENTS.md`. A document that no index references is unreachable. When adding one,
+add its index entry in the same change, and check whether an existing document already
+covers the topic — two documents describing one component will drift into contradiction.

--- a/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
+++ b/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
@@ -2,7 +2,7 @@
 
 Behaviour for how markdown reaches an agent is normative in
 [Agent Markdown Consumption — Behaviour Specification](./agent-markdown-consumption-contract.md)
-(R1–R7), across every transport — MCP and CLI alike. This document is mechanical reference,
+(R1–R8), across every transport — MCP and CLI alike. This document is mechanical reference,
 subordinate to that contract: ordinal addressing, navigation parameters, and response shapes
 for one conforming implementation, the `backlog_view` MCP tool. See
 [Backend Providers](./backend-providers.md) "CLI vs MCP Capability Surface" for the CLI


### PR DESCRIPTION
Adds the package-level component map this plugin did not have, and closes gaps a six-reviewer pass found in the markdown consumption contract.

Stacked on #3053 — review that first; this branch contains its commits.

## Why a component map

The plugin has eight code packages and one of them had an architecture document. Nothing described how they relate or which owns what. The practical consequence: work starting in the only documented package generalised from it, repeatedly. The `progressive_markdown` engine — which provides parsing, addressing, and pagination for markdown from any source — was invented around rather than used, and its `Navigator` and `Paginator` currently have no consumers at all.

Each package entry states role, what it owns, what it consumes, where its detail lives, and a do-not-confuse-with note wherever two components resemble each other. That last part is the load-bearing piece: the failure mode was never "could not find it," it was "found something adjacent and assumed."

## Review findings addressed

Six reviewers read existing documentation first, then the new documents, then reported contradictions. Changes made in response:

- Contract now names the operations it binds, on every transport. It previously claimed to serve the plan/task system without saying which operations that meant.
- R6 (sections and artifacts in one inventory) is marked as intended behaviour requiring a response-shape change. Three reviewers independently ranked its ambiguity highest — each had to guess whether it described current or future state.
- R8 added: paginated content is addressed by a content identity resolving against cached parsed content, so later pages are not re-collected and pages from two document versions are never stitched together. Reviewers confirmed no existing mechanism covers this.
- The plan mutation single-writer constraint from ADR-1770-1 is recorded in the map. It was omitted, and it is easy to violate silently when adding a mutation path.
- Artifact discovery ownership assigned. Three packages touch artifacts and none owned discovery.
- The dot-path address scheme and the bracket-numbered index are now explicitly distinguished, with which survives. A reviewer conflated them after reading both documents in full, which made the ambiguity mine rather than theirs.
- `backlog_core/ARCHITECTURE.md` claimed navigation ownership that belongs to the engine. Corrected to read as transitional, with a pointer to the boundary.

## Open questions

Five decisions are recorded in the contract rather than assumed: the budget default relative to the harness response cap, compact-form composition when both inventories are large, whether callers may set page size, and R8's cache scope and identity derivation.

## Sequencing note for implementation

The hand-built index structures marked for deletion are what the grooming validation gate currently reads to check section presence. That gate needs rewriting before they are removed.

Relates to #3054.

<!-- greptile_comment -->

<sub>Reviews (7): Last reviewed commit: ["docs(development-harness): track the con..."](https://github.com/jamie-bitflight/claude_skills/commit/7184b5721051a987e5fbd42d545b04ca27e80608) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55006104)</sub>

<!-- /greptile_comment -->