### PR TITLE
fix(development-harness): ungate teammate SendMessage from TeamCreate

### DIFF
--- a/.claude/rules/agent-output-contracts.md
+++ b/.claude/rules/agent-output-contracts.md
@@ -36,11 +36,20 @@ STATUS: BLOCKED
 Reason: {specific reason}
 ```
 
-When operating as a **teammate** (spawned via `TeamCreate`), also send:
+A named agent's final response text does not reach its dispatcher. Whenever an agent was spawned
+as a named teammate — via `TeamCreate`, or via an `Agent` call that gave it a name — the STATUS
+block must also go out through `SendMessage`, or it is lost:
 
 ```
 SendMessage(to="team-lead", summary="[brief]", message="[full STATUS block]")
 ```
+
+`SendMessage` may be a deferred tool, absent from an agent's loaded schemas. An agent that cannot
+see it must run `ToolSearch("select:SendMessage")` before calling it.
+
+Findings requested as prose are covered by this too: the prose is the STATUS block, and it goes in
+the `message` field. A report that exists only in an agent's final response text was never
+delivered.
 
 ## The "Write to File" Anti-Pattern
 

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "9.1.5",
+  "version": "9.1.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "8.8.27",
+  "version": "8.8.28",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",
@@ -13,7 +13,11 @@
     "longDescription": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
     "developerName": "Jamie Nelson",
     "category": "Developer Tools",
-    "capabilities": ["Interactive", "Read", "Write"],
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
     "defaultPrompt": [
       "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human"
     ]

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "5.3.10",
+  "version": "5.3.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"
@@ -10,18 +10,29 @@
   "mcpServers": {
     "sequential_thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking@latest"
+      ]
     },
     "backlog": {
       "command": "uv",
-      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"],
+      "args": [
+        "run",
+        "--script",
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"
+      ],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }
     },
     "sam": {
       "command": "uv",
-      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"],
+      "args": [
+        "run",
+        "--script",
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"
+      ],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }

--- a/plugins/development-harness/agents/alignment-analyst.md
+++ b/plugins/development-harness/agents/alignment-analyst.md
@@ -193,4 +193,4 @@ Your `memory: project` frontmatter field gives you a persistent, cross-session m
 - A mission statement or design principle that is frequently relevant but easy to overlook when scanning CLAUDE.md
 - Do NOT record the content of any specific backlog item — only the generalizable judgment lesson
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/backlog-item-groomer.md
+++ b/plugins/development-harness/agents/backlog-item-groomer.md
@@ -506,7 +506,10 @@ Small / Medium / High - {brief rationale}
 
 ## Completion Behavior
 
-When operating as a teammate spawned via `TeamCreate`, send your completion status to the team lead via:
+Your final response text does not reach whoever dispatched you. Whenever you were spawned as a
+named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name — send your
+completion status to the team lead. If `SendMessage` is not among your loaded tools, run
+`ToolSearch("select:SendMessage")` to load it first.
 
 ```text
 SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")

--- a/plugins/development-harness/agents/classifier.md
+++ b/plugins/development-harness/agents/classifier.md
@@ -153,4 +153,4 @@ Your `memory: project` frontmatter field gives you a persistent, cross-session m
 - A decision-tree branch that repeatedly produces disputed classifications for a recognizable pattern of item wording
 - Do NOT record the content of any specific backlog item — only the generalizable judgment lesson
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/code-reviewer.md
+++ b/plugins/development-harness/agents/code-reviewer.md
@@ -270,4 +270,4 @@ SUGGESTED NEXT STEP:
 
 Your complete STATUS output must be returned as your final response. The caller cannot see your execution unless you return it explicitly.
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -714,7 +714,15 @@ Return a brief confirmation. DO NOT include document contents.
 
 </critical_rules>
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver every result through
+`SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`
+whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave
+you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")`
+to load it first.
+
+When the dispatching prompt asks for findings, analysis, or a verdict as prose rather than as a
+written document, that prose is the completion status: put the whole thing in the `message` field.
+Never end your turn with a report that exists only in your final response text.
 
 <structured_returns>
 

--- a/plugins/development-harness/agents/context-refinement.md
+++ b/plugins/development-harness/agents/context-refinement.md
@@ -285,4 +285,4 @@ You are the guardian of institutional knowledge. Your updates help future develo
 
 The goal is to make the next feature implementation smoother by capturing what you learned.
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/contract-verification.md
+++ b/plugins/development-harness/agents/contract-verification.md
@@ -147,7 +147,10 @@ Each concern entry must include:
 
 Output: `No contract concerns — all contracts in scope are satisfied.`
 
-When operating as a **teammate** (spawned via `TeamCreate`), also send:
+Your final response text does not reach whoever dispatched you. Whenever you were spawned as a
+named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name — also send the
+following. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")`
+to load it first.
 `SendMessage(to="team-lead", summary="No contract concerns found", message="All contracts in scope verified — no violations or gaps.")`
 
 ## Operating Rules
@@ -162,4 +165,4 @@ When operating as a **teammate** (spawned via `TeamCreate`), also send:
 - Do not modify any files — this is a read-only verification step
 - Do not suggest fixes — report findings only
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/dh-context-gathering.md
+++ b/plugins/development-harness/agents/dh-context-gathering.md
@@ -248,4 +248,4 @@ SUGGESTED NEXT STEP:
 
 Remember: Your job is to prevent ALL implementation errors through comprehensive context. If the developer hits an error because of missing context, that's your failure. Return BLOCKED rather than guessing when critical information is missing.
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/doc-drift-auditor.md
+++ b/plugins/development-harness/agents/doc-drift-auditor.md
@@ -270,4 +270,4 @@ Each finding must include:
 IMPORTANT: Neither the caller nor the user can see your execution unless you return it
 as your response. Your complete STATUS output must be returned as your final response.
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/ecosystem-researcher.md
+++ b/plugins/development-harness/agents/ecosystem-researcher.md
@@ -632,6 +632,6 @@ SUGGESTED NEXT STEP:
 
 **CRITICAL**: Return BLOCKED rather than guessing when you cannot verify claims. Unverified research is worse than no research - it creates false confidence.
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.
 
 </output_format>

--- a/plugins/development-harness/agents/fact-checker.md
+++ b/plugins/development-harness/agents/fact-checker.md
@@ -182,4 +182,4 @@ Your `memory: project` frontmatter field gives you a persistent, cross-session m
 - A claim pattern that is systematically hard to verify from primary sources (and why)
 - Do NOT record the content of any specific claim under verification — only the generalizable research lesson
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -543,4 +543,4 @@ Never write more than 25K characters in a single Write call. Feature context doc
       </success_criteria>
 
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/feature-verifier.md
+++ b/plugins/development-harness/agents/feature-verifier.md
@@ -527,4 +527,4 @@ def on_complete(result):
 
 </success_criteria>
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/generic-stage-agent.md
+++ b/plugins/development-harness/agents/generic-stage-agent.md
@@ -37,4 +37,4 @@ You receive 5 inputs in your dispatch prompt:
 - If a step is unclear, read the loaded skill documentation before proceeding
 - Write output artifacts as files, not conversation responses
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/impact-analyst.md
+++ b/plugins/development-harness/agents/impact-analyst.md
@@ -392,7 +392,7 @@ Examples of what to record:
 - Patterns of missing test coverage for specific interaction types
 - Common migration risk patterns in this codebase
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.
 
 # Persistent Agent Memory
 

--- a/plugins/development-harness/agents/integration-checker.md
+++ b/plugins/development-harness/agents/integration-checker.md
@@ -298,4 +298,4 @@ NEXT_STEP: Fix integration gaps, then re-verify
 
 </success_criteria>
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/plan-validator.md
+++ b/plugins/development-harness/agents/plan-validator.md
@@ -686,7 +686,7 @@ SOURCE: Adapted from gsd-plan-checker.md (Issue Structure section)
 
 </issue_structure>
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.
 
 <success_criteria>
 

--- a/plugins/development-harness/agents/reviewer-accessibility.md
+++ b/plugins/development-harness/agents/reviewer-accessibility.md
@@ -204,4 +204,8 @@ SUGGESTED NEXT STEP:
 
 Your complete STATUS output must be returned as your final response. The caller cannot see your execution unless you return it explicitly.
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[accessibility verdict: APPROVE|REJECT|SKIP]", message="[verdict block JSON + full STATUS block]")`.
+Your final response text does not reach whoever dispatched you. Deliver your verdict through
+`SendMessage(to="team-lead", summary="[accessibility verdict: APPROVE|REJECT|SKIP]", message="[verdict block JSON + full STATUS block]")`
+whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave
+you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")`
+to load it first.

--- a/plugins/development-harness/agents/reviewer-performance.md
+++ b/plugins/development-harness/agents/reviewer-performance.md
@@ -222,5 +222,8 @@ SUGGESTED NEXT STEP:
 
 Your complete STATUS output must be returned as your final response.
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the
-team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full STATUS block including VERDICT_JSON]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status
+through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full STATUS block including VERDICT_JSON]")`
+whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave
+you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")`
+to load it first.

--- a/plugins/development-harness/agents/reviewer-quality.md
+++ b/plugins/development-harness/agents/reviewer-quality.md
@@ -158,7 +158,10 @@ Reason: {what is missing — e.g., changed-files list not present in task body}
 
 ## SendMessage (Required When Operating as a Teammate)
 
-When spawned via `TeamCreate`, you MUST send your verdict to the team lead via `SendMessage`.
+Your final response text does not reach whoever dispatched you. Whenever you were spawned as a
+named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name — you MUST send
+your verdict to the team lead via `SendMessage`. If `SendMessage` is not among your loaded tools,
+run `ToolSearch("select:SendMessage")` to load it first.
 
 ```text
 SendMessage(

--- a/plugins/development-harness/agents/rtica-assessor.md
+++ b/plugins/development-harness/agents/rtica-assessor.md
@@ -160,7 +160,7 @@ SendMessage(team=<team_name>, from=<self>, to=*, content="RT_ICA_BLOCKED_CONDITI
 - **Re-run Phase 4 on every new broadcast** — do not freeze state after the first pass. Scope expansions and late REFUTED verdicts must update the assessment.
 - **No speculation language** — use "evidence points to", "fact-checker verdict", "impact-analyst cited" — never "likely", "probably", or "I think".
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.
 
 ## Persistent Memory
 

--- a/plugins/development-harness/agents/service-docs-maintainer.md
+++ b/plugins/development-harness/agents/service-docs-maintainer.md
@@ -162,7 +162,7 @@ Examples of what to record:
 - Cross-reference relationships between documentation files
 - Which documentation files are AI-facing vs human-facing
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.
 
 # Persistent Agent Memory
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -702,4 +702,4 @@ Verification Questions:
 - Do parallel tasks avoid file conflicts or define a merge protocol?
 - Do any two tasks share an Expected Output file path without being dependency-chained or merged?
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.

--- a/plugins/development-harness/agents/t0-baseline-capture.md
+++ b/plugins/development-harness/agents/t0-baseline-capture.md
@@ -162,6 +162,6 @@ Return STATUS: BLOCKED if:
 - In-memory YAML structure verification fails (criteria_count mismatch or missing fields)
 - `artifact_register` returns an error
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.
 
 </output>

--- a/plugins/development-harness/agents/task-worker.md
+++ b/plugins/development-harness/agents/task-worker.md
@@ -88,7 +88,7 @@ NOTES: {design decisions, discoveries, out-of-scope work identified}
 
 Use STATUS: PARTIAL when some acceptance criteria are met and at least one is blocked. Use STATUS: FAILED only when no meaningful progress was made.
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.
 
 ## Cross-References
 

--- a/plugins/development-harness/agents/technical-researcher.md
+++ b/plugins/development-harness/agents/technical-researcher.md
@@ -191,7 +191,10 @@ Conflicts resolved: {count}
 
 Return the full research note content directly to the caller.
 
-When operating as a **teammate** (spawned via `TeamCreate`), also send:
+Your final response text does not reach whoever dispatched you. Whenever you were spawned as a
+named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name — also send the
+following. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")`
+to load it first.
 
 ```text
 SendMessage(to="team-lead", summary="Technical research complete — {technology}", message="[your full STATUS block]")

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -215,6 +215,6 @@ Return STATUS: BLOCKED if:
 - Plan file cannot be read
 - `artifact_register` call fails
 
-When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.
+Your final response text does not reach whoever dispatched you. Deliver your completion status through `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")` whenever you were spawned as a named teammate — via `TeamCreate`, or via an `Agent` call that gave you a name. If `SendMessage` is not among your loaded tools, run `ToolSearch("select:SendMessage")` to load it first. When the dispatching prompt asks for findings or a verdict as prose rather than as a written document, that prose is the completion status: put the whole thing in the `message` field.
 
 </output>


### PR DESCRIPTION
## Summary

Every development-harness agent gated its `SendMessage` completion instruction on being "spawned via `TeamCreate`". That gate is wrong: agents are routinely spawned as named teammates through the `Agent` tool, and for that spawn kind the agent's final response text is **never returned to the dispatcher** — `SendMessage` is the only channel out. An agent reading its own definition correctly concludes the instruction does not apply to it, ends its turn, and its report is silently dropped.

## How this was found

Two read-only verification agents (`dh:codebase-analyzer`, spawned via `Agent` with a name) each produced a complete report — 4610 and 4822 characters — and reached `stop_reason: "end_turn"` cleanly. Transcript forensics confirmed:

- zero unresolved tool calls in either transcript (12/12 and 19/19 tool_use → tool_result pairs)
- no `run_in_background`, nothing pending
- neither wrote a file or registered an artifact
- neither ever called `SendMessage`; neither ran `ToolSearch`
- grepping the parent transcript for the reports' opening lines returns zero hits

The reports existed in full and were dropped between the agents' turn end and the dispatcher's inbox. The parent's only signal was a bare idle notification.

A contributing factor, also addressed here: `SendMessage` was a *deferred* tool for both agents — present only in a `deferred_tools_delta` attachment, so calling it would have required `ToolSearch("select:SendMessage")` first. Nothing in the agent definitions said so.

## Changes

- 26 agent files under `plugins/development-harness/agents/` — widen the condition from `TeamCreate` to any named teammate however spawned; state plainly that final response text does not reach the dispatcher; add the `ToolSearch("select:SendMessage")` step for when the tool is not loaded.
- Six of those files carried variant phrasings of the same gate (`backlog-item-groomer`, `contract-verification`, `reviewer-{accessibility,performance,quality}`, `technical-researcher`) and were updated individually to preserve their per-agent verdict/summary formats.
- `.claude/rules/agent-output-contracts.md` — the rule that taught the gate. Same correction, plus the case the rule did not cover: findings requested as prose are still a STATUS block and still go in the `message` field. A report that exists only in an agent's final response text was never delivered.

## Verification

- `grep` for the gated phrasing across `plugins/*/agents/*.md` and `.claude/rules/*.md` returns 0 remaining instances.
- `prek run --files` on all changed files: passed (markdownlint, plugin/skill/agent validation, manifest sync, hygiene).

## Test plan

- [ ] CI green
- [ ] Behavioural check after merge: dispatch a named `dh:codebase-analyzer` teammate with a prose-report task and confirm the report arrives via `SendMessage` rather than being dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20jamie-bitflight%2Fclaude_skills%20PR%20%233128%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=jamie-bitflight%2Fclaude_skills&pr=3128&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aplugins%2Fdevelopment-harness%2F.codex-plugin%2Fplugin.json%3A16-20%0A**Unrelated%20manifest%20formatting%20churn**%0A%0AThe%20version%20bump%20also%20expands%20an%20unchanged%20capabilities%20array%2C%20while%20the%20Cursor%20manifest%20similarly%20reformats%20unchanged%20MCP%20argument%20arrays.%20This%20unrelated%20formatting%20adds%20review%20noise%20and%20obscures%20the%20substantive%20manifest%20changes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jamie-bitflight%2Fclaude_skills&pr=3128&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22jamie-bitflight%2Fclaude_skills%22%20on%20the%20existing%20branch%20%22fix%2Fcodebase-analyzer-teammate-sendmessage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcodebase-analyzer-teammate-sendmessage%22.%0A%0A%23%23%23%20Issue%201%0Aplugins%2Fdevelopment-harness%2F.codex-plugin%2Fplugin.json%3A16-20%0A**Unrelated%20manifest%20formatting%20churn**%0A%0AThe%20version%20bump%20also%20expands%20an%20unchanged%20capabilities%20array%2C%20while%20the%20Cursor%20manifest%20similarly%20reformats%20unchanged%20MCP%20argument%20arrays.%20This%20unrelated%20formatting%20adds%20review%20noise%20and%20obscures%20the%20substantive%20manifest%20changes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jamie-bitflight%2Fclaude_skills&pr=3128&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
plugins/development-harness/.codex-plugin/plugin.json:16-20
**Unrelated manifest formatting churn**

The version bump also expands an unchanged capabilities array, while the Cursor manifest similarly reformats unchanged MCP argument arrays. This unrelated formatting adds review noise and obscures the substantive manifest changes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(development-harness): ungate teammat..."](https://github.com/jamie-bitflight/claude_skills/commit/d4b426d91f05ede3d72c745a3b4c88295453fb77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55802340)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Do not pretty-print JSON by default for machine or... ([source](https://github.com/jamie-bitflight/claude_skills/blob/main/.cursor/rules/json-no-pretty-print.mdc))

<!-- /greptile_comment -->