### PR TITLE
docs(repo): scope the JSON no-pretty-print rule to runtime output only

### DIFF
--- a/.cursor/rules/json-no-pretty-print.mdc
+++ b/.cursor/rules/json-no-pretty-print.mdc
@@ -1,12 +1,21 @@
 ---
-description: Do not pretty-print JSON by default for machine or LLM consumption
+description: Do not pretty-print JSON emitted at runtime for machine or LLM consumption
 alwaysApply: true
 ---
 
 # JSON output (no pretty-print by default)
 
-When emitting JSON for **scripts, tools, MCP, or any path where output is consumed by programs or LLMs** (not a human reading a terminal for debugging):
+Scope: JSON a program emits at runtime — script stdout, CLI results, MCP tool payloads, API
+responses, generated report files. Anything a process prints or writes for another program or an
+LLM to parse.
 
-- Use **`JSON.stringify(value)`** only — do **not** use `JSON.stringify(value, null, 2)` or other spacing/indent by default.
-- Extra newlines and indentation are **token cost** for models and add no parsing benefit.
+- Emit compact JSON: `JSON.stringify(value)`, `json.dumps(data)`, `model_dump_json()`. Never
+  `JSON.stringify(value, null, 2)`, never `indent=`.
+- Indentation and newlines are token cost for a model and add no parsing benefit.
 
+Out of scope: JSON files committed to the repository as configuration or data — `package.json`,
+`tsconfig.json`, `biome.json`, every harness plugin manifest (`.claude-plugin/plugin.json`,
+`.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`), `marketplace.json`, test fixtures,
+snapshots. Humans read and edit these, git diffs them line by line, and non-AI tooling consumes
+them. Keep their existing pretty-printed formatting. Never reformat one as part of an unrelated
+change, and never cite this rule to justify compacting one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,9 +215,12 @@ guess:
   *repeated key* at each value — a more direct, unambiguous token-level association for an LLM
   parsing the output, with no risk of misparsing when a cell value contains whitespace. Emit
   compact JSON (`json.dumps(data)` / `model_dump_json()`, no `indent=`) for this — output a script
-  or CLI emits for an agent to parse. This does **not** apply to static repo config files
-  (`package.json`, `.claude-plugin/*.json`, `marketplace.json`) — those are read by humans
-  browsing the repo and by non-AI tooling (npm, git), and stay pretty-printed.
+  or CLI emits for an agent to parse. The rule governs JSON a program emits at runtime, nothing
+  else. It does not apply to JSON files committed to the repo as configuration or data — every
+  harness plugin manifest (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`),
+  `package.json`, `marketplace.json`, tool configs, fixtures, snapshots. Humans read and edit
+  those, git diffs them line by line, and non-AI tooling consumes them; they keep their existing
+  pretty-printed formatting. Never reformat one as part of an unrelated change.
 - **`logging` is for debug/trace/forensic output only** — never for primary output a calling agent
   needs to read or parse. Status messages, results, and errors meant to be consumed by the caller
   go through direct stdout/stderr emission (`typer.echo()`, `print()`, structured JSON), not a


### PR DESCRIPTION
## Summary

The JSON no-pretty-print rule was scoped as "any path where output is consumed by programs or LLMs". A committed plugin manifest satisfies that description, so the rule read as covering repo configuration files — which was never the intent. It governs JSON a program emits at runtime, nothing else.

This surfaced concretely on #3114: a review bot cited `.cursor/rules/json-no-pretty-print.mdc` against a one-line `version` bump in `.codex-plugin/plugin.json` and `.cursor-plugin/plugin.json`, asking for those manifests to be compacted.

## Changes

- `.cursor/rules/json-no-pretty-print.mdc` — rewritten with an explicit scope / out-of-scope split. In scope: script stdout, CLI results, MCP tool payloads, API responses, generated report files. Out of scope: JSON committed to the repo as configuration or data. Adds the directive that closes the loophole — never reformat such a file as part of an unrelated change, and never cite this rule to justify compacting one.
- `AGENTS.md` — the carve-out already existed but was written as an example list (`package.json`, `.claude-plugin/*.json`, `marketplace.json`) that omitted the Codex and Cursor manifests it was meant to cover. Now states the category first, with all three harness manifest directories named.

## Test plan

- [x] `prek run --files AGENTS.md .cursor/rules/json-no-pretty-print.mdc` — passed (markdownlint, hygiene, line endings)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20jamie-bitflight%2Fclaude_skills%20PR%20%233125%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=jamie-bitflight%2Fclaude_skills&pr=3125&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.cursor%2Frules%2Fjson-no-pretty-print.mdc%3A8-17%0A**Resolve%20overlapping%20JSON%20categories**%0A%0AA%20generated%20JSON%20report%20that%20is%20later%20committed%20as%20repository%20data%20matches%20both%20the%20compact-runtime%20rule%20and%20the%20pretty-printed%20committed-data%20exception.%20Define%20which%20category%20takes%20precedence%20so%20contributors%20and%20review%20automation%20apply%20consistent%20formatting.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jamie-bitflight%2Fclaude_skills&pr=3125&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22jamie-bitflight%2Fclaude_skills%22%20on%20the%20existing%20branch%20%22chore%2Fclarify-json-pretty-print-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fclarify-json-pretty-print-scope%22.%0A%0A%23%23%23%20Issue%201%0A.cursor%2Frules%2Fjson-no-pretty-print.mdc%3A8-17%0A**Resolve%20overlapping%20JSON%20categories**%0A%0AA%20generated%20JSON%20report%20that%20is%20later%20committed%20as%20repository%20data%20matches%20both%20the%20compact-runtime%20rule%20and%20the%20pretty-printed%20committed-data%20exception.%20Define%20which%20category%20takes%20precedence%20so%20contributors%20and%20review%20automation%20apply%20consistent%20formatting.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jamie-bitflight%2Fclaude_skills&pr=3125&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.cursor/rules/json-no-pretty-print.mdc:8-17
**Resolve overlapping JSON categories**

A generated JSON report that is later committed as repository data matches both the compact-runtime rule and the pretty-printed committed-data exception. Define which category takes precedence so contributors and review automation apply consistent formatting.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(repo): scope the JSON no-pretty-pri..."](https://github.com/jamie-bitflight/claude_skills/commit/7c51b530d2fa5e905e1572150f2310fdc3868241) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55798540)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->