### PR TITLE
fix(claude): remove unverified idleReason mechanism claim from idle-agent rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -143,7 +143,8 @@ through a single `Agent()` call terminate on their own — do not send those one
 the user to ask for cleanup after every batch.
 
 Treat an agent as finished only on an explicit completion report from the agent itself, or on a
-task state you have read. An idle notification is not a completion signal.
+task state you have read that means the work terminated. A non-terminal state such as `CLAIMED`
+is evidence it is still working. An idle notification carries no completion information at all.
 
 ## Autonomous Action Boundary
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -137,10 +137,13 @@ flowchart TD
 
 Load `agent-orchestration:agent-orchestration` for the dispatch decision (single `Agent()` vs `TeamCreate`, shared-file-mutation serialization) — see its "Parallel Dispatch — Teams as Standard Mechanism" section.
 
-**Close out idle completed agents.** A teammate that reports `idleReason: "available"` after
-finishing and being merged/reconciled is done — send it a `shutdown_request` rather than leaving
-it resident. An idle agent still holds terminal space and system resources on the user's machine.
-Do not wait for the user to ask for cleanup after every batch.
+Close out agents you have finished with. When an agent's work is done and you are no longer using
+it, send it a `shutdown_request`. An agent left resident holds terminal space and system resources
+on the user's machine. Do not wait for the user to ask for cleanup after every batch.
+
+An idle notification is not evidence that an agent finished — an agent can go idle while waiting
+on background work. Confirm completion from the agent's own report, or from its transcript ending
+on a completed turn rather than an unresolved tool call, before shutting it down.
 
 ## Autonomous Action Boundary
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -137,13 +137,13 @@ flowchart TD
 
 Load `agent-orchestration:agent-orchestration` for the dispatch decision (single `Agent()` vs `TeamCreate`, shared-file-mutation serialization) — see its "Parallel Dispatch — Teams as Standard Mechanism" section.
 
-Close out agents you have finished with. When an agent's work is done and you are no longer using
-it, send it a `shutdown_request`. An agent left resident holds terminal space and system resources
-on the user's machine. Do not wait for the user to ask for cleanup after every batch.
+Close out agents you have finished with. When a teammate's work is done and you are no longer
+using it, send it a `shutdown_request` rather than leaving it resident. Subagents dispatched
+through a single `Agent()` call terminate on their own — do not send those one. Do not wait for
+the user to ask for cleanup after every batch.
 
-An idle notification is not evidence that an agent finished — an agent can go idle while waiting
-on background work. Confirm completion from the agent's own report, or from its transcript ending
-on a completed turn rather than an unresolved tool call, before shutting it down.
+Treat an agent as finished only on an explicit completion report from the agent itself, or on a
+task state you have read. An idle notification is not a completion signal.
 
 ## Autonomous Action Boundary
 


### PR DESCRIPTION
## Summary

The idle-agent-cleanup rule in `.claude/CLAUDE.md`'s "Parallel Execution" section stated, as fact, that a teammate reporting `idleReason: "available"` means it has "finished and been merged/reconciled." That claim was never verified against harness internals — it was an expansion added on top of the owner's actual instruction, which was a simpler policy: don't leave agents that have finished their tasks running when you aren't using them.

That unverified mechanism claim caused a real wrong inference in a live session: an agent was treated as finished and shut down on the strength of an idle notification alone, when idle can also mean "waiting on background work," not "done."

## Changes

- Restores the owner's original policy — close out agents whose work is done — without asserting anything about what `idleReason` values mean.
- Adds an explicit guard: an idle notification is not proof of completion. Confirm from the agent's own report, or from its transcript ending on a completed turn rather than an unresolved tool call, before shutting it down.

We have not established what `idleReason` values actually signal at the harness level. This rule now deliberately asserts nothing about it — it governs only when an agent should be shut down, not how to detect "finished" from a status field.

## Test plan

- [x] `uv run prek run --files .claude/CLAUDE.md` — all hooks pass (markdownlint, trailing whitespace, symlink checks, conventional commit)
- [x] Diff limited to the one file, one section, as specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<sub>Reviews (3): Last reviewed commit: ["fix(claude): require a terminal task sta..."](https://github.com/jamie-bitflight/claude_skills/commit/ccf3a0bb27608c541ccdee69848cad26db41724e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55799939)</sub>

<!-- /greptile_comment -->