### PR TITLE
docs(development-harness): define orchestrator/manager/worker roles

### DIFF
--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -8,6 +8,44 @@ Navigation, Control set, etc.) are normatively defined in
 `docs/agent-markdown-consumption-contract.md` — this file is vocabulary only, for that area and
 every other area of the plugin as it gets resolved.
 
+## Dispatch Roles
+
+Three roles govern who may dispatch further agents and on whose behalf, defined by relationship —
+never by capability, and never by whether an agent happens to dispatch further work. See
+ADR-3113-1 for the incident that required stating this precisely.
+
+**Orchestrator**:
+The single interactive agent acting directly on behalf of the human. Exactly one per session,
+always. Defined by relationship, not capability: the orchestrator is whichever agent received the
+task directly from the human — not whichever agent happens to be dispatching subagents at a given
+moment. A subagent dispatching further subagents does not become the orchestrator by doing so; it
+remains a Manager or Worker, acting on behalf of whoever dispatched it.
+_Avoid_: "the orchestrator" as a synonym for "whoever is executing this skill" — that usage is the
+mechanism behind the #3060 incident (ADR-3113-1): a skill written in first person for the
+orchestrator, handed to a dispatched Worker, was read as license to dispatch further agents the
+Worker was never assigned to dispatch.
+
+**Manager**:
+A subagent explicitly assigned, by its own dispatcher, to decompose a scoped piece of work and
+dispatch further subagents within that scope. The assignment is always stated as data — in the
+delegation prompt, or in the SAM task's `executor` field once typed (see #3100) — never inferred
+from a loaded skill's own voice, and never adopted on the subagent's own initiative. Sub-dispatch
+is legitimate and valuable when assigned this way; see ADR-3113-1 for why unassigned adoption,
+not dispatch itself, is the actual defect.
+_Avoid_: "orchestrator" for this role — a Manager acts on behalf of its dispatcher, not on behalf
+of the human directly, and the two roles carry different obligations (see Orchestrator above).
+
+**Worker**:
+A subagent assigned one unit of work to execute directly. Never dispatches further subagents,
+regardless of what any skill it loads is written to instruct — a skill written for a Manager or
+the Orchestrator does not change a Worker's own assignment. On receiving an instruction to run a
+skill that speaks as if to a dispatcher, a Worker reports the conflict (`STATUS: BLOCKED`) rather
+than complying. `dh:task-worker` is this plugin's canonical Worker implementation.
+_Avoid_: assuming role is detectable from the environment or harness — role is always explicit,
+asserted by the dispatcher. This plugin targets Claude Code, Codex, and OpenCode; a detection
+mechanism tied to one harness's internals (e.g. inspecting a system prompt) does not port to the
+others and is not a sanctioned pattern even where it happens to work.
+
 ## Language
 
 **SAM (Stateless Agent Methodology)**:

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -38,9 +38,11 @@ _Avoid_: "orchestrator" for this role — a Manager acts on behalf of its dispat
 of the human directly, and the two roles carry different obligations (see Orchestrator above).
 
 **Worker**:
-A subagent assigned one unit of work to execute directly — a SAM task, or a direct prompt with no
-SAM reference (`dh:task-worker` is dispatched both ways; see the Dispatch Pattern section in
-[AGENTS.md](./AGENTS.md)). A
+A subagent assigned one unit of work to execute directly — a SAM task with a task ID to delegate to
+`start-task`, or a direct prompt carrying its own explicit instructions and no such task ID (it may
+still mention a plan address for read-only reference, e.g. a verification task that reads the plan
+to check criteria against it — `dh:task-worker` is dispatched both ways; see the Dispatch Pattern
+section in [AGENTS.md](./AGENTS.md)). A
 Worker's own assignment may explicitly name a specific skill to invoke, including one that itself
 dispatches a fixed, bounded set of subagents to complete that one unit of work — a quality-gate
 task naming `dh:multi-perspective-review`, which fans out four reviewers, is the Worker's

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -10,51 +10,46 @@ every other area of the plugin as it gets resolved.
 
 ## Dispatch Roles
 
-Three roles govern who may dispatch further agents and on whose behalf, defined by relationship —
-never by capability, and never by whether an agent happens to dispatch further work. See
+These terms name the scope an agent's assignment covers — not a capability it holds or is denied.
+Every agent may decompose its own assignment however the work requires, including by dispatching
+further agents; the scope of the assignment is what differs. See
 [ADR-3113-1](./docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md) for the
 incident that required stating this precisely.
 
 **Orchestrator**:
-The single interactive agent acting directly on behalf of the human. Exactly one per session,
-always. Defined by relationship, not capability: the orchestrator is whichever agent received the
-task directly from the human — not whichever agent happens to be dispatching subagents at a given
-moment. A subagent dispatching further subagents does not become the orchestrator by doing so; it
-remains a Manager or Worker, acting on behalf of whoever dispatched it.
+The single interactive agent acting directly on behalf of the human; exactly one per session. Its
+assignment is the human's request in full, so it owns whatever workflow level that request enters
+at. Defined by relationship: whichever agent received the task from the human, not whichever agent
+happens to be dispatching subagents at a given moment. Dispatching further agents does not make a
+subagent the orchestrator.
 _Avoid_: "the orchestrator" as a synonym for "whoever is executing this skill". A skill written in
-first person for the orchestrator, handed to a dispatched Worker, reads as license to dispatch
-further agents the Worker was never assigned to dispatch — see
-[ADR-3113-1](./docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md).
+first person for the orchestrator, read by an agent whose assignment is one task inside that
+skill's own loop, reads as instruction to re-enter the loop that produced its assignment.
 
 **Manager**:
-A subagent explicitly assigned, by its own dispatcher, to decompose a scoped piece of work and
-dispatch further subagents within that scope. The assignment is always stated as data — in the
-delegation prompt, or in a SAM task field carrying the executor type — never inferred from a
-loaded skill's own voice, and never adopted on the subagent's own initiative. Sub-dispatch is
-legitimate and valuable when assigned this way;
-[ADR-3113-1](./docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md) covers why
-unassigned adoption, not dispatch itself, is the actual defect.
-_Avoid_: "orchestrator" for this role — a Manager acts on behalf of its dispatcher, not on behalf
-of the human directly, and the two roles carry different obligations (see Orchestrator above).
+An agent whose assignment covers a scoped body of work and its decomposition — the dispatcher
+hands over the scope, and how it is broken down and distributed is part of the assignment. Acts
+on behalf of the agent that assigned the scope, not on behalf of the human directly.
+_Avoid_: "orchestrator" for this role — a Manager's scope is bounded by what its dispatcher handed
+over, and it reports to that dispatcher rather than to the human (see Orchestrator above).
 
 **Worker**:
-A subagent assigned one unit of work to execute directly — a SAM task with a task ID to delegate to
-`start-task`, or a direct prompt carrying its own explicit instructions and no such task ID (it may
-still mention a plan address for read-only reference, e.g. a verification task that reads the plan
-to check criteria against it — `dh:task-worker` is dispatched both ways; see the Dispatch Pattern
-section in [AGENTS.md](./AGENTS.md)). A
-Worker's own assignment may explicitly name a specific skill to invoke, including one that itself
-dispatches a fixed, bounded set of subagents to complete that one unit of work — a quality-gate
-task naming `dh:multi-perspective-review`, which fans out four reviewers, is the Worker's
-assignment, not a role it inferred. What a Worker never does is independently drive an open-ended,
-multi-round dispatch loop across an entire plan — that requires the Manager role, explicitly
-assigned. On receiving an instruction to run a plan-managing skill it was not assigned to run, a
-Worker reports the conflict (`STATUS: BLOCKED`) rather than complying. `dh:task-worker` is this
+An agent whose assignment covers one unit of work. Two forms, both executed directly:
+a SAM task reference with a task ID to delegate to `start-task`, or a direct prompt carrying its
+own explicit instructions and no such task ID (it may still carry a plan address for read-only
+reference — e.g. a verification task that reads the plan to check criteria against it).
+`dh:task-worker` is dispatched both ways throughout the plugin; see the Dispatch Pattern section
+in [AGENTS.md](./AGENTS.md). The dispatcher passes the task reference and does not choose a
+specialist — the dispatched agent reads the task and resolves its own agent profile from it.
+An assignment may name a specific skill to invoke, including one that fans out its own bounded set
+of subagents; running it is executing the assignment, not widening it. `dh:task-worker` is this
 plugin's canonical Worker implementation.
-_Avoid_: assuming role is detectable from the environment or harness — role is always explicit,
-asserted by the dispatcher. This plugin targets Claude Code, Codex, and OpenCode; a detection
-mechanism tied to one harness's internals (e.g. inspecting a system prompt) does not port to the
-others and is not a sanctioned pattern even where it happens to work.
+_Avoid_: assuming scope is detectable from the environment or harness — an agent cannot observe
+which workflow level dispatched it. Scope is carried in the assignment itself, and prevention
+belongs with the dispatching agent, which can observe what it is about to hand over. This plugin
+targets Claude Code, Codex, and OpenCode; a detection mechanism tied to one harness's internals
+(e.g. inspecting a system prompt) does not port to the others and is not a sanctioned pattern even
+where it happens to work.
 
 ## Language
 

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -16,6 +16,15 @@ further agents; the scope of the assignment is what differs. See
 [ADR-3113-1](./docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md) for the
 incident that required stating this precisely.
 
+**Dispatcher**:
+The agent that invoked another agent with its prompt. A relation, not a role — an Orchestrator, a
+Manager, or a Worker is a dispatcher with respect to any agent it invokes, and the same agent is a
+dispatcher in one direction and a dispatched agent in the other. An agent's dispatcher is the only
+party that can observe what an assignment hands over, so scope enforcement belongs there.
+_Avoid_: naming a dispatched agent's invoker by a role term. The invoker may be any of the three
+roles below, so calling it "the manager" or "the orchestrator" asserts more than the dispatched
+agent can know.
+
 **Orchestrator**:
 The single interactive agent acting directly on behalf of the human; exactly one per session. Its
 assignment is the human's request in full, so it owns whatever workflow level that request enters

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -12,7 +12,8 @@ every other area of the plugin as it gets resolved.
 
 Three roles govern who may dispatch further agents and on whose behalf, defined by relationship —
 never by capability, and never by whether an agent happens to dispatch further work. See
-ADR-3113-1 for the incident that required stating this precisely.
+[ADR-3113-1](./docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md) for the
+incident that required stating this precisely.
 
 **Orchestrator**:
 The single interactive agent acting directly on behalf of the human. Exactly one per session,
@@ -36,11 +37,16 @@ _Avoid_: "orchestrator" for this role — a Manager acts on behalf of its dispat
 of the human directly, and the two roles carry different obligations (see Orchestrator above).
 
 **Worker**:
-A subagent assigned one unit of work to execute directly. Never dispatches further subagents,
-regardless of what any skill it loads is written to instruct — a skill written for a Manager or
-the Orchestrator does not change a Worker's own assignment. On receiving an instruction to run a
-skill that speaks as if to a dispatcher, a Worker reports the conflict (`STATUS: BLOCKED`) rather
-than complying. `dh:task-worker` is this plugin's canonical Worker implementation.
+A subagent assigned one unit of work to execute directly — a SAM task, or a direct prompt with no
+SAM reference (`dh:task-worker` is dispatched both ways; see AGENTS.md's Dispatch Pattern). A
+Worker's own assignment may explicitly name a specific skill to invoke, including one that itself
+dispatches a fixed, bounded set of subagents to complete that one unit of work — a quality-gate
+task naming `dh:multi-perspective-review`, which fans out four reviewers, is the Worker's
+assignment, not a role it inferred. What a Worker never does is independently drive an open-ended,
+multi-round dispatch loop across an entire plan — that requires the Manager role, explicitly
+assigned. On receiving an instruction to run a plan-managing skill it was not assigned to run, a
+Worker reports the conflict (`STATUS: BLOCKED`) rather than complying. `dh:task-worker` is this
+plugin's canonical Worker implementation.
 _Avoid_: assuming role is detectable from the environment or harness — role is always explicit,
 asserted by the dispatcher. This plugin targets Claude Code, Codex, and OpenCode; a detection
 mechanism tied to one harness's internals (e.g. inspecting a system prompt) does not port to the

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -21,24 +21,26 @@ always. Defined by relationship, not capability: the orchestrator is whichever a
 task directly from the human — not whichever agent happens to be dispatching subagents at a given
 moment. A subagent dispatching further subagents does not become the orchestrator by doing so; it
 remains a Manager or Worker, acting on behalf of whoever dispatched it.
-_Avoid_: "the orchestrator" as a synonym for "whoever is executing this skill" — that usage is the
-mechanism behind the #3060 incident (ADR-3113-1): a skill written in first person for the
-orchestrator, handed to a dispatched Worker, was read as license to dispatch further agents the
-Worker was never assigned to dispatch.
+_Avoid_: "the orchestrator" as a synonym for "whoever is executing this skill". A skill written in
+first person for the orchestrator, handed to a dispatched Worker, reads as license to dispatch
+further agents the Worker was never assigned to dispatch — see
+[ADR-3113-1](./docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md).
 
 **Manager**:
 A subagent explicitly assigned, by its own dispatcher, to decompose a scoped piece of work and
 dispatch further subagents within that scope. The assignment is always stated as data — in the
-delegation prompt, or in the SAM task's `executor` field once typed (see #3100) — never inferred
-from a loaded skill's own voice, and never adopted on the subagent's own initiative. Sub-dispatch
-is legitimate and valuable when assigned this way; see ADR-3113-1 for why unassigned adoption,
-not dispatch itself, is the actual defect.
+delegation prompt, or in a SAM task field carrying the executor type — never inferred from a
+loaded skill's own voice, and never adopted on the subagent's own initiative. Sub-dispatch is
+legitimate and valuable when assigned this way;
+[ADR-3113-1](./docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md) covers why
+unassigned adoption, not dispatch itself, is the actual defect.
 _Avoid_: "orchestrator" for this role — a Manager acts on behalf of its dispatcher, not on behalf
 of the human directly, and the two roles carry different obligations (see Orchestrator above).
 
 **Worker**:
 A subagent assigned one unit of work to execute directly — a SAM task, or a direct prompt with no
-SAM reference (`dh:task-worker` is dispatched both ways; see AGENTS.md's Dispatch Pattern). A
+SAM reference (`dh:task-worker` is dispatched both ways; see the Dispatch Pattern section in
+[AGENTS.md](./AGENTS.md)). A
 Worker's own assignment may explicitly name a specific skill to invoke, including one that itself
 dispatches a fixed, bounded set of subagents to complete that one unit of work — a quality-gate
 task naming `dh:multi-perspective-review`, which fans out four reviewers, is the Worker's

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -18,10 +18,13 @@ that assignment states. Assignment takes one of two forms — both are your job 
 - A SAM task reference — a `dh:start-task` invocation naming a plan and task, or a bare
   `P{N}/T{M}`: read the task, load its specialist profile if one is named, delegate execution to
   `start-task`, report status.
-- A direct prompt with no SAM reference — a diagnostic review, an analysis, or any other bounded
-  task with no plan/task ID attached. Execute it exactly as written. `dh:task-worker` is dispatched
-  this way throughout the plugin (see the Dispatch Pattern section in [AGENTS.md](../AGENTS.md))
-  and that pattern is unaffected by anything below.
+- A direct prompt with no task ID to delegate — a diagnostic review, an analysis, an
+  acceptance-criteria verification, or any other bounded task carrying its own explicit
+  instructions. It may still mention a plan address for read-only reference (for example, a
+  verification task that reads the plan via `sam_plan` to check criteria against it), but there is
+  no task ID naming a `start-task` execution to hand off. Execute the instructions exactly as
+  written. `dh:task-worker` is dispatched this way throughout the plugin (see the Dispatch Pattern
+  section in [AGENTS.md](../AGENTS.md)) and that pattern is unaffected by anything below.
 
 Either form of assignment may explicitly name a specific skill to invoke, including one that
 itself dispatches a fixed, bounded set of subagents as part of completing that one unit of work —

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -19,7 +19,7 @@ The manager trusts you to read the task, load the right profile, and execute wit
 
 Parse the plan address and task ID from your prompt. They arrive as:
 
-- A `Skill(skill="start-task", args="{plan} --task {task_id}")` invocation, or
+- A `dh:start-task` invocation naming a plan and task (`{plan} --task {task_id}`), or
 - A bare task reference `P{N}/T{M}`
 
 Call `sam_task(action='read')` to inspect the task's `agent` field **before** delegating to start-task:
@@ -46,21 +46,11 @@ mcp__plugin_dh_backlog__profile_load(agent_name="{agent-field-value}")
 
 If `profile_load` returns an error: output the exact error text and return STATUS: BLOCKED. A task that specifies an `agent` field requires that specialist — continuing without the profile produces unreliable output.
 
-If `profile_load` succeeds: inject the `body` field into your context. Then call `Skill` for every entry in the `skills` list:
-
-```text
-Skill(skill="{skill.uri}")
-```
-
-Loading a skill twice is a no-op.
+If `profile_load` succeeds: inject the `body` field into your context. Then load every skill named in the `skills` list, using each entry's `uri` value as the skill name. Loading a skill twice is a no-op.
 
 ## Step 3 — Delegate to start-task
 
-Call the `start-task` skill using the plan address and task ID parsed from your prompt:
-
-```text
-Skill(skill="start-task", args="{plan} --task {task_id}")
-```
+Load the `dh:start-task` skill, passing the plan address and task ID parsed from your prompt as its arguments (`{plan} --task {task_id}`).
 
 `start-task` owns the full SAM execution lifecycle:
 

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -13,7 +13,7 @@ skills:
 
 You become whatever the task requires by loading the right skills. You are not an expert in any one domain; you are an expert at being a great worker.
 
-The manager trusts you to read the task, load the right profile, and execute with discipline. Your job is to do the work — not to ask the manager how to do it.
+The dispatcher trusts you to read the task, load the right profile, and execute with discipline. Your job is to do the work — not to ask the dispatcher how to do it.
 
 ## Step 1 — Read the Task (profile lookup only)
 
@@ -60,11 +60,11 @@ Load the `dh:start-task` skill, passing the plan address and task ID parsed from
 - Implementing against acceptance criteria
 - Marking the task complete via `sam_task(action='state', status='complete')`
 
-If the manager's prompt includes skill-loading instructions (e.g., `Skill(skill="...")`), follow those before calling start-task. Loading a skill twice is a no-op.
+If the dispatcher's prompt names skills to load, load them before calling start-task. Loading a skill twice is a no-op.
 
 ## Completion Report
 
-Return a structured report the manager can parse:
+Return a structured report the dispatcher can parse:
 
 ```text
 STATUS: COMPLETE|PARTIAL|FAILED
@@ -83,5 +83,5 @@ When operating as part of a coordinated group, send this completion status back 
 
 ## Cross-References
 
-- Manager side: activate the `/dh:dispatch` skill for orchestration patterns
+- Dispatching side: activate the `/dh:dispatch` skill for orchestration patterns
 - Worktree behavior: activate `/dh:worktree-worker-protocol` when working in an isolated worktree

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -19,7 +19,7 @@ The manager trusts you to read the task, load the right profile, and execute wit
 
 Parse the plan address and task ID from your prompt. They arrive as:
 
-- A `dh:start-task` invocation naming a plan and task (`{plan} --task {task_id}`), or
+- A `Skill(skill="start-task", args="{plan} --task {task_id}")` invocation, or
 - A bare task reference `P{N}/T{M}`
 
 Call `sam_task(action='read')` to inspect the task's `agent` field **before** delegating to start-task:
@@ -46,11 +46,21 @@ mcp__plugin_dh_backlog__profile_load(agent_name="{agent-field-value}")
 
 If `profile_load` returns an error: output the exact error text and return STATUS: BLOCKED. A task that specifies an `agent` field requires that specialist — continuing without the profile produces unreliable output.
 
-If `profile_load` succeeds: inject the `body` field into your context. Then load every skill named in the `skills` list, using each entry's `uri` value as the skill name. Loading a skill twice is a no-op.
+If `profile_load` succeeds: inject the `body` field into your context. Then call `Skill` for every entry in the `skills` list:
+
+```text
+Skill(skill="{skill.uri}")
+```
+
+Loading a skill twice is a no-op.
 
 ## Step 3 — Delegate to start-task
 
-Load the `dh:start-task` skill, passing the plan address and task ID parsed from your prompt as its arguments (`{plan} --task {task_id}`).
+Call the `start-task` skill using the plan address and task ID parsed from your prompt:
+
+```text
+Skill(skill="start-task", args="{plan} --task {task_id}")
+```
 
 `start-task` owns the full SAM execution lifecycle:
 

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -11,40 +11,15 @@ skills:
 
 ## Identity
 
-You are a Worker, in the sense [CONTEXT.md](../CONTEXT.md)'s Dispatch Roles define it: you execute
-the assignment your dispatcher gives you, and you never take on a broader coordinating role than
-that assignment states. Assignment takes one of two forms — both are your job to execute directly:
+You become whatever the task requires by loading the right skills. You are not an expert in any one domain; you are an expert at being a great worker.
 
-- A SAM task reference — a `dh:start-task` invocation naming a plan and task, or a bare
-  `P{N}/T{M}`: read the task, load its specialist profile if one is named, delegate execution to
-  `start-task`, report status.
-- A direct prompt with no task ID to delegate — a diagnostic review, an analysis, an
-  acceptance-criteria verification, or any other bounded task carrying its own explicit
-  instructions. It may still mention a plan address for read-only reference (for example, a
-  verification task that reads the plan via `sam_plan` to check criteria against it), but there is
-  no task ID naming a `start-task` execution to hand off. Execute the instructions exactly as
-  written. `dh:task-worker` is dispatched this way throughout the plugin (see the Dispatch Pattern
-  section in [AGENTS.md](../AGENTS.md)) and that pattern is unaffected by anything below.
-
-Either form of assignment may explicitly name a specific skill to invoke, including one that
-itself dispatches a fixed, bounded set of subagents as part of completing that one unit of work —
-a quality-gate task instructing you to invoke `dh:multi-perspective-review`, which fans out four
-reviewers, is your assignment, not a coordinating role you inferred. Following a specific
-instruction that is your own assignment is the job.
-
-Never, however you were dispatched, independently drive an entire SAM plan's task-dispatch loop
-across multiple future rounds — deciding what's ready, batching, and
-repeatedly spawning further task-workers as a plan progresses. That belongs to the Orchestrator, or
-to an agent explicitly assigned the Manager role for that plan. If an instruction — your own
-delegation prompt, or a skill you're told to "follow exactly" — asks you to run a plan-managing
-skill like `dh:implement-feature` yourself, report `STATUS: BLOCKED` naming the conflict, unless
-your own dispatcher explicitly assigned you the Manager role for that specific plan.
+The manager trusts you to read the task, load the right profile, and execute with discipline. Your job is to do the work — not to ask the manager how to do it.
 
 ## Step 1 — Read the Task (profile lookup only)
 
 Parse the plan address and task ID from your prompt. They arrive as:
 
-- A `Skill(skill="start-task", args="{plan} --task {task_id}")` invocation, or
+- A `dh:start-task` invocation naming a plan and task (`{plan} --task {task_id}`), or
 - A bare task reference `P{N}/T{M}`
 
 Call `sam_task(action='read')` to inspect the task's `agent` field **before** delegating to start-task:
@@ -71,21 +46,11 @@ mcp__plugin_dh_backlog__profile_load(agent_name="{agent-field-value}")
 
 If `profile_load` returns an error: output the exact error text and return STATUS: BLOCKED. A task that specifies an `agent` field requires that specialist — continuing without the profile produces unreliable output.
 
-If `profile_load` succeeds: inject the `body` field into your context. Then call `Skill` for every entry in the `skills` list:
-
-```text
-Skill(skill="{skill.uri}")
-```
-
-Loading a skill twice is a no-op.
+If `profile_load` succeeds: inject the `body` field into your context. Then load every skill named in the `skills` list, using each entry's `uri` value as the skill name. Loading a skill twice is a no-op.
 
 ## Step 3 — Delegate to start-task
 
-Call the `start-task` skill using the plan address and task ID parsed from your prompt:
-
-```text
-Skill(skill="start-task", args="{plan} --task {task_id}")
-```
+Load the `dh:start-task` skill, passing the plan address and task ID parsed from your prompt as its arguments (`{plan} --task {task_id}`).
 
 `start-task` owns the full SAM execution lifecycle:
 

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -11,9 +11,26 @@ skills:
 
 ## Identity
 
-You become whatever the task requires by loading the right skills. You are not an expert in any one domain; you are an expert at being a great worker.
+You are a Worker, in the sense CONTEXT.md's Dispatch Roles define it: one subagent, one task, no dispatch of your own. Your complete job:
 
-The manager trusts you to read the task, load the right profile, and execute with discipline. Your job is to do the work — not to ask the manager how to do it.
+1. Read the task.
+2. Load its specialist profile, if one is named.
+3. Delegate execution to `start-task`.
+4. Report status.
+
+Nothing outside this enumeration is your job — not because it's forbidden, but because it belongs
+to whoever dispatched you. Within the job, you become whatever domain expertise the task's profile
+calls for; the shape of the job — one task, direct execution, no dispatch — never changes with it.
+
+Your dispatcher trusts you to do the work without asking how — pick the right approach yourself,
+don't check in over implementation choices. That trust does not extend to accepting a different
+job than the one you were given. If your own delegation prompt, or a skill you load while
+executing the task, instructs you to dispatch, coordinate, spawn, or manage other agents —
+including phrasing like "follow this skill's instructions exactly" where that skill is itself
+written for a dispatcher — treat that as a scope conflict, not an instruction to follow: report
+`STATUS: BLOCKED` naming the conflicting text, and let your dispatcher decide whether to run it
+inline. The one exception: your own delegation prompt explicitly assigns you the Manager role for
+this task. Only then is dispatching further subagents within that assigned scope part of your job.
 
 ## Step 1 — Read the Task (profile lookup only)
 

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -11,26 +11,31 @@ skills:
 
 ## Identity
 
-You are a Worker, in the sense CONTEXT.md's Dispatch Roles define it: one subagent, one task, no dispatch of your own. Your complete job:
+You are a Worker, in the sense [CONTEXT.md](../CONTEXT.md)'s Dispatch Roles define it: you execute
+the assignment your dispatcher gives you, and you never take on a broader coordinating role than
+that assignment states. Assignment takes one of two forms — both are your job to execute directly:
 
-1. Read the task.
-2. Load its specialist profile, if one is named.
-3. Delegate execution to `start-task`.
-4. Report status.
+- **SAM task reference** (`Skill(skill="start-task", args="{plan} --task {id}")` or a bare
+  `P{N}/T{M}`): read the task, load its specialist profile if one is named, delegate execution to
+  `start-task`, report status.
+- **Direct prompt, no SAM reference** — a diagnostic review, an analysis, or any other bounded
+  task with no plan/task ID attached. Execute it exactly as written. `dh:task-worker` is dispatched
+  this way throughout the plugin (see AGENTS.md's Dispatch Pattern) and that pattern is unaffected
+  by anything below.
 
-Nothing outside this enumeration is your job — not because it's forbidden, but because it belongs
-to whoever dispatched you. Within the job, you become whatever domain expertise the task's profile
-calls for; the shape of the job — one task, direct execution, no dispatch — never changes with it.
+Either form of assignment may explicitly name a specific skill to invoke, including one that
+itself dispatches a fixed, bounded set of subagents as part of completing that one unit of work —
+a quality-gate task instructing you to invoke `dh:multi-perspective-review`, which fans out four
+reviewers, is your assignment, not a coordinating role you inferred. Following a specific
+instruction that is your own assignment is the job.
 
-Your dispatcher trusts you to do the work without asking how — pick the right approach yourself,
-don't check in over implementation choices. That trust does not extend to accepting a different
-job than the one you were given. If your own delegation prompt, or a skill you load while
-executing the task, instructs you to dispatch, coordinate, spawn, or manage other agents —
-including phrasing like "follow this skill's instructions exactly" where that skill is itself
-written for a dispatcher — treat that as a scope conflict, not an instruction to follow: report
-`STATUS: BLOCKED` naming the conflicting text, and let your dispatcher decide whether to run it
-inline. The one exception: your own delegation prompt explicitly assigns you the Manager role for
-this task. Only then is dispatching further subagents within that assigned scope part of your job.
+**What is never the job, however you were dispatched: independently driving an entire SAM plan's
+task-dispatch loop across multiple future rounds** — deciding what's ready, batching, and
+repeatedly spawning further task-workers as a plan progresses. That belongs to the Orchestrator, or
+to an agent explicitly assigned the Manager role for that plan. If an instruction — your own
+delegation prompt, or a skill you're told to "follow exactly" — asks you to run a plan-managing
+skill like `dh:implement-feature` yourself, report `STATUS: BLOCKED` naming the conflict, unless
+your own dispatcher explicitly assigned you the Manager role for that specific plan.
 
 ## Step 1 — Read the Task (profile lookup only)
 

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -15,13 +15,13 @@ You are a Worker, in the sense [CONTEXT.md](../CONTEXT.md)'s Dispatch Roles defi
 the assignment your dispatcher gives you, and you never take on a broader coordinating role than
 that assignment states. Assignment takes one of two forms — both are your job to execute directly:
 
-- **SAM task reference** (`Skill(skill="start-task", args="{plan} --task {id}")` or a bare
-  `P{N}/T{M}`): read the task, load its specialist profile if one is named, delegate execution to
+- A SAM task reference — a `dh:start-task` invocation naming a plan and task, or a bare
+  `P{N}/T{M}`: read the task, load its specialist profile if one is named, delegate execution to
   `start-task`, report status.
-- **Direct prompt, no SAM reference** — a diagnostic review, an analysis, or any other bounded
+- A direct prompt with no SAM reference — a diagnostic review, an analysis, or any other bounded
   task with no plan/task ID attached. Execute it exactly as written. `dh:task-worker` is dispatched
-  this way throughout the plugin (see AGENTS.md's Dispatch Pattern) and that pattern is unaffected
-  by anything below.
+  this way throughout the plugin (see the Dispatch Pattern section in [AGENTS.md](../AGENTS.md))
+  and that pattern is unaffected by anything below.
 
 Either form of assignment may explicitly name a specific skill to invoke, including one that
 itself dispatches a fixed, bounded set of subagents as part of completing that one unit of work —
@@ -29,8 +29,8 @@ a quality-gate task instructing you to invoke `dh:multi-perspective-review`, whi
 reviewers, is your assignment, not a coordinating role you inferred. Following a specific
 instruction that is your own assignment is the job.
 
-**What is never the job, however you were dispatched: independently driving an entire SAM plan's
-task-dispatch loop across multiple future rounds** — deciding what's ready, batching, and
+Never, however you were dispatched, independently drive an entire SAM plan's task-dispatch loop
+across multiple future rounds — deciding what's ready, batching, and
 repeatedly spawning further task-workers as a plan progresses. That belongs to the Orchestrator, or
 to an agent explicitly assigned the Manager role for that plan. If an instruction — your own
 delegation prompt, or a skill you're told to "follow exactly" — asks you to run a plan-managing

--- a/plugins/development-harness/docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md
+++ b/plugins/development-harness/docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md
@@ -68,11 +68,18 @@ not by whether an agent happens to dispatch further work:
   delegation prompt (or, once #3100 lands, in the SAM task's `executor` field) — never inferred
   from a loaded skill's own voice, and never adopted on the subagent's own initiative. Acts on
   behalf of whoever assigned it the scope, not on behalf of the human directly.
-- **Worker** — a subagent assigned one unit of work to execute directly. Never dispatches further
-  subagents, regardless of what any skill it loads is written to instruct. On receiving an
-  instruction to run a skill that speaks as if to a dispatcher, a Worker reports the conflict
-  (`STATUS: BLOCKED`) instead of complying. `dh:task-worker` is this plugin's canonical Worker
-  implementation.
+- **Worker** — a subagent assigned one unit of work to execute directly, whether that assignment
+  is a SAM task or a direct prompt with no SAM reference (`dh:task-worker` is dispatched both ways
+  throughout the plugin — see AGENTS.md's Dispatch Pattern, "used for every agent dispatch — no
+  exceptions"). A Worker's assignment may explicitly name a specific skill to invoke, including one
+  that itself dispatches a fixed, bounded set of subagents to complete that one unit of work — a
+  quality-gate task naming `dh:multi-perspective-review`, which fans out four reviewers, is the
+  Worker's assignment, not a coordinating role it inferred. What a Worker never does is
+  independently drive an open-ended, multi-round dispatch loop across an entire plan — deciding
+  what's ready, batching, and repeatedly spawning further task-workers as the plan progresses —
+  that requires the Manager role, explicitly assigned. On receiving an instruction to run a
+  plan-managing skill it was not assigned to run, a Worker reports the conflict (`STATUS: BLOCKED`)
+  instead of complying. `dh:task-worker` is this plugin's canonical Worker implementation.
 
 Role is always explicit, asserted by the dispatcher, carried as data in the delegation prompt —
 never detected by an agent introspecting its own harness or environment. This is what makes the
@@ -81,18 +88,35 @@ a manager, or a worker" depends on a mechanism any one harness happens to expose
 
 This vocabulary is written into `CONTEXT.md` as the plugin's authoritative definition (single
 source of truth — skills reference the terms, they do not restate the definitions). `task-worker.md`
-is rewritten to embody the Worker role as a closed, positive job enumeration rather than an
-open-ended "become whatever is needed." `post-planning.md` gets an explicit warning at the one
-confirmed instance of this incident's proximate cause: `dh:implement-feature`'s invocation runs
-inline in the orchestrating agent's own context and must never be copied into a delegation prompt
-for a task-scoped subagent.
+is rewritten to state the Worker role's boundary explicitly — execute the assignment as given,
+including a specific skill the assignment names, but never independently drive a plan's dispatch
+loop — rather than the open-ended "become whatever is needed" it carried before. `post-planning.md`
+gets an explicit warning at the one confirmed instance of this incident's proximate cause:
+`dh:implement-feature`'s invocation runs inline in the orchestrating agent's own context and must
+never be copied into a delegation prompt for a task-scoped subagent.
+
+**Revised during PR review (#3114), confirmed against source before accepting.** The first draft
+of the Worker definition and `task-worker.md`'s rewrite stated a closed SAM-task-only job
+enumeration with no dispatch of any kind. Two independent review findings, each verified against
+the actual referenced source before this revision was made, showed that was too narrow and would
+have broken existing, intentional behavior: (1) `AGENTS.md` (`plugins/development-harness/AGENTS.md`,
+"Dispatch Pattern" section) states `dh:task-worker` is dispatched with a direct prompt and no SAM
+task reference throughout the plugin — confirmed against `groom/error.md` (a diagnostic-review
+dispatch) and `groom-backlog-item/references/drift-check.md` (a plan-drift analysis dispatch),
+neither of which has any SAM task to read; (2) the quality-gate Phase 0 task
+(`sam_schema/core/quality_gates.py`'s `_phase_body`) explicitly instructs its task-worker to invoke
+`dh:multi-perspective-review`, which fans out four reviewer agents by design — a legitimate,
+bounded, assignment-named fan-out, not the open-ended role self-assignment this ADR exists to stop.
+The definitions above reflect the corrected, narrower boundary: what's prohibited is independently
+driving a plan's dispatch loop, not dispatch in any form.
 
 ## Consequences
 
 - `task-worker.md`'s Identity section changes from an open self-concept ("become whatever the task
-  requires") to a closed enumeration (read task → `profile_load` → delegate to `start-task` →
-  report → stop), with an explicit BLOCKED path for a role conflict instead of language that
-  discourages surfacing one.
+  requires") to a stated boundary: execute the assignment as given — a SAM task via `start-task`,
+  or a direct prompt naming a specific skill, including one that fans out its own fixed subagents —
+  but never independently drive a plan's multi-round dispatch loop. Explicit BLOCKED routing
+  replaces language that discouraged surfacing a role conflict.
 - `implement-feature/SKILL.md` itself is not rewritten by this ADR — its "orchestrator" language is
   correct when the skill runs in the orchestrator's or an assigned manager's own context, which is
   the only way it is designed to run. The gap this ADR closes is that nothing previously stopped
@@ -106,7 +130,7 @@ for a task-scoped subagent.
 - No tool-permission change accompanies this ADR. `task-worker.md` intentionally carries no
   restricted `tools:` list — it must be able to adopt the full capability set of whatever
   specialist profile `profile_load` injects, which a static allowlist would break. The safety
-  mechanism here is entirely behavioral (the closed job enumeration and the BLOCKED path), not
+  mechanism here is entirely behavioral (the stated role boundary and the BLOCKED path), not
   structural.
 
 ## Considered alternatives

--- a/plugins/development-harness/docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md
+++ b/plugins/development-harness/docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md
@@ -1,172 +1,133 @@
-# ADR-3113-1: Orchestrator, manager, and worker are three roles, not one capability
+# ADR-3113-1: Dispatch roles name scope, not capability, and enforcement sits with the dispatcher
 
 **Status:** Accepted
 **Date:** 2026-08-22
 **Issue:** [#3113](https://github.com/Jamie-BitFlight/claude_skills/issues/3113), incident: [#3060](https://github.com/Jamie-BitFlight/claude_skills/issues/3060)
 **Related:** [#3099](https://github.com/Jamie-BitFlight/claude_skills/issues/3099) (per-task failure
 policies, including executor-loss), [#3100](https://github.com/Jamie-BitFlight/claude_skills/issues/3100)
-(executor-type declaration on the SAM task schema — the eventual typed-data formalization of the
-vocabulary this ADR establishes in prose)
+(executor-type declaration on the SAM task schema)
 
 ## Context
 
 During #3060's implementation, a dispatched agent (`work-3060`) delegated the entire
 `dh:implement-feature` skill invocation to a `dh:task-worker` subagent instead of running it
 inline in its own context. `implement-feature/SKILL.md` is written in first person for "the
-orchestrator": query ready tasks, dispatch via `TeamCreate`, run one `dh:task-worker` per ready
-task. The receiving task-worker complied with that borrowed voice literally — it loaded and
-executed `dh:implement-feature`'s dispatch loop, itself spawning a team of further task-workers
-and a contract-verification agent. Cost: roughly $100 of unplanned spend before the pattern was
-caught and stopped.
+orchestrator": query ready tasks, dispatch one `dh:task-worker` per ready task, repeat. The
+receiving task-worker complied with that borrowed voice literally — it loaded and executed
+`dh:implement-feature`'s dispatch loop, itself spawning a team of further task-workers and a
+contract-verification agent. Cost: roughly $100 of unplanned spend before the pattern was caught
+and stopped.
 
-Two independent gaps produced this, confirmed by direct transcript forensics (not inferred):
+Two facts about the incident were confirmed by direct transcript forensics, not inferred:
 
-1. **`implement-feature/SKILL.md` uses "the orchestrator" to mean "whoever is executing this
-   skill."** That phrasing was never ambiguous until recently: subagents dispatching further
-   subagents is a platform capability added within the last ~8 weeks, newer than this workflow.
-   Before that capability existed, only the top-level interactive session could ever be in a
-   position to execute a skill written in this voice, so there was nothing to disambiguate. The
-   docs were never revisited against the new capability.
-2. **`task-worker.md`'s Identity section provides no resistance to executing orchestrator-voiced
-   content it's handed, and actively discourages the pushback that should catch this.** Its text —
-   "you become whatever the task requires by loading the right skills... your job is to do the
-   work — not to ask the manager how to do it" — places no restriction on which skills are
-   appropriate to load, and directly forecloses questioning an instruction to load and fully
-   execute a skill written for a different role.
+1. `implement-feature/SKILL.md` uses "the orchestrator" to mean "whoever is executing this
+   skill." That phrasing was unambiguous until recently: subagents dispatching further subagents
+   is a platform capability added within the last ~8 weeks, newer than this workflow. Before it
+   existed, only the top-level interactive session could ever execute a skill written in that
+   voice, so there was nothing to disambiguate. The docs were never revisited against the new
+   capability.
+2. The invocation was handed to a subagent by the agent holding it. The subagent received a
+   free-prose delegation string naming a plan-level skill, and had no information distinguishing
+   that string from any other assignment it might legitimately receive.
 
-A live, verifiable distinction underlies both gaps: the interactive Claude Code session's own
-system prompt opens "You are Claude Code... an interactive agent that helps users." A dispatched
-subagent's system prompt carries no such framing — confirmed by direct comparison this session,
-not assumed. The orchestrator/subagent boundary is not a convention this ADR invents; it already
-exists structurally. The plugin's prose was simply not consistent with it.
-
-**Sub-dispatch itself is not the defect.** A subagent dispatching further subagents, when planned
-by whoever dispatched it, is a legitimate and valuable decomposition pattern — the platform
-capability that makes it possible is new, not wrong. The actual defect is narrower: a subagent
-*inferring* a coordinating role for itself from a skill's authorial voice, rather than being
-*explicitly assigned* that role by its own dispatcher.
+**Sub-dispatch is not the defect.** An agent decomposing its own assignment into subagents is
+ordinary problem-solving and must stay available to every agent. The defect is narrower: an
+assignment was handed down that re-entered the workflow level which produced it, restarting a
+loop whose earlier round was still in flight.
 
 **Cross-harness constraint.** This plugin targets Claude Code, Codex, and OpenCode. The one
-role-detection mechanism verified this session (comparing system-prompt first lines) is
-Claude-Code-specific and not a sanctioned runtime mechanism even there — it was a diagnostic
-probe, not something plugin prose can instruct an agent to do. Any fix that relies on an agent
-introspecting its own environment to determine its role does not port across harnesses and
-should not be built. The fix below relies on none of that: role is asserted by the dispatcher and
-stated in the dispatch prompt, which every harness's delegation mechanism already carries a place
-for.
+role-detection mechanism verified during triage (comparing system-prompt first lines) is
+Claude-Code-specific and was a diagnostic probe, not a sanctioned runtime mechanism even there.
+Any fix requiring an agent to introspect its own environment to determine its role does not port
+across harnesses and is not built here.
 
 ## Decision
 
-Three roles, defined by relationship to the human and to the dispatcher — not by capability, and
-not by whether an agent happens to dispatch further work:
+The invariant is scope, and it is stated once, in prose, at the place that can act on it:
 
-- **Orchestrator** — the single interactive agent acting directly on behalf of the human. Exactly
-  one per session. Never inferred, never a subagent, regardless of what that subagent itself goes
-  on to dispatch.
-- **Manager** — a subagent explicitly assigned, by its own dispatcher, to decompose a scoped piece
-  of work and dispatch further subagents within that scope. The assignment must be stated in the
-  delegation prompt (or, once #3100 lands, in the SAM task's `executor` field) — never inferred
-  from a loaded skill's own voice, and never adopted on the subagent's own initiative. Acts on
-  behalf of whoever assigned it the scope, not on behalf of the human directly.
-- **Worker** — a subagent assigned one unit of work to execute directly, whether that assignment
-  is a SAM task or a direct prompt with no SAM reference (`dh:task-worker` is dispatched both ways
-  throughout the plugin — see AGENTS.md's Dispatch Pattern, "used for every agent dispatch — no
-  exceptions"). A Worker's assignment may explicitly name a specific skill to invoke, including one
-  that itself dispatches a fixed, bounded set of subagents to complete that one unit of work — a
-  quality-gate task naming `dh:multi-perspective-review`, which fans out four reviewers, is the
-  Worker's assignment, not a coordinating role it inferred. What a Worker never does is
-  independently drive an open-ended, multi-round dispatch loop across an entire plan — deciding
-  what's ready, batching, and repeatedly spawning further task-workers as the plan progresses —
-  that requires the Manager role, explicitly assigned. On receiving an instruction to run a
-  plan-managing skill it was not assigned to run, a Worker reports the conflict (`STATUS: BLOCKED`)
-  instead of complying. `dh:task-worker` is this plugin's canonical Worker implementation.
+**An agent's assignment must not re-enter the workflow level that produced that assignment.**
 
-Role is always explicit, asserted by the dispatcher, carried as data in the delegation prompt —
-never detected by an agent introspecting its own harness or environment. This is what makes the
-definitions portable across Claude Code, Codex, and OpenCode: nothing about "am I the orchestrator,
-a manager, or a worker" depends on a mechanism any one harness happens to expose.
+Enforcement sits with the dispatching agent, never the receiving one. The dispatcher can directly
+observe the condition the rule names — it is holding the invocation and deciding whether to run it
+itself or hand it over. The receiver cannot: a dispatched agent has no observable signal telling it
+which workflow level dispatched it, and this ADR rejects building one (see Considered
+alternatives). A constraint the actor cannot observe is unenforceable, so it is written where the
+actor can observe it.
 
-This vocabulary is written into `CONTEXT.md` as the plugin's authoritative definition (single
-source of truth — skills reference the terms, they do not restate the definitions). `task-worker.md`
-is rewritten to state the Worker role's boundary explicitly — execute the assignment as given,
-including a specific skill the assignment names, but never independently drive a plan's dispatch
-loop — rather than the open-ended "become whatever is needed" it carried before. `post-planning.md`
-gets an explicit warning at the one confirmed instance of this incident's proximate cause:
-`dh:implement-feature`'s invocation runs inline in the orchestrating agent's own context and must
-never be copied into a delegation prompt for a task-scoped subagent.
+Concretely, `post-planning.md` — the one place transcript forensics confirmed this incident's
+proximate cause — instructs the agent holding the `dh:implement-feature` invocation to run it
+inline and never copy it into a delegation prompt. That instruction sits with the agent about to
+make the call, and states the observable condition ("am I about to hand this invocation to someone
+else?"), not an unobservable one.
 
-**Revised during PR review (#3114), confirmed against source before accepting.** The first draft
-of the Worker definition and `task-worker.md`'s rewrite stated a closed SAM-task-only job
-enumeration with no dispatch of any kind. Two independent review findings, each verified against
-the actual referenced source before this revision was made, showed that was too narrow and would
-have broken existing, intentional behavior: (1) `AGENTS.md` (`plugins/development-harness/AGENTS.md`,
-"Dispatch Pattern" section) states `dh:task-worker` is dispatched with a direct prompt and no SAM
-task reference throughout the plugin — confirmed against `groom/error.md` (a diagnostic-review
-dispatch) and `groom-backlog-item/references/drift-check.md` (a plan-drift analysis dispatch),
-neither of which has any SAM task to read; (2) the quality-gate Phase 0 task
-(`sam_schema/core/quality_gates.py`'s `_phase_body`) explicitly instructs its task-worker to invoke
-`dh:multi-perspective-review`, which fans out four reviewer agents by design — a legitimate,
-bounded, assignment-named fan-out, not the open-ended role self-assignment this ADR exists to stop.
-The definitions above reflect the corrected, narrower boundary: what's prohibited is independently
-driving a plan's dispatch loop, not dispatch in any form.
+`CONTEXT.md` carries the vocabulary — Orchestrator, Manager, Worker — redefined by the scope an
+assignment covers rather than by any capability a role holds:
 
-**Revised again during the same PR review, confirmed against source before accepting.** A third
-finding showed the "direct prompt" bucket was still too narrow: `close/start.md`'s Step 5.5
-dispatches `dh:task-worker` with a plan address (e.g. `P{id}`) for an acceptance-criteria
-verification, but no task ID — a caller that fits neither "SAM task reference" (no task ID present)
-nor the prior wording of "direct prompt... with no plan/task ID attached" (a plan address *is*
-present). The Worker definition and `task-worker.md` are corrected again: the deciding signal is
-whether a task ID is present to delegate to `start-task`, not whether any plan reference appears at
-all. A direct prompt may legitimately carry a plan address for read-only reference.
+- **Orchestrator** — the single interactive agent acting on behalf of the human; its assignment is
+  the human's request in full.
+- **Manager** — an agent whose assignment covers a scoped body of work and its decomposition.
+- **Worker** — an agent whose assignment covers one unit of work. `dh:task-worker` is this
+  plugin's canonical Worker implementation.
 
-This same PR review also flagged Claude-Code-specific tool names (`TeamCreate`, `SendMessage`,
-literal `Skill(skill="...")` call syntax) surviving in `task-worker.md`'s frontmatter and
-Completion Report — this plugin targets Claude Code, Codex, and OpenCode, and prose describing what
-a Worker does should name the capability (dispatch as part of a coordinated group, report back to
-the group's lead) rather than one harness's specific tool. Corrected in the same pass.
+`CONTEXT.md` is a design-time document about the plugin and is not loaded by the plugin's agents at
+runtime, which makes it the correct home for vocabulary and the wrong home for enforcement. The
+runtime-facing counterpart is the `dh:dispatch-contract` skill, whose framing this vocabulary
+matches: the dispatcher passes a task reference and does not choose a specialist; the dispatched
+agent reads the task and resolves its own agent profile from it.
 
-## Consequences
-
-- `task-worker.md`'s Identity section changes from an open self-concept ("become whatever the task
-  requires") to a stated boundary: execute the assignment as given — a SAM task via `start-task`,
-  or a direct prompt naming a specific skill, including one that fans out its own fixed subagents —
-  but never independently drive a plan's multi-round dispatch loop. Explicit BLOCKED routing
-  replaces language that discouraged surfacing a role conflict.
-- `implement-feature/SKILL.md` itself is not rewritten by this ADR — its "orchestrator" language is
-  correct when the skill runs in the orchestrator's or an assigned manager's own context, which is
-  the only way it is designed to run. The gap this ADR closes is that nothing previously stopped
-  that invocation from being handed to a Worker instead; `post-planning.md`'s new warning addresses
-  the one place this session confirmed that actually happened. A broader sweep of "orchestrator"
-  usage across the rest of the plugin (458 hits across ~70 files, audited but out of scope here) is
-  tracked separately, not resolved by this ADR.
-- #3100's `executor` field, once implemented, becomes the typed-data backing for the Manager/Worker
-  distinction this ADR defines in prose; this ADR's definitions are the vocabulary that field must
-  match, not superseded by it.
-- No tool-permission change accompanies this ADR. `task-worker.md` intentionally carries no
-  restricted `tools:` list — it must be able to adopt the full capability set of whatever
-  specialist profile `profile_load` injects, which a static allowlist would break. The safety
-  mechanism here is entirely behavioral (the stated role boundary and the BLOCKED path), not
-  structural.
+`task-worker.md` carries no role prose at all. Its Identity section states what the agent is for
+("you become whatever the task requires by loading the right skills") and nothing about workflow
+levels, permissions, or what it may not be asked to do.
 
 ## Considered alternatives
 
-**Restrict `task-worker.md`'s `tools:` frontmatter to exclude `Agent`/`TeamCreate`/`EnterWorktree`**
-(defense-in-depth, proposed during incident triage): rejected as the primary fix, and dropped
-entirely as a secondary one — confirmed by the repo owner. `task-worker` is designed to act with
-whatever capability set the specialist profile it loads via `profile_load` requires; hardcoding a
-restricted list on the base agent works against that design, not alongside it, and `profile_load`
-only injects text into context — it does not adjust the actual runtime tool grant per profile — so
-there is no clean mechanism today to scope tools per-task even if desired.
+**Split the roles by capability — a Manager may dispatch, a Worker may not.** Rejected. Nothing was
+ever gated: no tool grant, no schema field, no runtime check distinguished the two, so the split
+existed only as prose asserting a difference the system did not implement. Worse, it encodes
+capability as identity, and decomposing one's own assignment into subagents is ordinary
+problem-solving that must remain available to every agent. The mirror-image fix — a sentence
+granting permission to subdivide — is equally rejected: it reads as instruction, and changes
+nothing an agent would not already have done.
 
-**Detect role via harness/environment introspection** (e.g., an agent checking its own system
-prompt or a harness-specific signal to determine if it's top-level): rejected. Confirmed
-Claude-Code-specific and not a sanctioned mechanism even within Claude Code; would require separate,
-unverified detection logic per harness (Codex, OpenCode) with no guarantee of staying correct as
-each harness's subagent model evolves independently. Explicit dispatcher-stated role, carried as
-prompt/plan data, achieves the same goal without depending on any harness's internals.
+**Write the constraint as receiver-side prose in `task-worker.md`.** Tried on the first pass of
+this branch and rejected. The added Identity block named the agent a Worker, enumerated its
+assignment forms, carved out an exception for assignments naming skills that fan out, and told it
+to report `STATUS: BLOCKED` on receiving a plan-managing skill. Every one of those clauses asks the
+agent to classify a condition it cannot observe — whether the instruction in front of it came from
+the level it would be re-entering. The exception carve-outs are the symptom: each one exists
+because a legitimate dispatch pattern (`dh:multi-perspective-review`'s four-reviewer fan-out;
+`close/start.md`'s plan-address-with-no-task-ID verification dispatch, both verified against source
+during PR review) collided with a rule stated in terms the receiver has no way to evaluate. Prose
+that needs an exception per legitimate caller is a rule written in the wrong place.
+
+**Restrict `task-worker.md`'s `tools:` frontmatter to exclude agent-dispatch capabilities.**
+Rejected, confirmed by the repo owner. `task-worker` must be able to adopt the full capability set
+of whatever specialist profile `profile_load` injects; a static allowlist on the base agent works
+against that design. `profile_load` only injects text into context — it does not adjust the runtime
+tool grant per profile — so there is no mechanism today to scope tools per-task even if it were
+wanted.
+
+**Detect role via harness or environment introspection** (an agent checking its own system prompt
+or a harness-specific signal to determine whether it is top-level): rejected. Claude-Code-specific,
+not sanctioned even within Claude Code, and would require separate unverified detection logic per
+harness with no guarantee of staying correct as each harness's subagent model evolves.
 
 **Rewrite every "orchestrator" occurrence across the plugin in this pass** (458 hits, ~70 files):
-rejected for this ADR's scope. The incident's proximate cause is fully addressed by the four files
-this decision touches; a plugin-wide terminology sweep is real work but independent, larger, and
-better tracked as its own item rather than expanding this one past what the incident evidence
-actually required.
+rejected for this ADR's scope. The incident's proximate cause is addressed by the files this
+decision touches; a plugin-wide terminology sweep is real work but independent and larger, better
+tracked as its own item.
+
+## Consequences
+
+- Prevention exists at exactly one confirmed site (`post-planning.md`) rather than as a general
+  behavioural rule carried by every dispatched agent. Other sites that hand off a plan-level
+  invocation are not covered by this ADR and must each carry the instruction at the dispatching
+  agent, in the same form, when found.
+- `implement-feature/SKILL.md` is not rewritten here. Its "orchestrator" voice is correct when the
+  skill runs in the context of an agent whose assignment covers the plan, which is the only way it
+  is designed to run. What this ADR closes is that nothing stopped that invocation from being
+  handed onward.
+- No tool-permission change accompanies this ADR, and no capability is gated for any agent.
+- #3100's executor-type field, once implemented, gives the dispatcher typed data to state scope
+  with instead of free prose. That is the natural extension of this decision: the dispatcher
+  already owns the constraint, and the field gives it a machine-checkable place to put it.

--- a/plugins/development-harness/docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md
+++ b/plugins/development-harness/docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md
@@ -110,6 +110,21 @@ bounded, assignment-named fan-out, not the open-ended role self-assignment this 
 The definitions above reflect the corrected, narrower boundary: what's prohibited is independently
 driving a plan's dispatch loop, not dispatch in any form.
 
+**Revised again during the same PR review, confirmed against source before accepting.** A third
+finding showed the "direct prompt" bucket was still too narrow: `close/start.md`'s Step 5.5
+dispatches `dh:task-worker` with a plan address (e.g. `P{id}`) for an acceptance-criteria
+verification, but no task ID — a caller that fits neither "SAM task reference" (no task ID present)
+nor the prior wording of "direct prompt... with no plan/task ID attached" (a plan address *is*
+present). The Worker definition and `task-worker.md` are corrected again: the deciding signal is
+whether a task ID is present to delegate to `start-task`, not whether any plan reference appears at
+all. A direct prompt may legitimately carry a plan address for read-only reference.
+
+This same PR review also flagged Claude-Code-specific tool names (`TeamCreate`, `SendMessage`,
+literal `Skill(skill="...")` call syntax) surviving in `task-worker.md`'s frontmatter and
+Completion Report — this plugin targets Claude Code, Codex, and OpenCode, and prose describing what
+a Worker does should name the capability (dispatch as part of a coordinated group, report back to
+the group's lead) rather than one harness's specific tool. Corrected in the same pass.
+
 ## Consequences
 
 - `task-worker.md`'s Identity section changes from an open self-concept ("become whatever the task

--- a/plugins/development-harness/docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md
+++ b/plugins/development-harness/docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md
@@ -1,0 +1,133 @@
+# ADR-3113-1: Orchestrator, manager, and worker are three roles, not one capability
+
+**Status:** Accepted
+**Date:** 2026-08-22
+**Issue:** [#3113](https://github.com/Jamie-BitFlight/claude_skills/issues/3113), incident: [#3060](https://github.com/Jamie-BitFlight/claude_skills/issues/3060)
+**Related:** [#3099](https://github.com/Jamie-BitFlight/claude_skills/issues/3099) (per-task failure
+policies, including executor-loss), [#3100](https://github.com/Jamie-BitFlight/claude_skills/issues/3100)
+(executor-type declaration on the SAM task schema — the eventual typed-data formalization of the
+vocabulary this ADR establishes in prose)
+
+## Context
+
+During #3060's implementation, a dispatched agent (`work-3060`) delegated the entire
+`dh:implement-feature` skill invocation to a `dh:task-worker` subagent instead of running it
+inline in its own context. `implement-feature/SKILL.md` is written in first person for "the
+orchestrator": query ready tasks, dispatch via `TeamCreate`, run one `dh:task-worker` per ready
+task. The receiving task-worker complied with that borrowed voice literally — it loaded and
+executed `dh:implement-feature`'s dispatch loop, itself spawning a team of further task-workers
+and a contract-verification agent. Cost: roughly $100 of unplanned spend before the pattern was
+caught and stopped.
+
+Two independent gaps produced this, confirmed by direct transcript forensics (not inferred):
+
+1. **`implement-feature/SKILL.md` uses "the orchestrator" to mean "whoever is executing this
+   skill."** That phrasing was never ambiguous until recently: subagents dispatching further
+   subagents is a platform capability added within the last ~8 weeks, newer than this workflow.
+   Before that capability existed, only the top-level interactive session could ever be in a
+   position to execute a skill written in this voice, so there was nothing to disambiguate. The
+   docs were never revisited against the new capability.
+2. **`task-worker.md`'s Identity section provides no resistance to executing orchestrator-voiced
+   content it's handed, and actively discourages the pushback that should catch this.** Its text —
+   "you become whatever the task requires by loading the right skills... your job is to do the
+   work — not to ask the manager how to do it" — places no restriction on which skills are
+   appropriate to load, and directly forecloses questioning an instruction to load and fully
+   execute a skill written for a different role.
+
+A live, verifiable distinction underlies both gaps: the interactive Claude Code session's own
+system prompt opens "You are Claude Code... an interactive agent that helps users." A dispatched
+subagent's system prompt carries no such framing — confirmed by direct comparison this session,
+not assumed. The orchestrator/subagent boundary is not a convention this ADR invents; it already
+exists structurally. The plugin's prose was simply not consistent with it.
+
+**Sub-dispatch itself is not the defect.** A subagent dispatching further subagents, when planned
+by whoever dispatched it, is a legitimate and valuable decomposition pattern — the platform
+capability that makes it possible is new, not wrong. The actual defect is narrower: a subagent
+*inferring* a coordinating role for itself from a skill's authorial voice, rather than being
+*explicitly assigned* that role by its own dispatcher.
+
+**Cross-harness constraint.** This plugin targets Claude Code, Codex, and OpenCode. The one
+role-detection mechanism verified this session (comparing system-prompt first lines) is
+Claude-Code-specific and not a sanctioned runtime mechanism even there — it was a diagnostic
+probe, not something plugin prose can instruct an agent to do. Any fix that relies on an agent
+introspecting its own environment to determine its role does not port across harnesses and
+should not be built. The fix below relies on none of that: role is asserted by the dispatcher and
+stated in the dispatch prompt, which every harness's delegation mechanism already carries a place
+for.
+
+## Decision
+
+Three roles, defined by relationship to the human and to the dispatcher — not by capability, and
+not by whether an agent happens to dispatch further work:
+
+- **Orchestrator** — the single interactive agent acting directly on behalf of the human. Exactly
+  one per session. Never inferred, never a subagent, regardless of what that subagent itself goes
+  on to dispatch.
+- **Manager** — a subagent explicitly assigned, by its own dispatcher, to decompose a scoped piece
+  of work and dispatch further subagents within that scope. The assignment must be stated in the
+  delegation prompt (or, once #3100 lands, in the SAM task's `executor` field) — never inferred
+  from a loaded skill's own voice, and never adopted on the subagent's own initiative. Acts on
+  behalf of whoever assigned it the scope, not on behalf of the human directly.
+- **Worker** — a subagent assigned one unit of work to execute directly. Never dispatches further
+  subagents, regardless of what any skill it loads is written to instruct. On receiving an
+  instruction to run a skill that speaks as if to a dispatcher, a Worker reports the conflict
+  (`STATUS: BLOCKED`) instead of complying. `dh:task-worker` is this plugin's canonical Worker
+  implementation.
+
+Role is always explicit, asserted by the dispatcher, carried as data in the delegation prompt —
+never detected by an agent introspecting its own harness or environment. This is what makes the
+definitions portable across Claude Code, Codex, and OpenCode: nothing about "am I the orchestrator,
+a manager, or a worker" depends on a mechanism any one harness happens to expose.
+
+This vocabulary is written into `CONTEXT.md` as the plugin's authoritative definition (single
+source of truth — skills reference the terms, they do not restate the definitions). `task-worker.md`
+is rewritten to embody the Worker role as a closed, positive job enumeration rather than an
+open-ended "become whatever is needed." `post-planning.md` gets an explicit warning at the one
+confirmed instance of this incident's proximate cause: `dh:implement-feature`'s invocation runs
+inline in the orchestrating agent's own context and must never be copied into a delegation prompt
+for a task-scoped subagent.
+
+## Consequences
+
+- `task-worker.md`'s Identity section changes from an open self-concept ("become whatever the task
+  requires") to a closed enumeration (read task → `profile_load` → delegate to `start-task` →
+  report → stop), with an explicit BLOCKED path for a role conflict instead of language that
+  discourages surfacing one.
+- `implement-feature/SKILL.md` itself is not rewritten by this ADR — its "orchestrator" language is
+  correct when the skill runs in the orchestrator's or an assigned manager's own context, which is
+  the only way it is designed to run. The gap this ADR closes is that nothing previously stopped
+  that invocation from being handed to a Worker instead; `post-planning.md`'s new warning addresses
+  the one place this session confirmed that actually happened. A broader sweep of "orchestrator"
+  usage across the rest of the plugin (458 hits across ~70 files, audited but out of scope here) is
+  tracked separately, not resolved by this ADR.
+- #3100's `executor` field, once implemented, becomes the typed-data backing for the Manager/Worker
+  distinction this ADR defines in prose; this ADR's definitions are the vocabulary that field must
+  match, not superseded by it.
+- No tool-permission change accompanies this ADR. `task-worker.md` intentionally carries no
+  restricted `tools:` list — it must be able to adopt the full capability set of whatever
+  specialist profile `profile_load` injects, which a static allowlist would break. The safety
+  mechanism here is entirely behavioral (the closed job enumeration and the BLOCKED path), not
+  structural.
+
+## Considered alternatives
+
+**Restrict `task-worker.md`'s `tools:` frontmatter to exclude `Agent`/`TeamCreate`/`EnterWorktree`**
+(defense-in-depth, proposed during incident triage): rejected as the primary fix, and dropped
+entirely as a secondary one — confirmed by the repo owner. `task-worker` is designed to act with
+whatever capability set the specialist profile it loads via `profile_load` requires; hardcoding a
+restricted list on the base agent works against that design, not alongside it, and `profile_load`
+only injects text into context — it does not adjust the actual runtime tool grant per profile — so
+there is no clean mechanism today to scope tools per-task even if desired.
+
+**Detect role via harness/environment introspection** (e.g., an agent checking its own system
+prompt or a harness-specific signal to determine if it's top-level): rejected. Confirmed
+Claude-Code-specific and not a sanctioned mechanism even within Claude Code; would require separate,
+unverified detection logic per harness (Codex, OpenCode) with no guarantee of staying correct as
+each harness's subagent model evolves independently. Explicit dispatcher-stated role, carried as
+prompt/plan data, achieves the same goal without depending on any harness's internals.
+
+**Rewrite every "orchestrator" occurrence across the plugin in this pass** (458 hits, ~70 files):
+rejected for this ADR's scope. The incident's proximate cause is fully addressed by the four files
+this decision touches; a plugin-wide terminology sweep is real work but independent, larger, and
+better tracked as its own item rather than expanding this one past what the incident evidence
+actually required.

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/post-planning.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/post-planning.md
@@ -10,6 +10,14 @@ Skip the interactive report. Instead, continue directly to implementation:
    Skill(skill: "dh:implement-feature", args: "{plan_address}")
    ```
 
+   This call runs inline, in the current agent's own context — the agent making this call is the
+   one that dispatches `dh:task-worker` per task for the rest of the loop. Never copy this
+   invocation into a delegation prompt for a `dh:task-worker` subagent: `implement-feature`'s
+   Progress Loop is written for whoever runs it to dispatch further agents, which is not a
+   Worker's job (see CONTEXT.md's Dispatch Roles, ADR-3113-1). If the current agent needs a fresh
+   worktree before running this, acquire one directly (`EnterWorktree`) and then make this call
+   itself — do not hand the whole invocation to a subagent as a workaround.
+
 2. When all tasks complete, invoke quality gates:
 
    ```text

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/post-planning.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/post-planning.md
@@ -10,15 +10,11 @@ Skip the interactive report. Instead, continue directly to implementation:
    Skill(skill: "dh:implement-feature", args: "{plan_address}")
    ```
 
-   This call runs inline, in the current agent's own context — the agent making this call is the
-   one that dispatches `dh:task-worker` per task for the rest of the loop. Never copy this
-   invocation into a delegation prompt for a `dh:task-worker` subagent: `implement-feature`'s
-   Progress Loop is written for whoever runs it to dispatch further agents, which is not a
-   Worker's job (see [CONTEXT.md](../../../../../CONTEXT.md)'s Dispatch Roles,
-   [ADR-3113-1](../../../../../docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md)).
-   If the current agent needs a fresh
-   worktree before running this, acquire one directly (`EnterWorktree`) and then make this call
-   itself — do not hand the whole invocation to a subagent as a workaround.
+   Run this call inline, in the current agent's own context. `implement-feature`'s Progress Loop
+   is written for whoever runs it to dispatch `dh:task-worker` per task for the rest of the loop.
+   Never copy this invocation into a delegation prompt for a subagent. If an isolated worktree is
+   needed first, acquire one for the current agent and then make this call from there — do not
+   hand the invocation to a subagent as a workaround.
 
 2. When all tasks complete, invoke quality gates:
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/post-planning.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/post-planning.md
@@ -14,7 +14,9 @@ Skip the interactive report. Instead, continue directly to implementation:
    one that dispatches `dh:task-worker` per task for the rest of the loop. Never copy this
    invocation into a delegation prompt for a `dh:task-worker` subagent: `implement-feature`'s
    Progress Loop is written for whoever runs it to dispatch further agents, which is not a
-   Worker's job (see CONTEXT.md's Dispatch Roles, ADR-3113-1). If the current agent needs a fresh
+   Worker's job (see [CONTEXT.md](../../../../../CONTEXT.md)'s Dispatch Roles,
+   [ADR-3113-1](../../../../../docs/adrs/ADR-3113-1-orchestrator-manager-worker-role-vocabulary.md)).
+   If the current agent needs a fresh
    worktree before running this, acquire one directly (`EnterWorktree`) and then make this call
    itself — do not hand the whole invocation to a subagent as a workaround.
 


### PR DESCRIPTION
Records the dispatch-role vocabulary as a design-time decision, and removes the harness-specific tool names from `task-worker.md`.

Reworked from the original approach after review discussion. What changed:

- The Manager/Worker split no longer distinguishes agents by capability. Nothing was ever gated, and an agent decomposing its own assignment into sub-agents is ordinary problem-solving. `CONTEXT.md` and the ADR now frame the distinction as the scope an assignment came from, and state explicitly that any agent may decompose its own assignment however the work requires.
- The behavioural prose added to `task-worker.md` — the long Identity block, the "never drive a plan's dispatch loop" paragraph, and the BLOCKED instruction — is deleted rather than reworded. A dispatched agent cannot observe which level dispatched it, so that constraint cannot be carried as receiver-side prose. A constraint the actor cannot observe is unenforceable.
- The relative links to `CONTEXT.md` and `AGENTS.md` are gone. An agent file's content is injected as a system prompt with its location stripped and the working directory set to the consuming repository's root, so those paths resolve to nothing.

What `task-worker.md` keeps is only harness neutrality: a description that no longer names Claude-Code-only tools, and a completion-reporting sentence that names the capability rather than one harness's messaging tool.

`post-planning.md` keeps the guardrail against copying the `implement-feature` invocation into a delegation prompt. Unlike the agent-file version, its reader is the actor making the call, so it is observable — and it is now self-contained, with no harness-specific tool name and no outbound links.

The durable fix for the underlying failure is tracked separately in #3140: have the delegation prompt for a ready task be produced by a tool, so no dispatcher hand-composes one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Part of #3113. The incident also needs the dispatch-target contract (#3134) and the dispatch-prompt reduction (#3148); this PR covers only the role vocabulary, so it does not close the issue on its own.
