### PR TITLE
docs(development-harness): correct TaskBackend/WorkItemBackend split in AGENTS.md

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.1.4",
+  "version": "9.1.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "8.8.26",
+  "version": "8.8.27",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",
@@ -13,7 +13,11 @@
     "longDescription": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
     "developerName": "Jamie Nelson",
     "category": "Developer Tools",
-    "capabilities": ["Interactive", "Read", "Write"],
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
     "defaultPrompt": [
       "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human"
     ]

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -13,11 +13,7 @@
     "longDescription": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
     "developerName": "Jamie Nelson",
     "category": "Developer Tools",
-    "capabilities": [
-      "Interactive",
-      "Read",
-      "Write"
-    ],
+    "capabilities": ["Interactive", "Read", "Write"],
     "defaultPrompt": [
       "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human"
     ]

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -10,29 +10,18 @@
   "mcpServers": {
     "sequential_thinking": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-sequential-thinking@latest"
-      ]
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
     },
     "backlog": {
       "command": "uv",
-      "args": [
-        "run",
-        "--script",
-        "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"
-      ],
+      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }
     },
     "sam": {
       "command": "uv",
-      "args": [
-        "run",
-        "--script",
-        "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"
-      ],
+      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "5.3.9",
+  "version": "5.3.10",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"
@@ -10,18 +10,29 @@
   "mcpServers": {
     "sequential_thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking@latest"
+      ]
     },
     "backlog": {
       "command": "uv",
-      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"],
+      "args": [
+        "run",
+        "--script",
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"
+      ],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }
     },
     "sam": {
       "command": "uv",
-      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"],
+      "args": [
+        "run",
+        "--script",
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"
+      ],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -584,18 +584,27 @@ issue or owner reference links a plan to its work item; it never selects a separ
 
 ### Plan and artifact capability boundary
 
-Backlog items and SAM plans/tasks do NOT share one backend protocol. Backlog operations
-(`backlog_add`, `backlog_view`, etc.) route through `WorkItemBackend`
-(`backlog_core/backend_types.py`). `sam_plan`, `sam_task`, and `sam_active_task` route through a
-separate `TaskBackend` protocol (`dh_core/protocols.py`, re-exported from
-`sam_schema/core/task_backend.py`) — every plan/task CRUD function in `dh_core/operations.py`
-(`create_plan`, `read_plan`, `list_plans`, `read_task`, `claim_task`, etc.) takes a `TaskBackend`
-parameter, not a `WorkItemBackend`. `artifact_*` calls route through `ContentProvider`
-(`backlog_core/backend_types.py`), the same protocol backlog content uses. There is no local
-filesystem fallback or per-plan backend selection — each protocol still resolves to exactly one
-configured backend instance per its own selection rules. Remote providers may use a private
-`FileCache` for stale reads and queued writes. Beads, SQLite, and Memory remain native-only and
-never use YAML or cache storage.
+Backlog items and SAM plans/tasks do NOT share one backend protocol, but this is a distinct-interface
+split, not a distinct-storage one. Backlog operations (`backlog_add`, `backlog_view`, etc.) route
+through `WorkItemBackend` (`./backlog_core/backend_types.py`), which is independently configurable
+across the `github`/`sqlite`/`memory`/`beads` families above. `sam_plan` and `sam_task` route
+through a separate `TaskBackend` protocol — defined in `./sam_schema/core/task_backend.py`,
+re-exported by `./dh_core/protocols.py` — and every plan/task CRUD function in
+`./dh_core/operations.py` (`create_plan`, `read_plan`, `list_plans`, `read_task`, `claim_task`,
+etc.) takes a `TaskBackend` parameter, not a `WorkItemBackend`. Concretely, `TaskBackend` is
+implemented by `ContentTaskProvider` (`./sam_schema/core/backends/content.py`), which is not an
+independently-selected backend the way `WorkItemBackend`'s GitHub/SQLite/Beads/Memory choice is —
+it is an adapter that persists plan/task state through the *same* `ContentProvider`
+(`./backlog_core/backend_types.py`) that `artifact_*` calls use, wrapping `InMemoryTaskProvider`'s
+established in-memory behavior. `sam_active_task` is not a `TaskBackend` consumer in the same way as
+`sam_plan`/`sam_task`: it primarily routes through a third, separate protocol, `ContextBackend`
+(`get_context_config().backend`), for session-scoped active-task state, and only incidentally
+resolves a `TaskBackend` on its `update` action (to cross-validate/append task-section content
+against the plan the active-task address points at). There is no local filesystem fallback or
+per-plan backend selection — each protocol still resolves to exactly one configured backend
+instance per its own selection rules. Remote providers may use a private `FileCache` for stale
+reads and queued writes. Beads, SQLite, and Memory remain native-only and never use YAML or cache
+storage.
 
 ---
 

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -584,11 +584,18 @@ issue or owner reference links a plan to its work item; it never selects a separ
 
 ### Plan and artifact capability boundary
 
-The configured backend implements the logical plan and artifact capabilities. `sam_plan`,
-`sam_task`, `sam_active_task`, and `artifact_*` calls use that same backend; there is no
-`TASKBACKEND`, independent artifact provider, local filesystem fallback, or per-plan backend
-selection. Remote providers may use a private `FileCache` for stale reads and queued writes.
-Beads, SQLite, and Memory remain native-only and never use YAML or cache storage.
+Backlog items and SAM plans/tasks do NOT share one backend protocol. Backlog operations
+(`backlog_add`, `backlog_view`, etc.) route through `WorkItemBackend`
+(`backlog_core/backend_types.py`). `sam_plan`, `sam_task`, and `sam_active_task` route through a
+separate `TaskBackend` protocol (`dh_core/protocols.py`, re-exported from
+`sam_schema/core/task_backend.py`) — every plan/task CRUD function in `dh_core/operations.py`
+(`create_plan`, `read_plan`, `list_plans`, `read_task`, `claim_task`, etc.) takes a `TaskBackend`
+parameter, not a `WorkItemBackend`. `artifact_*` calls route through `ContentProvider`
+(`backlog_core/backend_types.py`), the same protocol backlog content uses. There is no local
+filesystem fallback or per-plan backend selection — each protocol still resolves to exactly one
+configured backend instance per its own selection rules. Remote providers may use a private
+`FileCache` for stale reads and queued writes. Beads, SQLite, and Memory remain native-only and
+never use YAML or cache storage.
 
 ---
 

--- a/plugins/development-harness/docs/backend-providers.md
+++ b/plugins/development-harness/docs/backend-providers.md
@@ -47,7 +47,15 @@ ownership unified:
 | Document | Plan, context, design, validation, or report content | `sam_plan` and `artifact_*` |
 
 This is a domain model, not a permission to select separate stores. The active
-backend owns all three object types and resolves their owner references.
+backend owns all three object types and resolves their owner references — but
+"owns" refers to storage selection, not one shared access protocol. Work
+items go through `WorkItemBackend`; plans and tasks go through a separate
+`TaskBackend` protocol, concretely implemented by `ContentTaskProvider` as an
+adapter over the same `ContentProvider` that `artifact_*` calls use — the
+same underlying configured backend, reached through a different interface.
+`sam_active_task` primarily routes through a third protocol, `ContextBackend`,
+for its session-scoped state. See [AGENTS.md](../AGENTS.md)'s "Plan and artifact
+capability boundary" section for the concrete protocol names and file paths.
 
 ## CLI vs MCP Capability Surface
 


### PR DESCRIPTION
## Summary
- AGENTS.md claimed `sam_plan`/`sam_task`/`sam_active_task`/`artifact_*` all use "that same backend" as backlog items, and that there is no `TASKBACKEND`. This is factually wrong: `dh_core/protocols.py` defines a separate `TaskBackend` protocol, used by every plan/task CRUD function in `dh_core/operations.py`. Backlog items route through `WorkItemBackend` instead.
- Corrects the claim to state the actual split, cross-referencing the concrete files/functions.
- Fixes #3088

## Test plan
- Doc-only change, verified against `dh_core/protocols.py`, `dh_core/operations.py`, and `backlog_core/backend_types.py` directly before writing.

<!-- greptile_comment -->

<sub>Reviews (4): Last reviewed commit: ["chore(development-harness): fix Biome fo..."](https://github.com/jamie-bitflight/claude_skills/commit/fc02dff73d30ba28ce68673e0842d9495669a57c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55091532)</sub>

<!-- /greptile_comment -->