### PR TITLE
docs: replace false subagent tools: resolution claims with measured behaviour

### DIFF
--- a/.claude/rules/skill-substitution.md
+++ b/.claude/rules/skill-substitution.md
@@ -38,10 +38,17 @@ as **labels naming a key in that JSON** — not variables passed into the file. 
 "the value from the `item_ref` key," never "the parser provides `item_ref`."
 
 **Agent `tools:` frontmatter** requires exact, correctly-cased tool names
-(`mcp__Ref__ref_search_documentation`, not `mcp__ref__...`) — wildcards (`*`) and short-form MCP
-aliases (`mcp__context-mode__ctx_stats` instead of the full
-`mcp__plugin_context-mode_context-mode__ctx_stats`) silently resolve to zero tools, with no error
-raised.
+(`mcp__Ref__ref_search_documentation`, not `mcp__ref__...`). A name that does not match a live
+tool is dropped silently, with no error raised; the rest of the grant still resolves. A name for a
+tool on an MCP server that is not connected in the session behaves the same way — dropped, not
+granted. Verify every MCP name against the running server, not against another agent file.
+
+Bare `*` grants every tool. A server-scoped wildcard (`mcp__plugin_dh_backlog__*`) does not scope
+anything: it grants the full tool set, so an agent written expecting one server's tools silently
+receives all of them. Never write a server-scoped wildcard — enumerate the tool names.
+
+Measured 2026-08-22 against four probe agents. Harness tool resolution changes; re-measure before
+relying on any claim in this paragraph.
 
 After editing any SKILL.md, invoke the skill and confirm it still renders correctly with no
 unexpected prompts or extra steps.

--- a/.claude/rules/skill-substitution.md
+++ b/.claude/rules/skill-substitution.md
@@ -38,17 +38,19 @@ as **labels naming a key in that JSON** — not variables passed into the file. 
 "the value from the `item_ref` key," never "the parser provides `item_ref`."
 
 **Agent `tools:` frontmatter** requires exact, correctly-cased tool names
-(`mcp__Ref__ref_search_documentation`, not `mcp__ref__...`). A name that does not match a live
-tool is dropped silently, with no error raised; the rest of the grant still resolves. A name for a
-tool on an MCP server that is not connected in the session behaves the same way — dropped, not
-granted. Verify every MCP name against the running server, not against another agent file.
+(`mcp__Ref__ref_search_documentation`, not `mcp__ref__...`). Separator format is free — comma,
+comma-without-space, space, and a YAML list all parse identically; write comma-and-space. Verify
+every MCP name against the running server, not against another agent file.
 
-Bare `*` grants every tool. A server-scoped wildcard (`mcp__plugin_dh_backlog__*`) does not scope
-anything: it grants the full tool set, so an agent written expecting one server's tools silently
-receives all of them. Never write a server-scoped wildcard — enumerate the tool names.
+An entry that matches no live tool is dropped and the rest of the grant still resolves. When every
+entry resolves to nothing the subagent refuses to launch, reporting that it "would be spawned with
+zero tools" and naming the unresolved entries.
 
-Measured 2026-08-22 against four probe agents. Harness tool resolution changes; re-measure before
-relying on any claim in this paragraph.
+Grant a whole MCP server with `mcp__<server>__*` or `mcp__<server>` — both forms grant every tool
+that server exposes and compose with named tools. A plugin-bundled server registers as
+`mcp__plugin_<plugin-name>_<server-name>`. Either form grants nothing while that server is
+disconnected, so an agent whose `tools:` list is MCP-only cannot be invoked at all until the server
+returns. Give such an agent at least one non-MCP tool unless that runtime dependency is intended.
 
 After editing any SKILL.md, invoke the skill and confirm it still renders correctly with no
 unexpected prompts or extra steps.

--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "14.5.18",
+  "version": "14.5.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/.codex-plugin/plugin.json
+++ b/plugins/plugin-creator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-creator",
-  "version": "14.5.7",
+  "version": "14.5.8",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/plugin-creator/agents/agent-creator.md
+++ b/plugins/plugin-creator/agents/agent-creator.md
@@ -27,7 +27,8 @@ For the complete field specification (all fields with descriptions, env vars, an
 
 **Creation warnings:**
 
-- **MCP tool names**: must use exact registered names, case-sensitive. Wildcards (`mcp__Ref__*`) and wrong case (`mcp__ref__`) fail silently — agents with unresolvable MCP tool names hallucinate success. Verified 2026-03-22.
+- MCP tool names: use the exact registered name, case-sensitive (`mcp__Ref__ref_read_url`, never `mcp__ref__...`). Grant a whole server with `mcp__<server>__*` or `mcp__<server>` — both forms grant every tool that server exposes and compose with named tools. A plugin-bundled server registers as `mcp__plugin_<plugin-name>_<server-name>`.
+- MCP-only tool grants: an entry matching no live tool is dropped and the rest of the grant still resolves, but an agent whose every entry resolves to nothing refuses to launch. A server pattern grants nothing while that server is disconnected, so an agent granted only MCP tools cannot be invoked at all until the server returns — give it at least one non-MCP tool unless that runtime dependency is intended.
 - **Auto-discovery**: agents in the default `agents/` directory are registered automatically — never add them to `plugin.json`. Declaring the `agents` key overrides auto-discovery entirely (see Phase 5).
 - For plugin field restrictions (`permissionMode`, `hooks`, `mcpServers` silently ignored) and `Agent()` spawn syntax, see the preloaded `/plugin-creator:claude-subagent-reference`.
 

--- a/plugins/plugin-creator/skills/agent-creator/SKILL.md
+++ b/plugins/plugin-creator/skills/agent-creator/SKILL.md
@@ -364,7 +364,7 @@ mcpServers:
     cwd: path/to/server
 ```
 
-> **MCP tool name requirements** — Each MCP tool must be listed by its exact registered name with correct casing. Wildcards (e.g., `mcp__myserver__*`) do not resolve and silently fail. Case is sensitive (e.g., `mcp__Ref__` not `mcp__ref__`). Agents with unresolvable tool names receive no MCP tools and hallucinate success. Verified via controlled experiment 2026-03-22.
+> MCP tool name requirements — name each MCP tool by its exact registered name, case-sensitive (`mcp__Ref__`, not `mcp__ref__`). Grant a whole server with `mcp__<server>__*` or `mcp__<server>`; both forms grant every tool that server exposes and compose with named tools. A plugin-bundled server registers as `mcp__plugin_<plugin-name>_<server-name>`. An entry matching no live tool is dropped and the rest of the grant still resolves; an agent whose every entry resolves to nothing refuses to launch instead. A server pattern grants nothing while that server is disconnected, so an agent granted only MCP tools cannot be invoked until the server returns — give it at least one non-MCP tool unless that runtime dependency is intended.
 
 ### With MCP Server (reference to .mcp.json)
 

--- a/plugins/plugin-creator/skills/agent-creator/references/agent-schema.md
+++ b/plugins/plugin-creator/skills/agent-creator/references/agent-schema.md
@@ -28,23 +28,31 @@ description: >-
 description: 'This agent reviews code for quality issues.'
 ```
 
-### MCP tool name casing
+### MCP tool names and server patterns
 
-MCP tools must be listed by their exact registered name, case-sensitive. Wildcards and wrong
-case fail silently — the agent receives no MCP tools and hallucination ensues.
+Name each MCP tool by its exact registered name, case-sensitive. Grant a whole server with
+`mcp__<server>__*` or `mcp__<server>` — both forms grant every tool that server exposes and
+compose with named tools. A plugin-bundled server registers as
+`mcp__plugin_<plugin-name>_<server-name>`.
 
 ```yaml
-# CORRECT
+# CORRECT — named tool
 tools: Read, mcp__Ref__ref_read_url
 
-# WRONG — wildcard fails silently
-tools: Read, mcp__Ref__*
+# CORRECT — every tool from one server, plus Read
+tools: Read, mcp__plugin_dh_backlog__*
 
-# WRONG — wrong case fails silently
+# WRONG — wrong case matches no tool and is dropped
 tools: Read, mcp__ref__ref_read_url
 ```
 
-Verified via controlled experiment 2026-03-22.
+An entry that matches no live tool is dropped and the rest of the grant still resolves. When every
+entry resolves to nothing the agent refuses to launch, reporting that it "would be spawned with
+zero tools" and naming the unresolved entries.
+
+A server pattern grants nothing while that server is disconnected. An agent whose `tools:` list
+contains only MCP entries therefore cannot be invoked at all until the server returns — give it at
+least one non-MCP tool unless that runtime dependency is intended.
 
 ---
 

--- a/plugins/plugin-creator/skills/agent-creator/references/agent-schema.md
+++ b/plugins/plugin-creator/skills/agent-creator/references/agent-schema.md
@@ -40,11 +40,17 @@ compose with named tools. A plugin-bundled server registers as
 tools: Read, mcp__Ref__ref_read_url
 
 # CORRECT — every tool from one server, plus Read
-tools: Read, mcp__plugin_dh_backlog__*
+tools: Read, mcp__plugin_dh_backlog
 
 # WRONG — wrong case matches no tool and is dropped
 tools: Read, mcp__ref__ref_read_url
 ```
+
+Author server grants with the bare form (`mcp__<server>`), not the `mcp__<server>__*` glob. Both
+resolve identically at runtime, but `skilllint`'s AS007 check rejects the glob form and passes the
+bare form (confirmed: `skilllint 1.10.0` exits non-zero on `mcp__plugin_dh_backlog__*` and clean
+on `mcp__plugin_dh_backlog` for an otherwise-identical agent file) — an agent generated with the
+glob form fails Phase 6 validation.
 
 An entry that matches no live tool is dropped and the rest of the grant still resolves. When every
 entry resolves to nothing the agent refuses to launch, reporting that it "would be spawned with

--- a/plugins/plugin-creator/skills/agent-creator/references/agent-templates.md
+++ b/plugins/plugin-creator/skills/agent-creator/references/agent-templates.md
@@ -146,7 +146,7 @@ These templates follow a structured contract pattern with standardized inputs/ou
 | Field             | Type   | Default     | Valid Values                                               | Description                             |
 | ----------------- | ------ | ----------- | ---------------------------------------------------------- | --------------------------------------- |
 | `model`           | string | `inherit`   | `sonnet`, `opus`, `haiku`, `inherit`                       | Claude model to use                     |
-| `tools`           | string | (all tools) | Comma-separated: `Read, Grep, Glob, Bash, Edit, Write`. MCP tools: exact registered name required — no wildcards, case-sensitive. Wrong names silently fail (verified 2026-03-22). | Tools available to agent |
+| `tools`           | string | (all tools) | Comma-separated: `Read, Grep, Glob, Bash, Edit, Write`. MCP tools: exact registered name, case-sensitive; `mcp__<server>__*` or `mcp__<server>` grants that server's whole tool set. An entry matching no live tool is dropped; an agent whose entries all resolve to nothing refuses to launch. | Tools available to agent |
 | `disallowedTools` | string | (none)      | Comma-separated tool names                                 | Tools explicitly forbidden              |
 | `permissionMode`  | string | (inherit)   | `dontAsk`, `plan`, `acceptEdits`, `acceptAll`              | Permission behavior                     |
 | `skills`          | string | (none)      | Comma-separated skill names                                | Skills to load                          |

--- a/plugins/plugin-creator/skills/claude-subagent-reference/SKILL.md
+++ b/plugins/plugin-creator/skills/claude-subagent-reference/SKILL.md
@@ -72,8 +72,8 @@ Only `name` and `description` are required. All other fields are optional.
 |:------|:---------|:------------|
 | `name` | **Yes** | Unique identifier: lowercase letters and hyphens, max 64 chars. Hooks receive this as `agent_type`. Filename need not match |
 | `description` | **Yes** | When Claude should delegate to this subagent. Write clearly — Claude uses this for routing. Include "use proactively" to encourage automatic delegation |
-| `tools` | No | Allowlist of tools the subagent can use. Inherits all tools when omitted. Use `Agent(worker, researcher)` syntax to restrict which subagent types can be spawned. See [./references/tool-and-permission-control.md](./references/tool-and-permission-control.md) |
-| `disallowedTools` | No | Denylist — removed from inherited or specified list. When both fields set, `disallowedTools` applied first |
+| `tools` | No | Allowlist of tools the subagent can use. Inherits all tools when omitted. Accepts exact tool names and MCP server-level patterns (`mcp__<server>` or `mcp__<server>__*`). Use `Agent(worker, researcher)` syntax to restrict which subagent types can be spawned. A subagent whose entries all resolve to nothing refuses to launch. See [./references/tool-and-permission-control.md](./references/tool-and-permission-control.md) |
+| `disallowedTools` | No | Denylist — removed from inherited or specified list. Accepts the same MCP server-level patterns as `tools`. When both fields set, `disallowedTools` applied first |
 | `model` | No | Model to use: `sonnet`, `opus`, `haiku`, a full model ID (e.g., `claude-opus-4-7`), or `inherit`. Defaults to `inherit`. See [./references/model-and-effort.md](./references/model-and-effort.md) |
 | `permissionMode` | No | Permission mode: `default`, `acceptEdits`, `auto`, `dontAsk`, `bypassPermissions`, or `plan`. **Silently ignored for plugin subagents.** See [./references/tool-and-permission-control.md](./references/tool-and-permission-control.md) |
 | `maxTurns` | No | Maximum agentic turns before the subagent stops |

--- a/plugins/plugin-creator/skills/claude-subagent-reference/references/tool-and-permission-control.md
+++ b/plugins/plugin-creator/skills/claude-subagent-reference/references/tool-and-permission-control.md
@@ -37,8 +37,13 @@ the named server exposes, and each composes with named tools in the same list.
 
 ```yaml
 # Read plus every tool from the dh backlog server
-tools: Read, mcp__plugin_dh_backlog__*
+tools: Read, mcp__plugin_dh_backlog
 ```
+
+Author with the bare form. `skilllint`'s AS007 check rejects the `mcp__<server>__*` glob and
+passes the bare `mcp__<server>` form, even though both resolve to the identical tool set at
+runtime (confirmed: `skilllint 1.10.0` exits non-zero on the glob form and clean on the bare form
+for an otherwise-identical agent file).
 
 A plugin-bundled MCP server registers under `mcp__plugin_<plugin-name>_<server-name>`, and the
 server-level pattern composes with that prefix.

--- a/plugins/plugin-creator/skills/claude-subagent-reference/references/tool-and-permission-control.md
+++ b/plugins/plugin-creator/skills/claude-subagent-reference/references/tool-and-permission-control.md
@@ -13,6 +13,10 @@ tools: Read, Grep, Glob, Bash
 
 The subagent cannot use Edit, Write, Agent, or any MCP tools not in the list.
 
+Write entries comma-and-space separated, matching the documented convention. A comma without a
+space, a space-separated string, and a YAML list parse to the same tool set — none of them is an
+error.
+
 ## Tool denylist (`disallowedTools`)
 
 Remove specific tools from the inherited or specified pool.
@@ -22,6 +26,52 @@ disallowedTools: Write, Edit
 ```
 
 When both `tools` and `disallowedTools` are set, `disallowedTools` is applied first, then `tools` is resolved against the remaining pool. A tool listed in both is removed.
+
+## MCP server-level patterns
+
+SOURCE: <https://code.claude.com/docs/en/sub-agents.md> § Control subagent capabilities (accessed 2026-08-22)
+
+`tools` and `disallowedTools` both accept MCP server-level patterns in addition to exact tool
+names. `mcp__<server>` and `mcp__<server>__*` are equivalent — each grants or removes every tool
+the named server exposes, and each composes with named tools in the same list.
+
+```yaml
+# Read plus every tool from the dh backlog server
+tools: Read, mcp__plugin_dh_backlog__*
+```
+
+A plugin-bundled MCP server registers under `mcp__plugin_<plugin-name>_<server-name>`, and the
+server-level pattern composes with that prefix.
+
+MCP tool names are case-sensitive: `mcp__Ref__ref_read_url` resolves, `mcp__ref__ref_read_url`
+matches nothing.
+
+## How entries resolve
+
+SOURCE: <https://code.claude.com/docs/en/errors.md> (accessed 2026-08-22)
+
+An entry that matches no tool is dropped and the rest of the grant still resolves — one bad name
+does not empty the list.
+
+When every entry resolves to nothing, the subagent refuses to launch. The error names the agent and
+groups the failed entries by cause: `unrecognized` for a name matching no tool, and `recognized but
+matched no tools in this session` for a valid pattern with nothing to match.
+
+```text
+Agent 'probe-p2-bad-name' would be spawned with zero tools — refusing. Its tools list resolved to nothing: unrecognized [Grpe].
+```
+
+A server-level pattern resolves only while that server is connected. A subagent whose `tools` list
+contains only MCP entries therefore cannot be invoked at all while the server is down — the same
+definition that resolves to the server's full tool set when connected refuses to launch when it is
+not:
+
+```text
+Agent 'probe-p3-mcp-wildcard' would be spawned with zero tools — refusing. Its tools list resolved to nothing: recognized but matched no tools in this session [mcp__plugin_dh_backlog__*].
+```
+
+Grant at least one non-MCP tool to any subagent that must stay invocable regardless of server
+state; accept an MCP-only grant only where that hard runtime dependency is intended.
 
 ## Restrict which subagent types can be spawned
 

--- a/plugins/plugin-creator/skills/prompt-optimization/references/subagent-refactoring-methodology.md
+++ b/plugins/plugin-creator/skills/prompt-optimization/references/subagent-refactoring-methodology.md
@@ -204,7 +204,9 @@ VALIDATE NECESSITY:
 → For each tool: "Would the agent fail without this tool?" If no, remove it.
 ```
 
-**MCP tool name requirements** — When listing MCP tools in the `tools` field, each must use its exact registered name with correct casing. Wildcards (e.g., `mcp__Ref__*`) do not resolve and silently fail — the agent receives no MCP tools and hallucinate success. Case is sensitive: `mcp__Ref__ref_search_documentation` works; `mcp__ref__ref_search_documentation` fails with zero tool calls. Verify exact names from the running MCP server registration before including them. Verified via controlled experiment 2026-03-22.
+MCP tool name requirements — list each MCP tool in the `tools` field by its exact registered name, case-sensitive: `mcp__Ref__ref_search_documentation` resolves; `mcp__ref__ref_search_documentation` matches nothing and is dropped. Grant a whole server with `mcp__<server>__*` or `mcp__<server>`; both forms grant every tool that server exposes and compose with named tools. A plugin-bundled server registers as `mcp__plugin_<plugin-name>_<server-name>`. Verify exact names against the running MCP server registration before including them.
+
+An entry matching no live tool is dropped and the rest of the grant still resolves; an agent whose every entry resolves to nothing refuses to launch. A server pattern grants nothing while that server is disconnected, so an agent granted only MCP tools cannot be invoked until the server returns — leave it at least one non-MCP tool unless that runtime dependency is intended.
 
 ---
 


### PR DESCRIPTION
This repo documented several claims about how a subagent's `tools:` frontmatter resolves. Controlled single-entry probes — one variable each — run 2026-08-22 in Claude Code, cross-checked against `code.claude.com/docs/en/sub-agents` and `.../errors` (accessed 2026-08-22), show four of them are false.

**Measured:**

1. Separator format is free. `Read Grep`, `Read,Grep`, `Read, Grep`, and a YAML list each resolved to exactly Read and Grep. Comma-and-space is the documented convention in Anthropic's examples; the others are not errors. This makes skilllint FM007's stated rationale ("the parser expects comma-separated strings") wrong — the rule is a normalisation, not a correctness fix.
2. MCP server-level patterns work. An agent declaring only `mcp__plugin_dh_backlog__*` received exactly that server's 46 tools; `mcp__plugin_dh_backlog` received the identical 46. `Read, mcp__plugin_dh_backlog__*` yielded 47.
3. A plugin-bundled MCP server is named `mcp__plugin_<plugin-name>_<server-name>`, and the server-level pattern composes with that prefix.
4. An entry resolving to no tool is dropped and the rest of the grant survives. It is not an error and does not zero the list.
5. If every entry resolves to nothing, the subagent refuses to launch with a named error grouping entries by cause. It does not launch tool-less and does not fall back to a default toolset.
6. A server pattern grants tools only while that server is connected. The identical definition returned all 46 tools with the server up and refused to launch with it down — so an agent whose grant is MCP-only has a hard runtime dependency on that server.

**What was wrong:** that wildcards and short-form MCP aliases "silently resolve to zero tools, with no error raised"; that unresolvable names make agents "hallucinate success"; and — asserted on this branch's first commit and now retracted — that a server-scoped wildcard "fails open" and grants everything. That first commit used a single four-entry multi-variable grant and drew the wrong conclusion from it; the twelve single-variable probes in the second commit supersede it.

Blanket advice never to use `mcp__<server>__*` also removed the only group-grant mechanism the field offers, so it is dropped.

`.claude/rules/skill-substitution.md` keeps the directive only — the dated probe record two reviewers flagged is out, since rules carry the current requirement and not provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)