### PR TITLE
docs(agent-orchestration): add decomposition and adjudication to delegate skill

### DIFF
--- a/plugins/agent-orchestration/.claude-plugin/plugin.json
+++ b/plugins/agent-orchestration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-orchestration",
   "description": "This skill should be used when the model's ROLE_TYPE is orchestrator and needs to delegate tasks to specialist sub-agents. Provides scientific delegation framework ensuring world-building context (WHERE, WHAT, WHY) while preserving agent autonomy in implementation decisions (HOW). Use when planning task delegation, structuring sub-agent prompts, or coordinating multi-agent workflows.",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/agent-orchestration/.codex-plugin/plugin.json
+++ b/plugins/agent-orchestration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestration",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "This skill should be used when the model's ROLE_TYPE is orchestrator and needs to delegate tasks to specialist sub-agents. Provides scientific delegation framework ensuring world-building context (WHERE, WHAT, WHY) while preserving agent autonomy in implementation decisions (HOW). Use when planning task delegation, structuring sub-agent prompts, or coordinating multi-agent workflows.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/agent-orchestration/.codex-plugin/plugin.json
+++ b/plugins/agent-orchestration/.codex-plugin/plugin.json
@@ -13,7 +13,10 @@
     "longDescription": "This skill should be used when the model's ROLE_TYPE is orchestrator and needs to delegate tasks to specialist sub-agents. Provides scientific delegation framework ensuring world-building context (WHERE, WHAT, WHY) while preserving agent autonomy in implementation decisions (HOW). Use when planning task delegation, structuring sub-agent prompts, or coordinating multi-agent workflows.",
     "developerName": "Jamie Nelson",
     "category": "Developer Tools",
-    "capabilities": ["Interactive", "Read"],
+    "capabilities": [
+      "Interactive",
+      "Read"
+    ],
     "defaultPrompt": [
       "This skill should be used when the model's ROLE_TYPE is orchestrator and needs to delegate tasks to specialist sub-agents."
     ]

--- a/plugins/agent-orchestration/README.md
+++ b/plugins/agent-orchestration/README.md
@@ -67,7 +67,7 @@ When a task decomposes into independent subtasks, Claude dispatches agents in pa
 |---|---|
 | `agent-orchestration` | Full scientific delegation framework — verification checklist, delegation template, anti-patterns, parallel dispatch patterns |
 | `how-to-delegate` | 10-step preparation worksheet — guides through observations, success criteria, world-building context, agent selection, and pre-flight verification before constructing a delegation prompt |
-| `delegate` | Quick delegation template for single-agent prompts — the WHERE/WHAT/WHY format with a checklist |
+| `delegate` | Decomposes a request into phases, dispatches each phase to its own sub-agent, and adjudicates the results — the WHERE/WHAT/WHY dispatch template with a phase-scoped task table and pre-send checklist |
 | `orchestrating-swarms` | Patterns for large-scale parallel agent coordination — swarm spawning, task decomposition, agent pool management |
 
 ## Installation
@@ -94,7 +94,7 @@ Invoke manually when you want Claude to use the full 10-step preparation workshe
 /agent-orchestration:how-to-delegate
 ```
 
-Or use the quick delegation template before a specific Agent tool call:
+Or decompose, dispatch, and adjudicate a request before delegating it:
 
 ```text
 /agent-orchestration:delegate

--- a/plugins/agent-orchestration/skills/delegate/SKILL.md
+++ b/plugins/agent-orchestration/skills/delegate/SKILL.md
@@ -1,20 +1,69 @@
 ---
 name: delegate
-description: Quick delegation template for sub-agent prompts. Use when assigning work to a sub-agent, before invoking the Agent tool, or when preparing prompts for specialized agents. Provides the WHERE-WHAT-WHY framework. For comprehensive delegation guidance, activate the agent-orchestration how-to-delegate skill.
+description: Decompose a request into phases, dispatch those phases to sub-agents in parallel, and adjudicate what comes back — with the WHERE-WHAT-WHY prompt template for each dispatch. Use when a request asks for implementation, investigation, or any multi-step work, before invoking a sub-agent, when preparing prompts for specialist agents, or when deciding whether to do work inline or delegate it. Provides the OBSERVATIONS-SUCCESS-CONTEXT format with authoring rules and a pre-send checklist. For the full step-by-step preparation worksheet, activate the agent-orchestration how-to-delegate skill.
 user-invocable: true
 ---
 
-# Delegation Template
+# Delegation
 
-**Workflow Reference**: See [Multi-Agent Orchestration](../../../../.claude/knowledge/workflow-diagrams/multi-agent-orchestration.md) for complete delegation flow with DONE/BLOCKED signaling.
+Delegation is the default execution mode for a substantive request, not an escalation reserved for large ones. An orchestrator that reads the files and runs the commands itself is the anti-pattern: context spent holding file contents and command output is context no longer available for judgment and adjudication.
 
-**Step 1:** Analyze the task. Do you have the "WHERE, WHAT, WHY"?
+For the full step-by-step preparation worksheet, activate the agent-orchestration how-to-delegate skill. For the orchestration framework, anti-patterns, and parallel-dispatch mechanics, activate the agent-orchestration skill.
 
-**Step 2:** Construct the prompt using the template below.
+```mermaid
+flowchart TD
+    Req(["Substantive request received"]) --> Dec["Decompose into phases"]
+    Dec --> Dis["Dispatch — one phase per prompt<br>independent phases concurrently"]
+    Dis --> Adj["Adjudicate returned reports"]
+    Adj --> Q{"Do the reports establish<br>the requested outcome<br>with evidence?"}
+    Q -->|"No — gap, conflict, or unsupported claim"| Re["Re-dispatch naming the gap<br>or split the phase further"]
+    Re --> Adj
+    Q -->|"Yes"| Done(["Report outcome"])
+```
+
+---
+
+## 1. Decompose
+
+Split the request into phases before any dispatch happens. The phases:
+
+| Phase | Produces |
+| ----- | -------- |
+| read | The material the work depends on, located and read |
+| gather | External facts — documentation, prior art, current system state |
+| process | The analysis and the chosen approach |
+| verify | Confirmation that the approach holds against the actual code and environment |
+| write | The change |
+| validate | Lint, type-check, and build results |
+| test | Test runs, and new tests covering the change |
+| report | What changed, and the evidence supporting it |
+| review | Independent critique of the result |
+
+Drop any phase that produces no work for this request. Do not pad a decomposition with empty phases.
+
+Mechanical fan-out is delegated, never done inline: the same edit applied across many files, the same check run against many targets. "It is only a few files" is not a reason to keep it in the orchestrator.
+
+## 2. Dispatch
+
+- One phase, one prompt, one agent.
+- Send independent phases in a single message so they run concurrently.
+- Serialize only where one phase consumes another's result, or where two agents would write the same file.
+- Match the agent type to the phase rather than sending every phase to a generalist.
+
+## 3. Adjudicate
+
+Adjudication is what the orchestrator keeps for itself:
+
+- Judge the returned work instead of re-deriving it. Re-reading the files an agent already read spends the context that delegating them saved.
+- Treat every agent report as a claim, not a fact. Check that the stated evidence supports the conclusion, and require the command output rather than the assurance that a command passed.
+- Resolve conflicting reports by identifying which claim is falsifiable and dispatching a check for it — not by accepting the more confident report.
+- Decide what happens next: accept the result, re-dispatch with the gap named, or split the phase further.
 
 ---
 
 ## Template
+
+Construct each dispatch prompt from this template.
 
 ```text
 Your ROLE_TYPE is sub-agent.
@@ -31,13 +80,16 @@ DEFINITION OF SUCCESS:
 - [Acceptance criteria]
 - [Verification method]
 
+DELIVERY:
+- [The channel that reaches the dispatcher, and where any longer artifact is written]
+
 CONTEXT:
 - Location: [Where to look]
 - Scope: [Boundaries]
 - Constraints: [Hard requirements vs Preferences]
 
 ECOSYSTEM CONTEXT:
-- [Session-specific facts the agent cannot find in CLAUDE.md or tool descriptions]
+- [Session-specific facts the agent cannot find in project instructions or tool descriptions]
 - [Authenticated CLIs, non-obvious doc locations, task-specific access]
 
 YOUR TASK:
@@ -48,11 +100,12 @@ YOUR TASK:
 5. Only report completion after /dh:verify-done criteria are met
 ```
 
-**Authoring guidance** (for the orchestrator filling in this template — do not include these annotations in the delivered prompt):
+Authoring guidance (for the orchestrator filling in this template — do not include these annotations in the delivered prompt):
 
-- **OBSERVATIONS**: Pass-through only — data already in your context (user messages, prior agent reports, command outputs you already received). Include file:line references if already known. Include verbatim error messages, not paraphrased. Do NOT pre-gather data for the agent (e.g., don't run `ruff check .` before delegating to a linting agent). Do NOT read, grep, or glob files to find context for the agent — the agent has full tool access and an empty context window; it does its own discovery. No interpretations ("I think"), no assumptions ("probably"). SOURCE: [agent-orchestration SKILL.md](../agent-orchestration/SKILL.md) — Pre-Delegation Verification Checklist section.
-- **DEFINITION OF SUCCESS**: The "WHAT". Measurable outcomes the agent can verify. When the agent will produce more than ~1 line of output, instruct it to write results to a file and return only the path — this keeps orchestrator context lean. Example: `Write findings to .tmp/reports/NAME-YYYYMMDD.md. Return: STATUS: DONE + file path.` When directing agents to write to `.tmp/`, verify `.tmp/` is in the repo `.gitignore` before committing (`grep -q '^\.tmp/' .gitignore || echo '.tmp/' >> .gitignore`).
-- **CONTEXT**: The "WHERE" and "WHY". Location narrows scope; constraints bound the solution space.
+- OBSERVATIONS: Pass-through only — data already in your context (user messages, prior agent reports, command outputs you already received). Include `file:line` references if already known. Include verbatim error messages, not paraphrased. Do NOT pre-gather data for the agent (for example, do not run `ruff check .` before delegating to a linting agent). Do NOT read, grep, or glob files to find context for the agent — the agent has full tool access and an empty context window; it does its own discovery. No interpretations ("I think"), no assumptions ("probably"). SOURCE: [agent-orchestration SKILL.md](../agent-orchestration/SKILL.md) — Pre-Delegation Verification Checklist section.
+- DEFINITION OF SUCCESS: The "WHAT". Measurable outcomes the agent can verify. When the agent will produce more than roughly one line of output, instruct it to write results to a file and return only the path — this keeps orchestrator context lean. Example: `Write findings to .tmp/reports/NAME-YYYYMMDD.md. Return: STATUS: DONE + file path.` When directing agents to write to `.tmp/`, verify `.tmp/` is ignored by version control before committing.
+- DELIVERY: State the delivery channel explicitly. An agent's final response text does not always reach its dispatcher — depending on the harness it may be returned, dropped, or replaced by an explicit message the agent has to send. Name the channel that reaches you in this harness, and name the artifact fallback: the full result written to a file whose path the agent returns. A result that exists only in the agent's final response text may never be read. Do not assume the dispatcher receives anything the prompt did not ask the agent to send.
+- CONTEXT: The "WHERE" and "WHY". Location narrows scope; constraints bound the solution space.
 
 ---
 
@@ -60,20 +113,24 @@ YOUR TASK:
 
 Check before sending:
 
-| Rule               | Check                                                                                    |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| **Formula**        | Delegation = Observations + Success Criteria + Resources - Assumptions - Micromanagement |
-| **No HOW**         | Do NOT tell agent _how_ to implement (e.g., "Change line 42 to X")                       |
-| **Constraints OK** | DO tell agent _constraints_ (e.g., "Must use the 'requests' library")                    |
-| **No Assumptions** | Do NOT say "The issue is probably..."                                                    |
-| **Full Scope**     | If code smell found, instruct agent to audit _entire pattern_, not single instance       |
+| Rule | Check |
+| ---- | ----- |
+| Formula | Delegation = Observations + Success Criteria + Resources - Assumptions - Micromanagement |
+| No HOW | Do NOT tell the agent _how_ to implement (for example, "Change line 42 to X") |
+| Constraints OK | DO tell the agent _constraints_ (for example, "Must use the httpx library") |
+| No Assumptions | Do NOT say "The issue is probably..." |
+| Full Scope | If a code smell is found, instruct the agent to audit the _entire pattern_, not a single instance |
+| Stated Delivery | Every prompt names how the result reaches the dispatcher |
 
 ---
 
 ## Quick Checklist
 
+- [ ] Request was decomposed into phases before this dispatch was written
+- [ ] Independent phases are being sent concurrently, not one at a time
 - [ ] Starts with `Your ROLE_TYPE is sub-agent.`
 - [ ] Contains only factual observations
 - [ ] No assumptions stated as facts
 - [ ] Defines WHAT and WHY, not HOW
 - [ ] Lists resources without prescribing tools
+- [ ] Names the delivery channel and where any longer artifact is written

--- a/plugins/agent-orchestration/skills/delegate/SKILL.md
+++ b/plugins/agent-orchestration/skills/delegate/SKILL.md
@@ -101,6 +101,7 @@ CONTEXT:
 - Location: [Where to look]
 - Scope: [Boundaries]
 - Constraints: [Hard requirements vs Preferences]
+- Commands: [Exact commands this phase runs, or "discover the ones this project defines"]
 
 ECOSYSTEM CONTEXT:
 - [Session-specific facts the agent cannot find in project instructions or tool descriptions]
@@ -121,8 +122,8 @@ YOUR TASK:
 | process | Analyze the material the read and gather phases produced. Choose an approach. Report the approach and why alternatives were ruled out. Do not edit any file. |
 | verify | Check the chosen approach against the actual code and environment named in CONTEXT. Report where it holds and where it fails. Do not implement a fix. |
 | write | Make the change described in DEFINITION OF SUCCESS. Touch only the files named in CONTEXT. |
-| validate | Run the lint, type-check, and build commands named in CONTEXT. Report exact command output, pass and fail alike. Do not silence a failure without stating the fix. |
-| test | Run the test suite named in CONTEXT. Add tests covering the change. Report exact command output. |
+| validate | Run the lint, type-check, and build commands named in CONTEXT Commands. Where none are named, discover the ones this project defines and report which you ran. Report exact command output, pass and fail alike. Do not silence a failure without stating the fix. |
+| test | Run the test suite named in CONTEXT Commands. Where none is named, discover the invocation this project defines and report which you ran. Add tests covering the change. Report exact command output. |
 | report | Summarize what changed and the evidence supporting it. Cite the specific files, commands, and outputs. State no claim the evidence does not support. |
 | review | Independently critique the result named in CONTEXT against DEFINITION OF SUCCESS. Report gaps, contradictions, or unsupported claims. Do not fix them. |
 
@@ -133,7 +134,7 @@ Authoring guidance (for the orchestrator filling in this template — do not inc
 - OBSERVATIONS: Pass-through only — data already in your context (user messages, prior agent reports, command outputs you already received). Include `file:line` references if already known. Include verbatim error messages, not paraphrased. Do NOT pre-gather data for the agent (for example, do not run `ruff check .` before delegating to a linting agent). Do NOT read, grep, or glob files to find context for the agent — the agent has full tool access and an empty context window; it does its own discovery. No interpretations ("I think"), no assumptions ("probably"). SOURCE: [agent-orchestration SKILL.md](./../agent-orchestration/SKILL.md) — Pre-Delegation Verification Checklist section.
 - DEFINITION OF SUCCESS: The "WHAT". Measurable outcomes the agent can verify. When the agent will produce more than roughly one line of output, instruct it to write results to a file and return only the path — this keeps orchestrator context lean. Example: `Write findings to .tmp/reports/NAME-YYYYMMDD.md. Return: STATUS: DONE + file path.` When directing agents to write to `.tmp/`, verify `.tmp/` is ignored by version control before committing.
 - DELIVERY: State the delivery channel explicitly. The channel that carries an agent's final response back to its dispatcher differs between harnesses. Name the channel this dispatch expects, and name the artifact fallback: the full result written to a file whose path the agent returns. A result that exists only in the agent's final response text may never be read. Do not assume the dispatcher receives anything the prompt did not ask the agent to send.
-- CONTEXT: The "WHERE" and "WHY". Location narrows scope; constraints bound the solution space.
+- CONTEXT: The "WHERE" and "WHY". Location narrows scope; constraints bound the solution space. Commands is the one slot that carries literal invocations — the quality gates a `validate` or `test` dispatch has to run. Name them when this project defines them; write the discovery instruction when it does not, and never leave the slot blank on those two phases. Naming a project's own gate is not prescribing HOW: the gate is the acceptance bar, not the implementation.
 
 ---
 
@@ -161,5 +162,6 @@ Check before sending:
 - [ ] Contains only factual observations
 - [ ] No assumptions stated as facts
 - [ ] Defines WHAT and WHY, not HOW
-- [ ] Lists resources without prescribing tools
+- [ ] Lists resources without prescribing tools, apart from the quality gates named in CONTEXT Commands
+- [ ] A `validate` or `test` dispatch names its commands in CONTEXT Commands or instructs the agent to discover them
 - [ ] Names the delivery channel and where any longer artifact is written

--- a/plugins/agent-orchestration/skills/delegate/SKILL.md
+++ b/plugins/agent-orchestration/skills/delegate/SKILL.md
@@ -25,6 +25,8 @@ flowchart TD
 
 ## 1. Decompose
 
+<decompose>
+
 Split the request into phases before any dispatch happens. The phases:
 
 | Phase | Produces |
@@ -43,14 +45,22 @@ Drop any phase that produces no work for this request. Do not pad a decompositio
 
 Mechanical fan-out is delegated, never done inline: the same edit applied across many files, the same check run against many targets. "It is only a few files" is not a reason to keep it in the orchestrator.
 
+</decompose>
+
 ## 2. Dispatch
+
+<dispatch>
 
 - One phase, one prompt, one agent.
 - Send independent phases in a single message so they run concurrently.
 - Serialize only where one phase consumes another's result, or where two agents would write the same file.
 - Match the agent type to the phase rather than sending every phase to a generalist.
 
+</dispatch>
+
 ## 3. Adjudicate
+
+<adjudicate>
 
 Adjudication is what the orchestrator keeps for itself:
 
@@ -58,6 +68,8 @@ Adjudication is what the orchestrator keeps for itself:
 - Treat every agent report as a claim, not a fact. Check that the stated evidence supports the conclusion, and require the command output rather than the assurance that a command passed.
 - Resolve conflicting reports by identifying which claim is falsifiable and dispatching a check for it — not by accepting the more confident report.
 - Decide what happens next: accept the result, re-dispatch with the gap named, or split the phase further.
+
+</adjudicate>
 
 ---
 
@@ -100,6 +112,8 @@ YOUR TASK:
 
 ### Phase Task Table
 
+<phase_task_table>
+
 | Phase | YOUR TASK |
 | ----- | -------- |
 | read | Locate and read the material this work depends on. Report exact file paths and quoted content — do not summarize away detail a later phase needs. Do not edit any file. |
@@ -112,11 +126,13 @@ YOUR TASK:
 | report | Summarize what changed and the evidence supporting it. Cite the specific files, commands, and outputs. State no claim the evidence does not support. |
 | review | Independently critique the result named in CONTEXT against DEFINITION OF SUCCESS. Report gaps, contradictions, or unsupported claims. Do not fix them. |
 
+</phase_task_table>
+
 Authoring guidance (for the orchestrator filling in this template — do not include these annotations in the delivered prompt):
 
 - OBSERVATIONS: Pass-through only — data already in your context (user messages, prior agent reports, command outputs you already received). Include `file:line` references if already known. Include verbatim error messages, not paraphrased. Do NOT pre-gather data for the agent (for example, do not run `ruff check .` before delegating to a linting agent). Do NOT read, grep, or glob files to find context for the agent — the agent has full tool access and an empty context window; it does its own discovery. No interpretations ("I think"), no assumptions ("probably"). SOURCE: [agent-orchestration SKILL.md](./../agent-orchestration/SKILL.md) — Pre-Delegation Verification Checklist section.
 - DEFINITION OF SUCCESS: The "WHAT". Measurable outcomes the agent can verify. When the agent will produce more than roughly one line of output, instruct it to write results to a file and return only the path — this keeps orchestrator context lean. Example: `Write findings to .tmp/reports/NAME-YYYYMMDD.md. Return: STATUS: DONE + file path.` When directing agents to write to `.tmp/`, verify `.tmp/` is ignored by version control before committing.
-- DELIVERY: State the delivery channel explicitly. An agent's final response text does not always reach its dispatcher — depending on the harness it may be returned, dropped, or replaced by an explicit message the agent has to send. Name the channel that reaches you in this harness, and name the artifact fallback: the full result written to a file whose path the agent returns. A result that exists only in the agent's final response text may never be read. Do not assume the dispatcher receives anything the prompt did not ask the agent to send.
+- DELIVERY: State the delivery channel explicitly. The channel that carries an agent's final response back to its dispatcher differs between harnesses. Name the channel this dispatch expects, and name the artifact fallback: the full result written to a file whose path the agent returns. A result that exists only in the agent's final response text may never be read. Do not assume the dispatcher receives anything the prompt did not ask the agent to send.
 - CONTEXT: The "WHERE" and "WHY". Location narrows scope; constraints bound the solution space.
 
 ---

--- a/plugins/agent-orchestration/skills/delegate/SKILL.md
+++ b/plugins/agent-orchestration/skills/delegate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: delegate
-description: Decompose a request into phases, dispatch those phases to sub-agents in parallel, and adjudicate what comes back — with the WHERE-WHAT-WHY prompt template for each dispatch. Use when a request asks for implementation, investigation, or any multi-step work, before invoking a sub-agent, when preparing prompts for specialist agents, or when deciding whether to do work inline or delegate it. Provides the OBSERVATIONS-SUCCESS-CONTEXT format with authoring rules and a pre-send checklist. For the full step-by-step preparation worksheet, activate the agent-orchestration how-to-delegate skill.
+description: Decompose a request into phases, dispatch those phases to sub-agents in parallel, and adjudicate what comes back — with the WHERE-WHAT-WHY prompt template for each dispatch. Use when a request asks for implementation, investigation, or any multi-step work, before invoking a sub-agent, when preparing prompts for specialist agents, or when deciding whether to do work inline or delegate it. Provides the OBSERVATIONS-SUCCESS-CONTEXT format with authoring rules and a pre-send checklist. For the full step-by-step preparation worksheet, activate the `/agent-orchestration:how-to-delegate` skill.
 user-invocable: true
 ---
 
@@ -8,7 +8,7 @@ user-invocable: true
 
 Delegation is the default execution mode for a substantive request, not an escalation reserved for large ones. An orchestrator that reads the files and runs the commands itself is the anti-pattern: context spent holding file contents and command output is context no longer available for judgment and adjudication.
 
-For the full step-by-step preparation worksheet, activate the agent-orchestration how-to-delegate skill. For the orchestration framework, anti-patterns, and parallel-dispatch mechanics, activate the agent-orchestration skill.
+For the full step-by-step preparation worksheet, activate the `/agent-orchestration:how-to-delegate` skill. For the orchestration framework, anti-patterns, and parallel-dispatch mechanics, activate the `/agent-orchestration:agent-orchestration` skill.
 
 ```mermaid
 flowchart TD
@@ -63,10 +63,12 @@ Adjudication is what the orchestrator keeps for itself:
 
 ## Template
 
-Construct each dispatch prompt from this template.
+Construct each dispatch prompt from this template. Set `PHASE` to the phase this dispatch covers, then copy that phase's row from the Phase Task Table verbatim into `YOUR TASK`. Never blend rows from more than one phase into a single dispatch — a dispatch covers exactly one phase.
 
 ```text
 Your ROLE_TYPE is sub-agent.
+
+PHASE: [read | gather | process | verify | write | validate | test | report | review]
 
 [Task Identification - one sentence]
 
@@ -93,16 +95,26 @@ ECOSYSTEM CONTEXT:
 - [Authenticated CLIs, non-obvious doc locations, task-specific access]
 
 YOUR TASK:
-1. Run /dh:verify-done (as completion criteria guide)
-2. Perform comprehensive context gathering
-3. Form hypothesis → Experiment → Verify
-4. Implement solution
-5. Only report completion after /dh:verify-done criteria are met
+[Copy the row matching PHASE from the Phase Task Table below. Do not write a different task.]
 ```
+
+### Phase Task Table
+
+| Phase | YOUR TASK |
+| ----- | -------- |
+| read | Locate and read the material this work depends on. Report exact file paths and quoted content — do not summarize away detail a later phase needs. Do not edit any file. |
+| gather | Collect the external facts named in CONTEXT — documentation, prior art, current system state. Report each fact with its source. Do not edit any file. |
+| process | Analyze the material the read and gather phases produced. Choose an approach. Report the approach and why alternatives were ruled out. Do not edit any file. |
+| verify | Check the chosen approach against the actual code and environment named in CONTEXT. Report where it holds and where it fails. Do not implement a fix. |
+| write | Make the change described in DEFINITION OF SUCCESS. Touch only the files named in CONTEXT. |
+| validate | Run the lint, type-check, and build commands named in CONTEXT. Report exact command output, pass and fail alike. Do not silence a failure without stating the fix. |
+| test | Run the test suite named in CONTEXT. Add tests covering the change. Report exact command output. |
+| report | Summarize what changed and the evidence supporting it. Cite the specific files, commands, and outputs. State no claim the evidence does not support. |
+| review | Independently critique the result named in CONTEXT against DEFINITION OF SUCCESS. Report gaps, contradictions, or unsupported claims. Do not fix them. |
 
 Authoring guidance (for the orchestrator filling in this template — do not include these annotations in the delivered prompt):
 
-- OBSERVATIONS: Pass-through only — data already in your context (user messages, prior agent reports, command outputs you already received). Include `file:line` references if already known. Include verbatim error messages, not paraphrased. Do NOT pre-gather data for the agent (for example, do not run `ruff check .` before delegating to a linting agent). Do NOT read, grep, or glob files to find context for the agent — the agent has full tool access and an empty context window; it does its own discovery. No interpretations ("I think"), no assumptions ("probably"). SOURCE: [agent-orchestration SKILL.md](../agent-orchestration/SKILL.md) — Pre-Delegation Verification Checklist section.
+- OBSERVATIONS: Pass-through only — data already in your context (user messages, prior agent reports, command outputs you already received). Include `file:line` references if already known. Include verbatim error messages, not paraphrased. Do NOT pre-gather data for the agent (for example, do not run `ruff check .` before delegating to a linting agent). Do NOT read, grep, or glob files to find context for the agent — the agent has full tool access and an empty context window; it does its own discovery. No interpretations ("I think"), no assumptions ("probably"). SOURCE: [agent-orchestration SKILL.md](./../agent-orchestration/SKILL.md) — Pre-Delegation Verification Checklist section.
 - DEFINITION OF SUCCESS: The "WHAT". Measurable outcomes the agent can verify. When the agent will produce more than roughly one line of output, instruct it to write results to a file and return only the path — this keeps orchestrator context lean. Example: `Write findings to .tmp/reports/NAME-YYYYMMDD.md. Return: STATUS: DONE + file path.` When directing agents to write to `.tmp/`, verify `.tmp/` is ignored by version control before committing.
 - DELIVERY: State the delivery channel explicitly. An agent's final response text does not always reach its dispatcher — depending on the harness it may be returned, dropped, or replaced by an explicit message the agent has to send. Name the channel that reaches you in this harness, and name the artifact fallback: the full result written to a file whose path the agent returns. A result that exists only in the agent's final response text may never be read. Do not assume the dispatcher receives anything the prompt did not ask the agent to send.
 - CONTEXT: The "WHERE" and "WHY". Location narrows scope; constraints bound the solution space.
@@ -129,6 +141,7 @@ Check before sending:
 - [ ] Request was decomposed into phases before this dispatch was written
 - [ ] Independent phases are being sent concurrently, not one at a time
 - [ ] Starts with `Your ROLE_TYPE is sub-agent.`
+- [ ] YOUR TASK copies exactly one row from the Phase Task Table, matching the dispatch's PHASE
 - [ ] Contains only factual observations
 - [ ] No assumptions stated as facts
 - [ ] Defines WHAT and WHY, not HOW


### PR DESCRIPTION
## What was missing

The `delegate` skill taught exactly one thing: how to fill in a WHERE-WHAT-WHY prompt for a single sub-agent. That is the last step of the orchestrator's job, and the skill was silent on everything around it.

Nothing in the skill said that a substantive request gets split into phases before any dispatch happens, that delegation is the default execution mode rather than an escalation for large tasks, or that the orchestrator reading files and running commands itself is the anti-pattern — context spent holding file contents and command output is context unavailable for judgment. Nothing said what the orchestrator keeps for itself once reports come back.

## What was added

- An orchestrator loop — decompose, dispatch, adjudicate — with a re-dispatch branch when returned reports do not establish the outcome with evidence.
- A decomposition phase table (read, gather, process, verify, write, validate, test, report, review), with the instruction to drop phases that produce no work rather than pad the decomposition, and the rule that mechanical fan-out is delegated rather than done inline because "it is only a few files".
- Dispatch rules: one phase per prompt, independent phases sent concurrently in a single message, serialization only for consumed results or shared file writes.
- An adjudication section: judge returned work instead of re-deriving it, treat every agent report as a claim requiring evidence rather than a fact, resolve conflicting reports by dispatching a falsifiable check rather than accepting the more confident one.
- A `DELIVERY` section in the prompt template, plus its authoring guidance: a prompt must state how the agent's result reaches the dispatcher, because an agent's final response text does not always get returned. The guidance is harness-neutral — it names the requirement and the artifact fallback, not one harness's tool.

## Other changes in the same file

- Replaced a relative link that pointed out of the plugin into a consuming repository's `.claude/` directory. The plugin ships standalone, so that path never resolved for an installed user; it is now a skill handoff to `agent-orchestration:how-to-delegate` and `agent-orchestration:agent-orchestration`.
- Stripped decorative bold throughout — a model reads `**bold**` as no stronger a signal than plain text.
- Widened the frontmatter `description` to cover the new trigger conditions (deciding whether to do work inline or delegate it, preparing a multi-step request), and kept the handoff to `how-to-delegate` for the full preparation worksheet.

The existing WHERE-WHAT-WHY template, its authoring guidance, the delegation rules table, and the pre-send checklist are all intact. Depth deliberately left to `how-to-delegate`: the ten-step preparation worksheet, per-step examples, agent selection rationale, and the pre-flight verification pass. This skill stays the quick card and hands off.

## Validation

- `uvx skilllint@latest check plugins/agent-orchestration/skills/delegate` — exit 0, no findings.
- `uv run prek run --files plugins/agent-orchestration/skills/delegate/SKILL.md` — all hooks passed. The manifest auto-sync hook bumped both plugin.json versions; those bumps are in the commit.

Pre-existing and not addressed here: `skilllint` reports AS005 and SK006 on `plugins/agent-orchestration/skills/agent-orchestration/SKILL.md` (7477 tokens against a 4400 threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20jamie-bitflight%2Fclaude_skills%20PR%20%233130%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=jamie-bitflight%2Fclaude_skills&pr=3130&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aplugins%2Fagent-orchestration%2Fskills%2Fdelegate%2FSKILL.md%3A48%0A**Phase%20prompts%20retain%20full-solution%20duties**%0A%0AWhen%20the%20template%20is%20used%20for%20a%20read%2C%20gather%2C%20validate%2C%20test%2C%20report%2C%20or%20review%20phase%2C%20its%20mandatory%20task%20list%20still%20tells%20that%20agent%20to%20gather%20comprehensively%2C%20implement%20the%20solution%2C%20and%20verify%20overall%20completion%2C%20causing%20phase%20agents%20to%20duplicate%20work%20or%20make%20conflicting%20writes%20instead%20of%20remaining%20within%20the%20one-phase%20boundary.%0A%0A%23%23%23%20Issue%202%0Aplugins%2Fagent-orchestration%2Fskills%2Fdelegate%2FSKILL.md%3A105%0A**Relative%20link%20omits%20required%20prefix**%0A%0AThe%20changed%20source%20link%20uses%20%60..%2Fagent-orchestration%2FSKILL.md%60%20instead%20of%20the%20repository-required%20%60.%2F%60-prefixed%20relative-path%20form%2C%20reducing%20consistency%20with%20the%20file-reference%20convention%20and%20its%20validation%20tooling.%0A%0A%60%60%60suggestion%0A-%20OBSERVATIONS%3A%20Pass-through%20only%20%E2%80%94%20data%20already%20in%20your%20context%20%28user%20messages%2C%20prior%20agent%20reports%2C%20command%20outputs%20you%20already%20received%29.%20Include%20%60file%3Aline%60%20references%20if%20already%20known.%20Include%20verbatim%20error%20messages%2C%20not%20paraphrased.%20Do%20NOT%20pre-gather%20data%20for%20the%20agent%20%28for%20example%2C%20do%20not%20run%20%60ruff%20check%20.%60%20before%20delegating%20to%20a%20linting%20agent%29.%20Do%20NOT%20read%2C%20grep%2C%20or%20glob%20files%20to%20find%20context%20for%20the%20agent%20%E2%80%94%20the%20agent%20has%20full%20tool%20access%20and%20an%20empty%20context%20window%3B%20it%20does%20its%20own%20discovery.%20No%20interpretations%20%28%22I%20think%22%29%2C%20no%20assumptions%20%28%22probably%22%29.%20SOURCE%3A%20%5Bagent-orchestration%20SKILL.md%5D%28.%2F..%2Fagent-orchestration%2FSKILL.md%29%20%E2%80%94%20Pre-Delegation%20Verification%20Checklist%20section.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jamie-bitflight%2Fclaude_skills&pr=3130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22jamie-bitflight%2Fclaude_skills%22%20on%20the%20existing%20branch%20%22docs%2Fdelegate-decomposition-messaging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fdelegate-decomposition-messaging%22.%0A%0A%23%23%23%20Issue%201%0Aplugins%2Fagent-orchestration%2Fskills%2Fdelegate%2FSKILL.md%3A48%0A**Phase%20prompts%20retain%20full-solution%20duties**%0A%0AWhen%20the%20template%20is%20used%20for%20a%20read%2C%20gather%2C%20validate%2C%20test%2C%20report%2C%20or%20review%20phase%2C%20its%20mandatory%20task%20list%20still%20tells%20that%20agent%20to%20gather%20comprehensively%2C%20implement%20the%20solution%2C%20and%20verify%20overall%20completion%2C%20causing%20phase%20agents%20to%20duplicate%20work%20or%20make%20conflicting%20writes%20instead%20of%20remaining%20within%20the%20one-phase%20boundary.%0A%0A%23%23%23%20Issue%202%0Aplugins%2Fagent-orchestration%2Fskills%2Fdelegate%2FSKILL.md%3A105%0A**Relative%20link%20omits%20required%20prefix**%0A%0AThe%20changed%20source%20link%20uses%20%60..%2Fagent-orchestration%2FSKILL.md%60%20instead%20of%20the%20repository-required%20%60.%2F%60-prefixed%20relative-path%20form%2C%20reducing%20consistency%20with%20the%20file-reference%20convention%20and%20its%20validation%20tooling.%0A%0A%60%60%60suggestion%0A-%20OBSERVATIONS%3A%20Pass-through%20only%20%E2%80%94%20data%20already%20in%20your%20context%20%28user%20messages%2C%20prior%20agent%20reports%2C%20command%20outputs%20you%20already%20received%29.%20Include%20%60file%3Aline%60%20references%20if%20already%20known.%20Include%20verbatim%20error%20messages%2C%20not%20paraphrased.%20Do%20NOT%20pre-gather%20data%20for%20the%20agent%20%28for%20example%2C%20do%20not%20run%20%60ruff%20check%20.%60%20before%20delegating%20to%20a%20linting%20agent%29.%20Do%20NOT%20read%2C%20grep%2C%20or%20glob%20files%20to%20find%20context%20for%20the%20agent%20%E2%80%94%20the%20agent%20has%20full%20tool%20access%20and%20an%20empty%20context%20window%3B%20it%20does%20its%20own%20discovery.%20No%20interpretations%20%28%22I%20think%22%29%2C%20no%20assumptions%20%28%22probably%22%29.%20SOURCE%3A%20%5Bagent-orchestration%20SKILL.md%5D%28.%2F..%2Fagent-orchestration%2FSKILL.md%29%20%E2%80%94%20Pre-Delegation%20Verification%20Checklist%20section.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jamie-bitflight%2Fclaude_skills&pr=3130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
plugins/agent-orchestration/skills/delegate/SKILL.md:48
**Phase prompts retain full-solution duties**

When the template is used for a read, gather, validate, test, report, or review phase, its mandatory task list still tells that agent to gather comprehensively, implement the solution, and verify overall completion, causing phase agents to duplicate work or make conflicting writes instead of remaining within the one-phase boundary.

### Issue 2
plugins/agent-orchestration/skills/delegate/SKILL.md:105
**Relative link omits required prefix**

The changed source link uses `../agent-orchestration/SKILL.md` instead of the repository-required `./`-prefixed relative-path form, reducing consistency with the file-reference convention and its validation tooling.

```suggestion
- OBSERVATIONS: Pass-through only — data already in your context (user messages, prior agent reports, command outputs you already received). Include `file:line` references if already known. Include verbatim error messages, not paraphrased. Do NOT pre-gather data for the agent (for example, do not run `ruff check .` before delegating to a linting agent). Do NOT read, grep, or glob files to find context for the agent — the agent has full tool access and an empty context window; it does its own discovery. No interpretations ("I think"), no assumptions ("probably"). SOURCE: [agent-orchestration SKILL.md](./../agent-orchestration/SKILL.md) — Pre-Delegation Verification Checklist section.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agent-orchestration): add decomposi..."](https://github.com/jamie-bitflight/claude_skills/commit/595c5c5b8adfd1549d19867398ac501c1012a489) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55810684)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - .claude/rules/markdown-file-references.md ([source](https://github.com/jamie-bitflight/claude_skills/blob/main/.claude/rules/markdown-file-references.md))

<!-- /greptile_comment -->