### PR TITLE
fix(development-harness): separate perspective-review verdicts from codebase-analysis

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",
@@ -13,7 +13,11 @@
     "longDescription": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
     "developerName": "Jamie Nelson",
     "category": "Developer Tools",
-    "capabilities": ["Interactive", "Read", "Write"],
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
     "defaultPrompt": [
       "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human"
     ]

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"
@@ -10,18 +10,29 @@
   "mcpServers": {
     "sequential_thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking@latest"
+      ]
     },
     "backlog": {
       "command": "uv",
-      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"],
+      "args": [
+        "run",
+        "--script",
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run_backlog_server.py"
+      ],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }
     },
     "sam": {
       "command": "uv",
-      "args": ["run", "--script", "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"],
+      "args": [
+        "run",
+        "--script",
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run_sam_server.py"
+      ],
       "env": {
         "DH_PROJECT_ROOT": "${workspaceFolder}"
       }

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -153,11 +153,12 @@ authoritative flag mapping.
 | `TN-verification` | `@dh:tn-verification-gate` | Post-implementation verification |
 | `dispatch-plan` | `dispatch_create_plan` | Milestone dispatch plan |
 | `audit-report` | **`@dh:doc-drift-auditor`** | Documentation drift audit; NOT used by `@dh:code-reviewer` |
+| `perspective-review` | `@dh:reviewer-quality`, `@dh:reviewer-performance`, `@dh:reviewer-accessibility` | Per-perspective verdict from `dh:multi-perspective-review` Phase T0; NOT used by `@dh:code-reviewer` |
 
 Task plans are not artifact-manifest entries. Create, read, and update them through `sam_plan`, then
 associate the returned logical address with the owning work item through `backlog_update`.
 
-**CRITICAL — type ownership is exclusive:** `codebase-analysis` is owned by `@dh:code-reviewer`. `audit-report` is owned by `@dh:doc-drift-auditor`. These types must not be cross-assigned. `complete-implementation` reads the code review verdict via `artifact_read(item_id=<owner>, artifact_type="codebase-analysis")` — a wrong type silently skips the quality gate.
+**CRITICAL — type ownership is exclusive:** `codebase-analysis` is owned by `@dh:code-reviewer`. `audit-report` is owned by `@dh:doc-drift-auditor`. `perspective-review` is owned by the `dh:multi-perspective-review` perspective reviewers. These types must not be cross-assigned. `complete-implementation` reads the code review verdict via `artifact_read(item_id=<owner>, artifact_type="codebase-analysis")` — a wrong type silently skips the quality gate. This is why the four perspective reviewers dispatched by Phase T0 (Multi-Perspective Review) register under `perspective-review` rather than `codebase-analysis`: T0 and Phase T1 (Code Review, owned by `@dh:code-reviewer`) declare no dependency ordering between them, so a perspective reviewer registering under `codebase-analysis` could be the most recently registered entry of that type at the moment Phase T1's gate reads it — masking the actual code-review verdict with an incompatible schema.
 
 **Registration:** Producers call `artifact_register` after creating document-artifact content.
 Plans are the exception: `sam_plan` owns plan content and task state, and `backlog_update` stores

--- a/plugins/development-harness/agents/reviewer-accessibility.md
+++ b/plugins/development-harness/agents/reviewer-accessibility.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer-accessibility
-description: "Multi-perspective accessibility reviewer. Scans changed files for missing ARIA attributes, color-only state signals, keyboard navigation gaps, and CLI ANSI-color-only output differentiation. Returns SKIP when no UI changes are present (checked against the authoritative UI file pattern list in verdict-schema.md §2.3 before any scanning). Registers a structured verdict block as a codebase-analysis artifact. Use when dispatched by dh:multi-perspective-review for the accessibility perspective. Trigger: dispatched as a SAM task-worker teammate."
+description: "Multi-perspective accessibility reviewer. Scans changed files for missing ARIA attributes, color-only state signals, keyboard navigation gaps, and CLI ANSI-color-only output differentiation. Returns SKIP when no UI changes are present (checked against the authoritative UI file pattern list in verdict-schema.md §2.3 before any scanning). Registers a structured verdict block as a perspective-review artifact. Use when dispatched by dh:multi-perspective-review for the accessibility perspective. Trigger: dispatched as a SAM task-worker teammate."
 model: sonnet
 tools: Read, Grep, Glob, Bash, Skill, SendMessage, mcp__plugin_dh_backlog__artifact_register, mcp__plugin_dh_backlog__artifact_read
 skills:
@@ -23,7 +23,7 @@ You are **never** the implementer. You do not fix issues — you identify them a
 - Check whether any changed file matches the UI file pattern list (§2.3 of verdict-schema.md)
 - If no UI files present: emit SKIP verdict immediately and stop
 - If UI files present: apply accessibility SOP (Steps 3–6 below)
-- Register the structured verdict as a `codebase-analysis` artifact via MCP
+- Register the structured verdict as a `perspective-review` artifact via MCP
 - Send your verdict to the team lead via `SendMessage`
 
 **You do NOT:**
@@ -130,12 +130,16 @@ Record keyboard navigation gaps as:
 
 Assemble the structured verdict block per §2.1 of verdict-schema.md.
 
-Register via MCP:
+Register via MCP as a `perspective-review` artifact — a distinct type from `codebase-analysis`.
+`codebase-analysis` is reserved for the independent forensic code-review verdict produced by
+`dh:code-reviewer`, and `complete-implementation` reads that type exclusively to decide whether the
+code review phase passed. Registering under `codebase-analysis` here would collide with that
+verdict and silently corrupt the gate's read.
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
   item_id={issue_number},
-  artifact_type="codebase-analysis",
+  artifact_type="perspective-review",
   artifact_id="code-review-accessibility-{issue_number}",
   content={verdict_block_json},
   status="complete",
@@ -186,7 +190,7 @@ FINDINGS:
   - Blocking: {count}
   - Minor: {count}
 ARTIFACTS:
-  - Verdict registered as codebase-analysis artifact on item {issue_number}
+  - Verdict registered as perspective-review artifact on item {issue_number}
 ```
 
 ## BLOCKED Format

--- a/plugins/development-harness/agents/reviewer-performance.md
+++ b/plugins/development-harness/agents/reviewer-performance.md
@@ -122,13 +122,17 @@ whether minor issues were observed in config files.
 
 ### Step 5: Register Artifact
 
-Register the verdict as a `codebase-analysis` artifact if an `item_id` is available in
-the task or delegation prompt:
+Register the verdict as a `perspective-review` artifact if an `item_id` is available in
+the task or delegation prompt. `perspective-review` is a distinct artifact type from
+`codebase-analysis` — `codebase-analysis` is reserved for the independent forensic code-review
+verdict produced by `dh:code-reviewer`, and `complete-implementation` reads that type exclusively
+to decide whether the code review phase passed. Registering under `codebase-analysis` here would
+collide with that verdict and silently corrupt the gate's read.
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
   item_id={issue_number},
-  artifact_type="codebase-analysis",
+  artifact_type="perspective-review",
   artifact_id="code-review-performance-{issue_number}",
   content={structured_verdict_json},
   status="complete",
@@ -188,7 +192,7 @@ Perspective: performance
 Verdict: APPROVE | REJECT | SKIP
 Findings: {count BLOCKER} blocker(s), {count MINOR} minor
 Summary line: Performance: {token per §2.2}
-Artifact: registered as codebase-analysis on issue {N} | no item_id — not registered
+Artifact: registered as perspective-review on issue {N} | no item_id — not registered
 ```
 
 ## STATUS Output (MANDATORY)
@@ -201,7 +205,7 @@ SUMMARY: {one sentence — verdict, key findings, basis for decision}
 VERDICT_JSON:
 {paste the full structured verdict block}
 ARTIFACTS:
-  - codebase-analysis registered on issue {N} | not registered (no item_id)
+  - perspective-review registered on issue {N} | not registered (no item_id)
 NOTES:
   - {files inspected vs skipped}
   - {any scope limitations}

--- a/plugins/development-harness/agents/reviewer-quality.md
+++ b/plugins/development-harness/agents/reviewer-quality.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer-quality
-description: "Quality-perspective reviewer for multi-perspective code review. Scans changed files for naming violations, dead code, swallowed exceptions (bare except, except Exception with pass, empty catch blocks), test coverage gaps (new public functions without tests), and SOLID violations. Emits a structured verdict block (APPROVE/REJECT) and registers findings as a codebase-analysis artifact. SKIP is not applicable — quality perspective always runs on code changes. Use when dispatched by dh:multi-perspective-review as part of the parallel reviewer team. Trigger: reviewer-quality, quality review, code quality gate."
+description: "Quality-perspective reviewer for multi-perspective code review. Scans changed files for naming violations, dead code, swallowed exceptions (bare except, except Exception with pass, empty catch blocks), test coverage gaps (new public functions without tests), and SOLID violations. Emits a structured verdict block (APPROVE/REJECT) and registers findings as a perspective-review artifact. SKIP is not applicable — quality perspective always runs on code changes. Use when dispatched by dh:multi-perspective-review as part of the parallel reviewer team. Trigger: reviewer-quality, quality review, code quality gate."
 model: sonnet
 tools: Read, Grep, Glob, Bash, Skill, SendMessage, mcp__plugin_dh_backlog__artifact_register, mcp__plugin_dh_backlog__artifact_read
 skills:
@@ -119,12 +119,18 @@ Note: `skip_reason` is omitted — SKIP is never applicable for this perspective
 
 ### Step 8: Register Artifact
 
-Register the verdict as a `codebase-analysis` artifact via MCP. Use `issue_number` from the task context if provided; omit if not available.
+Register the verdict as a `perspective-review` artifact via MCP. Use `issue_number` from the task context if provided; omit if not available.
+
+`perspective-review` is a distinct artifact type from `codebase-analysis`. `codebase-analysis` is
+reserved for the independent forensic code-review verdict produced by `dh:code-reviewer` — the
+quality gate `complete-implementation` reads that type exclusively to decide whether the code
+review phase passed. Registering under `codebase-analysis` here would collide with that verdict
+and silently corrupt the gate's read.
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
   item_id={issue_number},
-  artifact_type="codebase-analysis",
+  artifact_type="perspective-review",
   artifact_id="code-review-quality-{issue_number}",
   content={verdict_block_json},
   status="complete",

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -1575,6 +1575,7 @@ class ArtifactType(StrEnum):
     RESEARCH = "research"
     DISPATCH_PLAN = "dispatch-plan"
     AUDIT_REPORT = "audit-report"
+    PERSPECTIVE_REVIEW = "perspective-review"
 
 
 class ArtifactStatus(StrEnum):

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -3296,7 +3296,7 @@ async def artifact_register(
         Field(
             description=(
                 "Artifact type: feature-context, architect, task-plan, T0-baseline, TN-verification, "
-                "codebase-analysis, research"
+                "codebase-analysis, research, dispatch-plan, audit-report, perspective-review"
             )
         ),
     ],

--- a/plugins/development-harness/tests_backlog/test_artifact_registry.py
+++ b/plugins/development-harness/tests_backlog/test_artifact_registry.py
@@ -377,6 +377,46 @@ class TestArtifactRegistryRegister:
         ca_entries = registry.get_by_type(manifest_after_second, ArtifactType.CODEBASE_ANALYSIS)
         assert len(ca_entries) == 2
 
+    def test_perspective_review_artifacts_do_not_collide_with_codebase_analysis(
+        self, registry: ArtifactRegistry, empty_manifest: ArtifactManifest
+    ) -> None:
+        """A perspective reviewer's verdict and a code-reviewer's verdict stay in separate types.
+
+        Tests: ArtifactType.PERSPECTIVE_REVIEW exists and is distinct from CODEBASE_ANALYSIS
+        How: Register one codebase-analysis entry (simulating dh:code-reviewer) and one
+             perspective-review entry (simulating a dh:multi-perspective-review reviewer) for
+             the same item; assert get_by_type(CODEBASE_ANALYSIS) returns only the code-reviewer
+             entry.
+        Why: dh:multi-perspective-review's Phase T0 (perspective reviewers) and Phase T1
+             (dh:code-reviewer) declare no dependency ordering, so registering both verdicts
+             under codebase-analysis let the most-recently-registered entry mask the other one
+             regardless of which agent produced it — complete-implementation's quality gate reads
+             codebase-analysis expecting the code-reviewer's PASS/NEEDS-WORK/FAIL verdict and must
+             never receive a perspective reviewer's APPROVE/REJECT/SKIP verdict instead.
+        """
+        # Arrange
+        code_review_entry = ArtifactEntry(
+            artifact_type=ArtifactType.CODEBASE_ANALYSIS, artifact_id="code-review-T1-foo", agent="code-reviewer"
+        )
+        perspective_entry = ArtifactEntry(
+            artifact_type=ArtifactType.PERSPECTIVE_REVIEW,
+            artifact_id="code-review-quality-42",
+            agent="reviewer-quality",
+        )
+
+        # Act
+        manifest_after_first = registry.register(empty_manifest, code_review_entry)
+        manifest_after_second = registry.register(manifest_after_first, perspective_entry)
+
+        # Assert
+        assert len(manifest_after_second.artifacts) == 2
+        ca_entries = registry.get_by_type(manifest_after_second, ArtifactType.CODEBASE_ANALYSIS)
+        assert len(ca_entries) == 1
+        assert ca_entries[0].agent == "code-reviewer"
+        pr_entries = registry.get_by_type(manifest_after_second, ArtifactType.PERSPECTIVE_REVIEW)
+        assert len(pr_entries) == 1
+        assert pr_entries[0].agent == "reviewer-quality"
+
     def test_register_auto_stamps_created_at_when_empty(
         self, registry: ArtifactRegistry, empty_manifest: ArtifactManifest
     ) -> None:


### PR DESCRIPTION
## Evidence for the defect

- `reviewer-quality.md`, `reviewer-performance.md`, and `reviewer-accessibility.md` each called `artifact_register(item_id, artifact_type="codebase-analysis", artifact_id="code-review-{perspective}-{issue_number}", ...)`.
- `AGENTS.md`'s artifact-type table documented `codebase-analysis` as owned exclusively by `@dh:code-reviewer` and read by `complete-implementation` Phase T1, with an explicit warning: "a wrong type silently skips the quality gate."
- `complete-implementation/SKILL.md`'s Recursive Follow-up Handling Step 1 reads `artifact_read(item_id={item_ref}, artifact_type="codebase-analysis")`, treats the result as "the review report registered by `@dh:code-reviewer` during Phase 1," and checks its `verdict` field for `PASS`/`NEEDS-WORK`/`FAIL` — a schema the perspective reviewers never emit (they emit `APPROVE`/`REJECT`/`SKIP`).
- The QG plan's Phase T0 (Multi-Perspective Review) and Phase T1 (Code Review) both declare `"dependencies": []`, so their dispatch order is not guaranteed.
- `artifact_read` in `backlog_core/server.py` resolves multiple same-type entries by sorting on `created_at` descending and returning only the most recent one (with a warning, not an error).

Together this confirmed the claim: whichever of the four T0 perspective reviewers or the T1 code-reviewer registers last under `codebase-analysis` is the entry `artifact_read` returns, so the quality gate could read an incompatible perspective verdict instead of the actual code review, or vice versa. `reviewer-security.md` was checked too — unlike the other three, its current SOP has no artifact-registration step at all, so it was not part of this collision and was left unchanged.

## Fix

`ArtifactType` (`backlog_core/models.py`) is a `StrEnum` — a constrained vocabulary already enforced by `artifact_register`/`artifact_read` (`ArtifactType(artifact_type)` raises on an unrecognized string). Rather than inventing an ad hoc type string, this PR extends that enum with `PERSPECTIVE_REVIEW = "perspective-review"` and repoints the three affected reviewer agents at it. `codebase-analysis` remains exclusive to `dh:code-reviewer`; the alternative of a gate that filters on something more specific than type (e.g. `artifact_id` prefix matching) was rejected because the manifest schema already has a first-class per-type discovery mechanism (`artifact_list`/`artifact_get`/`artifact_read` all key off `artifact_type`) and multiplexing producers inside one type via string-prefix filtering would still leave every other same-type reader (there are already other legitimate `codebase-analysis` producers, e.g. `codebase-analyzer`) exposed to the same class of ambiguity.

## Consumers traced

- **`complete-implementation`'s Recursive Follow-up Handling Step 1** (`artifact_read(item_id, artifact_type="codebase-analysis")`) — now receives only `dh:code-reviewer`'s entry during the QG dispatch loop; no change needed to the skill itself since it was never meant to read the perspective verdicts.
- **`dh:multi-perspective-review`'s own gate (Step 5/6 of its `SKILL.md`)** — collects verdicts in-memory via `SendMessage`, not by reading the artifact back, so it is unaffected by the artifact-type change.
- **`AGENTS.md`'s artifact ownership table** — added a `perspective-review` row and extended the "type ownership is exclusive" note to name the new type and explain why T0's registrations were moved off `codebase-analysis`.
- **`backlog_core/server.py`'s `artifact_register` tool description** — the type list documented in the tool's `Field` description now includes `perspective-review` (and the previously-undocumented `dispatch-plan`/`audit-report`).
- **`ArtifactEntry`/`ArtifactType` roundtrip tests** (`tests_backlog/test_artifact_registry.py`) — the existing `list(ArtifactType)`-parametrized roundtrip test picks up the new member automatically; no change needed there.

## Test

Added `test_perspective_review_artifacts_do_not_collide_with_codebase_analysis` to `tests_backlog/test_artifact_registry.py`. It registers a simulated `dh:code-reviewer` entry under `codebase-analysis` and a simulated `dh:reviewer-quality` entry under `perspective-review` for the same item, then asserts `get_by_type(CODEBASE_ANALYSIS)` returns only the code-reviewer entry. Verified this test fails on the pre-fix `models.py` (`AttributeError: type object 'ArtifactType' has no attribute 'PERSPECTIVE_REVIEW'`) and passes once the enum member is added — with the rest of the 58-test file unaffected.

## Verification

- `uv run pytest plugins/development-harness/tests_backlog/test_artifact_registry.py -q` — 58 passed
- `uv run ruff check --fix` / `uv run ruff format` / `uv run ty check` on every changed Python file — clean
- `uv run prek run --files <every changed file>` — all hooks passed (manifest auto-sync bumped `plugin.json`/`.codex-plugin/plugin.json`/`.cursor-plugin/plugin.json` as documented in this repo's plugin-development workflow)