### PR TITLE
fix(development-harness): register Systems Inventory as a known section name

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.1.5",
+  "version": "9.1.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "8.8.27",
+  "version": "8.8.28",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",
@@ -13,7 +13,11 @@
     "longDescription": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
     "developerName": "Jamie Nelson",
     "category": "Developer Tools",
-    "capabilities": ["Interactive", "Read", "Write"],
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
     "defaultPrompt": [
       "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human"
     ]

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -13,11 +13,7 @@
     "longDescription": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
     "developerName": "Jamie Nelson",
     "category": "Developer Tools",
-    "capabilities": [
-      "Interactive",
-      "Read",
-      "Write"
-    ],
+    "capabilities": ["Interactive", "Read", "Write"],
     "defaultPrompt": [
       "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human"
     ]

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -10,29 +10,18 @@
   "mcpServers": {
     "sequential_thinking": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-sequential-thinking@latest"
-      ]
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
     },
     "backlog": {
       "command": "uv",
-      "args": [
-        "run",
-        "--script",
-        "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"
-      ],
+      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }
     },
     "sam": {
       "command": "uv",
-      "args": [
-        "run",
-        "--script",
-        "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"
-      ],
+      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "5.3.10",
+  "version": "5.3.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"
@@ -10,18 +10,29 @@
   "mcpServers": {
     "sequential_thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking@latest"
+      ]
     },
     "backlog": {
       "command": "uv",
-      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"],
+      "args": [
+        "run",
+        "--script",
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"
+      ],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }
     },
     "sam": {
       "command": "uv",
-      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"],
+      "args": [
+        "run",
+        "--script",
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"
+      ],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }

--- a/plugins/development-harness/backlog_core/section_registry.py
+++ b/plugins/development-harness/backlog_core/section_registry.py
@@ -76,6 +76,7 @@ class SectionKey(StrEnum):
     RESOURCES = "resources"
     IMPACT = "impact"
     IMPACT_RADIUS = "impact_radius"
+    SYSTEMS_INVENTORY = "systems_inventory"
     DEPENDENCIES = "dependencies"
     PRIORITY = "priority"
     BENEFITS = "benefits"
@@ -109,6 +110,7 @@ _SECTION_DISPLAY: tuple[tuple[SectionKey, str], ...] = (
     (SectionKey.RESOURCES, "Resources"),
     (SectionKey.IMPACT, "Impact"),
     (SectionKey.IMPACT_RADIUS, "Impact Radius"),
+    (SectionKey.SYSTEMS_INVENTORY, "Systems Inventory"),
     (SectionKey.DEPENDENCIES, "Dependencies"),
     (SectionKey.PRIORITY, "Priority"),
     (SectionKey.BENEFITS, "Benefits"),


### PR DESCRIPTION
## Summary
- `Systems Inventory` is part of the documented Impact Radius output format (swarm.md's required "### Systems Inventory" subsection) but was never registered in `section_registry.py`, so every groom pass writing it hit an unregistered-section fallback-key warning.
- Registers it in `SectionKey` and `_SECTION_DISPLAY`, next to `Impact Radius`.
- Discovered live while grooming #3062.
- Fixes #3092

## Test plan
- `uv run pytest plugins/development-harness/tests/test_section_registry.py` — 204 passed
- `uv run ruff check`/`ruff format --check`/`ty check` on the changed file — all pass

<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["fix(development-harness): apply biome fo..."](https://github.com/jamie-bitflight/claude_skills/commit/a361b30d661925e309b42da8561a52b28ca9906d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55348492)</sub>

<!-- /greptile_comment -->