### PR TITLE
docs(development-harness): resolve the contract's five open decisions with ADRs

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -2,9 +2,11 @@
 
 ## Contexts
 
-- [Development Harness — Markdown Consumption](./plugins/development-harness/CONTEXT.md) — how
-  markdown content is collected, generated, and windowed to an AI agent across the plan/task and
-  backlog systems
+- [Development Harness](./plugins/development-harness/CONTEXT.md) — the `development-harness`
+  plugin: a distributable agent work-management system built on SAM (Stateless Agent
+  Methodology). Its 8 code packages (`agent_profile`, `backlog_core`, `dh_core`,
+  `dispatch_schema`, `hooks`, `progressive_markdown`, `sam_schema`, `scripts`) are one toolset
+  the plugin uses internally, not separate contexts.
 
 ## Relationships
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,12 @@
+# Context Map
+
+## Contexts
+
+- [Development Harness — Markdown Consumption](./plugins/development-harness/CONTEXT.md) — how
+  markdown content is collected, generated, and windowed to an AI agent across the plan/task and
+  backlog systems
+
+## Relationships
+
+Single context so far. Add a `Relationships` entry here when a second context is created and the
+two share vocabulary or interact.

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -424,6 +424,8 @@ Load these documents based on what you are doing. They contain the system design
 - Load [Component Architecture](./docs/component-architecture.md) — which package owns what, and the points where two components resemble each other and are not the same. Read this before working in any package in this plugin
 - Load [Agent Markdown Consumption — Behaviour Specification](./docs/agent-markdown-consumption-contract.md) — normative requirements R1-R8 for how markdown reaches an agent, across every transport
 - Load [MCP Progressive-Disclosure Contract](./docs/mcp-progressive-disclosure-contract.md) — mechanical reference for ordinal addressing, navigation parameters, and response shapes
+- Load [CONTEXT.md](./CONTEXT.md) — domain vocabulary for this area (Collection, Generation, Navigation, Control set, and related terms); read before writing new prose about markdown consumption so terminology matches
+- Read [docs/adrs/](./docs/adrs/) — reasoning and rejected alternatives behind the contract's decisions, not restated in the contract itself
 
 **Modifying `backlog_core/` internals — any backend implementation, GitHub content/CAS storage, offline queueing, or collaborator boundaries within `GitHubBackend`:**
 

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -64,8 +64,8 @@ or build the table of contents itself — those are Navigation's, derived from t
 (see Navigation and Table of contents below).
 
 **Navigation** (pipeline stage):
-The one system that takes a generated document, gives it a content identity, caches it for the
-session, and windows it to the agent. The only stage where a size budget applies. Source-agnostic:
+The one system that takes a generated document, gives it a content identity, caches it in the
+global control set, and windows it to the agent. The only stage where a size budget applies. Source-agnostic:
 it has no knowledge of what kind of thing it is windowing — issue, PR, plan, artifact, local
 file — the same relationship a browser's chrome has to the page it renders. Global, not
 per-source: one Navigation stage serves every source, never one implementation per source type.
@@ -87,8 +87,8 @@ caller, not one per tool, subcommand, transport, or session. Out-of-process by n
 preference: the CLI is not a running service — it's a fresh OS process per invocation with no
 memory of any prior call, so it needs external storage regardless, and an in-process cache (an
 MCP server's lifespan context, a module-level dict) cannot be shared with it either way. One
-SQLite database at `$DH_STATE_HOME/control-set.db` (WAL mode), rows keyed by `content_id` alone —
-no `session_id`, not a directory of loose files — with a bounded global storage budget (LRU
+SQLite database at `state_root()/control-set.db` (per-project, WAL mode), rows keyed by
+`content_id` alone — no `session_id`, not a directory of loose files — with a bounded global storage budget (LRU
 eviction by size, not entry count) and a periodic, rate-limited age-based cleanup pass (hourly to
 daily, not on every write). Holds no authoritative data — every row is a disposable cache
 Collection and Generation can rebuild on demand, so losing the whole database costs nothing but a

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -23,10 +23,12 @@ between the methodology and one literal stateless agent instance).
 **Collection**:
 Gathering source content from wherever it lives — issue body, plan file, task file, artifact.
 Unbounded: never truncated, never budget-checked. Unrelated to Control set below or to session
-identity: for remote-capable providers (GitHub today), already backed by `FileCache`
-(`backlog_core/file_cache.py`), a durable, provider-owned local cache of raw content keyed by
-project root — `FileCache.__init__` takes no session parameter and has no session concept — so a
-Collection re-run is routinely a local cache hit, not a network round-trip. Beads, SQLite, and
+identity. For remote-capable providers (GitHub today), Collection's primary path is a live
+network read, not a local cache hit — `GitHubContentCache.get_content()` reads online whenever
+GitHub is reachable, and `backlog_view`'s issue-body fetch has no cache layer at all. `FileCache`
+(`backlog_core/file_cache.py`) exists but only serves the offline-fallback path (GitHub
+unreachable, or the online read fails) plus write durability — `FileCache.__init__` takes no
+session parameter and has no session concept. Beads, SQLite, and
 Memory read and write native state directly and never instantiate `FileCache` (see
 `docs/backend-providers.md`'s provider table) — for those backends Collection has no local-cache
 layer to hit; a re-run reads the native store directly. `FileCache` predates this document and

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -8,7 +8,11 @@ behaviour lives in `docs/agent-markdown-consumption-contract.md` — this file i
 
 **Collection**:
 Gathering source content from wherever it lives — issue body, plan file, task file, artifact.
-Unbounded: never truncated, never budget-checked.
+Unbounded: never truncated, never budget-checked. Already backed by `FileCache`
+(`backlog_core/file_cache.py`), a durable, provider-owned local cache of raw content — a
+Collection re-run is routinely a local cache hit, not a network round-trip. Distinct from
+Control set below: Collection-layer raw content vs. Navigation-layer generated documents;
+durable vs. session-scoped.
 
 **Generation**:
 Assembling the complete markdown document for a requested scope — description, table of
@@ -30,12 +34,16 @@ supplies markdown text for a source without Navigation ever knowing what that so
 Matches `MarkdownContentProvider` already in code.
 
 **Control set**:
-The single, session-shared cache backing Navigation's content identity (R8). One instance for
-the whole session, not one per tool, subcommand, or transport — every operation touching the
-same generated content resolves against the same control set, regardless of which tool made
-the request.
-_Avoid_: building a per-tool or per-subcommand cache and calling it session-scoped — session
-describes the cache's lifetime, not its instance count.
+The single, session-shared store backing Navigation's content identity (R8). One store for the
+whole session, not one per tool, subcommand, or transport — every operation touching the same
+generated content resolves against the same control set, regardless of which tool made the
+request. Out-of-process by necessity, not by preference: the CLI is a separate OS process per
+invocation, so an in-process cache (an MCP server's lifespan context, a module-level dict)
+cannot be shared with it. Session-keyed on disk, following the existing
+`$DH_STATE_HOME/sessions/{CLAUDE_CODE_SESSION_ID}/` pattern (`get-gate-token.mjs`), not a new
+storage convention.
+_Avoid_: "in-process cache" or "shared dict" as a mental model — that shape cannot satisfy
+"same entry regardless of transport" no matter how carefully it's wired.
 
 **Navigate** (action):
 Requesting content at a specific address from the table of contents. Matches the `navigate`

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -1,10 +1,24 @@
-# Development Harness — Markdown Consumption
+# Development Harness
 
-How markdown content is collected, generated, and windowed to an AI agent across the plan/task
-system and the backlog system. Every consumer is an agent; there is no human reader. Normative
-behaviour lives in `docs/agent-markdown-consumption-contract.md` — this file is vocabulary only.
+Vocabulary for the `development-harness` plugin — one bounded context covering all 8 of its
+packages (`agent_profile`, `backlog_core`, `dh_core`, `dispatch_schema`, `hooks`,
+`progressive_markdown`, `sam_schema`, `scripts`), not one context per package. Every consumer is
+an agent; there is no human reader. The Markdown Consumption terms below (Collection, Generation,
+Navigation, Control set, etc.) are normatively defined in
+`docs/agent-markdown-consumption-contract.md` — this file is vocabulary only, for that area and
+every other area of the plugin as it gets resolved.
 
 ## Language
+
+**SAM (Stateless Agent Methodology)**:
+A constraint-driven development framework, external to this repo, treating an agent as a
+stateless computation engine — complete context in, one verified artifact out, no memory carried
+between calls. The canonical specification lives at `../stateless-agent-methodology/`
+(`bitflight-devops/stateless-agent-methodology` on GitHub) — this plugin implements SAM patterns
+for backlog-driven feature work, it does not define SAM.
+_Avoid_: "the SAM plugin" (there is no such thing — SAM is the methodology; `development-harness`
+is the plugin implementing it); "stateless agent" alone as a synonym for SAM itself (ambiguous
+between the methodology and one literal stateless agent instance).
 
 **Collection**:
 Gathering source content from wherever it lives — issue body, plan file, task file, artifact.

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -21,14 +21,21 @@ is the plugin implementing it); "stateless agent" alone as a synonym for SAM its
 between the methodology and one literal stateless agent instance).
 
 **Backend**:
-The data provider Collection reaches — the configured `WorkItemBackend` in most cases (GitHub,
-SQLite, Beads, or Memory; see `docs/backend-providers.md`), accessed through
-`MarkdownContentProvider` (a thinner, markdown-specific adapter protocol in front of it, not a
-competing concept). Confirmed by the repo owner: "backend" always means the data-providing
-system, never a call to the MCP tool or CLI — those are Frontend below.
+The data provider Collection reaches. Confirmed by the repo owner: "backend" always means the
+data-providing system, never a call to the MCP tool or CLI — those are Frontend below. Not one
+universal instance: backlog items route through `WorkItemBackend` (GitHub, SQLite, Beads, or
+Memory; see `docs/backend-providers.md`), accessed through `MarkdownContentProvider` (a thinner,
+markdown-specific adapter in front of it). SAM plans and tasks currently do **not** share that
+`WorkItemBackend` — they route through a separate `TaskBackend` protocol
+(`dh_core/protocols.py`), confirmed by the repo owner and verified against `dh_core/operations.py`
+(`create_plan(backend: TaskBackend, ...)` etc.). This contradicts `AGENTS.md`'s current "that same
+backend... there is no TASKBACKEND" claim — tracked as [#3088](https://github.com/Jamie-BitFlight/claude_skills/issues/3088),
+not corrected here since it's outside this document's scope.
 _Avoid_: "backend call" for an MCP tool invocation or CLI request — that ambiguity caused real
 confusion in this session's design discussion. A backend call is specifically Collection
-reaching this data provider.
+reaching a data provider. Also avoid assuming "the backend" means one shared instance across
+backlog items and SAM — verify which protocol (`WorkItemBackend` vs `TaskBackend`) a given
+subsystem actually uses before making that claim.
 
 **Frontend**:
 MCP, CLI, and the local navigator together — everything on the agent-facing side of a backend

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -1,0 +1,54 @@
+# Development Harness — Markdown Consumption
+
+How markdown content is collected, generated, and windowed to an AI agent across the plan/task
+system and the backlog system. Every consumer is an agent; there is no human reader. Normative
+behaviour lives in `docs/agent-markdown-consumption-contract.md` — this file is vocabulary only.
+
+## Language
+
+**Collection**:
+Gathering source content from wherever it lives — issue body, plan file, task file, artifact.
+Unbounded: never truncated, never budget-checked.
+
+**Generation**:
+Assembling the complete markdown document for a requested scope — description, table of
+contents, and every section or artifact content the request covers — before any windowing.
+Unbounded, same as Collection.
+
+**Navigation** (pipeline stage):
+The one system that takes a generated document, gives it a content identity, caches it for the
+session, and windows it to the agent. The only stage where a size budget applies. Source-agnostic:
+it has no knowledge of what kind of thing it is windowing — issue, PR, plan, artifact, local
+file — the same relationship a browser's chrome has to the page it renders. Global, not
+per-source: one Navigation stage serves every source, never one implementation per source type.
+_Avoid_: "pagination layer" as a synonym for the whole stage — pagination is one of the things
+Navigation does, not the stage's name.
+
+**Provider**:
+The seam that makes Navigation source-agnostic. Implements `get_markdown(source) -> str`;
+supplies markdown text for a source without Navigation ever knowing what that source is.
+Matches `MarkdownContentProvider` already in code.
+
+**Control set**:
+The single, session-shared cache backing Navigation's content identity (R8). One instance for
+the whole session, not one per tool, subcommand, or transport — every operation touching the
+same generated content resolves against the same control set, regardless of which tool made
+the request.
+_Avoid_: building a per-tool or per-subcommand cache and calling it session-scoped — session
+describes the cache's lifetime, not its instance count.
+
+**Navigate** (action):
+Requesting content at a specific address from the table of contents. Matches the `navigate`
+parameter and `NavigateResponse` type already in code. Distinct from the Navigation stage above —
+one is the system, the other is a single request against it.
+_Avoid_: "content navigation", "browse"
+
+**Table of contents (TOC)**:
+The addressable index of an item's sections. `map` is the parameter name used to request it;
+"table of contents" is the concept's name in prose.
+_Avoid_: "map" outside of naming the literal parameter
+
+**Budget**:
+The size limit applied exclusively at the Navigation stage when windowing a generated document
+to an agent. Never applied at Collection or Generation — there is nothing to fit a budget to
+until Navigation has a complete document in hand.

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -56,18 +56,18 @@ supplies markdown text for a source without Navigation ever knowing what that so
 Matches `MarkdownContentProvider` already in code.
 
 **Control set**:
-The single, session-shared store backing Navigation's content identity (R8). One store for the
-whole session, not one per tool, subcommand, or transport — every operation touching the same
-generated content resolves against the same control set, regardless of which tool made the
+The single, global store backing Navigation's content identity (R8). One store for every caller,
+not one per tool, subcommand, transport, or session — every operation touching the same generated
+content resolves against the same control set, regardless of which tool or session made the
 request. Out-of-process by necessity, not by preference: the CLI is not a running service — it's
 a fresh OS process per invocation with no memory of any prior call, so it needs external storage
 regardless, and an in-process cache (an MCP server's lifespan context, a module-level dict)
 cannot be shared with it either way. One SQLite database at `$DH_STATE_HOME/control-set.db`
-(WAL mode), rows keyed by `(session_id, content_id)` — not a directory of loose files — with a
-bounded per-session storage budget (LRU eviction by size, not entry count) and an opportunistic
-cross-session age-based sweep on every write. Holds no authoritative data — every row is a
-disposable cache Collection and Generation can rebuild on demand, so losing the whole database
-costs nothing but a cold cache. See ADR-3082-1.
+(WAL mode), rows keyed by `content_id` alone — no `session_id`, not a directory of loose files —
+with a bounded global storage budget (LRU eviction by size, not entry count) and a periodic,
+rate-limited age-based cleanup pass (hourly to daily, not on every write). Holds no authoritative
+data — every row is a disposable cache Collection and Generation can rebuild on demand, so losing
+the whole database costs nothing but a cold cache. See ADR-3082-1.
 _Avoid_: "in-process cache" or "shared dict" as a mental model — that shape cannot satisfy
 "same entry regardless of transport" no matter how carefully it's wired. Also avoid describing
 this as "a directory per session" — that was ADR-3075-4's original storage mechanism, superseded

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -57,13 +57,17 @@ Matches `MarkdownContentProvider` already in code.
 The single, session-shared store backing Navigation's content identity (R8). One store for the
 whole session, not one per tool, subcommand, or transport — every operation touching the same
 generated content resolves against the same control set, regardless of which tool made the
-request. Out-of-process by necessity, not by preference: the CLI is a separate OS process per
-invocation, so an in-process cache (an MCP server's lifespan context, a module-level dict)
-cannot be shared with it. Session-keyed on disk, following the existing
-`$DH_STATE_HOME/sessions/{CLAUDE_CODE_SESSION_ID}/` pattern (`get-gate-token.mjs`), not a new
-storage convention.
+request. Out-of-process by necessity, not by preference: the CLI is not a running service — it's
+a fresh OS process per invocation with no memory of any prior call, so it needs external storage
+regardless, and an in-process cache (an MCP server's lifespan context, a module-level dict)
+cannot be shared with it either way. One SQLite database at `$DH_STATE_HOME/control-set.db`
+(WAL mode), rows keyed by `(session_id, content_id)` — not a directory of loose files — with a
+bounded per-session entry cap (LRU eviction) and an opportunistic cross-session age-based sweep
+on every write. See ADR-3082-1.
 _Avoid_: "in-process cache" or "shared dict" as a mental model — that shape cannot satisfy
-"same entry regardless of transport" no matter how carefully it's wired.
+"same entry regardless of transport" no matter how carefully it's wired. Also avoid describing
+this as "a directory per session" — that was ADR-3075-4's original storage mechanism, superseded
+by ADR-3082-1.
 
 **Navigate** (action):
 Requesting content at a specific address from the table of contents. Matches the `navigate`

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -20,6 +20,21 @@ _Avoid_: "the SAM plugin" (there is no such thing — SAM is the methodology; `d
 is the plugin implementing it); "stateless agent" alone as a synonym for SAM itself (ambiguous
 between the methodology and one literal stateless agent instance).
 
+**Backend**:
+The data provider Collection reaches — the configured `WorkItemBackend` in most cases (GitHub,
+SQLite, Beads, or Memory; see `docs/backend-providers.md`), accessed through
+`MarkdownContentProvider` (a thinner, markdown-specific adapter protocol in front of it, not a
+competing concept). Confirmed by the repo owner: "backend" always means the data-providing
+system, never a call to the MCP tool or CLI — those are Frontend below.
+_Avoid_: "backend call" for an MCP tool invocation or CLI request — that ambiguity caused real
+confusion in this session's design discussion. A backend call is specifically Collection
+reaching this data provider.
+
+**Frontend**:
+MCP, CLI, and the local navigator together — everything on the agent-facing side of a backend
+call. The control set (below) is part of the Frontend: it's Navigation's local cache, not
+something the Backend knows about or participates in.
+
 **Collection**:
 Gathering source content from wherever it lives — issue body, plan file, task file, artifact.
 Unbounded: never truncated, never budget-checked. Unrelated to Control set below or to session

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -8,14 +8,15 @@ behaviour lives in `docs/agent-markdown-consumption-contract.md` — this file i
 
 **Collection**:
 Gathering source content from wherever it lives — issue body, plan file, task file, artifact.
-Unbounded: never truncated, never budget-checked. For remote-capable providers (GitHub today),
-already backed by `FileCache` (`backlog_core/file_cache.py`), a durable, provider-owned local
-cache of raw content — a Collection re-run is routinely a local cache hit, not a network
-round-trip. Beads, SQLite, and Memory read and write native state directly and never instantiate
-`FileCache` (see `docs/backend-providers.md`'s provider table) — for those backends Collection
-has no local-cache layer to hit; a re-run reads the native store directly. Distinct from Control
-set below: Collection-layer raw content vs. Navigation-layer generated documents; durable vs.
-session-scoped.
+Unbounded: never truncated, never budget-checked. Unrelated to Control set below or to session
+identity: for remote-capable providers (GitHub today), already backed by `FileCache`
+(`backlog_core/file_cache.py`), a durable, provider-owned local cache of raw content keyed by
+project root — `FileCache.__init__` takes no session parameter and has no session concept — so a
+Collection re-run is routinely a local cache hit, not a network round-trip. Beads, SQLite, and
+Memory read and write native state directly and never instantiate `FileCache` (see
+`docs/backend-providers.md`'s provider table) — for those backends Collection has no local-cache
+layer to hit; a re-run reads the native store directly. `FileCache` predates this document and
+is not part of the Navigation pipeline described here.
 
 **Generation**:
 Assembling the complete markdown document for a requested scope — description, and every

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -56,18 +56,21 @@ supplies markdown text for a source without Navigation ever knowing what that so
 Matches `MarkdownContentProvider` already in code.
 
 **Control set**:
-The single, global store backing Navigation's content identity (R8). One store for every caller,
-not one per tool, subcommand, transport, or session — every operation touching the same generated
-content resolves against the same control set, regardless of which tool or session made the
-request. Out-of-process by necessity, not by preference: the CLI is not a running service — it's
-a fresh OS process per invocation with no memory of any prior call, so it needs external storage
-regardless, and an in-process cache (an MCP server's lifespan context, a module-level dict)
-cannot be shared with it either way. One SQLite database at `$DH_STATE_HOME/control-set.db`
-(WAL mode), rows keyed by `content_id` alone — no `session_id`, not a directory of loose files —
-with a bounded global storage budget (LRU eviction by size, not entry count) and a periodic,
-rate-limited age-based cleanup pass (hourly to daily, not on every write). Holds no authoritative
-data — every row is a disposable cache Collection and Generation can rebuild on demand, so losing
-the whole database costs nothing but a cold cache. See ADR-3082-1.
+Navigation's local cache — the browser-cache half of the browser-chrome analogy above: it serves
+an already-fetched document back to the same navigation task without hitting the source again,
+not a shared server-side cache meant to save a different task or a later visit from re-fetching.
+Every full request still runs Collection and Generation and always writes; only a follow-up page
+request within one task reads the cache instead of hitting the source. One store for every
+caller, not one per tool, subcommand, transport, or session. Out-of-process by necessity, not by
+preference: the CLI is not a running service — it's a fresh OS process per invocation with no
+memory of any prior call, so it needs external storage regardless, and an in-process cache (an
+MCP server's lifespan context, a module-level dict) cannot be shared with it either way. One
+SQLite database at `$DH_STATE_HOME/control-set.db` (WAL mode), rows keyed by `content_id` alone —
+no `session_id`, not a directory of loose files — with a bounded global storage budget (LRU
+eviction by size, not entry count) and a periodic, rate-limited age-based cleanup pass (hourly to
+daily, not on every write). Holds no authoritative data — every row is a disposable cache
+Collection and Generation can rebuild on demand, so losing the whole database costs nothing but a
+cold cache. See ADR-3082-1.
 _Avoid_: "in-process cache" or "shared dict" as a mental model — that shape cannot satisfy
 "same entry regardless of transport" no matter how carefully it's wired. Also avoid describing
 this as "a directory per session" — that was ADR-3075-4's original storage mechanism, superseded

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -8,16 +8,21 @@ behaviour lives in `docs/agent-markdown-consumption-contract.md` — this file i
 
 **Collection**:
 Gathering source content from wherever it lives — issue body, plan file, task file, artifact.
-Unbounded: never truncated, never budget-checked. Already backed by `FileCache`
-(`backlog_core/file_cache.py`), a durable, provider-owned local cache of raw content — a
-Collection re-run is routinely a local cache hit, not a network round-trip. Distinct from
-Control set below: Collection-layer raw content vs. Navigation-layer generated documents;
-durable vs. session-scoped.
+Unbounded: never truncated, never budget-checked. For remote-capable providers (GitHub today),
+already backed by `FileCache` (`backlog_core/file_cache.py`), a durable, provider-owned local
+cache of raw content — a Collection re-run is routinely a local cache hit, not a network
+round-trip. Beads, SQLite, and Memory read and write native state directly and never instantiate
+`FileCache` (see `docs/backend-providers.md`'s provider table) — for those backends Collection
+has no local-cache layer to hit; a re-run reads the native store directly. Distinct from Control
+set below: Collection-layer raw content vs. Navigation-layer generated documents; durable vs.
+session-scoped.
 
 **Generation**:
-Assembling the complete markdown document for a requested scope — description, table of
-contents, and every section or artifact content the request covers — before any windowing.
-Unbounded, same as Collection.
+Assembling the complete markdown document for a requested scope — description, and every
+section or artifact content the request covers — before any windowing. Unbounded, same as
+Collection. Generation supplies Navigation the document to parse; it does not assign addresses
+or build the table of contents itself — those are Navigation's, derived from the parsed tree
+(see Navigation and Table of contents below).
 
 **Navigation** (pipeline stage):
 The one system that takes a generated document, gives it a content identity, caches it for the

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -64,8 +64,10 @@ a fresh OS process per invocation with no memory of any prior call, so it needs 
 regardless, and an in-process cache (an MCP server's lifespan context, a module-level dict)
 cannot be shared with it either way. One SQLite database at `$DH_STATE_HOME/control-set.db`
 (WAL mode), rows keyed by `(session_id, content_id)` — not a directory of loose files — with a
-bounded per-session entry cap (LRU eviction) and an opportunistic cross-session age-based sweep
-on every write. See ADR-3082-1.
+bounded per-session storage budget (LRU eviction by size, not entry count) and an opportunistic
+cross-session age-based sweep on every write. Holds no authoritative data — every row is a
+disposable cache Collection and Generation can rebuild on demand, so losing the whole database
+costs nothing but a cold cache. See ADR-3082-1.
 _Avoid_: "in-process cache" or "shared dict" as a mental model — that shape cannot satisfy
 "same entry regardless of transport" no matter how carefully it's wired. Also avoid describing
 this as "a directory per session" — that was ADR-3075-4's original storage mechanism, superseded

--- a/plugins/development-harness/docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md
+++ b/plugins/development-harness/docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md
@@ -1,0 +1,42 @@
+# ADR-3072-1: Budget applies only at the Navigation stage
+
+**Status:** Accepted
+**Date:** 2026-08-20
+**Issue:** [#3072](https://github.com/Jamie-BitFlight/claude_skills/issues/3072), also resolves
+[#3073](https://github.com/Jamie-BitFlight/claude_skills/issues/3073) and
+[#3074](https://github.com/Jamie-BitFlight/claude_skills/issues/3074)
+
+## Context
+
+The contract's open questions treated "what is the budget value" and "how do the table of
+contents and artifact inventory page when both are large" as separate, unrelated decisions.
+Before this ADR, budget checks were also implicitly assumed to happen at multiple points —
+`backlog_core/server.py` alone hardcoded two different budget constants
+(`_VIEW_TOKEN_BUDGET = 4_000`, `_LIST_TOKEN_BUDGET = 4_400`) for two operations, neither derived
+from the engine's own `progressive_markdown.models.TOKEN_BUDGET` (env-derived from
+`MAX_MCP_OUTPUT_TOKENS`, default 9,500).
+
+## Decision
+
+Collection (gathering source content) and Generation (assembling the complete document for a
+requested scope — description, table of contents, every requested section or artifact) are both
+unbounded: never truncated, never budget-checked. Navigation — the one engine described by R1 —
+is the only stage where a size budget is ever applied. It receives a fully generated document,
+gives it a content identity, caches it for the session, and windows it to the agent.
+
+Consequences:
+
+- One budget constant, sourced from the engine, not duplicated per operation. The two hardcoded
+  constants in `backlog_core/server.py` are deleted, not reconciled to a shared value.
+- The table of contents and the artifact inventory (R6) are not paginated as two independent
+  structures with their own budget logic — they are part of one generated document, windowed by
+  the same Navigation stage as everything else in it.
+- A caller may request a smaller page than the configured default. There is no local equivalent
+  of `tail` against a tool response, so the caller depends on the server accepting an explicit,
+  smaller page-size request to peek at part of a large result.
+
+## Considered alternative
+
+Per-operation budget constants (the pre-existing state) were considered and rejected — no
+evidence found that the 4,000/4,400 split was a deliberate sizing decision rather than drift
+from two people picking round numbers at different times.

--- a/plugins/development-harness/docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md
+++ b/plugins/development-harness/docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md
@@ -19,10 +19,12 @@ from the engine's own `progressive_markdown.models.TOKEN_BUDGET` (env-derived fr
 ## Decision
 
 Collection (gathering source content) and Generation (assembling the complete document for a
-requested scope — description, table of contents, every requested section or artifact) are both
-unbounded: never truncated, never budget-checked. Navigation — the one engine described by R1 —
-is the only stage where a size budget is ever applied. It receives a fully generated document,
-gives it a content identity, caches it for the session, and windows it to the agent.
+requested scope — description, every requested section or artifact) are both unbounded: never
+truncated, never budget-checked. Navigation — the one engine described by R1 — is the only
+stage where a size budget is ever applied, and the only stage that parses the document, assigns
+addresses, and derives the table of contents from the resulting tree. It receives a fully
+generated document, gives it a content identity, caches it for the session, and windows it to
+the agent.
 
 Consequences:
 

--- a/plugins/development-harness/docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md
+++ b/plugins/development-harness/docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md
@@ -23,8 +23,8 @@ requested scope — description, every requested section or artifact) are both u
 truncated, never budget-checked. Navigation — the one engine described by R1 — is the only
 stage where a size budget is ever applied, and the only stage that parses the document, assigns
 addresses, and derives the table of contents from the resulting tree. It receives a fully
-generated document, gives it a content identity, caches it for the session, and windows it to
-the agent.
+generated document, gives it a content identity, caches it in the global control set
+(ADR-3082-1), and windows it to the agent.
 
 Consequences:
 

--- a/plugins/development-harness/docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md
+++ b/plugins/development-harness/docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md
@@ -35,6 +35,18 @@ Consequences:
   of `tail` against a tool response, so the caller depends on the server accepting an explicit,
   smaller page-size request to peek at part of a large result.
 
+**Known limitation — "unbounded" has a practical ceiling, even though this decision imposes
+none.** Collection and Generation being unbounded means the first-generation cost for a
+pathological item is paid in full before Navigation ever gets to window it — this is a real
+cost, not merely a theoretical one: a peer review reproduced item #2953 at an estimated 270,946
+tokens across 91 sections, and its `map` response alone (over 125,000 characters) overflowed
+the harness's own tool-result cap. This decision does not impose a ceiling on Collection or
+Generation — doing so would reintroduce the truncation this whole contract exists to forbid.
+The ceiling that exists in practice is whatever the source itself imposes (an issue body's
+practical size, GitHub's own body-size limits) — not a budget this contract enforces. An item
+this large remains navigable once generated (R2 forbids dropping addressable nodes), the cost
+is concentrated at first generation, not spread across every page request.
+
 ## Considered alternative
 
 Per-operation budget constants (the pre-existing state) were considered and rejected — no

--- a/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
@@ -15,14 +15,22 @@ parsed tree), and how long the cache backing it lives (session vs. persisted). N
 
 ## Decision
 
-**Identity source:** a hash of the Generation stage's output — the complete assembled document
-for the request's specific scope (whole item, or a named artifact, or a filtered subtree) — not
-a hash of the raw upstream source alone. Two different requested scopes of the same source
-document (the whole item vs. one filtered section) produce different generated documents; if the
-identifier hashed only the shared upstream source, both would collide on the same identifier
-while windowing different content, which breaks R8's "identifier resolves against cached parsed
-content" property. Hashing the generated output is the option that yields a working scheme, not
-merely a style preference between two equally-valid choices.
+**Identity source:** derived from both the command (source, scope, parameters) and the
+Generation stage's output for that command — not a hash of the raw upstream source alone, and
+not a hash of the generated content alone either (the latter corrected after review found it
+insufficient — see below). Two different requested scopes of the same source document (the
+whole item vs. one filtered section) produce different generated documents; if the identifier
+hashed only the shared upstream source, both would collide on the same identifier while
+windowing different content, which breaks R8's "identifier resolves against cached parsed
+content" property.
+
+Content-only hashing was the original decision here and was corrected: two different commands
+can coincidentally produce byte-identical generated output, and a content-only hash would give
+them the same identifier while the control-set entry retains only one producing command — a
+later requery or revalidation (ADR-3075-2, ADR-3075-3) could then execute the wrong command and
+return content unrelated to what the caller asked for. Binding the identifier to the command as
+well as the content closes this — two different commands never collide even when their output
+happens to match.
 
 **Cache scope:** session-scoped only, not persisted across sessions. Re-parsing markdown is
 cheap relative to the rest of what a call already does (network round-trip to the backend); a

--- a/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
@@ -45,13 +45,17 @@ thoroughly as the collision this ADR just fixed — from the other direction.
 cheap relative to the rest of what a call already does (network round-trip to the backend); a
 persisted cache would need its own storage location, eviction policy, and a plan for backend
 content changing underneath a stale entry, for a cost that profiling has not shown to matter.
-Confirmed by the repo owner: Collection itself is already backed by `FileCache`
-(`backlog_core/file_cache.py`), an existing durable, provider-owned local cache of raw content
-records — a Collection-stage re-run triggered by ADR-3075-2's requery-on-stale behavior is
-routinely a local cache hit, not a network round-trip. This is a different cache from the one
-this ADR governs (Collection-layer raw content vs. Navigation-layer generated/parsed/paginated
-documents; durable vs. session-scoped) — not a reason to merge the two — but it is direct
-evidence for "re-parsing is cheap," not just an assumption.
+Confirmed by the repo owner: for remote-capable providers (GitHub today), Collection is already
+backed by `FileCache` (`backlog_core/file_cache.py`), an existing durable, provider-owned local
+cache of raw content records — a Collection-stage re-run triggered by ADR-3075-2's
+requery-on-stale behavior is routinely a local cache hit, not a network round-trip. Beads,
+SQLite, and Memory read and write native state directly and never instantiate `FileCache`
+(`docs/backend-providers.md`'s provider table) — for those backends a Collection-stage re-run
+reads the native store directly, not a `FileCache` hit. This is a different cache from the one
+this ADR governs regardless of backend (Collection-layer raw content vs. Navigation-layer
+generated/parsed/paginated documents; durable vs. session-scoped) — not a reason to merge the
+two — but for GitHub specifically it is direct evidence for "re-parsing is cheap," not just an
+assumption.
 
 ## Considered alternatives
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
@@ -32,6 +32,15 @@ return content unrelated to what the caller asked for. Binding the identifier to
 well as the content closes this — two different commands never collide even when their output
 happens to match.
 
+**Command canonicalization is required before hashing, not optional.** The command must be
+serialized to a stable, canonical form — fixed key order, defaults resolved to explicit values
+before hashing, not left implicit — before it contributes to the identifier. Two calls that are
+semantically the same request (same source, scope, parameters) but happen to serialize
+differently (different kwarg order, one passing a default explicitly and the other omitting it)
+must not hash differently. An identifier scheme that lets semantically identical requests miss
+the same cache entry defeats R8's "resolves against the same cache entry" property as
+thoroughly as the collision this ADR just fixed — from the other direction.
+
 **Cache scope:** session-scoped only, not persisted across sessions. Re-parsing markdown is
 cheap relative to the rest of what a call already does (network round-trip to the backend); a
 persisted cache would need its own storage location, eviction policy, and a plan for backend

--- a/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
@@ -55,7 +55,8 @@ reads the native store directly, not a `FileCache` hit. This is a different cach
 this ADR governs regardless of backend (Collection-layer raw content vs. Navigation-layer
 generated/parsed/paginated documents; durable vs. session-scoped) — not a reason to merge the
 two — but for GitHub specifically it is direct evidence for "re-parsing is cheap," not just an
-assumption.
+assumption. `FileCache.__init__` takes a project-root `Path` and no session parameter; it has no
+session concept and predates the control set this ADR defines.
 
 ## Considered alternatives
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
@@ -28,6 +28,13 @@ merely a style preference between two equally-valid choices.
 cheap relative to the rest of what a call already does (network round-trip to the backend); a
 persisted cache would need its own storage location, eviction policy, and a plan for backend
 content changing underneath a stale entry, for a cost that profiling has not shown to matter.
+Confirmed by the repo owner: Collection itself is already backed by `FileCache`
+(`backlog_core/file_cache.py`), an existing durable, provider-owned local cache of raw content
+records — a Collection-stage re-run triggered by ADR-3075-2's requery-on-stale behavior is
+routinely a local cache hit, not a network round-trip. This is a different cache from the one
+this ADR governs (Collection-layer raw content vs. Navigation-layer generated/parsed/paginated
+documents; durable vs. session-scoped) — not a reason to merge the two — but it is direct
+evidence for "re-parsing is cheap," not just an assumption.
 
 ## Considered alternatives
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
@@ -1,0 +1,41 @@
+# ADR-3075-1: Content identity and cache scope for paginated responses (R8)
+
+**Status:** Accepted
+**Date:** 2026-08-20
+**Issue:** [#3075](https://github.com/Jamie-BitFlight/claude_skills/issues/3075) and
+[#3076](https://github.com/Jamie-BitFlight/claude_skills/issues/3076), both blocking
+[#3062](https://github.com/Jamie-BitFlight/claude_skills/issues/3062)
+
+## Context
+
+R8 requires a stable identifier for a paginated response, derived from the content it
+paginates. Two sub-decisions were open: what the identifier is derived from (raw markdown vs.
+parsed tree), and how long the cache backing it lives (session vs. persisted). Nothing in
+`progressive_markdown` implements any caching or content-hashing today — this was greenfield.
+
+## Decision
+
+**Identity source:** a hash of the Generation stage's output — the complete assembled document
+for the request's specific scope (whole item, or a named artifact, or a filtered subtree) — not
+a hash of the raw upstream source alone. Two different requested scopes of the same source
+document (the whole item vs. one filtered section) produce different generated documents; if the
+identifier hashed only the shared upstream source, both would collide on the same identifier
+while windowing different content, which breaks R8's "identifier resolves against cached parsed
+content" property. Hashing the generated output is the option that yields a working scheme, not
+merely a style preference between two equally-valid choices.
+
+**Cache scope:** session-scoped only, not persisted across sessions. Re-parsing markdown is
+cheap relative to the rest of what a call already does (network round-trip to the backend); a
+persisted cache would need its own storage location, eviction policy, and a plan for backend
+content changing underneath a stale entry, for a cost that profiling has not shown to matter.
+
+## Considered alternatives
+
+Parsed-tree-derived identity was considered — it would keep pagination stable across
+cosmetic-only source edits — and rejected as unnecessary complexity: R8 only needs "did the
+content this response paginates change," not "is this semantically the same document," and a
+raw hash of the generated output answers the former without a new tree-equality definition.
+
+Persisted, cross-session caching was considered and rejected for the same reason: no measured
+cost that justifies the added invalidation surface. Revisit if profiling shows parsing is an
+actual bottleneck.

--- a/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
@@ -5,6 +5,10 @@
 **Issue:** [#3075](https://github.com/Jamie-BitFlight/claude_skills/issues/3075) and
 [#3076](https://github.com/Jamie-BitFlight/claude_skills/issues/3076), both blocking
 [#3062](https://github.com/Jamie-BitFlight/claude_skills/issues/3062)
+**Superseded in part by:** [ADR-3082-1](./ADR-3082-1-sqlite-backed-bounded-eviction.md) — the
+"session-scoped only" cache-scope decision below is reversed there: entries age out by a global
+TTL and size budget, not by session boundaries, and can be read across sessions. The identity
+scheme below (command+content-bound hash) is unchanged.
 
 ## Context
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md
@@ -42,21 +42,24 @@ the same cache entry defeats R8's "resolves against the same cache entry" proper
 thoroughly as the collision this ADR just fixed — from the other direction.
 
 **Cache scope:** session-scoped only, not persisted across sessions. Re-parsing markdown is
-cheap relative to the rest of what a call already does (network round-trip to the backend); a
-persisted cache would need its own storage location, eviction policy, and a plan for backend
-content changing underneath a stale entry, for a cost that profiling has not shown to matter.
-Confirmed by the repo owner: for remote-capable providers (GitHub today), Collection is already
-backed by `FileCache` (`backlog_core/file_cache.py`), an existing durable, provider-owned local
-cache of raw content records — a Collection-stage re-run triggered by ADR-3075-2's
-requery-on-stale behavior is routinely a local cache hit, not a network round-trip. Beads,
-SQLite, and Memory read and write native state directly and never instantiate `FileCache`
-(`docs/backend-providers.md`'s provider table) — for those backends a Collection-stage re-run
-reads the native store directly, not a `FileCache` hit. This is a different cache from the one
-this ADR governs regardless of backend (Collection-layer raw content vs. Navigation-layer
-generated/parsed/paginated documents; durable vs. session-scoped) — not a reason to merge the
-two — but for GitHub specifically it is direct evidence for "re-parsing is cheap," not just an
-assumption. `FileCache.__init__` takes a project-root `Path` and no session parameter; it has no
-session concept and predates the control set this ADR defines.
+cheap relative to whatever Collection itself already costs for a re-run — and for the GitHub
+backend's primary path, that cost is a live network round-trip, not a local cache hit. Verified
+directly against source: `GitHubContentCache.get_content()`
+(`backlog_core/backends/github_content_migration.py`) calls `_read_online_content()` — a live
+API read — whenever GitHub is reachable and no pending write blocks it; `FileCache` is only hit
+on the fallback paths (GitHub unreachable, or the online read fails), not the common case.
+`backlog_view`'s issue-body fetch (`_fetch_issue_graphql` in `gh_client.py`) has no cache layer
+at all — an unconditional network call every time. So a persisted Navigation-layer cache would
+not avoid the network cost Collection already pays on a re-run; it would only save the
+parsing/pagination-computation cost on top of that, which is the smaller of the two and the one
+profiling has not shown to matter. Beads, SQLite, and Memory read and write native state
+directly and never instantiate `FileCache` (`docs/backend-providers.md`'s provider table) — for
+those backends a Collection-stage re-run reads the native store directly. `FileCache` predates
+the control set this ADR defines, has no session concept (`FileCache.__init__` takes a
+project-root `Path`, no session parameter), and functions as an offline-fallback and
+write-durability layer for GitHub specifically — not a read-avoidance cache for Navigation's
+persistence question, and not evidence for "re-parsing is cheap" the way an earlier version of
+this ADR claimed.
 
 ## Considered alternatives
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md
@@ -20,16 +20,27 @@ invalidate the cache entry directly.
 
 **Recoverable staleness.** Each control-set entry stores the command that produced it — the
 source, scope, and parameters Collection and Generation used — alongside its content identity.
-On a stale-identifier request, that stored command re-runs Collection and Generation, produces
-a new identity, and serves the caller against it, rather than erroring and requiring the caller
-to reconstruct its original request from scratch.
+On a stale-identifier request, that stored command re-runs Collection and Generation, producing
+a new identity. Page boundaries and ordinal addresses can shift when the underlying source
+changes, so recovery does not re-apply the request's original page or `navigate` selector to
+the regenerated document — that would risk skipping or duplicating content, or resolving an
+address to a different node than the caller intended. Recovery instead serves page 1 of the
+regenerated document under the new identity (or, when a `navigate` ordinal no longer resolves,
+an explicit restart response pointing the caller back to the table of contents), informing the
+caller the identity changed — rather than erroring and requiring the caller to reconstruct its
+original request from scratch. This is what keeps R8's no-mixed-versions guarantee: pages are
+never served by applying an old request's addressing to a new document's structure.
 
-**Write-triggered invalidation.** Every write path that can modify a source this contract
-reads from — item updates, section writes, artifact registration, task and plan state changes
-— invalidates any control-set entry generated from what it touched, as a side effect of the
-write. This does not replace the identity check on read (R8's existing hash-mismatch
-detection); it adds a second, earlier path to the same outcome, so a stale entry is caught
-whether or not a read happens to hit it before a write does.
+**Write-triggered invalidation, same session only.** Every write path that can modify a source
+this contract reads from — item updates, section writes, artifact registration, task and plan
+state changes — invalidates any control-set entry in the writing session's own control set that
+was generated from what it touched, as a side effect of the write. This does not replace the
+identity check on read (R8's existing hash-mismatch detection); it adds a second, earlier path
+to the same outcome, so a stale entry is caught whether or not a read happens to hit it before a
+write does. A write from a different session, or through a path outside this contract's Scope,
+is not visible to this invalidation — it does not scan or mutate another session's control set —
+and is not guaranteed to surface as stale this way; this is the concurrent-session blind spot
+ADR-3075-3 documents, not a gap in this decision's own scope.
 
 ## Consequences
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md
@@ -42,9 +42,16 @@ from what it touched, as a side effect of the write, regardless of which session
 either the write or the original cached request. This is a direct consequence of ADR-3082-1's
 content-keyed reversal: there is one shared entry per `content_id`, not one per session, so there
 is nothing left to scope invalidation *to* — a write from any caller invalidates the one entry
-everyone shares. This does not replace the identity check on read (R8's existing hash-mismatch
-detection); it adds a second, earlier path to the same outcome, so a stale entry is caught
-whether or not a read happens to hit it before a write does. The "concurrent-session blind spot"
+everyone shares. **This is staleness detection's only mechanism, not one of two.** An earlier
+draft of this ADR described the write-triggered mark as running alongside a separate read-time
+hash-mismatch check; R8's later text corrects that framing and this ADR follows it: detection
+never happens by a read re-collecting content to compare hashes — that would mean an ordinary
+read reaching the source, which contradicts the control set's whole purpose (ADR-3082-1's
+"every source hit always writes a fresh document" describes recollection as something a request
+*does*, at a cost, not a passive background check every read performs for free). What a read
+does on a cache hit is check the row's already-set `stale` marker (below) — cheap, no
+recollection — and that marker is set by this write path, not derived independently by the read.
+The "concurrent-session blind spot"
 this ADR's earlier revision named (a write from a different session not being visible to
 invalidation) is resolved as a side effect of the reversal, not merely narrowed — there is no
 "different session's control set" any more for a write to be invisible to.

--- a/plugins/development-harness/docs/adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md
@@ -1,0 +1,47 @@
+# ADR-3075-2: Stale control-set entries requery instead of erroring; writes invalidate
+
+**Status:** Accepted
+**Date:** 2026-08-20
+**Issue:** New issue filed alongside this ADR (see cross-references below)
+**Related:** Extends [ADR-3075-1](./ADR-3075-1-content-identity-and-cache-scope.md) — does not
+reverse it. Session-scoped, non-persisted cache lifetime stands; this ADR adds behavior for
+what happens *within* that lifetime when content changes underneath a cache entry.
+
+## Context
+
+ADR-3075-1 settled R8's cache lifetime and identity derivation, but left staleness handling at
+"reported as stale" — a passive, read-time check with no recovery path and no connection to
+the write side of the system. The repo owner clarified two gaps while reviewing that behavior:
+a stale entry should be recoverable rather than a dead end, and staleness should not depend on
+a read happening to notice a hash mismatch — a write to the underlying content should
+invalidate the cache entry directly.
+
+## Decision
+
+**Recoverable staleness.** Each control-set entry stores the command that produced it — the
+source, scope, and parameters Collection and Generation used — alongside its content identity.
+On a stale-identifier request, that stored command re-runs Collection and Generation, produces
+a new identity, and serves the caller against it, rather than erroring and requiring the caller
+to reconstruct its original request from scratch.
+
+**Write-triggered invalidation.** Every write path that can modify a source this contract
+reads from — item updates, section writes, artifact registration, task and plan state changes
+— invalidates any control-set entry generated from what it touched, as a side effect of the
+write. This does not replace the identity check on read (R8's existing hash-mismatch
+detection); it adds a second, earlier path to the same outcome, so a stale entry is caught
+whether or not a read happens to hit it before a write does.
+
+## Consequences
+
+The control set needs an index from source to the entries generated from it, so a write can
+find what to invalidate without scanning every entry. This is new integration surface across
+every mutation path in the plugin, not confined to the read-path work already scoped by R1's
+duplicate-implementation cleanup (#3057-#3059) — tracked separately as its own issue since it
+touches write paths those issues do not.
+
+## Considered alternative
+
+Passive-only staleness (the ADR-3075-1 baseline: report stale, let the caller re-request) was
+considered and rejected — it was the explicit thing being revised here, not a live alternative
+this ADR is choosing between. Recorded for completeness, not because it was seriously weighed
+against the decision above.

--- a/plugins/development-harness/docs/adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md
@@ -4,8 +4,12 @@
 **Date:** 2026-08-20
 **Issue:** New issue filed alongside this ADR (see cross-references below)
 **Related:** Extends [ADR-3075-1](./ADR-3075-1-content-identity-and-cache-scope.md) — does not
-reverse it. Session-scoped, non-persisted cache lifetime stands; this ADR adds behavior for
-what happens *within* that lifetime when content changes underneath a cache entry.
+reverse it. This ADR adds behavior for what happens when content changes underneath a cache
+entry. **The "same session only" scoping in the Decision below is superseded by
+[ADR-3082-1](./ADR-3082-1-sqlite-backed-bounded-eviction.md)'s content-keyed reversal** — there
+is no per-session control-set partition to scope invalidation to any more; it now applies
+globally, to whichever caller made the write. The "Decision" section is kept for the recovery
+mechanism, which is unchanged; its session-scoping language is historical.
 
 ## Context
 
@@ -31,16 +35,31 @@ caller the identity changed — rather than erroring and requiring the caller to
 original request from scratch. This is what keeps R8's no-mixed-versions guarantee: pages are
 never served by applying an old request's addressing to a new document's structure.
 
-**Write-triggered invalidation, same session only.** Every write path that can modify a source
-this contract reads from — item updates, section writes, artifact registration, task and plan
-state changes — invalidates any control-set entry in the writing session's own control set that
-was generated from what it touched, as a side effect of the write. This does not replace the
-identity check on read (R8's existing hash-mismatch detection); it adds a second, earlier path
-to the same outcome, so a stale entry is caught whether or not a read happens to hit it before a
-write does. A write from a different session, or through a path outside this contract's Scope,
-is not visible to this invalidation — it does not scan or mutate another session's control set —
-and is not guaranteed to surface as stale this way; this is the concurrent-session blind spot
-ADR-3075-3 documents, not a gap in this decision's own scope.
+**Write-triggered invalidation, global — superseded scoping, corrected here.** Every write path
+that can modify a source this contract reads from — item updates, section writes, artifact
+registration, task and plan state changes — marks stale any control-set entry that was generated
+from what it touched, as a side effect of the write, regardless of which session or caller made
+either the write or the original cached request. This is a direct consequence of ADR-3082-1's
+content-keyed reversal: there is one shared entry per `content_id`, not one per session, so there
+is nothing left to scope invalidation *to* — a write from any caller invalidates the one entry
+everyone shares. This does not replace the identity check on read (R8's existing hash-mismatch
+detection); it adds a second, earlier path to the same outcome, so a stale entry is caught
+whether or not a read happens to hit it before a write does. The "concurrent-session blind spot"
+this ADR's earlier revision named (a write from a different session not being visible to
+invalidation) is resolved as a side effect of the reversal, not merely narrowed — there is no
+"different session's control set" any more for a write to be invisible to.
+
+**Invalidation marks the entry stale; it does not delete the row.** The stored command that
+produced an entry (source, scope, parameters) must survive invalidation — deleting the row on
+invalidation would destroy the very thing "recoverable staleness" above depends on: a
+stale-identifier request that arrives after invalidation has only the old `content_id` to look
+up with, not the caller's original scope (R8 explicitly does not have the caller carry that
+forward). If the row were gone, the server would have no stored command to re-run, and recovery
+would degenerate into an error requiring the caller to reconstruct its request from scratch —
+exactly what this ADR exists to avoid. The schema (ADR-3082-1) carries an explicit stale marker
+on each row for this reason; invalidation sets it, a subsequent stale-identifier request reads
+the still-present stored command to regenerate, and the stale row is replaced (not merely
+flagged) once regeneration under the new identity succeeds.
 
 ## Consequences
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
@@ -11,10 +11,12 @@ decides they are also caller-visible.
 ## Context
 
 ADR-3075-2 gives the control set automatic write-triggered invalidation, but automatic
-invalidation has blind spots: a write made through a path outside this contract's Scope, a
-write from a concurrent session, or simply an agent that wants certainty rather than trust
-before acting on content it just modified. The repo owner asked for the agent to have its own
-basis for judging freshness, not only the server's.
+invalidation has blind spots: a write made through a path outside this contract's Scope, or
+simply an agent that wants certainty rather than trust before acting on content it just
+modified. (A write from a concurrent session was originally listed here too — no longer a
+blind spot: ADR-3082-1's content-keyed reversal makes write-invalidation global, so a
+concurrent-session write is visible the same as any other.) The repo owner asked for the agent
+to have its own basis for judging freshness, not only the server's.
 
 ## Decision
 
@@ -28,13 +30,16 @@ the control set already holds. Both re-run Collection and Generation via the sto
 identity is derived from the command plus Generation's output, not from the raw source alone
 (ADR-3075-1), so recomputing current identity from the source alone is not an option. They
 differ only in what happens after: revalidation compares the freshly computed identity to the
-entry's stored identity and, on a match, reuses the entry's already-cached *parsed* document
-rather than re-parsing — cheaper than a forced refresh only in that one respect. A forced
-refresh skips the comparison and unconditionally re-parses and re-serves the fresh document
-regardless of whether the identity matches. Revalidation is a caller-triggered path to the same
-outcome ADR-3075-2's write-triggered invalidation reaches automatically — deliberately
-redundant with it, not a replacement for it, because the automatic path cannot see every reason
-an agent might have to distrust a cached entry.
+entry's stored identity and, on a match, leaves the existing row as-is rather than overwriting
+it — no write happens, since the stored content is confirmed still current. A forced refresh
+skips the comparison and unconditionally overwrites the row with the fresh document regardless
+of whether the identity matches. **This is not about avoiding a re-parse** — the control set
+stores raw content, not a parsed tree (ADR-3082-1), so serving any page from either path always
+reparses the row's raw content in-memory, the same cost either way. Revalidation's saving is
+narrower: skipping an unnecessary write when nothing actually changed. Revalidation is a
+caller-triggered path to the same outcome ADR-3075-2's write-triggered invalidation reaches
+automatically — deliberately redundant with it, not a replacement for it, because the automatic
+path cannot see every reason an agent might have to distrust a cached entry.
 
 ## Consequences
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
@@ -1,0 +1,45 @@
+# ADR-3075-3: Content identity, command, and timestamp are visible response metadata
+
+**Status:** Accepted
+**Date:** 2026-08-20
+**Issue:** New issue filed alongside this ADR (see cross-references below)
+**Related:** Extends [ADR-3075-1](./ADR-3075-1-content-identity-and-cache-scope.md) and
+[ADR-3075-2](./ADR-3075-2-stale-cache-recovery-and-write-invalidation.md) — both treated the
+control set's identity, command, and staleness handling as internal server mechanics. This ADR
+decides they are also caller-visible.
+
+## Context
+
+ADR-3075-2 gives the control set automatic write-triggered invalidation, but automatic
+invalidation has blind spots: a write made through a path outside this contract's Scope, a
+write from a concurrent session, or simply an agent that wants certainty rather than trust
+before acting on content it just modified. The repo owner asked for the agent to have its own
+basis for judging freshness, not only the server's.
+
+## Decision
+
+Every response backed by the control set carries three pieces of metadata the cache already
+computes for its own internal use: the content identity (R8's hash), the command that produced
+it (source, scope, parameters — ADR-3075-2), and a timestamp of when it was generated. An agent
+may use this to decide, on its own, whether to trust what it received.
+
+A caller may explicitly request revalidation (cheap: recompute the source's current identity,
+confirm or refute a match) or a forced refresh (unconditionally re-run Collection and
+Generation via the stored command, bypassing the cache regardless of hash match) instead of
+accepting whatever the control set already holds. This is a caller-triggered path to the same
+outcome ADR-3075-2's write-triggered invalidation reaches automatically — deliberately
+redundant with it, not a replacement for it, because the automatic path cannot see every reason
+an agent might have to distrust a cached entry.
+
+## Consequences
+
+Response shapes for every operation backed by the control set gain three metadata fields. This
+composes with R6 (sections and artifacts as one inventory) and R8's existing identifier field —
+it is additive to response shape, not a new response mode.
+
+## Considered alternative
+
+Keeping identity/command/timestamp purely internal (the ADR-3075-1/3075-2 baseline) was
+considered and rejected: it leaves an agent with no way to act on a freshness concern except
+trusting the server's automatic invalidation, which the context above shows is not always
+enough.

--- a/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
@@ -47,6 +47,10 @@ Response shapes for every operation backed by the control set gain three metadat
 composes with R6 (sections and artifacts as one inventory) and R8's existing identifier field —
 it is additive to response shape, not a new response mode.
 
+Revalidation and forced refresh need a concrete way for the caller to ask for them, not just a
+prose description — added to R8's request shape as an optional `refresh` selector (`revalidate`
+or `force`), absent by default.
+
 ## Considered alternative
 
 Keeping identity/command/timestamp purely internal (the ADR-3075-1/3075-2 baseline) was

--- a/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
@@ -44,6 +44,22 @@ caller-triggered path to the same outcome ADR-3075-2's write-triggered invalidat
 automatically — deliberately redundant with it, not a replacement for it, because the automatic
 path cannot see every reason an agent might have to distrust a cached entry.
 
+**When the fresh document's identity differs from the one the caller held, the storage
+transition mirrors ADR-3075-2's automatic-recovery path exactly — there is no separate,
+revalidation-specific behavior to invent.** Rows are keyed by `content_id` (ADR-3082-1); an
+identity change is a different key, not an in-place update of the old row. The fresh document is
+inserted as a new row under its new `content_id`; the old row is marked `stale` the same way
+write-triggered invalidation marks it (ADR-3075-2's `stale` marker, not deletion — so a caller
+still mid-navigation on the old identifier is told plainly it changed, rather than erroring or
+silently seeing new content under an identifier it never asked to change). The response reports
+the new identity and serves page 1 of the fresh document (or, when the caller's `navigate`
+ordinal no longer resolves, an explicit restart response) — the same recovery shape ADR-3075-2
+defines for an ordinary stale hit, because both paths land in the identical state: an entry
+whose content changed underneath a stored identity. Revalidation reports the identity change
+explicitly (that comparison is the whole point of the `revalidate` mode); forced refresh performs
+the identical transition without reporting it as a change, consistent with forced refresh always
+skipping the comparison (above).
+
 ## Consequences
 
 Response shapes for every operation backed by the control set gain three metadata fields. This

--- a/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
@@ -28,15 +28,18 @@ may use this to decide, on its own, whether to trust what it received.
 A caller may explicitly request revalidation or a forced refresh instead of accepting whatever
 the control set already holds. Both re-run Collection and Generation via the stored command —
 identity is derived from the command plus Generation's output, not from the raw source alone
-(ADR-3075-1), so recomputing current identity from the source alone is not an option. They
-differ only in what happens after: revalidation compares the freshly computed identity to the
-entry's stored identity and, on a match, leaves the existing row as-is rather than overwriting
-it — no write happens, since the stored content is confirmed still current. A forced refresh
-skips the comparison and unconditionally overwrites the row with the fresh document regardless
-of whether the identity matches. **This is not about avoiding a re-parse** — the control set
-stores raw content, not a parsed tree (ADR-3082-1), so serving any page from either path always
-reparses the row's raw content in-memory, the same cost either way. Revalidation's saving is
-narrower: skipping an unnecessary write when nothing actually changed. Revalidation is a
+(ADR-3075-1), so recomputing current identity from the source alone is not an option. **Both
+always write a fresh navigation document, confirmed by the repo owner: the control set is not a
+durable reuse-optimization cache — it is temporary scratch space for one navigation task, for an
+agent to page and jump around in while it locates currently-needed data. Any hit against the
+backend produces a new document; nothing skips the write to avoid "redundant" work, because
+reuse across separate requests was never the point.** Revalidation and forced refresh differ
+only in what's reported, not in whether a write happens: revalidation compares the freshly
+computed identity to the entry's previously-known identity and tells the caller whether it
+changed; a forced refresh skips that comparison and reporting, unconditionally serving the fresh
+document. **This is not about avoiding a re-parse** — the control set stores raw content, not a
+parsed tree (ADR-3082-1), so serving any page from either path always reparses the row's raw
+content in-memory, the same cost either way. Revalidation is a
 caller-triggered path to the same outcome ADR-3075-2's write-triggered invalidation reaches
 automatically — deliberately redundant with it, not a replacement for it, because the automatic
 path cannot see every reason an agent might have to distrust a cached entry.

--- a/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-3-cache-metadata-visible-to-agent.md
@@ -23,10 +23,15 @@ computes for its own internal use: the content identity (R8's hash), the command
 it (source, scope, parameters — ADR-3075-2), and a timestamp of when it was generated. An agent
 may use this to decide, on its own, whether to trust what it received.
 
-A caller may explicitly request revalidation (cheap: recompute the source's current identity,
-confirm or refute a match) or a forced refresh (unconditionally re-run Collection and
-Generation via the stored command, bypassing the cache regardless of hash match) instead of
-accepting whatever the control set already holds. This is a caller-triggered path to the same
+A caller may explicitly request revalidation or a forced refresh instead of accepting whatever
+the control set already holds. Both re-run Collection and Generation via the stored command —
+identity is derived from the command plus Generation's output, not from the raw source alone
+(ADR-3075-1), so recomputing current identity from the source alone is not an option. They
+differ only in what happens after: revalidation compares the freshly computed identity to the
+entry's stored identity and, on a match, reuses the entry's already-cached *parsed* document
+rather than re-parsing — cheaper than a forced refresh only in that one respect. A forced
+refresh skips the comparison and unconditionally re-parses and re-serves the fresh document
+regardless of whether the identity matches. Revalidation is a caller-triggered path to the same
 outcome ADR-3075-2's write-triggered invalidation reaches automatically — deliberately
 redundant with it, not a replacement for it, because the automatic path cannot see every reason
 an agent might have to distrust a cached entry.

--- a/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
@@ -43,6 +43,29 @@ convention this decision reuses, not a new storage mechanism invented for R8.
 signatures as a prerequisite for any implementation of #3062 — this was not previously called
 out as required plumbing anywhere in this contract or its ADRs, and is now explicit.
 
+## Known gaps — named, not solved by this ADR
+
+**Concurrent writers within one session.** `CLAUDE_CODE_SESSION_ID` is shared not only across
+one agent's own MCP-vs-CLI calls but across every subagent this repo's `TeamCreate` and
+parallel `Agent()` patterns spawn within that session — they inherit the same session ID. That
+means multiple OS processes (a parallel review team all viewing or grooming the same item, for
+example) can perform a concurrent read-modify-write against the same session-keyed store.
+`get-gate-token.mjs` is not precedent for this: it only ever performs one atomic
+`writeFileSync` of a single value, never a keyed read-modify-write, and has nothing analogous
+to write-triggered invalidation (ADR-3075-2) racing a concurrent requery. This ADR does not
+specify a locking scheme — that is deferred to implementation, tracked as
+[#3081](https://github.com/Jamie-BitFlight/claude_skills/issues/3081) — but the concurrency
+hazard is a real gap in what "session-keyed" solves, not an incidental detail.
+
+**No stated cleanup or TTL.** Control-set entries can hold full generated documents, and
+ADR-3072-1's known limitation already establishes this is not a hypothetical size — item #2953
+alone generates an estimated 270,946+ tokens. Without a cleanup mechanism for
+`$DH_STATE_HOME/sessions/{id}/` directories after a session ends, entries accumulate on disk
+unboundedly across every session ever run. `get-gate-token.mjs`'s single small token file never
+faced this problem; a control-set store holding full generated documents does. Not solved here
+— tracked as [#3082](https://github.com/Jamie-BitFlight/claude_skills/issues/3082) so it is not
+silently absent from the design.
+
 ## Considered alternative
 
 An in-process cache (module-level dict, FastMCP lifespan context) was the implicit assumption

--- a/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
@@ -1,0 +1,51 @@
+# ADR-3075-4: The control set is out-of-process and session-keyed, not an in-process cache
+
+**Status:** Accepted
+**Date:** 2026-08-20
+**Issue:** Extends [#3062](https://github.com/Jamie-BitFlight/claude_skills/issues/3062)
+**Related:** Corrects an implicit assumption in [ADR-3075-1](./ADR-3075-1-content-identity-and-cache-scope.md)
+and the initial R8 wording — neither specified storage locality, and both were written as
+though an in-process cache would satisfy "one shared control set." It does not.
+
+## Context
+
+R8 requires one control set per session, shared across every tool, subcommand, and transport
+that touches the same generated content. A peer review, dispatched specifically to check this
+claim's feasibility against the actual codebase (not the contract's own framing), found it
+false as an in-process design:
+
+- `_backlog_lifespan` (`backlog_core/server.py`) yields an empty `{}` — there is no shared
+  state today for MCP tools to hook into.
+- `backlog_view` and `artifact_read` — the two tools this whole contract centers on — do not
+  even accept a `ctx: Context` parameter. Only a handful of other tools do.
+- The CLI runs as a separate OS process per invocation. FastMCP's lifespan context is scoped to
+  one server process's lifetime; it cannot be shared with a CLI subprocess by construction, no
+  matter how the MCP-side wiring is improved. "Viewed through one tool, then the CLI, still
+  hits the same entry" cannot be true of an in-process cache regardless of implementation
+  effort.
+
+All three findings were verified directly against `backlog_core/server.py` before being
+accepted into this ADR.
+
+## Decision
+
+The control set is an out-of-process, session-keyed store — not a server-held dict or MCP
+lifespan context. It follows the pattern already established by
+`plugins/development-harness/skills/work-backlog-item/scripts/get-gate-token.mjs`: a directory
+at `$DH_STATE_HOME/sessions/{CLAUDE_CODE_SESSION_ID}/` (default `~/.dh/sessions/...`), keyed by
+the `CLAUDE_CODE_SESSION_ID` environment variable already shared between an MCP-tool-calling
+agent process and any CLI subprocess it spawns in the same session. This is an existing
+convention this decision reuses, not a new storage mechanism invented for R8.
+
+## Consequences
+
+`backlog_view` and `artifact_read` need `ctx: Context` (or equivalent) added to their
+signatures as a prerequisite for any implementation of #3062 — this was not previously called
+out as required plumbing anywhere in this contract or its ADRs, and is now explicit.
+
+## Considered alternative
+
+An in-process cache (module-level dict, FastMCP lifespan context) was the implicit assumption
+behind the original "one shared control set" wording and is rejected here for the reason
+above: it cannot be true across the MCP/CLI process boundary regardless of implementation
+quality, not merely a weaker version of the decision above.

--- a/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
@@ -39,9 +39,20 @@ convention this decision reuses, not a new storage mechanism invented for R8.
 
 ## Consequences
 
-`backlog_view` and `artifact_read` need `ctx: Context` (or equivalent) added to their
-signatures as a prerequisite for any implementation of #3062 — this was not previously called
-out as required plumbing anywhere in this contract or its ADRs, and is now explicit.
+`backlog_view` and `artifact_read` need a session-identifying value added to their signatures
+as a prerequisite for any implementation of #3062. **This was originally stated as "add
+`ctx: Context`" and that was wrong** — checked directly against every existing `ctx: Context`
+usage in `backlog_core/server.py`: `ctx` is used exclusively for `ctx.info()`/`ctx.warning()`/
+`ctx.report_progress()`, a logging and progress channel to the calling client, and carries no
+session identity anywhere in this codebase. The actual established pattern for session
+identity is an explicit `gate_token`-style parameter: `backlog_add` (which does take
+`ctx: Context`) determines the caller's session not from `ctx` but from a `gate_token` string
+(`{session_id}:{hex}`) the client generates via `get-gate-token.mjs` and passes as an ordinary
+parameter — `_read_gate_token`'s own docstring states this exists specifically "so the MCP
+server never needs its own `CLAUDE_CODE_SESSION_ID`." `backlog_view` and `artifact_read`
+currently have neither `ctx: Context` nor a `gate_token`-style parameter. The prerequisite is
+the latter, following the existing pattern — not `ctx: Context`, which would not solve this
+even if added.
 
 ## Known gaps — named, not solved by this ADR
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
@@ -77,6 +77,15 @@ faced this problem; a control-set store holding full generated documents does. N
 — tracked as [#3082](https://github.com/Jamie-BitFlight/claude_skills/issues/3082) so it is not
 silently absent from the design.
 
+**Not harness-neutral.** The only mechanism that populates `CLAUDE_CODE_SESSION_ID` today is
+`hooks/session-start-session-id.cjs`, which fires on Claude Code's `SessionStart` hook event and
+writes the value to `CLAUDE_ENV_FILE` — both are Claude-Code-specific. This repo's plugin
+content targets Codex, OpenCode, and GitHub's coding agent as well, and none of those provide an
+equivalent `SessionStart` event or `CLAUDE_ENV_FILE`-style shell injection. Under those harnesses
+the CLI and an MCP server have no shared mechanism to resolve the same session directory,
+defeating the cross-transport guarantee this ADR exists to provide. Not solved here — tracked as
+[#3085](https://github.com/Jamie-BitFlight/claude_skills/issues/3085).
+
 ## Considered alternative
 
 An in-process cache (module-level dict, FastMCP lifespan context) was the implicit assumption

--- a/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
@@ -6,6 +6,9 @@
 **Related:** Corrects an implicit assumption in [ADR-3075-1](./ADR-3075-1-content-identity-and-cache-scope.md)
 and the initial R8 wording — neither specified storage locality, and both were written as
 though an in-process cache would satisfy "one shared control set." It does not.
+**Superseded in part by:** [ADR-3082-1](./ADR-3082-1-sqlite-backed-bounded-eviction.md) — the
+storage mechanism below (a directory of files) is replaced by a single SQLite database. The
+out-of-process, session-keyed decision this ADR makes is unchanged.
 
 ## Context
 
@@ -67,15 +70,16 @@ to write-triggered invalidation (ADR-3075-2) racing a concurrent requery. This A
 specify a locking scheme — that is deferred to implementation, tracked as
 [#3081](https://github.com/Jamie-BitFlight/claude_skills/issues/3081) — but the concurrency
 hazard is a real gap in what "session-keyed" solves, not an incidental detail.
+[ADR-3082-1](./ADR-3082-1-sqlite-backed-bounded-eviction.md)'s move to a single SQLite database
+partially mitigates this (WAL mode makes individual statements atomic across concurrent OS
+processes) but does not solve it — the full check-cap/evict/insert sequence still needs an
+explicit transaction, which #3081 remains open to specify.
 
-**No stated cleanup or TTL.** Control-set entries can hold full generated documents, and
-ADR-3072-1's known limitation already establishes this is not a hypothetical size — item #2953
-alone generates an estimated 270,946+ tokens. Without a cleanup mechanism for
-`$DH_STATE_HOME/sessions/{id}/` directories after a session ends, entries accumulate on disk
-unboundedly across every session ever run. `get-gate-token.mjs`'s single small token file never
-faced this problem; a control-set store holding full generated documents does. Not solved here
-— tracked as [#3082](https://github.com/Jamie-BitFlight/claude_skills/issues/3082) so it is not
-silently absent from the design.
+**No stated cleanup or TTL.** Resolved by
+[ADR-3082-1](./ADR-3082-1-sqlite-backed-bounded-eviction.md) — bounded per-session LRU eviction
+plus an opportunistic cross-session age-based sweep, replacing the directory-of-files storage
+this ADR originally specified. Tracked as
+[#3082](https://github.com/Jamie-BitFlight/claude_skills/issues/3082) for implementation.
 
 **Not harness-neutral.** The only mechanism that populates `CLAUDE_CODE_SESSION_ID` today is
 `hooks/session-start-session-id.cjs`, which fires on Claude Code's `SessionStart` hook event and

--- a/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
@@ -6,9 +6,13 @@
 **Related:** Corrects an implicit assumption in [ADR-3075-1](./ADR-3075-1-content-identity-and-cache-scope.md)
 and the initial R8 wording — neither specified storage locality, and both were written as
 though an in-process cache would satisfy "one shared control set." It does not.
-**Superseded in part by:** [ADR-3082-1](./ADR-3082-1-sqlite-backed-bounded-eviction.md) — the
-storage mechanism below (a directory of files) is replaced by a single SQLite database. The
-out-of-process, session-keyed decision this ADR makes is unchanged.
+**Superseded by:** [ADR-3082-1](./ADR-3082-1-sqlite-backed-bounded-eviction.md), on two points.
+First: the storage mechanism below (a directory of files) is replaced by a single SQLite
+database. Second, in a later revision of that same ADR: **the session-keyed decision itself is
+reversed** — the control set is content-keyed only, no `session_id` anywhere. Only the
+out-of-process decision below (not in-process, not a server-held dict) is still current. The
+"Decision" and "Consequences" sections below are kept for history; read ADR-3082-1's "Reversal:
+content-keyed, not session-keyed" section for what's actually current.
 
 ## Context
 
@@ -99,14 +103,13 @@ plus an opportunistic cross-session age-based sweep, replacing the directory-of-
 this ADR originally specified. Tracked as
 [#3082](https://github.com/Jamie-BitFlight/claude_skills/issues/3082) for implementation.
 
-**Not harness-neutral.** The only mechanism that populates `CLAUDE_CODE_SESSION_ID` today is
-`hooks/session-start-session-id.cjs`, which fires on Claude Code's `SessionStart` hook event and
-writes the value to `CLAUDE_ENV_FILE` — both are Claude-Code-specific. This repo's plugin
-content targets Codex, OpenCode, and GitHub's coding agent as well, and none of those provide an
-equivalent `SessionStart` event or `CLAUDE_ENV_FILE`-style shell injection. Under those harnesses
-the CLI and an MCP server have no shared mechanism to resolve the same session directory,
-defeating the cross-transport guarantee this ADR exists to provide. Not solved here — tracked as
-[#3085](https://github.com/Jamie-BitFlight/claude_skills/issues/3085).
+**Not harness-neutral.** Named against this ADR's original session-keyed design. Moot for the
+control set specifically now that ADR-3082-1 reversed session-keying — a content-keyed store
+needs no session-identifying value from any harness, so there is nothing left for this gap to
+apply to on that path. Tracked as
+[#3085](https://github.com/Jamie-BitFlight/claude_skills/issues/3085), flagged there for the repo
+owner to close or repurpose — `CLAUDE_CODE_SESSION_ID` may still matter to something else in this
+codebase (e.g. `gate_token`, tracked separately in #3087) independent of the control set.
 
 ## Considered alternative
 

--- a/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
+++ b/plugins/development-harness/docs/adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md
@@ -47,15 +47,33 @@ as a prerequisite for any implementation of #3062. **This was originally stated 
 `ctx: Context`" and that was wrong** — checked directly against every existing `ctx: Context`
 usage in `backlog_core/server.py`: `ctx` is used exclusively for `ctx.info()`/`ctx.warning()`/
 `ctx.report_progress()`, a logging and progress channel to the calling client, and carries no
-session identity anywhere in this codebase. The actual established pattern for session
-identity is an explicit `gate_token`-style parameter: `backlog_add` (which does take
-`ctx: Context`) determines the caller's session not from `ctx` but from a `gate_token` string
-(`{session_id}:{hex}`) the client generates via `get-gate-token.mjs` and passes as an ordinary
-parameter — `_read_gate_token`'s own docstring states this exists specifically "so the MCP
-server never needs its own `CLAUDE_CODE_SESSION_ID`." `backlog_view` and `artifact_read`
-currently have neither `ctx: Context` nor a `gate_token`-style parameter. The prerequisite is
-the latter, following the existing pattern — not `ctx: Context`, which would not solve this
-even if added.
+session identity anywhere in this codebase.
+
+**A second correction, found the same way: reusing the `gate_token` pattern was also wrong.**
+`backlog_add` does determine the caller's session from a client-supplied parameter rather than
+`ctx`, but that parameter is not a stable session identifier and does not solve this. Checked
+directly against `get-gate-token.mjs` and `_read_gate_token()` in `backlog_core/server.py`:
+`get-gate-token.mjs` generates a *new* random token and overwrites the single
+`.gate-token` file on every invocation; `_read_gate_token()` validates a caller's token against
+only the file's *current* contents. A token obtained by an earlier call in a session becomes
+invalid the moment anything else in that session reloads the skill and regenerates the file —
+including a paginated request's own later follow-up call. `gate_token`'s actual purpose (per its
+own docstring and the error message `backlog_add` returns on mismatch) is gating unauthorized
+direct tool calls, forcing skill-mediated access to `create`'s duplicate-detection step — not
+carrying session identity for cache routing. Those are different requirements and the same
+mechanism cannot serve both: cache routing needs a value stable for the session's whole
+lifetime; the gate needs a value that becomes invalid, since its entire point is to reject a
+caller that bypassed the skill.
+
+The correct prerequisite is a plain, non-rotating `session_id` parameter carrying the caller's
+`CLAUDE_CODE_SESSION_ID` value directly — following the same reasoning `gate_token`'s docstring
+gives for why the client must pass it explicitly (the MCP server has no way to read the caller's
+own environment), without adopting `gate_token`'s rotation or its access-gating property, neither
+of which cache routing needs. `backlog_view` and `artifact_read` currently have neither
+`ctx: Context` nor any session-identifying parameter. Whether `gate_token` itself should be
+reviewed or replaced as an access-gating mechanism is a separate question, raised by the repo
+owner and tracked as [#3087](https://github.com/Jamie-BitFlight/claude_skills/issues/3087) — out
+of scope for this ADR, which only concerns cache routing.
 
 ## Known gaps — named, not solved by this ADR
 

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -49,12 +49,35 @@ that cost to create what turns out to be an arbitrary boundary between sessions 
 **The key is `content_id` alone** — the command+content-bound identity from ADR-3075-1. No
 `session_id`, anywhere: not in the schema, not as an MCP tool parameter, not read from the CLI's
 environment for this purpose. Two different sessions running the identical command against
-identical content resolve to the same row and share it — this is now a deliberate feature, not
-an accident to guard against: it avoids duplicate storage and duplicate Collection+Generation
-work for the same request made twice. `backlog_view` and `artifact_read` need **no**
-session-identifying parameter added to their signatures for control-set purposes — the entire
-prerequisite ADR-3075-4 stated in its Consequences section (adding a `gate_token`-style or
-`session_id`-style parameter) is void for this reason, not merely revised.
+identical content resolve to the same row on write. **This avoids duplicate storage, not
+duplicate work** — every full request still runs Collection and Generation unconditionally (see
+"Every backend hit always writes a fresh document" below); `content_id` isn't even knowable until
+that work has already happened, since it's a hash of the *generated* output, so there is nothing
+to check in advance that would let a repeat request skip the fetch. The benefit of dropping
+`session_id` from the key is narrower than originally claimed here: two callers producing
+identical content upsert the same row instead of each holding their own permanent duplicate, so
+storage doesn't grow with caller count — it says nothing about compute cost. `backlog_view` and
+`artifact_read` need **no** session-identifying parameter added to their signatures for
+control-set purposes — the entire prerequisite ADR-3075-4 stated in its Consequences section
+(adding a `gate_token`-style or `session_id`-style parameter) is void for this reason, not merely
+revised.
+
+**Every source hit always writes a fresh document, confirmed by the repo owner.** "Backend call"
+is two different things and this ADR must not conflate them: a call to the navigation system
+(the MCP tool or CLI — every request, page 1 or page 2, is one of these) versus Collection and
+Generation actually reaching the original *source* (GitHub, etc.). The control set is not a
+durable reuse-optimization cache — it is temporary scratch space for one navigation task: an
+agent pages and jumps around in a document it just fetched, and the external store exists only
+because the CLI can't hold that document in memory between its own invocations (see Context
+above). A request that reaches the source — an ordinary initial request, revalidation, or a
+forced refresh (ADR-3075-3) — always regenerates and always writes; nothing skips the write to
+avoid "redundant" recomputation, because reuse across separate top-level requests was never the
+design's point. A follow-up page request against a document an agent is *already* navigating
+(R8) is still a call to the navigation system — the caller still invokes a tool — but it does not
+reach the source: it reads the row this task already wrote. **This is a genuine, deliberate
+caching effect, confirmed by the repo owner — a side effect of solving the CLI-not-a-service
+problem, not the reason the control set exists.** It's scoped to one navigation task's own
+follow-up calls, not to avoiding Collection and Generation across separate top-level requests.
 
 ## Decision
 
@@ -162,10 +185,13 @@ eviction is a periodic pass rather than inline on every write — the expensive 
 deleting down to target) runs at most hourly-to-daily, rate-limited by the stored
 `last_cleanup_at` check, not per-write. What remains on the write/read path is just the cheap
 parts: an insert of new content, and a single-row `last_accessed_at` update on read. Second,
-dropping `session_id` from the key (see "Reversal" above) means identical requests across
-different callers now share one row instead of writing duplicate ones — fewer total writes than
-the session-keyed design would have produced, not more. **Confirmed by the repo owner: accepted
-as-is** at this reduced scope. Revisit if contention is ever measured to matter in practice.
+every backend hit always writes regardless of key design (see "Every backend hit always writes a
+fresh document" above), so dropping `session_id` from the key does not reduce write *count* —
+identical requests from different callers still each write. What it reduces is storage: those
+writes upsert one shared row instead of each caller permanently holding its own duplicate, so the
+database doesn't grow with caller count for identical content. **Confirmed by the repo owner:
+accepted as-is** at this reduced scope. Revisit if contention is ever measured to matter in
+practice.
 
 ## Consequences
 

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -41,40 +41,78 @@ backend convention (`docs/backend-providers.md`) for the choice of engine; that 
 docs do not analyze WAL/writer-serialization behavior, so it is precedent for "SQLite is an
 established storage choice here," not for the contention trade-off named below. Rows are keyed
 by `(session_id, content_id)`, where `content_id` is the command+content-bound identity from
-ADR-3075-1. Each row stores the generated content, its hash, the canonicalized generating
-command, the request's `source` (see schema note below), `created_at`, and `last_accessed_at`.
+ADR-3075-1. Each row stores the generated content (raw, not a parsed tree — see "Re-parsing on
+follow-up pages" below), its hash, the canonicalized generating command, the request's `source`
+(see schema note below), `created_at`, and `last_accessed_at`.
 
-**Bounded per-session eviction, by size not count.** Confirmed by the repo owner: each
-`session_id` may hold at most **40MB** of total content (tunable), not a fixed entry count. On a
-write that would push a session over that budget, entries for that session are evicted
-least-recently-accessed first (**LRU, confirmed by the repo owner**) until the write fits.
+**`session_id` stays in the key, confirmed by the repo owner.** Without it, `content_id` alone
+would let two different sessions running the identical command against identical content share
+one row — mechanically fine, but it reverses an earlier, explicit requirement: "I don't want the
+cache values to be shared between agents or sessions." `session_id` in the key is what enforces
+that isolation, and is also what makes the per-session size target and per-session LRU ordering
+meaningful — without it, both would have to become global, and one agent's unrelated work could
+evict another's.
+
+**Re-parsing on follow-up pages is allowed, confirmed by the repo owner — this clarifies R8, not
+this ADR's schema.** The contract's R8 states a later page "does not re-parse." Taken literally,
+that's incompatible with storing only raw content: a follow-up landing on a fresh CLI process (no
+in-memory parsed tree survives across processes, per this ADR's own Context) would have nothing
+to slice without reparsing the stored raw markdown. Resolved by clarifying what R8's "does not
+re-parse" actually protects against: a repeated network round-trip to re-run Collection, and
+re-running Generation — not the cheap, deterministic, in-memory step of turning already-fetched
+raw markdown back into an addressable structure. That reading is consistent with ADR-3075-1's own
+"re-parsing is cheap" premise, which only makes sense if reparsing already-stored content is
+expected to happen routinely. The schema therefore stores raw generated content only, not a
+parsed tree — see `docs/agent-markdown-consumption-contract.md`'s R8 section for the corrected
+wording.
+
+**Bounded per-session storage, by size not count — a soft target, not a hard per-write limit.**
+Confirmed by the repo owner: each `session_id` targets at most **40MB** of total content
+(tunable). This is not enforced synchronously on every write — its only purpose is that stored
+content doesn't grow continuously and unboundedly, not to guarantee the budget is never exceeded
+at any instant. Trimming happens during periodic cleanup (below), not inline on the write path.
+
+**Periodic cleanup, not per-write eviction — confirmed by the repo owner.** A single maintenance
+pass does both jobs together: (1) delete rows whose `last_accessed_at` is older than a TTL,
+regardless of session, and (2) for any session over its 40MB target, delete
+least-recently-accessed rows for that session down to target (**LRU, confirmed by the repo
+owner**). This pass runs on a rate-limited cadence — **hourly to daily, confirmed by the repo
+owner as the target frequency; the exact value is an unsourced starting default, not a confirmed
+number, and should be revisited under real usage** — not synchronously on every write or every
+query. Mechanically: a single stored `last_cleanup_at` timestamp is checked cheaply (one row
+read) on write; the maintenance pass itself (the expensive scan-and-delete work) only executes
+when enough time has elapsed since the last run, otherwise the check is a no-op. This is what
+`#3082`'s second acceptance criterion (cleanup not dependent on clean exit) is actually satisfied
+by: the check runs opportunistically off of any session's write, so a crashed or killed session's
+rows still get swept the next time anything touches the database and the cadence has elapsed —
+just not synchronously with that session's own activity.
 
 **The goal, confirmed by the repo owner: avoid evicting an entry an agent is actively navigating
 within.** LRU achieves this structurally, not just incidentally: reading an entry (any page or
-address request against it) updates its `last_accessed_at`, so an entry under active navigation
-is by construction the most-recently-touched one in its session and is always evicted last under
-budget pressure. This is a best-effort property, not a guarantee — a paused multi-page read
-(fetch page 1, long gap, fetch page 2) can still lose to a burst of new content in the same
-session during the gap. Confirmed by the repo owner: that residual case is acceptable — the
-"eviction is not an error" fallback below means the agent just re-queries, which is a nice-to-avoid
-cost, not a correctness problem. See "Known tradeoff" below for what read-triggered writes cost.
+address request against it) updates its `last_accessed_at` — a cheap, single-row write, separate
+from the periodic cleanup pass — so an entry under active navigation is by construction the
+most-recently-touched one in its session and is always trimmed last whenever cleanup does run.
+This is a best-effort property, not a guarantee — a paused multi-page read (fetch page 1, long
+gap, fetch page 2) can still lose to a cleanup pass landing during the gap. Confirmed by the repo
+owner: that residual case is acceptable — the "eviction is not an error" fallback below means the
+agent just re-queries, which is a nice-to-avoid cost, not a correctness problem.
 
 Confirmed by the repo owner: an agent-level keying granularity (one store per subagent, not per
 session) was considered and rejected — there is no identifier that reliably survives a subagent
 spawning its own CLI subprocess, so session remains the practical and only reliably propagatable
 key.
 
-**Age-based cross-session sweep:** on every write (from any session), rows whose
-`last_accessed_at` is older than a TTL are deleted, regardless of which session they belong to.
-**The TTL value (currently 24h) is an unsourced starting default, not a confirmed decision** —
-tunable, and should be revisited once real usage data exists, not treated as settled. The sweep
-mechanism itself satisfies #3082's second acceptance criterion directly: it runs opportunistically
-on the next write from *any* session, so cleanup does not depend on the originating session
-exiting cleanly. A crashed or killed session's rows still age out the next time anything touches
-the database.
+**A single entry larger than the 40MB target is kept anyway, confirmed by the repo owner.**
+Collection and Generation are explicitly unbounded, so a single generated document can itself
+exceed the per-session target — trimming every other entry in that session still can't make it
+fit. Rather than reject the write or serve that document uncached (which would silently exempt
+the largest, most expensive-to-generate documents from R8's identity/staleness guarantees — the
+ones that benefit from caching the most), the write is allowed through as a documented exception:
+a session's effective budget is "40MB, or one entry's actual size if larger." The next cleanup
+pass still trims everything else in that session normally.
 
 **Eviction is not an error.** When an agent references a `content_id` that has since been
-evicted (by the size budget or by TTL), the response states plainly that the content is no
+evicted (by cleanup's size trim or TTL sweep), the response states plainly that the content is no
 longer cached and must be requested again — not a generic error, not a silent empty result.
 
 **Schema must include a `source` column and an index on it.** ADR-3075-2 requires "an index from
@@ -89,23 +127,25 @@ canonicalized command it's extracted from.
 Moving from one file per session to one global database trades reduced write contention *within*
 a session for new write contention *across every session running on the machine*: SQLite WAL
 mode allows concurrent readers alongside one writer, but writers still serialize against each
-other process-wide, not just against other writers in the same session. Because LRU eviction
+other process-wide, not just against other writers in the same session. Because LRU tracking
 requires bumping `last_accessed_at` on every read, a content read through this design is also a
-write transaction — multiplying how often that single-writer lock gets contended, beyond just
-inserts, evictions, and sweeps.
+write transaction.
 
-**Confirmed by the repo owner: accepted as-is**, given writes are still occasional relative to
-what a single global lock can serialize (new content, eviction, and LRU-triggered reads — not a
-high-frequency path), against one SQLite file per session (which would restore write isolation
-but turn the cross-session TTL sweep into an open-and-check-every-file operation instead of one
-query, losing the reason SQLite was chosen). Revisit if contention is ever measured to matter in
-practice.
+**Substantially smaller than originally assessed, now that eviction is a periodic pass rather
+than inline on every write.** The expensive part — scanning a session's rows and deleting down to
+target — no longer runs per-write; it runs at most hourly-to-daily, rate-limited by the stored
+`last_cleanup_at` check. What remains on the write/read path is just the cheap parts: an insert
+of new content, and a single-row `last_accessed_at` update on read. **Confirmed by the repo
+owner: accepted as-is** at this reduced scope, against one SQLite file per session (which would
+restore write isolation but turn the periodic cross-session sweep into an open-and-check-every-
+file operation instead of one query, losing the reason SQLite was chosen). Revisit if contention
+is ever measured to matter in practice.
 
 ## Consequences
 
-- `#3082`'s two acceptance criteria are both satisfied: entries never accumulate unboundedly
-  (bounded per-session size budget), and cleanup does not depend on clean exit (opportunistic TTL
-  sweep).
+- `#3082`'s two acceptance criteria are both satisfied: entries never accumulate unboundedly (the
+  40MB-per-session soft target, trimmed by periodic cleanup), and cleanup does not depend on clean
+  exit (the rate-limited cleanup check runs opportunistically off of any session's write).
 - `#3081`'s concurrent-writer hazard is partially mitigated, not solved: SQLite's WAL mode makes
   each individual statement atomic and safe under concurrent access from multiple OS processes,
   which a hand-rolled multi-file read-modify-write was not. It does **not** by itself make the

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -7,7 +7,8 @@ mitigates [#3081](https://github.com/Jamie-BitFlight/claude_skills/issues/3081)
 **Related:** Supersedes the storage-mechanism detail of
 [ADR-3075-4](./ADR-3075-4-out-of-process-session-keyed-control-set.md) — "a directory at
 `$DH_STATE_HOME/sessions/{CLAUDE_CODE_SESSION_ID}/`" — while keeping that ADR's higher-level
-decision (out-of-process, session-keyed, not in-process) unchanged. Confirmed by the repo owner.
+decision (out-of-process, session-keyed, not in-process) unchanged. Reviewed independently after
+first being written — see "Independent review" below for what that pass changed.
 
 ## Context
 
@@ -23,46 +24,101 @@ fresh OS process per invocation with no memory of any prior call. It cannot hold
 between invocations under any design — external storage is required regardless of session
 identity, purely because the CLI has nothing else to remember with.
 
+**Confirmed by the repo owner: this database holds no authoritative data.** Every row is a
+disposable, regenerable cache — Collection and Generation can rebuild any entry from source on
+demand. Losing the entire database (corruption, deletion, disk issue, a bad migration) causes no
+data loss, only a cold cache: the next request simply regenerates and repopulates it. This
+governs the rest of this ADR — no backup, no migration path, and no corruption-recovery
+procedure are needed beyond "delete the file and let it recreate itself." It's also why the
+cross-session write-contention trade-off below is acceptable at low stakes: contention costs
+latency, never correctness or data loss.
+
 ## Decision
 
 **One SQLite database**, not a directory of files, at a fixed path
 (`$DH_STATE_HOME/control-set.db`), WAL mode — consistent with this repo's existing `sqlite`
-backend convention (`docs/backend-providers.md`). Rows are keyed by `(session_id, content_id)`,
-where `content_id` is the command+content-bound identity from ADR-3075-1. Each row stores the
-generated content, its hash, the canonicalized generating command, `created_at`, and
-`last_accessed_at`.
+backend convention (`docs/backend-providers.md`) for the choice of engine; that backend's own
+docs do not analyze WAL/writer-serialization behavior, so it is precedent for "SQLite is an
+established storage choice here," not for the contention trade-off named below. Rows are keyed
+by `(session_id, content_id)`, where `content_id` is the command+content-bound identity from
+ADR-3075-1. Each row stores the generated content, its hash, the canonicalized generating
+command, the request's `source` (see schema note below), `created_at`, and `last_accessed_at`.
 
-**Bounded per-session eviction:** each `session_id` may hold at most N entries (default 10,
-tunable). On insert past the cap, the least-recently-accessed entry for that session is deleted
-first. Confirmed by the repo owner: an agent-level keying granularity (one stack per subagent,
-not per session) was considered and rejected — there is no identifier that reliably survives a
-subagent spawning its own CLI subprocess, so session remains the practical and only reliably
-propagatable key.
+**Bounded per-session eviction, by size not count.** Confirmed by the repo owner: each
+`session_id` may hold at most **40MB** of total content (tunable), not a fixed entry count. On a
+write that would push a session over that budget, entries for that session are evicted
+least-recently-accessed first (**LRU, confirmed by the repo owner**) until the write fits.
+Reading an entry updates its `last_accessed_at` — see "Known tradeoff" below for what this costs.
+
+Confirmed by the repo owner: an agent-level keying granularity (one store per subagent, not per
+session) was considered and rejected — there is no identifier that reliably survives a subagent
+spawning its own CLI subprocess, so session remains the practical and only reliably propagatable
+key.
 
 **Age-based cross-session sweep:** on every write (from any session), rows whose
-`last_accessed_at` is older than a configurable TTL (default 24h) are deleted, regardless of
-which session they belong to. This satisfies #3082's second acceptance criterion directly — the
-sweep runs opportunistically on the next write from *any* session, so it does not depend on the
-originating session exiting cleanly. A crashed or killed session's rows still age out the next
-time anything touches the database.
+`last_accessed_at` is older than a TTL are deleted, regardless of which session they belong to.
+**The TTL value (currently 24h) is an unsourced starting default, not a confirmed decision** —
+tunable, and should be revisited once real usage data exists, not treated as settled. The sweep
+mechanism itself satisfies #3082's second acceptance criterion directly: it runs opportunistically
+on the next write from *any* session, so cleanup does not depend on the originating session
+exiting cleanly. A crashed or killed session's rows still age out the next time anything touches
+the database.
 
 **Eviction is not an error.** When an agent references a `content_id` that has since been
-evicted (by cap or by TTL), the response states plainly that the content is no longer cached and
-must be requested again — not a generic error, not a silent empty result.
+evicted (by the size budget or by TTL), the response states plainly that the content is no
+longer cached and must be requested again — not a generic error, not a silent empty result.
+
+**Schema must include a `source` column and an index on it.** ADR-3075-2 requires "an index from
+source to the entries generated from it, so a write can find what to invalidate without scanning
+every entry." The schema in this ADR's first draft omitted this — `source` was only recoverable
+by parsing the stored canonicalized command per row, exactly the full-table scan ADR-3075-2 said
+to avoid. Corrected: `source` is its own column, indexed, populated at write time alongside the
+canonicalized command it's extracted from.
+
+## Known tradeoff — cross-session write contention (confirmed accepted, not silently assumed)
+
+Moving from one file per session to one global database trades reduced write contention *within*
+a session for new write contention *across every session running on the machine*: SQLite WAL
+mode allows concurrent readers alongside one writer, but writers still serialize against each
+other process-wide, not just against other writers in the same session. Because LRU eviction
+requires bumping `last_accessed_at` on every read, a content read through this design is also a
+write transaction — multiplying how often that single-writer lock gets contended, beyond just
+inserts, evictions, and sweeps.
+
+**Confirmed by the repo owner: accepted as-is**, given writes are still occasional relative to
+what a single global lock can serialize (new content, eviction, and LRU-triggered reads — not a
+high-frequency path), against one SQLite file per session (which would restore write isolation
+but turn the cross-session TTL sweep into an open-and-check-every-file operation instead of one
+query, losing the reason SQLite was chosen). Revisit if contention is ever measured to matter in
+practice.
 
 ## Consequences
 
 - `#3082`'s two acceptance criteria are both satisfied: entries never accumulate unboundedly
-  (bounded per-session cap), and cleanup does not depend on clean exit (opportunistic TTL sweep).
+  (bounded per-session size budget), and cleanup does not depend on clean exit (opportunistic TTL
+  sweep).
 - `#3081`'s concurrent-writer hazard is partially mitigated, not solved: SQLite's WAL mode makes
   each individual statement atomic and safe under concurrent access from multiple OS processes,
   which a hand-rolled multi-file read-modify-write was not. It does **not** by itself make the
-  full "check cap, evict, insert" sequence atomic across concurrent writers — that still requires
-  wrapping the sequence in an explicit transaction, which is an implementation detail deferred to
-  #3081, not decided here.
+  full "check budget, evict, insert" sequence atomic across concurrent writers — that still
+  requires wrapping the sequence in an explicit transaction, which is an implementation detail
+  deferred to #3081, not decided here. The same open question applies to a read racing a
+  concurrent sweep (a check-then-consume sequence spanning two statements, with an eviction
+  landing in between) — not a new hazard, the same class already deferred to #3081, just also
+  present on the read side once LRU makes reads into writes.
 - Implementation must add a session-keyed table to `$DH_STATE_HOME`, distinct from any per-plugin
   provider database (e.g. the `sqlite` backend's 6-table schema) — this is Navigation-layer
   cache state, not work-item state, and must not be added to that schema.
+
+## Independent review
+
+This ADR was reviewed by an independent agent with no involvement in writing it, specifically to
+avoid the author checking its own work. It found the cross-session write-contention trade-off
+above unnamed, the eviction order (LRU) and defaults (cap, TTL) asserted without attributed
+confirmation, and the `source` index requirement from ADR-3075-2 silently dropped. All four are
+addressed above. Everything else it checked — `content_id`'s definition against ADR-3075-1, both
+of #3082's acceptance criteria, the "partially mitigates #3081" framing, and consistency with
+`CONTEXT.md`/the contract doc — held up as sound and is unchanged.
 
 ## Considered alternatives
 
@@ -80,3 +136,7 @@ sweep-on-write.
 from an agent process to a CLI subprocess it spawns, other than the session ID already
 established by ADR-3075-4. Adopting this would also silently break the R8 guarantee that a
 subagent's own CLI calls resolve against the same control set as its MCP calls.
+
+**One SQLite file per session** (restores write isolation between sessions): rejected in favor
+of one global database — see "Known tradeoff" above. The isolation this would restore was judged
+not worth losing the single-query cross-session TTL sweep that motivated the move to SQLite.

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -51,7 +51,7 @@ that cost to create what turns out to be an arbitrary boundary between sessions 
 environment for this purpose. Two different sessions running the identical command against
 identical content resolve to the same row on write. **This avoids duplicate storage, not
 duplicate work** — every full request still runs Collection and Generation unconditionally (see
-"Every backend hit always writes a fresh document" below); `content_id` isn't even knowable until
+"Every source hit always writes a fresh document" below); `content_id` isn't even knowable until
 that work has already happened, since it's a hash of the *generated* output, so there is nothing
 to check in advance that would let a repeat request skip the fetch. The benefit of dropping
 `session_id` from the key is narrower than originally claimed here: two callers producing
@@ -185,7 +185,7 @@ eviction is a periodic pass rather than inline on every write — the expensive 
 deleting down to target) runs at most hourly-to-daily, rate-limited by the stored
 `last_cleanup_at` check, not per-write. What remains on the write/read path is just the cheap
 parts: an insert of new content, and a single-row `last_accessed_at` update on read. Second,
-every backend hit always writes regardless of key design (see "Every backend hit always writes a
+every source hit always writes regardless of key design (see "Every source hit always writes a
 fresh document" above), so dropping `session_id` from the key does not reduce write *count* —
 identical requests from different callers still each write. What it reduces is storage: those
 writes upsert one shared row instead of each caller permanently holding its own duplicate, so the

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -65,7 +65,8 @@ docs do not analyze WAL/writer-serialization behavior, so it is precedent for "S
 established storage choice here," not for the contention trade-off named below. Rows are keyed
 by `content_id` alone. Each row stores the generated content (raw, not a parsed tree — see
 "Re-parsing on follow-up pages" below), its hash, the canonicalized generating command, the
-request's `source` (see schema note below), `created_at`, and `last_accessed_at`.
+request's `source` (see schema note below), a `stale` marker (see schema note below), `created_at`,
+and `last_accessed_at`.
 
 **Re-parsing on follow-up pages is allowed, confirmed by the repo owner — this clarifies R8, not
 this ADR's schema.** The contract's R8 states a later page "does not re-parse." Taken literally,
@@ -131,6 +132,23 @@ every entry." The schema in this ADR's first draft omitted this — `source` was
 by parsing the stored canonicalized command per row, exactly the full-table scan ADR-3075-2 said
 to avoid. Corrected: `source` is its own column, indexed, populated at write time alongside the
 canonicalized command it's extracted from.
+
+**Schema must include a `stale` marker, not rely on deletion for invalidation.** ADR-3075-2's
+write-triggered invalidation must mark an entry stale without destroying its stored command —
+deleting the row on invalidation would remove the only thing a subsequent stale-identifier
+request can use to auto-regenerate (the request carries only the old `content_id`, not the
+original scope, per R8). Corrected: invalidation sets a `stale` boolean on the row rather than
+deleting it. A stale-identifier read finds the row, sees `stale=true`, re-runs its stored command
+to regenerate under a new identity, and only then does the old row get replaced — not before.
+
+**The 40MB target counts complete row storage, not raw content bytes alone.** As originally
+written, the budget summed only the `content` column, which undercounts real storage: every row
+also carries its canonicalized command, `source`, timestamps, and the `stale` marker, plus
+whatever indexes cover them. A workload of many small or empty generated documents could add
+rows without ever moving the "content" total, growing the database unboundedly while never
+tripping eviction — the opposite of what a bounded-storage design is for. Corrected: the budget
+is measured against total row storage (every column, not content alone), so row count itself is
+implicitly bounded even when individual documents are tiny.
 
 ## Known tradeoff — global write contention (confirmed accepted, not silently assumed)
 

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -1,0 +1,82 @@
+# ADR-3082-1: The control set is one SQLite database with bounded, session-scoped LRU eviction
+
+**Status:** Accepted
+**Date:** 2026-08-20
+**Issue:** [#3082](https://github.com/Jamie-BitFlight/claude_skills/issues/3082), partially
+mitigates [#3081](https://github.com/Jamie-BitFlight/claude_skills/issues/3081)
+**Related:** Supersedes the storage-mechanism detail of
+[ADR-3075-4](./ADR-3075-4-out-of-process-session-keyed-control-set.md) — "a directory at
+`$DH_STATE_HOME/sessions/{CLAUDE_CODE_SESSION_ID}/`" — while keeping that ADR's higher-level
+decision (out-of-process, session-keyed, not in-process) unchanged. Confirmed by the repo owner.
+
+## Context
+
+ADR-3075-4 named two gaps it did not solve: no cleanup/TTL for session directories (#3082) and
+no locking scheme for concurrent writers sharing one session ID (#3081). Both trace back to the
+same root cause: a directory of loose files, one per session, has no way to bound its own growth
+or age itself out safely, and a hand-rolled multi-file read-modify-write has no atomicity
+guarantee against a concurrent writer.
+
+A second, previously unstated constraint sharpens the requirement: the CLI is not a running
+service. Unlike the MCP server, which holds process lifetime across many tool calls, the CLI is a
+fresh OS process per invocation with no memory of any prior call. It cannot hold state itself
+between invocations under any design — external storage is required regardless of session
+identity, purely because the CLI has nothing else to remember with.
+
+## Decision
+
+**One SQLite database**, not a directory of files, at a fixed path
+(`$DH_STATE_HOME/control-set.db`), WAL mode — consistent with this repo's existing `sqlite`
+backend convention (`docs/backend-providers.md`). Rows are keyed by `(session_id, content_id)`,
+where `content_id` is the command+content-bound identity from ADR-3075-1. Each row stores the
+generated content, its hash, the canonicalized generating command, `created_at`, and
+`last_accessed_at`.
+
+**Bounded per-session eviction:** each `session_id` may hold at most N entries (default 10,
+tunable). On insert past the cap, the least-recently-accessed entry for that session is deleted
+first. Confirmed by the repo owner: an agent-level keying granularity (one stack per subagent,
+not per session) was considered and rejected — there is no identifier that reliably survives a
+subagent spawning its own CLI subprocess, so session remains the practical and only reliably
+propagatable key.
+
+**Age-based cross-session sweep:** on every write (from any session), rows whose
+`last_accessed_at` is older than a configurable TTL (default 24h) are deleted, regardless of
+which session they belong to. This satisfies #3082's second acceptance criterion directly — the
+sweep runs opportunistically on the next write from *any* session, so it does not depend on the
+originating session exiting cleanly. A crashed or killed session's rows still age out the next
+time anything touches the database.
+
+**Eviction is not an error.** When an agent references a `content_id` that has since been
+evicted (by cap or by TTL), the response states plainly that the content is no longer cached and
+must be requested again — not a generic error, not a silent empty result.
+
+## Consequences
+
+- `#3082`'s two acceptance criteria are both satisfied: entries never accumulate unboundedly
+  (bounded per-session cap), and cleanup does not depend on clean exit (opportunistic TTL sweep).
+- `#3081`'s concurrent-writer hazard is partially mitigated, not solved: SQLite's WAL mode makes
+  each individual statement atomic and safe under concurrent access from multiple OS processes,
+  which a hand-rolled multi-file read-modify-write was not. It does **not** by itself make the
+  full "check cap, evict, insert" sequence atomic across concurrent writers — that still requires
+  wrapping the sequence in an explicit transaction, which is an implementation detail deferred to
+  #3081, not decided here.
+- Implementation must add a session-keyed table to `$DH_STATE_HOME`, distinct from any per-plugin
+  provider database (e.g. the `sqlite` backend's 6-table schema) — this is Navigation-layer
+  cache state, not work-item state, and must not be added to that schema.
+
+## Considered alternatives
+
+**One file per session, bounded by count** (keep ADR-3075-4's directory shape, just cap and
+LRU-evict files within it): rejected — solves #3082's growth bound within an active session but
+not its cross-session accumulation requirement (many capped-but-permanent session directories
+still accumulate forever without an age-based sweep, and a directory of files has no efficient
+way to run that sweep without listing and stat-ing every session directory on every write).
+
+**Cleanup-on-session-exit hook**: rejected — #3082 explicitly requires cleanup not to depend on
+clean exit (crashes, kills, abrupt termination). A hook is not a substitute for opportunistic
+sweep-on-write.
+
+**Per-subagent keying** (finer than per-session): rejected — no identifier reliably propagates
+from an agent process to a CLI subprocess it spawns, other than the session ID already
+established by ADR-3075-4. Adopting this would also silently break the R8 guarantee that a
+subagent's own CLI calls resolve against the same control set as its MCP calls.

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -48,7 +48,16 @@ command, the request's `source` (see schema note below), `created_at`, and `last
 `session_id` may hold at most **40MB** of total content (tunable), not a fixed entry count. On a
 write that would push a session over that budget, entries for that session are evicted
 least-recently-accessed first (**LRU, confirmed by the repo owner**) until the write fits.
-Reading an entry updates its `last_accessed_at` — see "Known tradeoff" below for what this costs.
+
+**The goal, confirmed by the repo owner: avoid evicting an entry an agent is actively navigating
+within.** LRU achieves this structurally, not just incidentally: reading an entry (any page or
+address request against it) updates its `last_accessed_at`, so an entry under active navigation
+is by construction the most-recently-touched one in its session and is always evicted last under
+budget pressure. This is a best-effort property, not a guarantee — a paused multi-page read
+(fetch page 1, long gap, fetch page 2) can still lose to a burst of new content in the same
+session during the gap. Confirmed by the repo owner: that residual case is acceptable — the
+"eviction is not an error" fallback below means the agent just re-queries, which is a nice-to-avoid
+cost, not a correctness problem. See "Known tradeoff" below for what read-triggered writes cost.
 
 Confirmed by the repo owner: an agent-level keying granularity (one store per subagent, not per
 session) was considered and rejected — there is no identifier that reliably survives a subagent

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -81,14 +81,25 @@ follow-up calls, not to avoiding Collection and Generation across separate top-l
 
 ## Decision
 
-**One SQLite database**, not a directory of files, at a fixed path
-(`$DH_STATE_HOME/control-set.db`), WAL mode — consistent with this repo's existing `sqlite`
-backend convention (`docs/backend-providers.md`) for the choice of engine; that backend's own
-docs do not analyze WAL/writer-serialization behavior, so it is precedent for "SQLite is an
-established storage choice here," not for the contention trade-off named below. Rows are keyed
-by `content_id` alone. Each row stores the generated content (raw, not a parsed tree — see
-"Re-parsing on follow-up pages" below), its hash, the canonicalized generating command, the
-request's `source` (see schema note below), a `stale` marker (see schema note below), `created_at`,
+**One SQLite database**, not a directory of files, at `state_root()/control-set.db` — the
+existing per-project state directory (`dh_paths.py`'s `state_root()`, `~/.dh/projects/{slug}/`
+or `$DH_STATE_HOME/projects/{slug}/` under an override), not a bare `$DH_STATE_HOME`. Every
+other state artifact this repo persists (`backlog/`, `plan/`, `milestones/`, `context/`,
+`reports/`) already nests under `state_root()`; a machine-global path was a review-caught
+mistake in this ADR's first draft — under a shared `$DH_STATE_HOME`, two different repositories
+running the harness could produce the same canonicalized command against unrelated content and
+collide on the same `content_id` row. One database per project makes that collision structurally
+impossible, at zero cost: nothing about the control set's global-not-session-scoped design
+(above) requires sharing storage *across* projects, only across sessions and tools *within* one.
+WAL mode — consistent with this repo's existing `sqlite` backend convention
+(`docs/backend-providers.md`) for the choice of engine; that backend's own docs do not analyze
+WAL/writer-serialization behavior, so it is precedent for "SQLite is an established storage
+choice here," not for the contention trade-off named below. Rows are keyed by `content_id`
+alone — `content_id` does not need to also encode project or backend identity, since one
+database per project already provides that boundary. Each row stores the generated content
+(raw, not a parsed tree — see "Re-parsing on follow-up pages" below), its hash, the
+canonicalized generating command, the request's `source` (see schema note below), a `stale`
+marker (see schema note below), `created_at`,
 and `last_accessed_at`.
 
 **Re-parsing on follow-up pages is allowed, confirmed by the repo owner — this clarifies R8, not
@@ -125,6 +136,18 @@ on clean exit) is actually satisfied by: the check runs opportunistically off of
 any caller, so a crashed or killed process's rows still get swept the next time anything touches
 the database and the cadence has elapsed — just not synchronously with that caller's own
 activity.
+
+**Cleanup must reclaim pages, not just delete rows.** SQLite's default `auto_vacuum = NONE`
+moves a deleted row's pages onto an internal freelist for reuse by future writes — it does not
+shrink the file on disk. Without an explicit reclaim step, the 40MB target bounds *live* row
+storage but not `control-set.db`'s file size, which only grows: a write burst or an oversized
+entry (below) can push the file to a peak that later trimming never gives back. The database is
+created with `PRAGMA auto_vacuum = INCREMENTAL`, and each periodic cleanup pass ends by running
+`PRAGMA incremental_vacuum` to return freed pages to the filesystem. Incremental vacuum was
+chosen over a full `VACUUM`: `VACUUM` rewrites the entire database file and requires an
+exclusive lock for its duration, which is disproportionate to a background maintenance pass on
+a cache running hourly-to-daily; incremental vacuum reclaims pages a chunk at a time without
+that exclusive rewrite.
 
 **The goal, confirmed by the repo owner: avoid evicting an entry an agent is actively navigating
 within.** LRU achieves this structurally, not just incidentally: reading an entry (any page or

--- a/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
+++ b/plugins/development-harness/docs/adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md
@@ -1,14 +1,16 @@
-# ADR-3082-1: The control set is one SQLite database with bounded, session-scoped LRU eviction
+# ADR-3082-1: The control set is one SQLite database, content-keyed, with periodic global eviction
 
 **Status:** Accepted
 **Date:** 2026-08-20
 **Issue:** [#3082](https://github.com/Jamie-BitFlight/claude_skills/issues/3082), partially
 mitigates [#3081](https://github.com/Jamie-BitFlight/claude_skills/issues/3081)
-**Related:** Supersedes the storage-mechanism detail of
-[ADR-3075-4](./ADR-3075-4-out-of-process-session-keyed-control-set.md) — "a directory at
-`$DH_STATE_HOME/sessions/{CLAUDE_CODE_SESSION_ID}/`" — while keeping that ADR's higher-level
-decision (out-of-process, session-keyed, not in-process) unchanged. Reviewed independently after
-first being written — see "Independent review" below for what that pass changed.
+**Related:** Supersedes [ADR-3075-4](./ADR-3075-4-out-of-process-session-keyed-control-set.md)
+on two points, not one: the storage mechanism (a directory of files → one SQLite database, as
+first decided here) **and, in a later revision of this same ADR, the session-keying decision
+itself** (see "Reversal: content-keyed, not session-keyed" below). ADR-3075-4's remaining
+decision — out-of-process, not an in-process cache — is unchanged. Reviewed independently after
+first being written — see "Independent review" for what that pass changed, before the
+session-keying reversal below.
 
 ## Context
 
@@ -29,9 +31,30 @@ disposable, regenerable cache — Collection and Generation can rebuild any entr
 demand. Losing the entire database (corruption, deletion, disk issue, a bad migration) causes no
 data loss, only a cold cache: the next request simply regenerates and repopulates it. This
 governs the rest of this ADR — no backup, no migration path, and no corruption-recovery
-procedure are needed beyond "delete the file and let it recreate itself." It's also why the
-cross-session write-contention trade-off below is acceptable at low stakes: contention costs
-latency, never correctness or data loss.
+procedure are needed beyond "delete the file and let it recreate itself."
+
+## Reversal: content-keyed, not session-keyed
+
+This ADR originally kept `session_id` as part of the primary key, reasoning that the repo
+owner's earlier statement — "I don't want the cache values to be shared between agents or
+sessions" — was a standing isolation requirement. **Corrected, confirmed by the repo owner:**
+that statement was a reaction to a specific proposal being presented as a default, not a general
+principle requiring `session_id` to be threaded through the design. Adding `session_id` means
+obtaining a value that is genuinely hard to get reliably — it requires a Claude-Code-specific
+hook (`session-start-session-id.cjs`) with no equivalent under other harnesses this repo's
+content targets (Codex, OpenCode, GitHub's coding agent — see #3085), and, even within Claude
+Code, means adding a parameter to `backlog_view`/`artifact_read` that doesn't exist today. Paying
+that cost to create what turns out to be an arbitrary boundary between sessions is not justified.
+
+**The key is `content_id` alone** — the command+content-bound identity from ADR-3075-1. No
+`session_id`, anywhere: not in the schema, not as an MCP tool parameter, not read from the CLI's
+environment for this purpose. Two different sessions running the identical command against
+identical content resolve to the same row and share it — this is now a deliberate feature, not
+an accident to guard against: it avoids duplicate storage and duplicate Collection+Generation
+work for the same request made twice. `backlog_view` and `artifact_read` need **no**
+session-identifying parameter added to their signatures for control-set purposes — the entire
+prerequisite ADR-3075-4 stated in its Consequences section (adding a `gate_token`-style or
+`session_id`-style parameter) is void for this reason, not merely revised.
 
 ## Decision
 
@@ -40,18 +63,9 @@ latency, never correctness or data loss.
 backend convention (`docs/backend-providers.md`) for the choice of engine; that backend's own
 docs do not analyze WAL/writer-serialization behavior, so it is precedent for "SQLite is an
 established storage choice here," not for the contention trade-off named below. Rows are keyed
-by `(session_id, content_id)`, where `content_id` is the command+content-bound identity from
-ADR-3075-1. Each row stores the generated content (raw, not a parsed tree — see "Re-parsing on
-follow-up pages" below), its hash, the canonicalized generating command, the request's `source`
-(see schema note below), `created_at`, and `last_accessed_at`.
-
-**`session_id` stays in the key, confirmed by the repo owner.** Without it, `content_id` alone
-would let two different sessions running the identical command against identical content share
-one row — mechanically fine, but it reverses an earlier, explicit requirement: "I don't want the
-cache values to be shared between agents or sessions." `session_id` in the key is what enforces
-that isolation, and is also what makes the per-session size target and per-session LRU ordering
-meaningful — without it, both would have to become global, and one agent's unrelated work could
-evict another's.
+by `content_id` alone. Each row stores the generated content (raw, not a parsed tree — see
+"Re-parsing on follow-up pages" below), its hash, the canonicalized generating command, the
+request's `source` (see schema note below), `created_at`, and `last_accessed_at`.
 
 **Re-parsing on follow-up pages is allowed, confirmed by the repo owner — this clarifies R8, not
 this ADR's schema.** The contract's R8 states a later page "does not re-parse." Taken literally,
@@ -66,50 +80,46 @@ expected to happen routinely. The schema therefore stores raw generated content 
 parsed tree — see `docs/agent-markdown-consumption-contract.md`'s R8 section for the corrected
 wording.
 
-**Bounded per-session storage, by size not count — a soft target, not a hard per-write limit.**
-Confirmed by the repo owner: each `session_id` targets at most **40MB** of total content
-(tunable). This is not enforced synchronously on every write — its only purpose is that stored
-content doesn't grow continuously and unboundedly, not to guarantee the budget is never exceeded
-at any instant. Trimming happens during periodic cleanup (below), not inline on the write path.
+**Bounded global storage, by size not count — a soft target, not a hard per-write limit.**
+Confirmed by the repo owner: the whole database targets at most **40MB** of total content
+(tunable) — global now that there is no session dimension to partition it by. This is not
+enforced synchronously on every write — its only purpose is that stored content doesn't grow
+continuously and unboundedly, not to guarantee the budget is never exceeded at any instant.
+Trimming happens during periodic cleanup (below), not inline on the write path.
 
 **Periodic cleanup, not per-write eviction — confirmed by the repo owner.** A single maintenance
-pass does both jobs together: (1) delete rows whose `last_accessed_at` is older than a TTL,
-regardless of session, and (2) for any session over its 40MB target, delete
-least-recently-accessed rows for that session down to target (**LRU, confirmed by the repo
-owner**). This pass runs on a rate-limited cadence — **hourly to daily, confirmed by the repo
-owner as the target frequency; the exact value is an unsourced starting default, not a confirmed
-number, and should be revisited under real usage** — not synchronously on every write or every
-query. Mechanically: a single stored `last_cleanup_at` timestamp is checked cheaply (one row
-read) on write; the maintenance pass itself (the expensive scan-and-delete work) only executes
-when enough time has elapsed since the last run, otherwise the check is a no-op. This is what
-`#3082`'s second acceptance criterion (cleanup not dependent on clean exit) is actually satisfied
-by: the check runs opportunistically off of any session's write, so a crashed or killed session's
-rows still get swept the next time anything touches the database and the cadence has elapsed —
-just not synchronously with that session's own activity.
+pass does both jobs together: (1) delete rows whose `last_accessed_at` is older than a TTL, and
+(2) if the database is over its 40MB target, delete least-recently-accessed rows down to target
+(**LRU, confirmed by the repo owner**). This pass runs on a rate-limited cadence — **hourly to
+daily, confirmed by the repo owner as the target frequency; the exact value is an unsourced
+starting default, not a confirmed number, and should be revisited under real usage** — not
+synchronously on every write or every query. Mechanically: a single stored `last_cleanup_at`
+timestamp is checked cheaply (one row read) on write; the maintenance pass itself (the expensive
+scan-and-delete work) only executes when enough time has elapsed since the last run, otherwise
+the check is a no-op. This is what `#3082`'s second acceptance criterion (cleanup not dependent
+on clean exit) is actually satisfied by: the check runs opportunistically off of any write from
+any caller, so a crashed or killed process's rows still get swept the next time anything touches
+the database and the cadence has elapsed — just not synchronously with that caller's own
+activity.
 
 **The goal, confirmed by the repo owner: avoid evicting an entry an agent is actively navigating
 within.** LRU achieves this structurally, not just incidentally: reading an entry (any page or
 address request against it) updates its `last_accessed_at` — a cheap, single-row write, separate
 from the periodic cleanup pass — so an entry under active navigation is by construction the
-most-recently-touched one in its session and is always trimmed last whenever cleanup does run.
-This is a best-effort property, not a guarantee — a paused multi-page read (fetch page 1, long
-gap, fetch page 2) can still lose to a cleanup pass landing during the gap. Confirmed by the repo
-owner: that residual case is acceptable — the "eviction is not an error" fallback below means the
-agent just re-queries, which is a nice-to-avoid cost, not a correctness problem.
-
-Confirmed by the repo owner: an agent-level keying granularity (one store per subagent, not per
-session) was considered and rejected — there is no identifier that reliably survives a subagent
-spawning its own CLI subprocess, so session remains the practical and only reliably propagatable
-key.
+most-recently-touched one and is always trimmed last whenever cleanup does run. This is a
+best-effort property, not a guarantee — a paused multi-page read (fetch page 1, long gap, fetch
+page 2) can still lose to a cleanup pass landing during the gap. Confirmed by the repo owner:
+that residual case is acceptable — the "eviction is not an error" fallback below means the agent
+just re-queries, which is a nice-to-avoid cost, not a correctness problem.
 
 **A single entry larger than the 40MB target is kept anyway, confirmed by the repo owner.**
 Collection and Generation are explicitly unbounded, so a single generated document can itself
-exceed the per-session target — trimming every other entry in that session still can't make it
-fit. Rather than reject the write or serve that document uncached (which would silently exempt
-the largest, most expensive-to-generate documents from R8's identity/staleness guarantees — the
-ones that benefit from caching the most), the write is allowed through as a documented exception:
-a session's effective budget is "40MB, or one entry's actual size if larger." The next cleanup
-pass still trims everything else in that session normally.
+exceed the target — trimming every other entry still can't make it fit. Rather than reject the
+write or serve that document uncached (which would silently exempt the largest, most
+expensive-to-generate documents from R8's identity/staleness guarantees — the ones that benefit
+from caching the most), the write is allowed through as a documented exception: the effective
+budget is "40MB, or one entry's actual size if larger." The next cleanup pass still trims
+everything else normally.
 
 **Eviction is not an error.** When an agent references a `content_id` that has since been
 evicted (by cleanup's size trim or TTL sweep), the response states plainly that the content is no
@@ -122,30 +132,28 @@ by parsing the stored canonicalized command per row, exactly the full-table scan
 to avoid. Corrected: `source` is its own column, indexed, populated at write time alongside the
 canonicalized command it's extracted from.
 
-## Known tradeoff — cross-session write contention (confirmed accepted, not silently assumed)
+## Known tradeoff — global write contention (confirmed accepted, not silently assumed)
 
-Moving from one file per session to one global database trades reduced write contention *within*
-a session for new write contention *across every session running on the machine*: SQLite WAL
-mode allows concurrent readers alongside one writer, but writers still serialize against each
-other process-wide, not just against other writers in the same session. Because LRU tracking
-requires bumping `last_accessed_at` on every read, a content read through this design is also a
-write transaction.
+One SQLite database means every write on the machine — from every session, every agent —
+serializes against every other write: SQLite WAL mode allows concurrent readers alongside one
+writer, but writers still serialize process-wide. Because LRU tracking requires bumping
+`last_accessed_at` on every read, a content read through this design is also a write transaction.
 
-**Substantially smaller than originally assessed, now that eviction is a periodic pass rather
-than inline on every write.** The expensive part — scanning a session's rows and deleting down to
-target — no longer runs per-write; it runs at most hourly-to-daily, rate-limited by the stored
-`last_cleanup_at` check. What remains on the write/read path is just the cheap parts: an insert
-of new content, and a single-row `last_accessed_at` update on read. **Confirmed by the repo
-owner: accepted as-is** at this reduced scope, against one SQLite file per session (which would
-restore write isolation but turn the periodic cross-session sweep into an open-and-check-every-
-file operation instead of one query, losing the reason SQLite was chosen). Revisit if contention
-is ever measured to matter in practice.
+**Substantially smaller than it would otherwise be, for two independent reasons.** First,
+eviction is a periodic pass rather than inline on every write — the expensive part (scanning and
+deleting down to target) runs at most hourly-to-daily, rate-limited by the stored
+`last_cleanup_at` check, not per-write. What remains on the write/read path is just the cheap
+parts: an insert of new content, and a single-row `last_accessed_at` update on read. Second,
+dropping `session_id` from the key (see "Reversal" above) means identical requests across
+different callers now share one row instead of writing duplicate ones — fewer total writes than
+the session-keyed design would have produced, not more. **Confirmed by the repo owner: accepted
+as-is** at this reduced scope. Revisit if contention is ever measured to matter in practice.
 
 ## Consequences
 
 - `#3082`'s two acceptance criteria are both satisfied: entries never accumulate unboundedly (the
-  40MB-per-session soft target, trimmed by periodic cleanup), and cleanup does not depend on clean
-  exit (the rate-limited cleanup check runs opportunistically off of any session's write).
+  40MB global soft target, trimmed by periodic cleanup), and cleanup does not depend on clean
+  exit (the rate-limited cleanup check runs opportunistically off of any write).
 - `#3081`'s concurrent-writer hazard is partially mitigated, not solved: SQLite's WAL mode makes
   each individual statement atomic and safe under concurrent access from multiple OS processes,
   which a hand-rolled multi-file read-modify-write was not. It does **not** by itself make the
@@ -155,37 +163,46 @@ is ever measured to matter in practice.
   concurrent sweep (a check-then-consume sequence spanning two statements, with an eviction
   landing in between) — not a new hazard, the same class already deferred to #3081, just also
   present on the read side once LRU makes reads into writes.
-- Implementation must add a session-keyed table to `$DH_STATE_HOME`, distinct from any per-plugin
-  provider database (e.g. the `sqlite` backend's 6-table schema) — this is Navigation-layer
-  cache state, not work-item state, and must not be added to that schema.
+- Implementation must add a table to `$DH_STATE_HOME`, distinct from any per-plugin provider
+  database (e.g. the `sqlite` backend's 6-table schema) — this is Navigation-layer cache state,
+  not work-item state, and must not be added to that schema.
+- [#3085](https://github.com/Jamie-BitFlight/claude_skills/issues/3085) ("harness-neutral
+  session-ID resolver for the session-keyed control set") was filed against this ADR's earlier,
+  session-keyed revision. Its premise no longer applies to the control set specifically — flagged
+  for the repo owner to close or repurpose, not closed here, since `session_id` may still matter
+  to something else in the codebase independent of this ADR.
 
 ## Independent review
 
 This ADR was reviewed by an independent agent with no involvement in writing it, specifically to
-avoid the author checking its own work. It found the cross-session write-contention trade-off
-above unnamed, the eviction order (LRU) and defaults (cap, TTL) asserted without attributed
-confirmation, and the `source` index requirement from ADR-3075-2 silently dropped. All four are
-addressed above. Everything else it checked — `content_id`'s definition against ADR-3075-1, both
-of #3082's acceptance criteria, the "partially mitigates #3081" framing, and consistency with
-`CONTEXT.md`/the contract doc — held up as sound and is unchanged.
+avoid the author checking its own work, **before the session-keying reversal above**. It found
+the write-contention trade-off unnamed, the eviction order (LRU) and defaults (cap, TTL) asserted
+without attributed confirmation, and the `source` index requirement from ADR-3075-2 silently
+dropped. All four were addressed in the revision that review produced. Everything else it
+checked — `content_id`'s definition against ADR-3075-1, both of #3082's acceptance criteria, the
+"partially mitigates #3081" framing, and consistency with `CONTEXT.md`/the contract doc — held up
+as sound at the time. The session-keying reversal happened in a later round, directed by the repo
+owner, after that review; it has not had an independent pass of its own.
 
 ## Considered alternatives
 
+**Session-keyed control set** (this ADR's own original decision, and ADR-3075-4's): superseded —
+see "Reversal" above. Not rejected for being unworkable; rejected because the isolation it bought
+was never actually required, and the cost of obtaining `session_id` reliably (a
+Claude-Code-specific mechanism, per #3085) wasn't worth paying for a boundary nobody needed.
+
 **One file per session, bounded by count** (keep ADR-3075-4's directory shape, just cap and
-LRU-evict files within it): rejected — solves #3082's growth bound within an active session but
-not its cross-session accumulation requirement (many capped-but-permanent session directories
-still accumulate forever without an age-based sweep, and a directory of files has no efficient
-way to run that sweep without listing and stat-ing every session directory on every write).
+LRU-evict files within it): rejected even before the session-keying reversal — solves #3082's
+growth bound within an active session but not its cross-session accumulation requirement (many
+capped-but-permanent session directories still accumulate forever without an age-based sweep, and
+a directory of files has no efficient way to run that sweep without listing and stat-ing every
+session directory on every write). Moot now that there is no per-session storage unit at all.
 
 **Cleanup-on-session-exit hook**: rejected — #3082 explicitly requires cleanup not to depend on
-clean exit (crashes, kills, abrupt termination). A hook is not a substitute for opportunistic
-sweep-on-write.
+clean exit (crashes, kills, abrupt termination). A hook is not a substitute for opportunistic,
+rate-limited sweep-on-write.
 
-**Per-subagent keying** (finer than per-session): rejected — no identifier reliably propagates
-from an agent process to a CLI subprocess it spawns, other than the session ID already
-established by ADR-3075-4. Adopting this would also silently break the R8 guarantee that a
-subagent's own CLI calls resolve against the same control set as its MCP calls.
-
-**One SQLite file per session** (restores write isolation between sessions): rejected in favor
-of one global database — see "Known tradeoff" above. The isolation this would restore was judged
-not worth losing the single-query cross-session TTL sweep that motivated the move to SQLite.
+**Per-subagent keying** (finer than per-session): considered and rejected before the session-
+keying reversal, for the same underlying reason the reversal itself later applied at the session
+level — no identifier reliably propagates from an agent process to a CLI subprocess it spawns.
+Moot now that there is no session or subagent dimension in the key at all.

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -149,16 +149,22 @@ A response that paginates returns a stable identifier derived from the content i
 alongside the page position. Subsequent pages are requested with that identifier plus a page
 selector or an address, never by re-describing the source. The original scope or query is not
 repeated on follow-up calls — it is retained server-side as the entry's stored command (see
-below), not something the caller carries forward. Concretely, an initial request states scope
-(`selector="#2529", section="RT-ICA"` or similar); every request after that states only
-`hash="<identifier>"` plus `page`, `navigate` (R4's address), `pagesize` (the caller override
-from R2), and — on transports where the control set is out-of-process (ADR-3075-4) — a
-session-identifying value the request needs to locate its session's store: a plain, non-rotating
-`session_id` parameter carrying `CLAUDE_CODE_SESSION_ID`'s value directly for MCP tools, per
-ADR-3075-4's Consequences, since `backlog_view` and `artifact_read` have no in-process session
-identity to read from `ctx` — not a `gate_token`-style parameter, which rotates on every skill
-load and cannot serve as a stable session key; the CLI instead reads `CLAUDE_CODE_SESSION_ID`
-directly and needs no such parameter.
+below), not something the caller carries forward.
+
+On transports where the control set is out-of-process (ADR-3075-4), every request — including
+the initial one — carries a session-identifying value the request needs to locate its session's
+store: a plain, non-rotating `session_id` parameter carrying `CLAUDE_CODE_SESSION_ID`'s value
+directly for MCP tools, per ADR-3075-4's Consequences, since `backlog_view` and `artifact_read`
+have no in-process session identity to read from `ctx` — not a `gate_token`-style parameter,
+which rotates on every skill load and cannot serve as a stable session key; the CLI instead reads
+`CLAUDE_CODE_SESSION_ID` directly and needs no such parameter. The initial write into the control
+set happens on the first call, not the second — the row cannot be keyed by `(session_id,
+content_id)` without `session_id` at that point, so this is not optional on follow-ups only.
+
+Concretely, an initial request states scope (`selector="#2529", section="RT-ICA"` or similar)
+plus `session_id` on MCP transports; every request after that states only `hash="<identifier>"`
+plus `page`, `navigate` (R4's address), `pagesize` (the caller override from R2), and
+`session_id` again.
 
 This hash-plus-session-routing shape states intended behaviour, not current behaviour: the
 control set it depends on (ADR-3075-1 through ADR-3075-4) is not yet implemented, and

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -51,7 +51,7 @@ and the table of contents built from them, exist only after Navigation parses th
 document and builds its addressable tree. Collection and Generation are unbounded — never
 truncated, never budget-checked. The engine's authority is over Navigation only: it receives a
 complete generated document,
-gives it a content identity (R8), caches it for the session, and is the only point anywhere in
+gives it a content identity (R8), caches it globally (ADR-3082-1), and is the only point anywhere in
 the path where a size budget is applied. "Unbounded" is a real cost for a pathological source,
 not a theoretical one — see ADR-3072-1's known limitation for a concrete measurement and why
 this decision does not add a ceiling to fix it.
@@ -154,9 +154,11 @@ below), not something the caller carries forward.
 The control set (ADR-3075-4, ADR-3082-1) is out-of-process and content-keyed only — no
 session-identifying value is part of any request. Concretely, an initial request states scope
 (`selector="#2529", section="RT-ICA"` or similar); every request after that states only
-`hash="<identifier>"` plus `page`, `navigate` (R4's address), and `pagesize` (the caller override
-from R2). Nothing about locating the control set depends on which session, tool, or transport
-made the request — `content_id` alone addresses the row.
+`hash="<identifier>"` plus `page`, `navigate` (R4's address), `pagesize` (the caller override
+from R2), and an optional `refresh` selector — one of `revalidate` or `force` (ADR-3075-3) —
+absent by default, meaning "serve whatever the control set already holds." Nothing about locating
+the control set depends on which session, tool, or transport made the request — `content_id`
+alone addresses the row.
 
 This hash-based shape states intended behaviour, not current behaviour: the
 control set it depends on (ADR-3075-1 through ADR-3075-4) is not yet implemented, and

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -202,20 +202,24 @@ same binding, different identifiers. The cache backing this is held for the dura
 requesting session only; it is not persisted across sessions (ADR-3075-1).
 
 **One shared control set for the whole session — out-of-process, not an in-process cache**
-(ADR-3075-4). The control set is a single store for the whole session, not reinstantiated per
-operation, per subcommand, or per transport — but it cannot be an in-process cache (a
-server-held dict, an MCP lifespan context) and satisfy that, because the CLI is a separate OS
-process per invocation with no shared memory to an MCP server process, by construction, no
-matter how the MCP side is wired. The store is out-of-process, keyed by session — the same
-pattern already used by `get-gate-token.mjs`, which persists to
-`$DH_STATE_HOME/sessions/{CLAUDE_CODE_SESSION_ID}/` (default `~/.dh/sessions/...`) using the
-session-ID environment variable both MCP-tool-calling agents and CLI invocations already share.
-An item viewed through one MCP tool and then again through a different tool, or through the
-CLI, still hits the same entry if the request scope and content identity match — because both
-sides read and write the same session-keyed store on disk, not because either holds the other
-in memory. A cache scoped to one process is a violation of R1 (a second, narrower
-implementation of what the engine already owns), not a smaller version of a correct
-implementation.
+(ADR-3075-4, storage mechanism per ADR-3082-1). The control set is a single store for the whole
+session, not reinstantiated per operation, per subcommand, or per transport — but it cannot be
+an in-process cache (a server-held dict, an MCP lifespan context) and satisfy that, because the
+CLI is not a running service: it is a separate OS process per invocation with no memory of any
+prior call and no shared memory to an MCP server process, by construction, no matter how the MCP
+side is wired. The store is one out-of-process SQLite database at
+`$DH_STATE_HOME/control-set.db` (WAL mode), rows keyed by `(session_id, content_id)` using the
+session-ID environment variable both MCP-tool-calling agents and CLI invocations already share —
+bounded per session (LRU eviction past a tunable cap) with an opportunistic cross-session
+age-based sweep on every write, so entries never accumulate unboundedly and cleanup does not
+depend on any session exiting cleanly. An item viewed through one MCP tool and then again
+through a different tool, or through the CLI, still hits the same entry if the request scope and
+content identity match and the entry has not since been evicted — because both sides read and
+write the same session-keyed rows, not because either holds the other in memory. If the entry
+has been evicted, the response states plainly that the content must be requested again, not a
+generic error or silent empty result. A cache scoped to one process is a violation of R1 (a
+second, narrower implementation of what the engine already owns), not a smaller version of a
+correct implementation.
 
 **Stale entries are recoverable, not dead ends** (ADR-3075-2). A control-set entry retains the
 command that produced it — the source, scope, and parameters Collection and Generation used to

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -66,6 +66,13 @@ to the page it renders, indifferent to whether the page came from `file://` or `
 every source implements `get_markdown(source) -> str`, and nothing past that seam is
 source-specific.
 
+The control set (ADR-3082-1) extends this analogy: it is that browser's local cache, not a
+shared server-side one. It serves an already-fetched page back to the same browsing activity
+without hitting the network again — that's what makes a follow-up page request cheap — but it
+isn't there to save a *different* tab, a *different* session, or a repeat visit later from
+re-fetching. Navigation is the frontend the agent talks to; the control set is what that
+frontend caches locally while the agent is looking at one thing.
+
 ### R2 — Everything paginates, including the table of contents
 
 Every response that can exceed the window budget paginates. This applies recursively and

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -46,7 +46,9 @@ scope: description, table of contents, every requested section or artifact), and
 (this engine). Collection and Generation are unbounded — never truncated, never budget-checked.
 The engine's authority is over Navigation only: it receives a complete generated document,
 gives it a content identity (R8), caches it for the session, and is the only point anywhere in
-the path where a size budget is applied.
+the path where a size budget is applied. "Unbounded" is a real cost for a pathological source,
+not a theoretical one — see ADR-3072-1's known limitation for a concrete measurement and why
+this decision does not add a ceiling to fix it.
 
 **Navigation is source-agnostic.** It has no knowledge of, and no need to know, what kind of
 thing it is windowing — an issue, a PR, a plan, an artifact, a local file. It receives markdown
@@ -142,7 +144,12 @@ re-collect from the provider and does not re-parse.
 
 A request whose identifier no longer matches current content is reported as stale. Pages
 from two different versions of a document are never returned as though they were one
-document.
+document. **This is not a contradiction of "does not re-collect" above** (flagged in review —
+worth stating plainly): staleness is detected by write-triggered invalidation (below), a side
+effect of the write that changed the source, not by the read path re-collecting to compare.
+The one path that does re-collect on a read is explicit, caller-requested revalidation — an
+opt-in exception the caller chooses, never something the server does silently on an ordinary
+page request.
 
 The identifier is a hash of the Generation stage's output for the request's specific scope —
 not a hash of the raw upstream source alone (ADR-3075-1). Two different scopes of the same
@@ -150,13 +157,20 @@ source (the whole item vs. one filtered section) produce different generated doc
 must not collide on one identifier. The cache backing this is held for the duration of the
 requesting session only; it is not persisted across sessions (ADR-3075-1).
 
-**One shared cache, not one per tool.** The cache is a single control set for the whole
-session — not reinstantiated per operation, per subcommand, or per transport. Every operation
-bound by this contract (Scope) that touches the same generated content within one session
-resolves against the same cache entry. An item viewed through one MCP tool and then again
-through a different tool, or through the CLI, still hits the same entry if the request scope
-and content identity match. A cache scoped to one tool call is a violation of R1 (a second,
-narrower implementation of what the engine already owns), not a smaller version of a correct
+**One shared control set for the whole session — out-of-process, not an in-process cache**
+(ADR-3075-4). The control set is a single store for the whole session, not reinstantiated per
+operation, per subcommand, or per transport — but it cannot be an in-process cache (a
+server-held dict, an MCP lifespan context) and satisfy that, because the CLI is a separate OS
+process per invocation with no shared memory to an MCP server process, by construction, no
+matter how the MCP side is wired. The store is out-of-process, keyed by session — the same
+pattern already used by `get-gate-token.mjs`, which persists to
+`$DH_STATE_HOME/sessions/{CLAUDE_CODE_SESSION_ID}/` (default `~/.dh/sessions/...`) using the
+session-ID environment variable both MCP-tool-calling agents and CLI invocations already share.
+An item viewed through one MCP tool and then again through a different tool, or through the
+CLI, still hits the same entry if the request scope and content identity match — because both
+sides read and write the same session-keyed store on disk, not because either holds the other
+in memory. A cache scoped to one process is a violation of R1 (a second, narrower
+implementation of what the engine already owns), not a smaller version of a correct
 implementation.
 
 **Stale entries are recoverable, not dead ends** (ADR-3075-2). A control-set entry retains the
@@ -219,11 +233,19 @@ flowchart TD
 
 The five questions previously open in this section (#3072–#3076) are resolved and folded into
 R1, R2, R6, and R8 above. The reasoning, rejected alternatives, and why each choice is hard to
-reverse are recorded in `docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md` and
-`docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md`, not restated here.
+reverse are recorded in ADRs, not restated here:
+[ADR-3072-1](./adrs/ADR-3072-1-budget-applies-only-at-navigation.md) (budget/layering),
+[ADR-3075-1](./adrs/ADR-3075-1-content-identity-and-cache-scope.md) (identity/scope),
+[ADR-3075-2](./adrs/ADR-3075-2-stale-cache-recovery-and-write-invalidation.md) (requery on
+stale, write invalidation),
+[ADR-3075-3](./adrs/ADR-3075-3-cache-metadata-visible-to-agent.md) (agent-visible cache
+metadata), and
+[ADR-3075-4](./adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md) (out-of-process,
+session-keyed store).
 
 Vocabulary introduced by these decisions — Collection, Generation, Navigation, Navigate, table
-of contents, budget — is defined once in `CONTEXT.md`, not duplicated in this contract.
+of contents, budget — is defined once in [`CONTEXT.md`](../CONTEXT.md), not duplicated in this
+contract.
 
 ## Implementation appendix — shape to code
 

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -37,6 +37,19 @@ No component may hand-build a table of contents, a section listing, a content ex
 bounded response of its own. Where such an implementation exists today it is deleted, not
 maintained in parallel. A second implementation is a defect regardless of whether it works.
 
+**Known gap, blocks deletion of the duplicate implementation until resolved.** Today's two
+engines address content differently: `backlog_core`'s `ordinal_mapper.py`/`disclosure_handler.py`
+accepts dot ordinals (`4.0.1`, `4.0.1.code.0`, validated by `_ORDINAL_PATTERN`), while
+`progressive_markdown`'s `indexer.py::_build_selector()` emits hierarchical selectors
+(`h2.1.2`) and `ProgressiveMarkdownNavigator.view_code()` addresses code blocks by ID
+(`code_0001`). Deleting the `ordinal_mapper` path as this requirement mandates, before
+reconciling these grammars, would mean agents can no longer copy an address from a table of
+contents into a follow-up retrieval request (R4) — the surviving engine wouldn't accept the
+addresses the deleted one taught callers to expect. This requirement does not resolve which
+grammar wins or how the reconciliation is built; it records the constraint so the deletion is
+sequenced correctly: the surviving engine must emit or accept the canonical ordinal grammar
+before, not after, `ordinal_mapper` is removed.
+
 Sources include, and are not limited to: issue and item bodies, plan documents, task
 documents, and the reports and artifacts produced during grooming.
 
@@ -225,7 +238,7 @@ but it cannot be an in-process cache (a server-held dict, an MCP lifespan contex
 that, because the CLI is not a running service: it is a separate OS process per invocation with
 no memory of any prior call and no shared memory to an MCP server process, by construction, no
 matter how the MCP side is wired. The store is one out-of-process SQLite database at
-`$DH_STATE_HOME/control-set.db` (WAL mode), rows keyed by `content_id` alone — no
+`state_root()/control-set.db` (per-project, WAL mode), rows keyed by `content_id` alone — no
 session-identifying value anywhere — bounded globally (LRU eviction past a tunable size target)
 with a periodic, rate-limited age-based cleanup pass (hourly to daily, not on every write), so
 entries never accumulate unboundedly and cleanup does not depend on any caller exiting cleanly.

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -151,8 +151,12 @@ selector or an address, never by re-describing the source. The original scope or
 repeated on follow-up calls — it is retained server-side as the entry's stored command (see
 below), not something the caller carries forward. Concretely, an initial request states scope
 (`selector="#2529", section="RT-ICA"` or similar); every request after that states only
-`hash="<identifier>"` plus `page`, `navigate` (R4's address), and `pagesize` (the caller
-override from R2) — nothing about where the content came from.
+`hash="<identifier>"` plus `page`, `navigate` (R4's address), `pagesize` (the caller override
+from R2), and — on transports where the control set is out-of-process (ADR-3075-4) — a
+session-identifying value the request needs to locate its session's store: a `gate_token`-style
+parameter for MCP tools, per ADR-3075-4's Consequences, since `backlog_view` and `artifact_read`
+have no in-process session identity to read from `ctx`; the CLI instead reads
+`CLAUDE_CODE_SESSION_ID` directly and needs no such parameter.
 
 The identifier resolves against cached parsed content. Serving a later page does not
 re-collect from the provider and does not re-parse.
@@ -241,7 +245,7 @@ instead of trusting whatever the control set already holds.
 flowchart TD
     Req([Agent requests content<br>from any source]) --> Coll[Collection: gather source content<br>unbounded — no budget check]
     Coll --> Gen["Generation: assemble the complete document<br>for the requested scope — description +<br>every requested section or artifact —<br>unbounded R1"]
-    Gen --> Nav[Navigation engine: parse, build<br>addressable tree and table of contents,<br>hash the generated document for<br>content identity R8]
+    Gen --> Nav[Navigation engine: parse, build<br>addressable tree and table of contents,<br>hash command + generated document<br>together for content identity R8]
     Nav --> Cache["Cache the generated document<br>for the session, keyed by that identity R8"]
     Cache --> Eng[Window the cached document<br>to the agent]
     Eng --> Measure{Response exceeds<br>window budget?<br>only checked here}

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -151,22 +151,14 @@ selector or an address, never by re-describing the source. The original scope or
 repeated on follow-up calls — it is retained server-side as the entry's stored command (see
 below), not something the caller carries forward.
 
-On transports where the control set is out-of-process (ADR-3075-4), every request — including
-the initial one — carries a session-identifying value the request needs to locate its session's
-store: a plain, non-rotating `session_id` parameter carrying `CLAUDE_CODE_SESSION_ID`'s value
-directly for MCP tools, per ADR-3075-4's Consequences, since `backlog_view` and `artifact_read`
-have no in-process session identity to read from `ctx` — not a `gate_token`-style parameter,
-which rotates on every skill load and cannot serve as a stable session key; the CLI instead reads
-`CLAUDE_CODE_SESSION_ID` directly and needs no such parameter. The initial write into the control
-set happens on the first call, not the second — the row cannot be keyed by `(session_id,
-content_id)` without `session_id` at that point, so this is not optional on follow-ups only.
+The control set (ADR-3075-4, ADR-3082-1) is out-of-process and content-keyed only — no
+session-identifying value is part of any request. Concretely, an initial request states scope
+(`selector="#2529", section="RT-ICA"` or similar); every request after that states only
+`hash="<identifier>"` plus `page`, `navigate` (R4's address), and `pagesize` (the caller override
+from R2). Nothing about locating the control set depends on which session, tool, or transport
+made the request — `content_id` alone addresses the row.
 
-Concretely, an initial request states scope (`selector="#2529", section="RT-ICA"` or similar)
-plus `session_id` on MCP transports; every request after that states only `hash="<identifier>"`
-plus `page`, `navigate` (R4's address), `pagesize` (the caller override from R2), and
-`session_id` again.
-
-This hash-plus-session-routing shape states intended behaviour, not current behaviour: the
+This hash-based shape states intended behaviour, not current behaviour: the
 control set it depends on (ADR-3075-1 through ADR-3075-4) is not yet implemented, and
 `backlog_view`'s current parameters carry no `hash` or session-routing field. [MCP
 Progressive-Disclosure Contract](./mcp-progressive-disclosure-contract.md) documents today's
@@ -211,26 +203,29 @@ then execute the wrong command entirely and return content unrelated to what the
 for. The identifier binds command and content together precisely so two different commands
 never collide even when their output happens to match. Two different scopes of the same source
 (the whole item vs. one filtered section) produce different generated documents and, by the
-same binding, different identifiers. The cache backing this is held for the duration of the
-requesting session only; it is not persisted across sessions (ADR-3075-1).
+same binding, different identifiers. The cache backing this has no fixed retention window tied
+to any session — see ADR-3082-1's "Reversal: content-keyed, not session-keyed", which corrects
+ADR-3075-1's original "session-scoped only" framing: entries age out by a global TTL and size
+budget, not by the requesting session ending, and an entry can outlive the session that created
+it or be read by a different session entirely.
 
-**One shared control set for the whole session — out-of-process, not an in-process cache**
-(ADR-3075-4, storage mechanism per ADR-3082-1). The control set is a single store for the whole
-session, not reinstantiated per operation, per subcommand, or per transport — but it cannot be
-an in-process cache (a server-held dict, an MCP lifespan context) and satisfy that, because the
-CLI is not a running service: it is a separate OS process per invocation with no memory of any
-prior call and no shared memory to an MCP server process, by construction, no matter how the MCP
-side is wired. The store is one out-of-process SQLite database at
-`$DH_STATE_HOME/control-set.db` (WAL mode), rows keyed by `(session_id, content_id)` using the
-session-ID environment variable both MCP-tool-calling agents and CLI invocations already share —
-bounded per session (LRU eviction past a tunable cap) with an opportunistic cross-session
-age-based sweep on every write, so entries never accumulate unboundedly and cleanup does not
-depend on any session exiting cleanly. An item viewed through one MCP tool and then again
-through a different tool, or through the CLI, still hits the same entry if the request scope and
-content identity match and the entry has not since been evicted — because both sides read and
-write the same session-keyed rows, not because either holds the other in memory. If the entry
-has been evicted, the response states plainly that the content must be requested again, not a
-generic error or silent empty result. A cache scoped to one process is a violation of R1 (a
+**One shared, global control set — out-of-process, not an in-process cache** (ADR-3075-4,
+storage mechanism and content-keying per ADR-3082-1). The control set is a single store for
+every caller, not reinstantiated per operation, per subcommand, per transport, or per session —
+but it cannot be an in-process cache (a server-held dict, an MCP lifespan context) and satisfy
+that, because the CLI is not a running service: it is a separate OS process per invocation with
+no memory of any prior call and no shared memory to an MCP server process, by construction, no
+matter how the MCP side is wired. The store is one out-of-process SQLite database at
+`$DH_STATE_HOME/control-set.db` (WAL mode), rows keyed by `content_id` alone — no
+session-identifying value anywhere — bounded globally (LRU eviction past a tunable size target)
+with a periodic, rate-limited age-based cleanup pass (hourly to daily, not on every write), so
+entries never accumulate unboundedly and cleanup does not depend on any caller exiting cleanly.
+An item viewed through one MCP tool and then again through a different tool, through the CLI, or
+by an entirely different session, still hits the same entry if the request scope and content
+identity match and the entry has not since been evicted — because every caller reads and writes
+the same content-keyed rows, not because any of them hold state in memory. If the entry has been
+evicted, the response states plainly that the content must be requested again, not a generic
+error or silent empty result. A cache scoped to one process is a violation of R1 (a
 second, narrower implementation of what the engine already owns), not a smaller version of a
 correct implementation.
 
@@ -312,8 +307,9 @@ reverse are recorded in ADRs, not restated here:
 stale, write invalidation),
 [ADR-3075-3](./adrs/ADR-3075-3-cache-metadata-visible-to-agent.md) (agent-visible cache
 metadata), and
-[ADR-3075-4](./adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md) (out-of-process,
-session-keyed store).
+[ADR-3075-4](./adrs/ADR-3075-4-out-of-process-session-keyed-control-set.md) (out-of-process
+store; its session-keying decision is superseded by
+[ADR-3082-1](./adrs/ADR-3082-1-sqlite-backed-bounded-eviction.md), which is content-keyed only).
 
 Vocabulary introduced by these decisions — Collection, Generation, Navigation, Navigate, table
 of contents, budget — is defined once in [`CONTEXT.md`](../CONTEXT.md), not duplicated in this

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -42,9 +42,15 @@ documents, and the reports and artifacts produced during grooming.
 
 **Pipeline layering** (ADR-3072-1): three stages, in order — Collection (gathering source
 content from wherever it lives), Generation (assembling the complete document for a requested
-scope: description, table of contents, every requested section or artifact), and Navigation
-(this engine). Collection and Generation are unbounded — never truncated, never budget-checked.
-The engine's authority is over Navigation only: it receives a complete generated document,
+scope: description and every requested section or artifact), and Navigation (this engine).
+Generation supplies Navigation the document to parse; it does not assign addresses or build the
+table of contents itself — `component-architecture.md` gives `progressive_markdown` sole
+ownership of "assigning addresses" and "pagination of every result including a table of
+contents," and R4 requires every table-of-contents entry to carry an address, so those addresses,
+and the table of contents built from them, exist only after Navigation parses the generated
+document and builds its addressable tree. Collection and Generation are unbounded — never
+truncated, never budget-checked. The engine's authority is over Navigation only: it receives a
+complete generated document,
 gives it a content identity (R8), caches it for the session, and is the only point anywhere in
 the path where a size budget is applied. "Unbounded" is a real cost for a pathological source,
 not a theoretical one — see ADR-3072-1's known limitation for a concrete measurement and why
@@ -108,10 +114,13 @@ page selector to traverse it.
 
 ### R6 — Sections and artifacts are one inventory
 
-An agent viewing an item receives, in one response, both awareness of its sections and the
-associated reports and artifacts. Both are requestable by name. Discovering what exists never
-requires a second call to a different tool. This is the invariant R6 guarantees; it does not
-require a table-of-contents structure to always be present. When content fits in one page
+An agent viewing an item discovers both its sections and its associated reports and artifacts
+without a second call to a different tool. Both are requestable by name. This is the invariant
+R6 guarantees — not that both inventories always fit in the first page: sections and artifacts
+are windowed by the same paginated response (R2), so when the combined inventory exceeds one
+page, the caller reaches the remainder with a same-tool page request named by R7's hint, never a
+different tool or a separate lookup. It does not require a table-of-contents structure to always
+be present. When content fits in one page
 (R3), sections and artifacts appear directly in that single response, without table-of-contents
 scaffolding around them — there is nothing to navigate, so there is nothing to name a table of
 contents. The table of contents exists only when there is more than one page's worth of content
@@ -122,9 +131,10 @@ and supersedes the current arrangement in which artifacts are discovered through
 lookup. It states intended behaviour, not current behaviour.
 
 The Generation stage (R1) realizes this directly: sections and artifact content are assembled
-into one document, in one address space (R4), before Navigation windows it. There is no
-separate pagination path for the artifact inventory — it pages exactly as the rest of the
-generated document does (ADR-3072-1).
+into one document before Navigation parses it, assigns it one address space (R4), and windows
+it. There is no separate pagination path for the artifact inventory — it pages exactly as the
+rest of the generated document does (ADR-3072-1), so a combined inventory larger than one page
+is reached by a page request, not by a second call to a different tool.
 
 ### R7 — Hints must be actionable
 
@@ -147,14 +157,25 @@ override from R2) — nothing about where the content came from.
 The identifier resolves against cached parsed content. Serving a later page does not
 re-collect from the provider and does not re-parse.
 
-A request whose identifier no longer matches current content is reported as stale. Pages
-from two different versions of a document are never returned as though they were one
-document. **This is not a contradiction of "does not re-collect" above** (flagged in review —
-worth stating plainly): staleness is detected by write-triggered invalidation (below), a side
-effect of the write that changed the source, not by the read path re-collecting to compare.
-The one path that does re-collect on a read is explicit, caller-requested revalidation — an
-opt-in exception the caller chooses, never something the server does silently on an ordinary
-page request.
+A request whose identifier no longer matches current content, because of a write this
+contract's own paths can see, is reported as stale and then automatically recovered — see
+"Stale entries are recoverable, not dead ends" below (ADR-3075-2) for the recovery behaviour,
+which happens on the same ordinary request and is not gated behind a caller opt-in. Pages from
+two different versions of a document are never returned as though they were one document.
+**This is not a contradiction of "does not re-collect" above** (flagged in review — worth
+stating plainly): the distinction is between re-collecting to *detect* staleness and
+re-collecting to *recover* from it once detected. Detection never happens by the read path
+re-collecting to compare — it happens by write-triggered invalidation (below), a side effect of
+the write that changed the source. Recovery does re-collect, automatically, once an entry is
+known stale (below).
+
+A write made through a path outside this contract's Scope, or from a concurrent session, is not
+visible to write-triggered invalidation and is therefore not guaranteed to surface as stale this
+way — an acknowledged blind spot, not an oversight (see ADR-3075-3). An agent that needs
+certainty against that blind spot uses the explicit, caller-requested revalidation or forced
+refresh described in "Cache metadata is visible to the agent" below — an opt-in path the caller
+chooses for confidence before automatic detection would otherwise catch a change, additive to
+write-triggered invalidation, not the only path that ever re-collects.
 
 The identifier is derived from both the command (source, scope, parameters) and the Generation
 stage's output for that command — not a hash of the raw upstream source alone (ADR-3075-1), and
@@ -190,7 +211,11 @@ command that produced it — the source, scope, and parameters Collection and Ge
 build it — not only its content identity. When a request's identifier no longer matches
 current content, the stored command is used to requery the backend and regenerate the
 document, serving against the new identity and informing the caller the identity changed. The
-caller is not required to restate its whole request from scratch.
+caller is not required to restate its whole request from scratch, and this recovery happens
+automatically on the very request that surfaces the stale identifier — it is not an opt-in the
+caller must request separately. The explicit revalidation and forced-refresh paths (ADR-3075-3,
+below) serve a different purpose: gaining certainty before write-triggered invalidation would
+otherwise catch a change, not the only path that ever recollects.
 
 **Writes invalidate; reads do not have to discover staleness on their own** (ADR-3075-2). A
 control-set entry is not left to be discovered stale only when a later read happens to hit it
@@ -215,8 +240,8 @@ instead of trusting whatever the control set already holds.
 ```mermaid
 flowchart TD
     Req([Agent requests content<br>from any source]) --> Coll[Collection: gather source content<br>unbounded — no budget check]
-    Coll --> Gen["Generation: assemble the complete document<br>for the requested scope — description +<br>table of contents + every requested<br>section or artifact — unbounded R1"]
-    Gen --> Nav[Navigation engine: parse, build<br>addressable tree, hash the generated<br>document for content identity R8]
+    Coll --> Gen["Generation: assemble the complete document<br>for the requested scope — description +<br>every requested section or artifact —<br>unbounded R1"]
+    Gen --> Nav[Navigation engine: parse, build<br>addressable tree and table of contents,<br>hash the generated document for<br>content identity R8]
     Nav --> Cache["Cache the generated document<br>for the session, keyed by that identity R8"]
     Cache --> Eng[Window the cached document<br>to the agent]
     Eng --> Measure{Response exceeds<br>window budget?<br>only checked here}

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -173,8 +173,13 @@ Progressive-Disclosure Contract](./mcp-progressive-disclosure-contract.md) docum
 shipped parameter set (`selector` plus `navigate`, repeated on every call) and must be updated
 to this shape once the control set ships.
 
-The identifier resolves against cached parsed content. Serving a later page does not
-re-collect from the provider and does not re-parse.
+The identifier resolves against cached content. Serving a later page does not re-collect from the
+provider and does not re-run Generation — "does not re-parse" means no repeated network
+round-trip and no repeated document assembly, not a promise that the stored raw markdown is never
+turned back into an addressable structure. The control set (ADR-3082-1) stores raw generated
+content, not a parsed tree, and a follow-up call landing on a fresh CLI process reparses that
+stored content in-memory to serve the requested page — a cheap, deterministic, in-process step,
+consistent with ADR-3075-1's premise that re-parsing is cheap.
 
 A request whose identifier no longer matches current content, because of a write this
 contract's own paths can see, is reported as stale and then automatically recovered — see

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -108,9 +108,14 @@ page selector to traverse it.
 
 ### R6 — Sections and artifacts are one inventory
 
-An agent viewing an item receives, in one response, both the section table of contents and
-the associated reports and artifacts. Both are requestable by name. Discovering what exists
-never requires a second call to a different tool.
+An agent viewing an item receives, in one response, both awareness of its sections and the
+associated reports and artifacts. Both are requestable by name. Discovering what exists never
+requires a second call to a different tool. This is the invariant R6 guarantees; it does not
+require a table-of-contents structure to always be present. When content fits in one page
+(R3), sections and artifacts appear directly in that single response, without table-of-contents
+scaffolding around them — there is nothing to navigate, so there is nothing to name a table of
+contents. The table of contents exists only when there is more than one page's worth of content
+to navigate (R3); R6's discoverability guarantee holds either way.
 
 This requirement changes the response shape of the item-view operation on every transport,
 and supersedes the current arrangement in which artifacts are discovered through a separate
@@ -151,10 +156,17 @@ The one path that does re-collect on a read is explicit, caller-requested revali
 opt-in exception the caller chooses, never something the server does silently on an ordinary
 page request.
 
-The identifier is a hash of the Generation stage's output for the request's specific scope —
-not a hash of the raw upstream source alone (ADR-3075-1). Two different scopes of the same
-source (the whole item vs. one filtered section) produce different generated documents and
-must not collide on one identifier. The cache backing this is held for the duration of the
+The identifier is derived from both the command (source, scope, parameters) and the Generation
+stage's output for that command — not a hash of the raw upstream source alone (ADR-3075-1), and
+not a hash of the generated content alone either. Content-only hashing was flagged in review as
+a real collision: two different commands can produce byte-identical generated documents (a
+coincidence, not a contract violation), and a content-only hash would give them the same
+identifier while the entry retains only one command — a later requery or revalidation could
+then execute the wrong command entirely and return content unrelated to what the caller asked
+for. The identifier binds command and content together precisely so two different commands
+never collide even when their output happens to match. Two different scopes of the same source
+(the whole item vs. one filtered section) produce different generated documents and, by the
+same binding, different identifiers. The cache backing this is held for the duration of the
 requesting session only; it is not persisted across sessions (ADR-3075-1).
 
 **One shared control set for the whole session — out-of-process, not an in-process cache**

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -158,6 +158,13 @@ parameter for MCP tools, per ADR-3075-4's Consequences, since `backlog_view` and
 have no in-process session identity to read from `ctx`; the CLI instead reads
 `CLAUDE_CODE_SESSION_ID` directly and needs no such parameter.
 
+This hash-plus-session-routing shape states intended behaviour, not current behaviour: the
+control set it depends on (ADR-3075-1 through ADR-3075-4) is not yet implemented, and
+`backlog_view`'s current parameters carry no `hash` or session-routing field. [MCP
+Progressive-Disclosure Contract](./mcp-progressive-disclosure-contract.md) documents today's
+shipped parameter set (`selector` plus `navigate`, repeated on every call) and must be updated
+to this shape once the control set ships.
+
 The identifier resolves against cached parsed content. Serving a later page does not
 re-collect from the provider and does not re-parse.
 
@@ -214,20 +221,27 @@ implementation.
 command that produced it — the source, scope, and parameters Collection and Generation used to
 build it — not only its content identity. When a request's identifier no longer matches
 current content, the stored command is used to requery the backend and regenerate the
-document, serving against the new identity and informing the caller the identity changed. The
-caller is not required to restate its whole request from scratch, and this recovery happens
-automatically on the very request that surfaces the stale identifier — it is not an opt-in the
-caller must request separately. The explicit revalidation and forced-refresh paths (ADR-3075-3,
-below) serve a different purpose: gaining certainty before write-triggered invalidation would
-otherwise catch a change, not the only path that ever recollects.
+document. Recovery does not re-apply the request's original page or `navigate` address selector
+to the regenerated document — page boundaries and addresses can shift underneath it, and
+honoring the old selector risks skipping, duplicating, or misresolving content. Recovery serves
+page 1 of the regenerated document under the new identity instead (or an explicit restart
+response, for a `navigate` ordinal that no longer resolves), informing the caller the identity
+changed — this is what keeps the "never mixed-versions" guarantee above true rather than
+contradicting it. The caller is not required to restate its whole request from scratch, and this
+recovery happens automatically on the very request that surfaces the stale identifier — it is
+not an opt-in the caller must request separately. The explicit revalidation and forced-refresh
+paths (ADR-3075-3, below) serve a different purpose: gaining certainty before write-triggered
+invalidation would otherwise catch a change, not the only path that ever recollects.
 
-**Writes invalidate; reads do not have to discover staleness on their own** (ADR-3075-2). A
-control-set entry is not left to be discovered stale only when a later read happens to hit it
-with a mismatched hash. A write that modifies the source a cache entry was generated from
-invalidates that entry as a side effect of the write. Every mutation path bound by this
-contract's sources — item updates, section writes, artifact registration, task and plan state
-changes — is a source of invalidation for any control-set entry generated from what it
-touched.
+**Writes invalidate within the same session; reads do not have to discover staleness on their
+own** (ADR-3075-2). A control-set entry is not left to be discovered stale only when a later
+read happens to hit it with a mismatched hash. A write that modifies the source a cache entry
+was generated from invalidates that entry, in the writing session's own control set, as a side
+effect of the write. Every mutation path bound by this contract's sources — item updates,
+section writes, artifact registration, task and plan state changes — is a source of invalidation
+for any control-set entry, in that same session's store, generated from what it touched. A write
+from a different session does not scan or mutate another session's control set — see the blind
+spot noted above (ADR-3075-3).
 
 **Cache metadata is visible to the agent, not only used internally** (ADR-3075-3). Every
 response backed by the control set carries its content identity, the command that produced it,

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -153,10 +153,12 @@ below), not something the caller carries forward. Concretely, an initial request
 (`selector="#2529", section="RT-ICA"` or similar); every request after that states only
 `hash="<identifier>"` plus `page`, `navigate` (R4's address), `pagesize` (the caller override
 from R2), and — on transports where the control set is out-of-process (ADR-3075-4) — a
-session-identifying value the request needs to locate its session's store: a `gate_token`-style
-parameter for MCP tools, per ADR-3075-4's Consequences, since `backlog_view` and `artifact_read`
-have no in-process session identity to read from `ctx`; the CLI instead reads
-`CLAUDE_CODE_SESSION_ID` directly and needs no such parameter.
+session-identifying value the request needs to locate its session's store: a plain, non-rotating
+`session_id` parameter carrying `CLAUDE_CODE_SESSION_ID`'s value directly for MCP tools, per
+ADR-3075-4's Consequences, since `backlog_view` and `artifact_read` have no in-process session
+identity to read from `ctx` — not a `gate_token`-style parameter, which rotates on every skill
+load and cannot serve as a stable session key; the CLI instead reads `CLAUDE_CODE_SESSION_ID`
+directly and needs no such parameter.
 
 This hash-plus-session-routing shape states intended behaviour, not current behaviour: the
 control set it depends on (ADR-3075-1 through ADR-3075-4) is not yet implemented, and

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -2,8 +2,9 @@
 
 Every consumer of every operation described here is an AI agent. There is no human reader.
 
-Requirements R1–R8 are normative. The open questions section names decisions not yet made;
-until each is resolved, an implementation satisfying the surrounding requirements is correct.
+Requirements R1–R8 are normative. Design decisions resulting from questions raised while
+implementing this contract are recorded as ADRs in `docs/adrs/`, referenced from the
+requirement they resolve — not left as unresolved prose in this document.
 
 ## Purpose
 
@@ -39,6 +40,24 @@ maintained in parallel. A second implementation is a defect regardless of whethe
 Sources include, and are not limited to: issue and item bodies, plan documents, task
 documents, and the reports and artifacts produced during grooming.
 
+**Pipeline layering** (ADR-3072-1): three stages, in order — Collection (gathering source
+content from wherever it lives), Generation (assembling the complete document for a requested
+scope: description, table of contents, every requested section or artifact), and Navigation
+(this engine). Collection and Generation are unbounded — never truncated, never budget-checked.
+The engine's authority is over Navigation only: it receives a complete generated document,
+gives it a content identity (R8), caches it for the session, and is the only point anywhere in
+the path where a size budget is applied.
+
+**Navigation is source-agnostic.** It has no knowledge of, and no need to know, what kind of
+thing it is windowing — an issue, a PR, a plan, an artifact, a local file. It receives markdown
+text and the parameters of the current request (scope, address, page) and renders a view; it
+never learns where that text came from or reaches back to a backend to get more of it. This is
+a global markdown viewer, not a per-source one — the same relationship a browser's chrome has
+to the page it renders, indifferent to whether the page came from `file://` or `https://`. The
+`MarkdownContentProvider` protocol (implementation appendix) is the seam that makes this true:
+every source implements `get_markdown(source) -> str`, and nothing past that seam is
+source-specific.
+
 ### R2 — Everything paginates, including the table of contents
 
 Every response that can exceed the window budget paginates. This applies recursively and
@@ -49,7 +68,12 @@ No response may drop, elide, or truncate addressable nodes to fit a budget. Cont
 does not fit the current page is reachable on a subsequent page, never merely implied.
 
 Harnesses commonly cap a single tool response at ~10,000 tokens, adjustable. The engine's
-budget is configurable and must not exceed the harness cap.
+budget is configurable and must not exceed the harness cap, is sourced from one constant
+(ADR-3072-1), and is never applied outside the Navigation stage (R1).
+
+A caller may request a page smaller than the configured default. A tool response has no local
+equivalent of `tail` — a caller that wants to peek at part of a large result depends on the
+server accepting an explicit, smaller page-size request.
 
 ### R3 — Threshold triggers the compact form, automatically
 
@@ -58,6 +82,16 @@ automatic: no opt-in parameter, no prior knowledge required of the caller.
 
 The compact form contains item metadata, the top description, the table of contents, the
 inventory of associated reports and artifacts, and a hint naming the exact next call.
+
+This is progressive disclosure: an agent never receives structure it has no use for. The
+table of contents is not the whole item's table of contents by default — it is scoped to
+exactly what was requested (R5), and sized accordingly. Requesting one section with several
+subheadings returns a table of contents no larger than that section's own subheadings.
+Requesting two or three sections returns a table of contents spanning only those. Requesting
+the item as a whole returns a table of contents spanning the whole item. If what was
+requested fits in one page regardless of scope, no table of contents is returned at all —
+there is nothing to navigate when everything already fits, so the navigational aid is pure
+overhead and is omitted, not just collapsed to a stub.
 
 ### R4 — One addressing scheme
 
@@ -80,6 +114,11 @@ This requirement changes the response shape of the item-view operation on every 
 and supersedes the current arrangement in which artifacts are discovered through a separate
 lookup. It states intended behaviour, not current behaviour.
 
+The Generation stage (R1) realizes this directly: sections and artifact content are assembled
+into one document, in one address space (R4), before Navigation windows it. There is no
+separate pagination path for the artifact inventory — it pages exactly as the rest of the
+generated document does (ADR-3072-1).
+
 ### R7 — Hints must be actionable
 
 A response that withholds content states what the caller must do to obtain it, using
@@ -91,7 +130,12 @@ name a mechanism absent from the response it accompanies.
 
 A response that paginates returns a stable identifier derived from the content it paginates,
 alongside the page position. Subsequent pages are requested with that identifier plus a page
-selector or an address, never by re-describing the source.
+selector or an address, never by re-describing the source. The original scope or query is not
+repeated on follow-up calls — it is retained server-side as the entry's stored command (see
+below), not something the caller carries forward. Concretely, an initial request states scope
+(`selector="#2529", section="RT-ICA"` or similar); every request after that states only
+`hash="<identifier>"` plus `page`, `navigate` (R4's address), and `pagesize` (the caller
+override from R2) — nothing about where the content came from.
 
 The identifier resolves against cached parsed content. Serving a later page does not
 re-collect from the provider and does not re-parse.
@@ -100,12 +144,56 @@ A request whose identifier no longer matches current content is reported as stal
 from two different versions of a document are never returned as though they were one
 document.
 
+The identifier is a hash of the Generation stage's output for the request's specific scope —
+not a hash of the raw upstream source alone (ADR-3075-1). Two different scopes of the same
+source (the whole item vs. one filtered section) produce different generated documents and
+must not collide on one identifier. The cache backing this is held for the duration of the
+requesting session only; it is not persisted across sessions (ADR-3075-1).
+
+**One shared cache, not one per tool.** The cache is a single control set for the whole
+session — not reinstantiated per operation, per subcommand, or per transport. Every operation
+bound by this contract (Scope) that touches the same generated content within one session
+resolves against the same cache entry. An item viewed through one MCP tool and then again
+through a different tool, or through the CLI, still hits the same entry if the request scope
+and content identity match. A cache scoped to one tool call is a violation of R1 (a second,
+narrower implementation of what the engine already owns), not a smaller version of a correct
+implementation.
+
+**Stale entries are recoverable, not dead ends** (ADR-3075-2). A control-set entry retains the
+command that produced it — the source, scope, and parameters Collection and Generation used to
+build it — not only its content identity. When a request's identifier no longer matches
+current content, the stored command is used to requery the backend and regenerate the
+document, serving against the new identity and informing the caller the identity changed. The
+caller is not required to restate its whole request from scratch.
+
+**Writes invalidate; reads do not have to discover staleness on their own** (ADR-3075-2). A
+control-set entry is not left to be discovered stale only when a later read happens to hit it
+with a mismatched hash. A write that modifies the source a cache entry was generated from
+invalidates that entry as a side effect of the write. Every mutation path bound by this
+contract's sources — item updates, section writes, artifact registration, task and plan state
+changes — is a source of invalidation for any control-set entry generated from what it
+touched.
+
+**Cache metadata is visible to the agent, not only used internally** (ADR-3075-3). Every
+response backed by the control set carries its content identity, the command that produced it,
+and when it was generated — the same three things the cache uses internally to detect
+staleness. This is not exposed as a debugging aid; it gives the agent a basis to judge
+freshness itself, independent of the server's own write-triggered invalidation (which may not
+have run yet, or may not know about a write made through a path outside this contract). An
+agent that just wrote to something it is about to re-read, or that otherwise has reason to
+distrust automatic invalidation, may explicitly request revalidation or a forced refresh
+instead of trusting whatever the control set already holds.
+
 ## Required flow
 
 ```mermaid
 flowchart TD
-    Req([Agent requests content<br>from any source]) --> Eng[Markdown engine parses<br>and builds addressable tree<br>R1]
-    Eng --> Measure{Response exceeds<br>window budget?}
+    Req([Agent requests content<br>from any source]) --> Coll[Collection: gather source content<br>unbounded — no budget check]
+    Coll --> Gen["Generation: assemble the complete document<br>for the requested scope — description +<br>table of contents + every requested<br>section or artifact — unbounded R1"]
+    Gen --> Nav[Navigation engine: parse, build<br>addressable tree, hash the generated<br>document for content identity R8]
+    Nav --> Cache["Cache the generated document<br>for the session, keyed by that identity R8"]
+    Cache --> Eng[Window the cached document<br>to the agent]
+    Eng --> Measure{Response exceeds<br>window budget?<br>only checked here}
 
     Measure -->|No| Full[Return full content]
     Measure -->|Yes| Compact["Return compact form R3:<br>metadata + description<br>+ table of contents R4<br>+ artifact inventory R6<br>+ actionable hint R7"]
@@ -122,31 +210,20 @@ flowchart TD
     Children -->|No| Fits{Content exceeds<br>window budget?}
 
     Fits -->|No| Deliver[Return full node content]
-    Fits -->|Yes| Window["Return page 1 + page selector R2<br>no content dropped"]
+    Fits -->|Yes| Window["Return page 1 + page selector R2<br>no content dropped — caller may<br>request a smaller page than default R2"]
     Window --> Cont[Agent requests next page]
     Cont --> Fits
 ```
 
-## Open questions requiring a decision
+## Design decisions
 
-Each open question is tracked as an issue so a decision made here is discoverable and enforced
-against the work it blocks, rather than existing only as prose in this section.
+The five questions previously open in this section (#3072–#3076) are resolved and folded into
+R1, R2, R6, and R8 above. The reasoning, rejected alternatives, and why each choice is hard to
+reverse are recorded in `docs/adrs/ADR-3072-1-budget-applies-only-at-navigation.md` and
+`docs/adrs/ADR-3075-1-content-identity-and-cache-scope.md`, not restated here.
 
-1. Budget value — one configurable constant for all operations, and what default relative to
-   the ~10,000 token harness cap. Tracked in #3072.
-2. Compact-form composition when both the table of contents and the artifact inventory are
-   large — page them together, or independently. Tracked in #3073.
-3. Whether an agent may request an explicit page size, or only accept the configured budget.
-   Tracked in #3074.
-4. Cache lifetime and scope for R8 — held for the duration of a session, or persisted across
-   sessions. Tracked in #3075. Blocks #3062.
-5. Whether R8's identifier is derived from the raw markdown or from the parsed tree. Raw
-   detects every change; parsed would keep pagination stable across cosmetic edits. Tracked in
-   #3076. Blocks #3062.
-
-When an issue above closes, remove its list item here and fold the decision into the relevant
-requirement (R2, R5, R6, or R8) as normative text — this section holds undecided questions
-only, not a permanent record of resolved ones.
+Vocabulary introduced by these decisions — Collection, Generation, Navigation, Navigate, table
+of contents, budget — is defined once in `CONTEXT.md`, not duplicated in this contract.
 
 ## Implementation appendix — shape to code
 

--- a/plugins/development-harness/docs/agent-markdown-consumption-contract.md
+++ b/plugins/development-harness/docs/agent-markdown-consumption-contract.md
@@ -185,13 +185,13 @@ re-collecting to compare — it happens by write-triggered invalidation (below),
 the write that changed the source. Recovery does re-collect, automatically, once an entry is
 known stale (below).
 
-A write made through a path outside this contract's Scope, or from a concurrent session, is not
-visible to write-triggered invalidation and is therefore not guaranteed to surface as stale this
-way — an acknowledged blind spot, not an oversight (see ADR-3075-3). An agent that needs
-certainty against that blind spot uses the explicit, caller-requested revalidation or forced
-refresh described in "Cache metadata is visible to the agent" below — an opt-in path the caller
-chooses for confidence before automatic detection would otherwise catch a change, additive to
-write-triggered invalidation, not the only path that ever re-collects.
+Only a write made through a path outside this contract's Scope is invisible to write-triggered
+invalidation — a write from a concurrent session is not a blind spot: invalidation is global
+(ADR-3082-1, ADR-3075-2), so any caller's write reaches the one shared entry. An agent that needs
+certainty against the out-of-Scope-write blind spot uses the explicit, caller-requested
+revalidation or forced refresh described in "Cache metadata is visible to the agent" below — an
+opt-in path the caller chooses for confidence before automatic detection would otherwise catch a
+change, additive to write-triggered invalidation, not the only path that ever re-collects.
 
 The identifier is derived from both the command (source, scope, parameters) and the Generation
 stage's output for that command — not a hash of the raw upstream source alone (ADR-3075-1), and
@@ -245,15 +245,15 @@ not an opt-in the caller must request separately. The explicit revalidation and 
 paths (ADR-3075-3, below) serve a different purpose: gaining certainty before write-triggered
 invalidation would otherwise catch a change, not the only path that ever recollects.
 
-**Writes invalidate within the same session; reads do not have to discover staleness on their
-own** (ADR-3075-2). A control-set entry is not left to be discovered stale only when a later
-read happens to hit it with a mismatched hash. A write that modifies the source a cache entry
-was generated from invalidates that entry, in the writing session's own control set, as a side
-effect of the write. Every mutation path bound by this contract's sources — item updates,
-section writes, artifact registration, task and plan state changes — is a source of invalidation
-for any control-set entry, in that same session's store, generated from what it touched. A write
-from a different session does not scan or mutate another session's control set — see the blind
-spot noted above (ADR-3075-3).
+**Writes invalidate globally; reads do not have to discover staleness on their own**
+(ADR-3075-2, scoping corrected by ADR-3082-1's content-keyed reversal). A control-set entry is
+not left to be discovered stale only when a later read happens to hit it with a mismatched hash.
+A write that modifies the source a cache entry was generated from marks that entry stale (not
+deleted — its stored command survives, see "Stale entries are recoverable" below) as a side
+effect of the write, regardless of which caller made the write. Every mutation path bound by
+this contract's sources — item updates, section writes, artifact registration, task and plan
+state changes — is a source of invalidation for the one shared control-set entry generated from
+what it touched, whichever session or tool happens to have written it.
 
 **Cache metadata is visible to the agent, not only used internally** (ADR-3075-3). Every
 response backed by the control set carries its content identity, the command that produced it,
@@ -272,7 +272,7 @@ flowchart TD
     Req([Agent requests content<br>from any source]) --> Coll[Collection: gather source content<br>unbounded — no budget check]
     Coll --> Gen["Generation: assemble the complete document<br>for the requested scope — description +<br>every requested section or artifact —<br>unbounded R1"]
     Gen --> Nav[Navigation engine: parse, build<br>addressable tree and table of contents,<br>hash command + generated document<br>together for content identity R8]
-    Nav --> Cache["Cache the generated document<br>for the session, keyed by that identity R8"]
+    Nav --> Cache["Cache the generated document<br>globally, keyed by that identity R8"]
     Cache --> Eng[Window the cached document<br>to the agent]
     Eng --> Measure{Response exceeds<br>window budget?<br>only checked here}
 
@@ -325,6 +325,19 @@ The engine described by R1 exists as the `progressive_markdown` package:
 `ProgressiveMarkdownNavigator` and `Paginator` currently have no consumers. The engine's
 parser and indexer are imported by the address-navigation path; its navigation and
 pagination layer is not used by anything.
+
+**A naming caveat on stage boundaries, flagged in review.** `ProgressiveMarkdownNavigator.load()`
+itself calls `provider.get_markdown(source, ...)` — the class named "Navigator" contains a method
+that performs Collection (fetching from the provider). Read narrowly, this looks like it
+contradicts R1's "Navigation never reaches back to a backend." It doesn't, but the class
+boundary doesn't make that obvious: `load()` is the Collection+Generation entry point (it fetches
+and assembles the document once), and the *other* methods on the same object — `map`,
+`view_section`, `view_code`, `links`, `search_sections` — are the actual Navigation stage,
+operating on what `load()` already fetched. One class currently hosts both a Collection+Generation
+step and the Navigation stage proper; the seam described in R1 (`MarkdownContentProvider`) is
+real and does separate them by responsibility, but not by class boundary. Not a contradiction of
+R1's layering, but the class name invites the misreading — worth a rename or a doc comment when
+this code is next touched, not a reason to treat R1 and the shipped code as inconsistent.
 
 Duplicate implementations to delete rather than refactor, in the backlog server layer
 (`backlog_core/server.py`, `backlog_core/operations.py`) shared by the MCP tool and CLI paths

--- a/plugins/development-harness/docs/component-architecture.md
+++ b/plugins/development-harness/docs/component-architecture.md
@@ -127,8 +127,13 @@ and durability are already split exactly as intended; delivery is not.
 
 - `backlog_core` owns artifact registration, identity, and the association between an
   artifact and its item — artifact discovery is part of item state. Confirmed:
-  `artifact_register()` computes identity and writes the manifest entry; this is the only
-  place that does.
+  `artifact_manifest_store.py::publish_artifact()` computes content identity
+  (`content_revision`, a sha256 of the artifact content) and writes the manifest entry. Both
+  the `artifact_register()` MCP tool and `_try_register_dispatch_plan_artifact()` (both in
+  `backlog_core/server.py`) route through it — `publish_artifact()` is the shared owner, not
+  `artifact_register()` alone. `artifact_migration.py::_migrate_register_one()` bypasses it: it
+  calls `ArtifactRegistry.register()` and `provider.set_manifest()` directly and never computes
+  `content_revision`. Tracked in #3086.
 - The storage provider owns durability of artifact content. Confirmed: the GitHub backend's
   `put_content()` writes directly when online and queues durably via `FileCache` when
   offline; no other component performs physical persistence.

--- a/plugins/development-harness/docs/component-architecture.md
+++ b/plugins/development-harness/docs/component-architecture.md
@@ -122,18 +122,28 @@ response rather than by querying separate tools.
 Artifact identity and retrieval are provider-independent: the same name resolves the same
 artifact regardless of which provider stores it.
 
-Ownership divides as follows, because three packages each touch artifacts and only one owns
-each concern:
+Ownership divides as follows. Verified against the current code (not assumed): registration
+and durability are already split exactly as intended; delivery is not.
 
 - `backlog_core` owns artifact registration, identity, and the association between an
-  artifact and its item — artifact discovery is part of item state.
-- The storage provider owns durability of artifact content.
-- `progressive_markdown` owns delivery of artifact content to an agent, on the same terms as
-  any other markdown.
+  artifact and its item — artifact discovery is part of item state. Confirmed:
+  `artifact_register()` computes identity and writes the manifest entry; this is the only
+  place that does.
+- The storage provider owns durability of artifact content. Confirmed: the GitHub backend's
+  `put_content()` writes directly when online and queues durably via `FileCache` when
+  offline; no other component performs physical persistence.
+- `progressive_markdown` **should** own delivery of artifact content to an agent, on the same
+  terms as any other markdown — this is intended behaviour, not current behaviour.
+  `artifact_read()` today calls the provider's `get_content()` directly and returns raw
+  content, with no engine involvement at all. This is the same "second implementation"
+  pattern R1 forbids elsewhere: artifact content delivery is a markdown consumption path with
+  no navigation, pagination, or content identity, entirely outside the engine described by R1.
+  Tracked in #3078.
 
-Discovery is not a provider concern and not an engine concern. An artifact listed as
-registered whose content cannot be retrieved is a defect in the boundary between the first
-two, not an expected outcome.
+Discovery is not a provider concern and not an engine concern. An artifact registered as
+`current` whose content cannot be retrieved is a defect — concretely, `artifact_migration.py`
+can write a manifest entry with `status: current` before its content write is confirmed to
+succeed, with no verification step tying the two together. Tracked in #3055.
 
 ## Provider independence
 

--- a/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
+++ b/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
@@ -15,12 +15,13 @@ map down to full section, sub-heading, or code-fence content.
 Design decisions are specified in the architecture spec for issue #2529 (artifact type
 `architect`). This document describes the shipped contract — what agents observe.
 
-R8's hash-plus-session-routing follow-up-call shape (ADR-3075-1 through ADR-3075-4) is not
-reflected below: that control set is not yet implemented, and `backlog_view` currently has no
-`hash` or session-routing parameter. Every example in this document — including "Typical
-Navigation Flow" below — uses today's shipped shape, repeating `selector` on every call. Update
-this document's examples and response shapes to the hash-plus-session shape once the control
-set ships.
+R8's hash-only follow-up-call shape (ADR-3075-1 through ADR-3082-1) is not reflected
+below: that control set is not yet implemented, and `backlog_view` currently has no `hash`
+parameter. There is no session-identifying value anywhere in that shape — ADR-3082-1 reversed
+session-keying, so the control set is addressed by `content_id` alone. Every example in this
+document — including "Typical Navigation Flow" below — uses today's shipped shape, repeating
+`selector` on every call. Update this document's examples and response shapes to the hash-only
+shape once the control set ships.
 
 ---
 

--- a/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
+++ b/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
@@ -15,6 +15,13 @@ map down to full section, sub-heading, or code-fence content.
 Design decisions are specified in the architecture spec for issue #2529 (artifact type
 `architect`). This document describes the shipped contract — what agents observe.
 
+R8's hash-plus-session-routing follow-up-call shape (ADR-3075-1 through ADR-3075-4) is not
+reflected below: that control set is not yet implemented, and `backlog_view` currently has no
+`hash` or session-routing parameter. Every example in this document — including "Typical
+Navigation Flow" below — uses today's shipped shape, repeating `selector` on every call. Update
+this document's examples and response shapes to the hash-plus-session shape once the control
+set ships.
+
 ---
 
 ## Ordinal Grammar


### PR DESCRIPTION
## Summary

- Resolves all five open design questions in the markdown consumption contract via a `/grilling` session with the repo owner: #3072 (budget applies only at a source-agnostic Navigation stage), #3073 (TOC/artifact inventory page together, scoped to what was requested, omitted when content already fits one page), #3074 (caller-controlled page size), #3075 (session-shared control set; stale entries requery via a stored command; writes invalidate directly), #3076 (R8 identity hashes the generated scoped document, not raw source)
- Adds cache metadata visibility (identity, command, timestamp) to every control-set-backed response, and a caller-facing revalidate/force-refresh path
- Four new ADRs recording reasoning and rejected alternatives: ADR-3072-1, ADR-3075-1, ADR-3075-2, ADR-3075-3
- Corrects `component-architecture.md`'s artifact-ownership claim after direct code verification: delivery is not actually routed through the engine today (filed #3078); found #3055's precise root cause in the same pass (manifest entries can be marked `current` before content write is confirmed)
- New `plugins/development-harness/CONTEXT.md` + root `CONTEXT-MAP.md` — domain vocabulary (Collection/Generation/Navigation/Navigate/TOC/Provider/Control set) per the `mattpocock-skills:domain-modeling` discipline

## New issues filed this session

#3078 (artifact delivery bypasses the engine), #3079 (writes invalidate control-set entries)

## Test plan

- [x] `uv run prek run --files <changed files>` — all hooks pass
- [x] markdownlint clean on all new/changed docs
- [ ] Reviewer confirms the five ADR decisions match intent before this merges — this is a design-decision PR, not an implementation PR; no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg

<!-- greptile_comment -->

<sub>Reviews (17): Last reviewed commit: ["docs(development-harness): fix remaining..."](https://github.com/jamie-bitflight/claude_skills/commit/d4be908dc5b6c8e9e81308efbb0cc3807f496524) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55031041)</sub>

<!-- /greptile_comment -->