### PR TITLE
chore(development-harness): add PR watch-list for the cloud PR-review-response routine

### DIFF
--- a/.claude/pr-watch-list.json
+++ b/.claude/pr-watch-list.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "internal — list of PR numbers a cloud routine should actively monitor for new reviews/comments. Not a general PR index; PRs not on this list are ignored by the watcher routine.",
+  "watched_prs": [3080]
+}

--- a/.claude/pr-watch-list.json
+++ b/.claude/pr-watch-list.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "internal — list of PR numbers a cloud routine should actively monitor for new reviews/comments. Not a general PR index; PRs not on this list are ignored by the watcher routine.",
-  "watched_prs": [3080]
-}
+{"$schema":"internal — list of PR numbers a cloud routine should actively monitor for new reviews/comments. Not a general PR index; PRs not on this list are ignored by the watcher routine.","watched_prs":[3080]}

--- a/.claude/pr-watch-list.json
+++ b/.claude/pr-watch-list.json
@@ -1,1 +1,4 @@
-{"$schema":"internal — list of PR numbers a cloud routine should actively monitor for new reviews/comments. Not a general PR index; PRs not on this list are ignored by the watcher routine.","watched_prs":[3080]}
+{
+  "$schema": "internal — list of PR numbers a cloud routine should actively monitor for new reviews/comments. Not a general PR index; PRs not on this list are ignored by the watcher routine.",
+  "watched_prs": [3080]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/pr-watch-list.json`, a subscription list a cloud routine reads to decide which PRs to actively monitor for new reviews/comments — not a repo-wide reactive watcher (which would fire, and cost a cloud-agent run, on every PR regardless of relevance)
- Seeded with #3080

## Test plan

- [x] Valid JSON, `uv run prek run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg

<!-- greptile_comment -->

<sub>Reviews (3): Last reviewed commit: ["Update .claude/pr-watch-list.json"](https://github.com/jamie-bitflight/claude_skills/commit/02551b3cf0c4799499133c8a41fd46ed12122e66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55053340)</sub>

**Context used:**

- Context used - Do not pretty-print JSON by default for machine or... ([source](https://github.com/jamie-bitflight/claude_skills/blob/main/.cursor/rules/json-no-pretty-print.mdc))

<!-- /greptile_comment -->