### PR TITLE
fix(development-harness): remove mechanism-leak sentence + codify skills-say-what-not-how rule

### DIFF
--- a/.claude/rules/review-and-correction-discipline.md
+++ b/.claude/rules/review-and-correction-discipline.md
@@ -76,8 +76,8 @@ state. Confirm agents are idle — token count stable across two readings — th
   same leak covers a skill narrating itself: the design or safety rationale behind why an instruction
   is phrased as it is belongs to documentation, not the prompt the executing agent reads. A skill is
   a prompt, not documentation of its own prompt. Provide CLEAR + CoVe instructions for the executing
-  agent; delete self-description on the same test as any other leak. See instruction-hygiene §1–2 for
-  the full rubric and worked examples.
+  agent; delete self-description on the same test as any other leak. Full rubric and worked
+  examples: [instruction-hygiene §1–2](../../plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md).
 - **Custom agents only; verify their claims** — never use general-purpose agents for workers (they
   inherit ~100k tokens of tool/skill/MCP descriptions). Treat agent reports as claims, not facts:
   an agent that lacks execution tools cannot run a gate (the orchestrator runs it), and an agent's

--- a/.claude/rules/review-and-correction-discipline.md
+++ b/.claude/rules/review-and-correction-discipline.md
@@ -78,5 +78,4 @@ state. Confirm agents are idle — token count stable across two readings — th
 - **Custom agents only; verify their claims** — never use general-purpose agents for workers (they
   inherit ~100k tokens of tool/skill/MCP descriptions). Treat agent reports as claims, not facts:
   an agent that lacks execution tools cannot run a gate (the orchestrator runs it), and an agent's
-  "not found" is often a wrong-directory confabulation — verify against primary source. See
-  source-fidelity §4.
+  "not found" is often a wrong-directory confabulation — verify against primary source.

--- a/.claude/rules/review-and-correction-discipline.md
+++ b/.claude/rules/review-and-correction-discipline.md
@@ -71,11 +71,10 @@ state. Confirm agents are idle — token count stable across two readings — th
 
 ## Cross-references
 
-- **Mechanism leaks** in task prompts, skills, and task files — the prompt is what a real user would
-  type; schema, paths, model tier, and skill names live in the executor config, not the prompt. Covers
-  a skill narrating its own design or safety rationale too, not just the surrounding system's. Full
-  rubric and worked examples:
-  [instruction-hygiene §1–2](../../plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md).
+- **Mechanism leaks** — read
+  [instruction-hygiene §1–2](../../plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md)
+  before writing or reviewing any task prompt, skill, or agent file: what belongs in the prompt
+  versus the executor config, and when a skill narrates itself instead of the reader's task.
 - **Custom agents only; verify their claims** — never use general-purpose agents for workers (they
   inherit ~100k tokens of tool/skill/MCP descriptions). Treat agent reports as claims, not facts:
   an agent that lacks execution tools cannot run a gate (the orchestrator runs it), and an agent's

--- a/.claude/rules/review-and-correction-discipline.md
+++ b/.claude/rules/review-and-correction-discipline.md
@@ -72,8 +72,12 @@ state. Confirm agents are idle — token count stable across two readings — th
 ## Cross-references
 
 - **Mechanism leaks** in task prompts, skills, and task files — the prompt is what a real user would
-  type; schema, paths, model tier, and skill names live in the executor config. Provide CLEAR + CoVe
-  instructions for the executing agent, not the system's implementation. See instruction-hygiene §1–2.
+  type; schema, paths, model tier, and skill names live in the executor config, not the prompt. The
+  same leak covers a skill narrating itself: the design or safety rationale behind why an instruction
+  is phrased as it is belongs to documentation, not the prompt the executing agent reads. A skill is
+  a prompt, not documentation of its own prompt. Provide CLEAR + CoVe instructions for the executing
+  agent; delete self-description on the same test as any other leak. See instruction-hygiene §1–2 for
+  the full rubric and worked examples.
 - **Custom agents only; verify their claims** — never use general-purpose agents for workers (they
   inherit ~100k tokens of tool/skill/MCP descriptions). Treat agent reports as claims, not facts:
   an agent that lacks execution tools cannot run a gate (the orchestrator runs it), and an agent's

--- a/.claude/rules/review-and-correction-discipline.md
+++ b/.claude/rules/review-and-correction-discipline.md
@@ -72,12 +72,10 @@ state. Confirm agents are idle — token count stable across two readings — th
 ## Cross-references
 
 - **Mechanism leaks** in task prompts, skills, and task files — the prompt is what a real user would
-  type; schema, paths, model tier, and skill names live in the executor config, not the prompt. The
-  same leak covers a skill narrating itself: the design or safety rationale behind why an instruction
-  is phrased as it is belongs to documentation, not the prompt the executing agent reads. A skill is
-  a prompt, not documentation of its own prompt. Provide CLEAR + CoVe instructions for the executing
-  agent; delete self-description on the same test as any other leak. Full rubric and worked
-  examples: [instruction-hygiene §1–2](../../plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md).
+  type; schema, paths, model tier, and skill names live in the executor config, not the prompt. Covers
+  a skill narrating its own design or safety rationale too, not just the surrounding system's. Full
+  rubric and worked examples:
+  [instruction-hygiene §1–2](../../plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md).
 - **Custom agents only; verify their claims** — never use general-purpose agents for workers (they
   inherit ~100k tokens of tool/skill/MCP descriptions). Treat agent reports as claims, not facts:
   an agent that lacks execution tools cannot run a gate (the orchestrator runs it), and an agent's

--- a/plugins/development-harness/skills/work-backlog-item/SKILL.md
+++ b/plugins/development-harness/skills/work-backlog-item/SKILL.md
@@ -19,10 +19,8 @@ decision you made in this session). In the self-initiated case you already know 
 directly — go straight to producing the coerced result; there is nothing in <provided_arguments/>
 you don't already know, and no reason to route it through anything else.
 
-Coerce <provided_arguments/> to match this schema yourself, then treat the result as `<input/>`:
-[parse.schema.json](./scripts/parser/parse.schema.json). Never embed <provided_arguments/> in a
-`` !`...` `` line or any other shell-interpreted string to produce `<input/>` — reasoning it out
-against the vocabulary below is the only safe path.
+Coerce <provided_arguments/> to match this schema yourself, using the vocabulary below, then treat
+the result as `<input/>`: [parse.schema.json](./scripts/parser/parse.schema.json).
 
 Argument vocabulary:
 

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "14.5.12",
+  "version": "14.5.13",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md
@@ -43,19 +43,14 @@ an executing agent where its model is configured, when it cannot change it.
 The fix for non-functional prose is deletion, not explanation. Replacing a decorative `(Haiku)` tag
 with a paragraph on where the model is set stacks noise on noise — remove the tag and stop.
 
-A skill is a prompt: a clear set of instructions for an exact process to follow, or constraints for
-a task. It is not documentation about itself. It does not say how it works, why it works, or what
-problem an earlier phrasing of it had — a prompt does not describe that it is prompting. If a
-sentence is *about* the skill (its own design, its own safety rationale, an alternative it is
-steering the reader away from and why) rather than a command the reader executes or knowledge the
-reader needs to act, it is self-narration, not instruction. Delete it; if the rationale is worth
-keeping anywhere, that is a docs/ file or a commit message, never the prompt.
-
-Example: `Never embed <input> in a shell-interpreted line — [names the injection vector] —
-reasoning it out instead is the only safe path` narrates the skill's own defensive design. The
-preceding sentence — `Coerce <input> using the vocabulary below` — was already the complete
-instruction; the reader who follows it never constructs a shell-interpreted line in the first
-place, so naming the vulnerability it avoids adds no executable content, only self-description.
+The test covers the skill narrating itself, not just the surrounding system: a sentence explaining
+why an instruction is phrased as it is — the design or safety rationale behind it — is knowledge
+about the prompt, not for the reader executing it, so it leaks exactly like an architecture
+explanation does. `Never embed <input> in a shell-interpreted line — [names the injection vector] —
+reasoning it out instead is the only safe path` leaked this way: the preceding instruction (`coerce
+<input> using the vocabulary below`) already left the reader no path to constructing that line, so
+naming the vulnerability it forecloses added no executable content — only self-description. Delete
+on the same test as any other leak.
 
 ## 3. Single source of truth — no restated or derived values
 

--- a/plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md
+++ b/plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md
@@ -43,6 +43,20 @@ an executing agent where its model is configured, when it cannot change it.
 The fix for non-functional prose is deletion, not explanation. Replacing a decorative `(Haiku)` tag
 with a paragraph on where the model is set stacks noise on noise — remove the tag and stop.
 
+A skill is a prompt: a clear set of instructions for an exact process to follow, or constraints for
+a task. It is not documentation about itself. It does not say how it works, why it works, or what
+problem an earlier phrasing of it had — a prompt does not describe that it is prompting. If a
+sentence is *about* the skill (its own design, its own safety rationale, an alternative it is
+steering the reader away from and why) rather than a command the reader executes or knowledge the
+reader needs to act, it is self-narration, not instruction. Delete it; if the rationale is worth
+keeping anywhere, that is a docs/ file or a commit message, never the prompt.
+
+Example: `Never embed <input> in a shell-interpreted line — [names the injection vector] —
+reasoning it out instead is the only safe path` narrates the skill's own defensive design. The
+preceding sentence — `Coerce <input> using the vocabulary below` — was already the complete
+instruction; the reader who follows it never constructs a shell-interpreted line in the first
+place, so naming the vulnerability it avoids adds no executable content, only self-description.
+
 ## 3. Single source of truth — no restated or derived values
 
 A value written in two files will drift. Define it once; reference it everywhere else.


### PR DESCRIPTION
## Summary

1. Removes a trailing sentence from `work-backlog-item/SKILL.md`'s argument-coercion instruction that explained *why* not to embed user input in a shell-interpreted line (naming the specific injection vector) rather than simply directing the agent's behavior.
2. Codifies this in the instruction-hygiene audit rubric (`plugins/plugin-creator/skills/ensemble-rule-review/references/instruction-hygiene.md`): a skill is a prompt, not documentation about itself.
3. Promotes it to a repo-wide rule via `.claude/rules/review-and-correction-discipline.md`, which already auto-loads on every `SKILL.md`/agent/command/rules-file edit.
4. Fixes that same file's mechanism-leaks cross-reference: it was a dangling bare-text pointer that also near-verbatim restated instruction-hygiene.md §1's content. Rewritten as a hook (name, when to read it, link) matching this repo's own `MEMORY.md` convention — no restated rule content.
5. Fixes the sibling "Custom agents only; verify their claims" bullet: it referenced `source-fidelity §4`, but `.claude/rules/source-fidelity.md` doesn't exist anywhere in the repo — confirmed via full git history (`git log --all --full-history` returns nothing for that path). Not just unlinked; the target was never created. Dropped the dead reference; the bullet's own prose already stands alone.

Explicitly distinguished from Check 3 ("Reasoning over Directives") in `audit-skill-completeness`'s checklist, which rewards *domain-fact* rationale that helps an agent generalize to edge cases — a different, still-valid pattern this rule doesn't touch. Left that checklist unchanged.

**Known follow-up, not included here**: two other stale mentions of `source-fidelity.md` exist elsewhere in the repo (`plugins/agent-orchestration/skills/agent-orchestration/references/ecosystem-context-patterns.md` and a resolved backlog item under `.claude/backlog/`) — out of scope for this PR.

## Not related

Split out of a larger branch (`codex-plugin-usability-port`, PR #2787) so it can merge independently. Unrelated to a separate, still-unresolved `dh:work-backlog-item` gate-token invocation failure — confirmed via direct testing that content edits have no effect on that failure.

## Test plan

- [x] `uvx skilllint@latest check` on touched skill files — clean
- [x] `uv run prek run --files <touched files>` — all hooks pass, every commit
- [x] Diff reviewed against `origin/main` — isolated to the intended changes plus the expected auto-sync-manifests version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (5): Last reviewed commit: ["fix(rules): drop broken source-fidelity ..."](https://github.com/jamie-bitflight/claude_skills/commit/098bf6b9b84e7e82562c0d74a43baa07bc2ff77c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55012304)</sub>

<!-- /greptile_comment -->