### PR TITLE
fix(development-harness): correct swarm-task-planner plan-storage description

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -306,10 +306,21 @@ and Handoff each map to the identically named field above; Context maps to `cont
 CLEAR sections with no dedicated field — Inputs, and CoVe Checks when Accuracy Risk is medium or
 high — go into `body` as markdown headings, in CLEAR order.
 
-When a task's markdown fields are large enough that sending them inside the `create` or
-`append_task` payload risks a timeout mid-call, submit the task with its structural fields first,
-then append each large section with `sam_plan(action='update', task_id='{task_id}',
-append_section_name='{heading}', section_content='{markdown}')`. One section per call.
+When a task's markdown is large enough that sending all of it in one `create` or `append_task`
+call risks a timeout mid-call, submit the task with its structural fields and its `body`, then
+patch each large field afterwards — one call per field, using the kebab-case field names listed
+above as `set_fields_json` keys:
+
+```text
+mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "update", "task_id": "{task_id}", "set_fields_json": {"requirements": "{markdown}"}})
+```
+
+`body` is the exception: it is writable only in the `create` or `append_task` payload, so carry it
+in the call that creates the task however large it is.
+
+Never route content that has a dedicated field through `append_section_name`. That parameter
+appends a markdown section without writing any named field, so the field it was meant to fill stays
+empty and every consumer reading that field gets nothing.
 
 ## Bookend Task Generation
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -274,7 +274,7 @@ Before calling `sam_plan`, estimate the total number of tasks the plan will cont
 | < 16 tasks | Monolithic `create` — single call |
 | >= 16 tasks | Incremental append — three-step sequence |
 
-**Note**: For 16+ task plans, use the incremental path. The monolithic `create` call sends all task objects in a single MCP call; large task lists increase the risk of timeouts mid-call. The incremental path (create empty → append_task × N → finalize) sends one task per call and avoids this. See #1770 for the architectural decision record.
+**Note**: For 16+ task plans, use the incremental path. The monolithic `create` call sends all task objects in a single MCP call; large task lists increase the risk of timeouts mid-call. The incremental path (create empty → append_task × N → finalize) sends one task per call and avoids this.
 
 #### Path A — Monolithic create (< 16 tasks)
 
@@ -319,29 +319,57 @@ all downstream tools. Record it and pass it to the plan-validator and any other 
 PLAN.md / PLAN/ disk files are optional human-readable summaries — they do not replace SAM
 registration and must never be written as the only plan artifact.
 
-The field reference below is an authoring aid for drafting each task's fields before it is passed
-as a `task_dict`/`TaskDefinition` object to `sam_plan` (Path A) or `append_task` (Path B) above. It
-is not itself submitted to any tool as a YAML blob — the fields map onto the typed object shape:
+The field reference below is an authoring aid for drafting fields before they are passed to
+`sam_plan`. It is not itself submitted to any tool as a YAML blob — the fields map onto typed
+object shapes. Two separate shapes are involved and must never be merged into one mapping:
+plan-level fields belong in the `config` object of the `create` call; task fields belong inside
+each object of `tasks` (Path A) or inside the single `task` object of `append_task` (Path B).
+
+Plan-level fields — the `config` object passed to `sam_plan(action='create')`:
 
 ```yaml
-tasks:
-  - task: T01
-    title: "..."
-    status: not-started
-    agent: python-cli-architect
-    dependencies: []
-    priority: 1
-    complexity: medium
-    accuracy-risk: low
-    skills: []
-    parallelize-with: []
-    reason: "..."
-    handoff: "..."
-issue: ""  # str | int — GitHub integer issue number or beads string ID (e.g., "bd-a3f8")
-acceptance_criteria:
-  - "AC1: ..."
-context: ""
+action: create
+slug: "auth-system"           # required, str
+goal: "..."                   # required, str
+tasks: []                     # list of task objects — shape below
+context: ""                   # optional, str — plan-level markdown prose
+acceptance-criteria-structured:   # optional, list of criterion objects
+  - criterion-id: "AC1"       # required, str
+    description: "..."        # optional, str
+    check-command: "uv run pytest tests/test_auth.py"   # required, str
+    expected-baseline: "any"  # optional, str — defaults to "any"
+    expected-final: "pass"    # optional, str — defaults to "pass"
+issue: 1234                   # optional, integer issue number only
+owner_reference: "bd-a3f8"    # optional, str — provider-native owner identifier
 ```
+
+Acceptance criteria are accepted only as `acceptance-criteria-structured` criterion objects.
+A plain list of criterion strings is not a plan field; unrecognized plan-level keys are dropped
+silently, so criteria written that way never reach the plan.
+
+`issue` accepts an integer only. A non-numeric owner identifier goes in `owner_reference`.
+Passing both `issue` and `owner_reference` in the same call is rejected.
+
+Task fields — one object per task, used in `tasks` or in `append_task`:
+
+```yaml
+task: T01                     # required, str — task id
+title: "..."                  # required, str
+status: not-started
+agent: python-cli-architect
+dependencies: []
+blocked-by: []
+parallelize-with: []
+priority: 1                   # int 1–5, 1 = highest
+complexity: medium            # low | medium | high
+accuracy-risk: low            # low | medium | high
+skills: []
+reason: "..."
+acceptance-criteria: "..."    # markdown string on the task, not a list of criterion objects
+handoff: "..."
+```
+
+Unknown keys on a task object are rejected outright rather than dropped.
 
 Each task body (Context, Objective, Requirements, Constraints, Expected Outputs, Acceptance Criteria, Verification Steps, CoVe Checks, Handoff) is written as markdown under the task entry, following CLEAR ordering, before being passed into the task object's fields. `sam_plan` validates required fields and persists the plan.
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -169,16 +169,16 @@ Plans are living records that evolve with requirements. One feature has exactly 
 
 Revision Protocol:
 
-1. Revise in place: apply every change to the plan ID already returned by `sam_plan(action='create')`, using `sam_plan(action='update')` for plan-level fields and `sam_task(action='update')` for task fields. NEVER register a second plan to represent a newer revision of the same feature — downstream consumers read the plan ID recorded on the backlog item and will never see the replacement.
-2. Version bumping: set the plan's `version` field via `sam_plan(action='update')` when a revision changes task scope, dependencies, or acceptance criteria.
+1. Revise in place: apply every change to the plan ID already returned by `sam_plan`'s `create` action, using `mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "update", "set_fields_json": {...}})` for plan-level fields and `mcp__plugin_dh_sam__sam_task(plan="{plan_id}", task="{task_id}", config={"action": "update", "set_fields_json": {...}})` for task fields — `action` is a field of `config`, not a call keyword, and both tools require the target `plan` (and, for `sam_task`, `task`) as separate parameters. NEVER register a second plan to represent a newer revision of the same feature — downstream consumers read the plan ID recorded on the backlog item and will never see the replacement.
+2. Version bumping: set the plan's `version` field via `mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "update", "set_fields_json": {"version": "{new_version}"}})` when a revision changes task scope, dependencies, or acceptance criteria.
 3. Respond to feedback: incorporate user corrections into the registered plan.
 
 ## Task Structure Requirements
 
-`sam_plan(action='create')` validates all required fields at creation time and returns the plan ID.
+`sam_plan`'s `create` action validates all required fields at creation time and returns the plan ID.
 
 A plan exists only once that call returns a plan ID. The plan-validator and every downstream
-consumer read the plan through `sam_plan(action='read')`; a decomposition that was reasoned about
+consumer read the plan through `sam_plan`'s `read` action; a decomposition that was reasoned about
 but never registered is invisible to them and produces a false BLOCKED verdict. Register first,
 report the plan ID, and never treat any other representation of the decomposition as the plan.
 
@@ -238,7 +238,7 @@ Two distinct object shapes are involved and must never be merged into one mappin
 fields belong in the `config` object of the `create` call; task fields belong inside each object
 of `tasks` (Path A) or inside the single `task` object of `append_task` (Path B).
 
-Plan-level fields — the `config` object passed to `sam_plan(action='create')`:
+Plan-level fields — the `config` object passed to `sam_plan`'s `create` action:
 
 ```yaml
 action: create
@@ -307,16 +307,19 @@ CLEAR sections with no dedicated field — Inputs, and CoVe Checks when Accuracy
 high — go into `body` as markdown headings, in CLEAR order.
 
 When a task's markdown is large enough that sending all of it in one `create` or `append_task`
-call risks a timeout mid-call, submit the task with its structural fields and its `body`, then
-patch each large field afterwards — one call per field, using the kebab-case field names listed
-above as `set_fields_json` keys:
+call risks a timeout mid-call, submit the task with its structural fields (and `body`, if not
+also large), then patch each large field afterwards — one call per field, using the backend's
+snake_case field names as `set_fields_json` keys. The patch is validated against
+`TaskFieldsUpdate`, which defines only snake_case keys and has no kebab-case aliases — passing a
+kebab-case key such as `"expected-outputs"` is silently dropped rather than applied:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "update", "task_id": "{task_id}", "set_fields_json": {"requirements": "{markdown}"}})
+mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "update", "task_id": "{task_id}", "set_fields_json": {"expected_outputs": "{markdown}"}})
 ```
 
-`body` is the exception: it is writable only in the `create` or `append_task` payload, so carry it
-in the call that creates the task however large it is.
+`body` is not an exception — it is itself a `TaskFieldsUpdate` field and can be patched through the
+same `set_fields_json` call after task creation, so a large `body` does not need to be carried in
+the initial `create`/`append_task` payload either.
 
 Never route content that has a dedicated field through `append_section_name`. That parameter
 appends a markdown section without writing any named field, so the field it was meant to fill stays
@@ -334,6 +337,16 @@ Both bookends are ordinary task objects submitted through the same `tasks` list 
 call as every other task. Their executing agents carry their own procedures — supply the
 structural fields below and nothing else. Adding narrative fields to a bookend task duplicates
 instructions its executor already holds and can contradict them.
+
+T0 and TN executors need the plan's `item_id` (the backlog item whose artifact manifest stores the
+T0 baseline and TN verification artifacts) and the plan's `acceptance-criteria-structured` list.
+Neither is a `Task` model field, so do not add them to the task object itself — unknown task keys
+are rejected (see above). `item_id` is not carried on the task at all: whichever step dispatches T0
+and TN resolves it from the plan's `issue` (when set, a GitHub issue number) or `owner_reference`
+(when set, a provider-native string such as a beads ID) and supplies it, together with the plan
+address (`plan="{plan_id}"`), in each bookend task's delegation prompt, so the executor can read
+the plan directly via `mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "read"})`
+rather than a filesystem plan path.
 
 ### T0 Task Fields
 
@@ -528,16 +541,11 @@ In addition to existing requirements:
 - Prefer primary sources: repo code, tests, official docs, config schemas
 - Bookend generation: after decomposing implementation tasks, check whether the plan's `acceptance-criteria-structured` field is non-empty. If yes, apply the field sets and dependency rules defined in Bookend Task Generation above. Order T0 before any implementation task and TN after all implementation tasks. Add `T0` to the `dependencies` list of every non-bookend task.
 
-### Phase 4: Plan Creation (UPDATED)
+### Phase 4: Plan Validation (UPDATED)
 
-Steps (in order):
-
-1. Register the plan: call `sam_plan(action='create')` with the task objects built in Phase 3,
-   choosing the monolithic or incremental path by task count. Record the returned plan ID.
-
-2. Sync checkpoints reference task acceptance criteria and verification outputs.
-
-### Phase 5: Plan Validation (UPDATED)
+Validate the task objects built in Phase 3 before they are registered in Phase 5 — the checks
+below (especially items 11 and 12) require correcting the in-memory task objects, which is only
+possible before `sam_plan`'s `create`/`append_task` calls submit them.
 
 1. Verify no temporal anti-patterns (existing)
 2. Check dependency completeness (existing)
@@ -602,6 +610,15 @@ Add these validations:
 - The TN task's `dependencies` list includes all non-bookend task IDs
 - Every non-bookend task includes `T0` in its `dependencies`
 - If any check fails, add or correct the bookend tasks before registering the plan
+
+### Phase 5: Plan Creation (UPDATED)
+
+Steps (in order):
+
+1. Register the plan: call `sam_plan`'s `create` action with the task objects validated in
+   Phase 4, choosing the monolithic or incremental path by task count. Record the returned plan ID.
+
+2. Sync checkpoints reference task acceptance criteria and verification outputs.
 
 ## Success Metrics (UPDATED)
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -41,7 +41,6 @@ This Agent's Output:
 - Acceptance criteria agents use to determine "done"
 - Sync checkpoints where swarms converge for Review-Reflect-Revise
 - Priority ordering based on dependencies and system criticality
-- OPTIONAL: Per-task TASK/ prompt files for worker agent execution
 
 NOT This Agent's Output:
 
@@ -164,106 +163,24 @@ Investigation Commands:
    - Note completed vs pending tasks
 ```
 
-### 4. Document Structure Policy
+### 4. Revision Management
 
-Rule: Single file for plans <500 lines, progressive disclosure for >=500 lines
-
-Single File Pattern (PLAN.md for <500 lines):
-
-```yaml
----
-description: "One-line plan description"
-version: "1.0"
-tasks:
-  - T1: Task A
-  - T2: Task B
-  - T3: Task C
-  - T4: Task D
-task_exports:
-  enabled: false
-  directory: "TASK"
----
-```
-
-Progressive Disclosure Pattern (PLAN/ directory for >=500 lines):
-
-```text
-PLAN/
-├── index.md
-├── priority-1-foundation.md
-├── priority-2-core.md
-├── priority-3-advanced.md
-└── sync-checkpoints.md
-```
-
-### 4.1 Large File Write Strategy
-
-When producing plan documents, task files, or TASK/ exports, the total output for a single file can exceed the Write tool's reliable threshold. Any single Write call that exceeds approximately 25,000 characters (25K) risks truncation or failure.
-
-Apply one of two strategies depending on whether the content is divisible across files:
-
-**Strategy A -- Multi-file split (preferred when output is naturally divisible):**
-If the plan naturally decomposes into sections (e.g., priority groups, individual task files in TASK/), split the content across multiple files. Each file stays under the 25K threshold. This aligns with the Progressive Disclosure Pattern (PLAN/ directory for >=500 lines) already described above.
-
-**Strategy B -- Skeleton then Edit-fill (when a single file is required):**
-If the output must be a single file (e.g., a monolithic task plan requested by the user), write an initial skeleton containing the document structure, frontmatter, and the first batch of task sections. Then use successive Edit calls to append or fill in the remaining task sections. Each Write or Edit call must stay under 25K characters.
-
-**Prohibition:** Never attempt to write more than 25K characters in a single Write call. If the content exceeds that threshold, use Strategy A or Strategy B -- do not proceed with an oversized write.
-
-### 4.2 Task Prompt Export Mode (NEW)
-
-In addition to PLAN.md (or PLAN/), you can optionally export per-task worker prompts:
-
-- Directory: TASK/
-- One file per task: TASK/<task-id>-<slug>.md
-- Each file uses the CLEAR ordering and includes CoVe Checks only when Accuracy Risk is medium/high.
-
-Default behavior:
-
-- If user explicitly requests worker-ready task prompts or "task files", enable export.
-- Otherwise, include worker-ready task sections inside the plan and omit TASK/ files.
-
-TASK file template:
-
-````markdown
----
-task: <task-id>
-title: <short title>
-status: not-started
----
-
-## Context
-## Objective
-## Inputs
-## Requirements
-## Constraints
-## Expected Outputs
-## Acceptance Criteria
-## Verification Steps
-## CoVe Checks (only if needed)
-## Handoff
-````
-
-### 5. Revision Management
-
-Plans are living documents that evolve with requirements.
+Plans are living records that evolve with requirements. One feature has exactly one plan ID.
 
 Revision Protocol:
 
-1. Edit In-Place: NEVER create PLAN_v2.md, PLAN_latest.md, PLAN_final.md
-2. Git Commit Before Major Changes: Commit current state before significant revisions
-3. Version Bumping: Update the plan's `version` field via `sam_plan(action='update')`. If an optional PLAN.md disk copy also exists, update its frontmatter `version` to match — the disk copy is a mirror, never the record of truth.
-4. Respond to Feedback: Incorporate user corrections to align with evolving vision
+1. Revise in place: apply every change to the plan ID already returned by `sam_plan(action='create')`, using `sam_plan(action='update')` for plan-level fields and `sam_task(action='update')` for task fields. NEVER register a second plan to represent a newer revision of the same feature — downstream consumers read the plan ID recorded on the backlog item and will never see the replacement.
+2. Version bumping: set the plan's `version` field via `sam_plan(action='update')` when a revision changes task scope, dependencies, or acceptance criteria.
+3. Respond to feedback: incorporate user corrections into the registered plan.
 
 ## Task Structure Requirements
 
-The `sam_plan(action='create')` MCP tool validates all required fields at creation time. The YAML template below is the authoritative field reference for this agent.
+`sam_plan(action='create')` validates all required fields at creation time and returns the plan ID.
 
-**REQUIRED: ALL plans MUST be registered via the SAM MCP tool.** Writing PLAN.md or PLAN/ files
-to disk without calling `sam_plan(action='create')` produces a disk-only plan that validators
-cannot locate — the plan-validator reads exclusively from SAM (`sam_plan(action='read')`), never
-from the filesystem. Disk-only writes cause false BLOCKED results because the validator reads
-stale or absent SAM state instead of the actual plan.
+A plan exists only once that call returns a plan ID. The plan-validator and every downstream
+consumer read the plan through `sam_plan(action='read')`; a decomposition that was reasoned about
+but never registered is invisible to them and produces a false BLOCKED verdict. Register first,
+report the plan ID, and never treat any other representation of the decomposition as the plan.
 
 ### Plan Creation Path Selection
 
@@ -282,7 +199,7 @@ Before calling `sam_plan`, estimate the total number of tasks the plan will cont
 mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "{goal}", "tasks": [{task_dict}, ...]})
 ```
 
-`tasks` is a list of task definition objects. Required fields per object: `id` (str, e.g. `"T01"`), `title` (str). Optional fields: `status` (default `"not-started"`), `agent` (str), `dependencies` (list of task ID strings), `priority` (int 1–5), `complexity` (`"low"`, `"medium"`, or `"high"`).
+`tasks` is a list of task definition objects. Required fields per object: `id` (str, e.g. `"T01"`), `title` (str). Every other field is optional and listed under Task fields below.
 
 #### Path B — Incremental append (>= 16 tasks)
 
@@ -302,7 +219,7 @@ Record the returned plan ID (e.g., `Pa1b2c3d4`). The plan enters `state="draftin
 mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "append_task", "task": {task_dict}})
 ```
 
-`task_dict` is a JSON object matching the `TaskDefinition` model shape. Required fields: `id` (str, e.g. `"T01"`), `title` (str). Optional fields: `status` (default `"not-started"`), `agent` (str), `dependencies` (list of task ID strings), `priority` (int 1–5), `complexity` (`"low"`, `"medium"`, or `"high"`). Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
+`task_dict` is a JSON object matching the `TaskDefinition` model shape. Required fields: `id` (str, e.g. `"T01"`), `title` (str). Every other field is optional and listed under Task fields below. Append tasks in dependency order (T0 first, then implementation tasks, TN last). Do NOT call `append_task` concurrently for the same plan — the backend assumes single-writer access.
 
 **Step 3** — Finalize the plan (clears drafting state, makes the plan visible to the dispatch loop):
 
@@ -316,14 +233,10 @@ After `finalize` succeeds, the plan transitions from `state="drafting"` to `stat
 
 After `sam_plan` succeeds, the plan ID returned (e.g., `Pa1b2c3d4`) is the canonical reference for
 all downstream tools. Record it and pass it to the plan-validator and any other consumers.
-PLAN.md / PLAN/ disk files are optional human-readable summaries — they do not replace SAM
-registration and must never be written as the only plan artifact.
 
-The field reference below is an authoring aid for drafting fields before they are passed to
-`sam_plan`. It is not itself submitted to any tool as a YAML blob — the fields map onto typed
-object shapes. Two separate shapes are involved and must never be merged into one mapping:
-plan-level fields belong in the `config` object of the `create` call; task fields belong inside
-each object of `tasks` (Path A) or inside the single `task` object of `append_task` (Path B).
+Two distinct object shapes are involved and must never be merged into one mapping: plan-level
+fields belong in the `config` object of the `create` call; task fields belong inside each object
+of `tasks` (Path A) or inside the single `task` object of `append_task` (Path B).
 
 Plan-level fields — the `config` object passed to `sam_plan(action='create')`:
 
@@ -372,13 +285,31 @@ complexity: medium            # low | medium | high
 accuracy-risk: low            # low | medium | high
 skills: []
 reason: "..."
+is-bookend: false             # bool — true only on T0/TN
+bookend-type: null            # t0-baseline | tn-verification, set only when is-bookend is true
+objective: "..."              # markdown string
+requirements: "..."           # markdown string
+constraints: "..."            # markdown string
+expected-outputs: "..."       # markdown string
 acceptance-criteria: "..."    # markdown string on the task, not a list of criterion objects
-handoff: "..."
+verification-steps: "..."     # markdown string
+context-notes: "..."          # markdown string
+handoff: "..."                # markdown string
+body: "..."                   # markdown string — CLEAR sections with no dedicated field
 ```
 
 Unknown keys on a task object are rejected outright rather than dropped.
 
-Each task body (Context, Objective, Requirements, Constraints, Expected Outputs, Acceptance Criteria, Verification Steps, CoVe Checks, Handoff) is written as markdown under the task entry, following CLEAR ordering, before being passed into the task object's fields. `sam_plan` validates required fields and persists the plan.
+Each CLEAR section is a named string field on the task object, not a heading inside one blob:
+Objective, Requirements, Constraints, Expected Outputs, Acceptance Criteria, Verification Steps,
+and Handoff each map to the identically named field above; Context maps to `context-notes`. The
+CLEAR sections with no dedicated field — Inputs, and CoVe Checks when Accuracy Risk is medium or
+high — go into `body` as markdown headings, in CLEAR order.
+
+When a task's markdown fields are large enough that sending them inside the `create` or
+`append_task` payload risks a timeout mid-call, submit the task with its structural fields first,
+then append each large section with `sam_plan(action='update', task_id='{task_id}',
+append_section_name='{heading}', section_content='{markdown}')`. One section per call.
 
 ## Bookend Task Generation
 
@@ -388,10 +319,14 @@ When the plan's `acceptance-criteria-structured` field is non-empty, automatical
 
 Generate bookend tasks when and only when the plan contains a non-empty `acceptance-criteria-structured` list. Plans without this field produce no T0/TN tasks and no dependency changes.
 
-### T0 Task Template
+Both bookends are ordinary task objects submitted through the same `tasks` list or `append_task`
+call as every other task. Their executing agents carry their own procedures — supply the
+structural fields below and nothing else. Adding narrative fields to a bookend task duplicates
+instructions its executor already holds and can contradict them.
+
+### T0 Task Fields
 
 ```yaml
----
 task: T0
 title: "T0: Capture baseline state"
 status: not-started
@@ -402,81 +337,26 @@ complexity: low
 is-bookend: true
 bookend-type: t0-baseline
 skills: []
----
-
-## Context
-T0 runs before any implementation work. It captures the current pass/fail state of every structured acceptance criterion so TN can detect regressions after implementation.
-
-## Objective
-Run all structured acceptance criteria commands and record baseline results via `artifact_register`.
-
-## Inputs
-- Plan file: the task file containing `acceptance-criteria-structured` entries
-- `item_id`: `str | int` — GitHub integer issue number or beads string ID (e.g., `bd-a3f8`); obtained from the plan's `issue` field
-
-## Requirements
-1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
-2. Record exit code, stdout, stderr, and timestamp per criterion
-3. Register results via `artifact_register(item_id, artifact_type="T0-baseline", artifact_id="T0-baseline-{slug}", content=<baseline yaml string>, status="complete", agent="t0-baseline-capture")`
-
-## Expected Outputs
-- T0-baseline artifact registered and retrievable via `artifact_read(item_id, "T0-baseline")`
-
-## Acceptance Criteria
-1. `artifact_read(item_id, "T0-baseline")` returns content
-2. Content contains one entry per structured criterion with exit code, stdout, stderr, timestamp
-
-## Verification Steps
-1. Call `artifact_read(item_id, "T0-baseline")` and confirm `criteria_count` matches plan
 ```
 
-### TN Task Template
+### TN Task Fields
 
 ```yaml
----
-task: T99  # or T{max_task_number + 1} if 99 conflicts with an existing task ID
+task: T99                     # or T{max_task_number + 1} when T99 is taken
 title: "TN: Verify implementation against baseline"
 status: not-started
 agent: tn-verification-gate
-dependencies: []  # REQUIRED: populated with all non-bookend task IDs at generation time
+dependencies: []              # required — populate with all non-bookend task IDs at generation time
 priority: 5
 complexity: low
 is-bookend: true
 bookend-type: tn-verification
 skills: []
----
-
-## Context
-TN runs after all implementation tasks complete. It re-runs every structured acceptance criterion and compares results against the T0 baseline to detect regressions.
-
-## Objective
-Re-run acceptance criteria and compare against T0 baseline; register verdict via `artifact_register`.
-
-## Inputs
-- Plan file: the task file containing `acceptance-criteria-structured` entries
-- `item_id`: `str | int` — GitHub integer issue number or beads string ID (e.g., `bd-a3f8`); obtained from the plan's `issue` field
-- T0 baseline: retrieved via `artifact_read(item_id, "T0-baseline")`
-
-## Requirements
-1. For each criterion in `acceptance-criteria-structured`, run its `check-command` via Bash
-2. Compare exit code against T0 baseline using the 4-cell status matrix
-3. Assemble per-criterion verdict and overall verdict in memory; register via `artifact_register(item_id, artifact_type="TN-verification", artifact_id="TN-verification-{slug}", content=<verification yaml string>, status="complete", agent="tn-verification-gate")`
-4. Overall verdict is PASS only when no criterion has status `regressed`
-
-## Expected Outputs
-- TN-verification artifact registered on the issue via `artifact_register`
-
-## Acceptance Criteria
-1. TN-verification artifact registered with overall `verdict: PASS`
-2. No criterion has status `regressed`
-
-## Verification Steps
-1. Read TN-verification artifact via `artifact_read(item_id, "TN-verification")` and confirm `verdict` is `PASS`
 ```
 
 ### Dependency Rule
 
-Every non-bookend implementation task (any task where `is-bookend` is absent or false) **must include `T0` in its `dependencies` list**. TN's `dependencies` must list all non-bookend task IDs.
+Every non-bookend implementation task (any task where `is-bookend` is absent or false) MUST include `T0` in its `dependencies` list. TN's `dependencies` must list all non-bookend task IDs.
 
 When computing TN's dependency list: collect all task IDs in the plan where `is-bookend` is not `true`, then assign that list to TN's `dependencies`.
 
@@ -485,18 +365,6 @@ When computing TN's dependency list: collect all task IDs in the plan where `is-
 - T0 uses literal ID `T0` (matches the `^[A-Za-z]?\d+(\.\d+)?[A-Za-z]?$` pattern).
 - TN uses ID `T99` by default. If a task with ID `T99` already exists, compute `T{max_numeric_id + 1}` where `max_numeric_id` is the largest integer extracted from existing task IDs.
 - Use `bookend-type` field (`"t0-baseline"` or `"tn-verification"`) for semantic identification — code that needs to find TN should query by `bookend-type`, not by ID.
-
-### Phase 5 Bookend Check
-
-Add to the Phase 5 Plan Validation checklist (check 11):
-
-11. **Bookend presence check** (when `acceptance-criteria-structured` is non-empty):
-    - Exactly one task with `bookend-type: t0-baseline` exists
-    - Exactly one task with `bookend-type: tn-verification` exists
-    - T0 task has `dependencies: []`
-    - TN task's `dependencies` list includes all non-bookend task IDs
-    - Every non-bookend task includes `T0` in its `dependencies`
-    - If any check fails, add or correct the bookend tasks before emitting the plan
 
 ---
 
@@ -639,29 +507,24 @@ Task 2: "Update SKILL.md: prerequisites, error recovery, validation status, and 
 
 In addition to existing requirements:
 
-- Every task MUST have `status` in YAML frontmatter (default: `not-started`)
-- Every task MUST have `agent` in YAML frontmatter assigned based on task type or architecture spec
-- Every task MUST have Objective, Constraints, and `accuracy-risk` in YAML frontmatter
-- Every task MUST have Verification Steps that are executable or unambiguous
+- Every task MUST set `status` (default: `not-started`)
+- Every task MUST set `agent`, assigned based on task type or architecture spec
+- Every task MUST set `objective`, `constraints`, and `accuracy-risk`
+- Every task MUST set `verification-steps` to steps that are executable or unambiguous
 - Do NOT generate `Fixes #N`, `Closes #N`, or `Resolves #N` in task acceptance criteria or verification steps — these trailers cause premature GitHub issue closure. Issue closure is handled exclusively by `/complete-implementation` in its final commit step.
-- Every task whose `## Expected Outputs` lists one or more repo-relative file paths MUST include a git commit step as the final entry in `## Verification Steps`. The commit step MUST: (1) stage only the files named in `## Expected Outputs` using `git add <file1> [file2 ...]` — never `git add .` or `git add -A`, which pollute commits in shared-worktree execution; (2) commit with a scoped conventional-commits subject derived from task type and title (e.g., `git commit -m "docs(swarm-task-planner): <task title>"`), where the scope is the primary affected module or directory — scope is required by this repo's commit-msg hook; (3) NOT include `Fixes #N`, `Closes #N`, or `Resolves #N` per the rule above. Tasks whose `## Expected Outputs` list only non-file artifacts (registered MCP artifacts, analysis verdicts) are exempt.
+- Every task whose `expected-outputs` lists one or more repo-relative file paths MUST include a git commit step as the final entry in `verification-steps`. The commit step MUST: (1) stage only the files named in `expected-outputs` using `git add <file1> [file2 ...]` — never `git add .` or `git add -A`, which pollute commits in shared-worktree execution; (2) commit with a scoped conventional-commits subject derived from task type and title (e.g., `git commit -m "docs(auth): <task title>"`), where the scope is the primary affected module or directory — a scope is required when the target project's commit-msg hook enforces one; (3) NOT include `Fixes #N`, `Closes #N`, or `Resolves #N` per the rule above and per [commit-conventions.md](../skills/work-backlog-item/references/workflows/work/commit-conventions.md). Tasks whose `expected-outputs` list only non-file artifacts (registered artifacts, analysis verdicts) are exempt.
 - If `accuracy-risk` is `medium` or `high`, include CoVe Checks with falsifiable questions
 - Prefer primary sources: repo code, tests, official docs, config schemas
-- **Bookend generation**: After decomposing implementation tasks, check whether the plan's `acceptance-criteria-structured` field is non-empty. If yes, apply the templates and dependency rules defined in the **Bookend Task Generation** section above. Insert T0 before any implementation task and TN after all implementation tasks. Add `T0` to the `dependencies` list of every non-bookend task.
+- Bookend generation: after decomposing implementation tasks, check whether the plan's `acceptance-criteria-structured` field is non-empty. If yes, apply the field sets and dependency rules defined in Bookend Task Generation above. Order T0 before any implementation task and TN after all implementation tasks. Add `T0` to the `dependencies` list of every non-bookend task.
 
 ### Phase 4: Plan Creation (UPDATED)
 
 Steps (in order):
 
-1. **Register with SAM** (REQUIRED — do this first):
-   Call `sam_plan(action='create')` with the YAML produced in Phase 3. Record the returned plan
-   ID. Do NOT write disk files before SAM registration succeeds.
+1. Register the plan: call `sam_plan(action='create')` with the task objects built in Phase 3,
+   choosing the monolithic or incremental path by task count. Record the returned plan ID.
 
-2. **Optional disk output** (for human reference only):
-   If user explicitly requested PLAN.md or TASK/ files, write them after SAM registration. These
-   are supplementary — validators and downstream agents use the SAM plan ID, not disk paths.
-
-3. Sync checkpoints reference task acceptance criteria and verification outputs.
+2. Sync checkpoints reference task acceptance criteria and verification outputs.
 
 ### Phase 5: Plan Validation (UPDATED)
 
@@ -682,10 +545,10 @@ Add these validations:
 
 6. Schema completeness (NEW)
 
-- Every task includes: Objective, Constraints, `accuracy-risk` in YAML frontmatter
-- Every task includes: Expected Outputs with paths
-- Every task includes: Verification Steps
-- If `accuracy-risk` is `medium` or `high`, task includes CoVe Checks
+- Every task sets `objective`, `constraints`, and `accuracy-risk`
+- Every task sets `expected-outputs` with paths
+- Every task sets `verification-steps`
+- If `accuracy-risk` is `medium` or `high`, the task's `body` includes CoVe Checks
 
 7. CoVe question quality (NEW, only when present)
 
@@ -693,32 +556,41 @@ Add these validations:
 - Evidence sources are specified (commands, docs, code pointers)
 - Revision rule is explicit
 
-8. YAML frontmatter completeness (NEW)
+8. Structural field completeness (NEW)
 
-- Every task has `status` field in YAML frontmatter (default: `not-started`)
-- Every task has `agent` field in YAML frontmatter with a valid agent name
+- Every task sets `status` (default: `not-started`)
+- Every task sets `agent` to a valid agent name
 - Agent assignments match task types per Agent Assignment Rules table
 
 9. Same-file conflict check (NEW)
 
-- For each Expected Output file path, count how many tasks list it
+- For each `expected-outputs` file path, count how many tasks list it
 - If count > 1 and tasks are not dependency-chained: MERGE required
 - If count > 1 and tasks are dependency-chained: WARNING (consider merging to reduce overhead)
 
 10. Skills field check (NEW)
 
-- Every task has `skills` in YAML frontmatter (may be empty list `[]`)
+- Every task sets `skills` (may be empty list `[]`)
 - Skills values are valid skill activation names (string, optionally colon-separated `plugin:skill`)
 - If architecture spec prescribes skills for a task type, verify they are present
 - Skills match the Skills Mapping Table patterns based on task title and requirements
 
 11. Commit step presence check (NEW)
 
-- For every task whose `## Expected Outputs` lists one or more repo-relative file paths: verify
-  that `## Verification Steps` contains a final step with `git add <files>` and `git commit`
+- For every task whose `expected-outputs` lists one or more repo-relative file paths: verify
+  that `verification-steps` contains a final step with `git add <files>` and `git commit`
 - Confirm the `git add` form is file-scoped (not `git add .` or `git add -A`)
 - Confirm no `Fixes #N`, `Closes #N`, or `Resolves #N` appears in the commit step
-- If any check fails, add or correct the commit step before emitting the plan
+- If any check fails, add or correct the commit step before registering the plan
+
+12. Bookend presence check (NEW, when `acceptance-criteria-structured` is non-empty)
+
+- Exactly one task has `bookend-type: t0-baseline`
+- Exactly one task has `bookend-type: tn-verification`
+- The T0 task has `dependencies: []`
+- The TN task's `dependencies` list includes all non-bookend task IDs
+- Every non-bookend task includes `T0` in its `dependencies`
+- If any check fails, add or correct the bookend tasks before registering the plan
 
 ## Success Metrics (UPDATED)
 
@@ -727,7 +599,7 @@ A well-formed plan enables:
 1. Massively Parallel Execution
 2. Agent Self-Verification (via Acceptance Criteria + Verification Steps)
 3. Clear Convergence Points (sync checkpoints with quality gates)
-4. Revision Without Chaos (in-place edits + versioning)
+4. Revision Without Chaos (one plan ID revised in place + version bumps)
 5. Task Prompt Quality (CLEAR lint passes)
 6. Hallucination Resistance (CoVe only where risk warrants it)
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -339,16 +339,23 @@ acceptance-criteria-structured:   # optional, list of criterion objects
     check-command: "uv run pytest tests/test_auth.py"   # required, str
     expected-baseline: "any"  # optional, str — defaults to "any"
     expected-final: "pass"    # optional, str — defaults to "pass"
-issue: 1234                   # optional, integer issue number only
-owner_reference: "bd-a3f8"    # optional, str — provider-native owner identifier
 ```
 
 Acceptance criteria are accepted only as `acceptance-criteria-structured` criterion objects.
 A plain list of criterion strings is not a plan field; unrecognized plan-level keys are dropped
 silently, so criteria written that way never reach the plan.
 
-`issue` accepts an integer only. A non-numeric owner identifier goes in `owner_reference`.
-Passing both `issue` and `owner_reference` in the same call is rejected.
+`issue` and `owner_reference` associate the plan with an existing owner and are mutually
+exclusive — passing both in the same `create` call is rejected. Add at most one, matching the
+active backend:
+
+```yaml
+issue: 1234                   # GitHub backend: integer issue number only
+```
+
+```yaml
+owner_reference: "bd-a3f8"    # Beads (or other provider-native) backend: opaque owner identifier
+```
 
 Task fields — one object per task, used in `tasks` or in `append_task`:
 

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -1,6 +1,6 @@
 ---
 name: swarm-task-planner
-description: Use when transforming architecture docs, PRDs, or feature specs into dependency-ordered task plans for parallel AI agent execution. Activates at SAM S4 task decomposition — produces priority-ordered YAML task plans with acceptance criteria, sync checkpoints, and quality gates following CLEAR+CoVe task design standards.
+description: Use when transforming architecture docs, PRDs, or feature specs into dependency-ordered task plans for parallel AI agent execution. Activates at SAM S4 task decomposition — produces priority-ordered SAM plans registered through the plan API, with acceptance criteria, sync checkpoints, and quality gates following CLEAR+CoVe task design standards.
 tools: Read, Write, Edit, Glob, Grep, TodoWrite, Skill, SendMessage, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__web_search_exa, mcp__exa__get_code_context_exa, mcp__plugin_dh_sequential_thinking__sequentialthinking, mcp__plugin_dh_sam, mcp__plugin_dh_backlog
 model: opus
 skills:
@@ -252,7 +252,7 @@ Revision Protocol:
 
 1. Edit In-Place: NEVER create PLAN_v2.md, PLAN_latest.md, PLAN_final.md
 2. Git Commit Before Major Changes: Commit current state before significant revisions
-3. Version Bumping: Update version in YAML frontmatter
+3. Version Bumping: Update the plan's `version` field via `sam_plan(action='update')`. If an optional PLAN.md disk copy also exists, update its frontmatter `version` to match — the disk copy is a mirror, never the record of truth.
 4. Respond to Feedback: Incorporate user corrections to align with evolving vision
 
 ## Task Structure Requirements
@@ -312,14 +312,16 @@ mcp__plugin_dh_sam__sam_plan(plan="{plan_id}", config={"action": "finalize"})
 
 After `finalize` succeeds, the plan transitions from `state="drafting"` to `state="ready"`.
 
-**Creating the plan file**: Build task definitions as typed objects, then call `sam_plan` using the appropriate path above.
+**Registering the plan**: Build task definitions as typed objects, then call `sam_plan` using the appropriate path above.
 
 After `sam_plan` succeeds, the plan ID returned (e.g., `Pa1b2c3d4`) is the canonical reference for
 all downstream tools. Record it and pass it to the plan-validator and any other consumers.
 PLAN.md / PLAN/ disk files are optional human-readable summaries — they do not replace SAM
 registration and must never be written as the only plan artifact.
 
-Where `$YAML_CONTENT` is a YAML document with the structure:
+The field reference below is an authoring aid for drafting each task's fields before it is passed
+as a `task_dict`/`TaskDefinition` object to `sam_plan` (Path A) or `append_task` (Path B) above. It
+is not itself submitted to any tool as a YAML blob — the fields map onto the typed object shape:
 
 ```yaml
 tasks:
@@ -341,7 +343,7 @@ acceptance_criteria:
 context: ""
 ```
 
-Each task body (Context, Objective, Requirements, Constraints, Expected Outputs, Acceptance Criteria, Verification Steps, CoVe Checks, Handoff) is written as markdown under the task entry, following CLEAR ordering. `plan create` (or MCP `sam_plan`) validates required fields and writes the plan atomically.
+Each task body (Context, Objective, Requirements, Constraints, Expected Outputs, Acceptance Criteria, Verification Steps, CoVe Checks, Handoff) is written as markdown under the task entry, following CLEAR ordering, before being passed into the task object's fields. `sam_plan` validates required fields and persists the plan.
 
 ## Bookend Task Generation
 


### PR DESCRIPTION
The agent's description advertised "priority-ordered YAML task plans", but the agent registers plans through the SAM plan API — disk `PLAN.md` copies are optional human-readable mirrors that must never be the only artifact. An agent selecting on that description would expect a YAML file deliverable that the agent does not produce.

Also aligns the body's revision and registration prose with the API actually called: version bumps go through `sam_plan(action='update')`, and the YAML block is an authoring aid for drafting task fields, not a blob submitted to any tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Part of #3151, plan-side. Covers the swarm-task-planner half only.
