### PR TITLE
fix(development-harness): reduce the task dispatch prompt to a task reference

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -96,24 +96,20 @@ Spawn one teammate per ready task. When only one task is ready, a single Agent c
 For each task being dispatched:
 
 - Choose the `subagent_type` with the decision in `dh:dispatch-contract`. Pass only the task reference (`plan_ref` + task ID) — the task definition's `agent` field is read after dispatch, not by the orchestrator.
-- Check the task's `skills` list from the ready-tasks JSON output.
-- If `skills` is non-empty, include skill-loading instructions in the delegation prompt:
+- Launch the chosen agent with the task reference as its entire prompt:
 
 ```text
-Before starting work, load these skills: {comma-separated skill names}.
-For each skill, call: Skill(skill="{skill-name}")
+{plan_ref}/{task_id}
 ```
 
-- If `skills` is empty or missing, do not add skill-loading instructions (backward compatible).
-- Launch the chosen agent with a prompt that invokes `start-task`:
-
-```text
-Skill(skill="start-task", args="{plan_ref} --task {task_id}")
-```
-
-> **Note**: Task-level skills are additive to agent-level skills. If the agent definition
-> already declares skills via its frontmatter, task-level skills supplement them (they do not
-> replace agent-level skills). Loading the same skill twice is a no-op.
+- Do not name a skill in the delegation prompt. A dispatch carries a task reference; the receiver
+  resolves what to load from it. `dh:task-worker` reads the task record, loads the profile named
+  in its `agent` field, and the task-execution skill it delegates to loads the task's own
+  `skills` list; a specialist dispatched directly already carries its own behavior. A skill name
+  written into a dispatch prompt is an instruction whose scope the receiver cannot check against
+  its own — that is the route by which a plan-level workflow reaches a task-level agent.
+- Do not restate the task's `skills` list in the prompt. The receiver reads it from the task
+  record, and task-level skills stay additive to whatever the agent profile declares.
 
 ### Agent Health Check (While Waiting)
 
@@ -345,8 +341,5 @@ If the issue number is not known, skip registration.
 
 ## Completion Gate
 
-When all tasks show `COMPLETE`, invoke:
-
-```text
-Skill(skill="complete-implementation", args="{plan_ref}")
-```
+When all tasks show `COMPLETE`, load the `dh:complete-implementation` skill with `{plan_ref}` as
+its argument, in this workflow's own context. Never pass that skill name to a dispatched agent.

--- a/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
+++ b/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
@@ -214,6 +214,23 @@ def _plan_arg_to_path(plan_arg: str) -> Path | None:
         return None
 
 
+def _resolve_matched_task(match: re.Match[str]) -> tuple[Path | None, str | None]:
+    """Resolve a plan/task regex match's groups to (task_file, task_id).
+
+    Shared by every pattern in ``extract_task_info_from_prompt`` — each pattern differs
+    only in how it locates the plan-arg/task-id groups in the prompt, not in what happens
+    once they're found.
+
+    Returns:
+        ``(task_file, task_id)``, or ``(None, None)`` when the plan arg cannot be resolved
+        to a filesystem path (plan not found in the DH state directory).
+    """
+    task_file = _plan_arg_to_path(match.group("plan"))
+    if task_file is None:
+        return None, None
+    return task_file, match.group("task_id")
+
+
 def extract_task_info_from_prompt(prompt: str) -> tuple[Path | None, str | None]:
     """Extract task file path and task ID from sub-agent prompt.
 
@@ -239,10 +256,7 @@ def extract_task_info_from_prompt(prompt: str) -> tuple[Path | None, str | None]
         rf"/start-task\s+{_PLAN_ARG_RE}(?:\s+--task\s+(?P<task_id>{_TASK_ID_RE}))?", prompt, re.IGNORECASE
     )
     if match:
-        task_file = _plan_arg_to_path(match.group("plan"))
-        if task_file is None:
-            return None, None
-        return task_file, match.group("task_id")
+        return _resolve_matched_task(match)
 
     # Pattern 2: Skill(skill="start-task", args="<plan-arg> --task <id>")
     # The orchestrator invokes start-task via the Skill tool, not as a literal command.
@@ -255,10 +269,16 @@ def extract_task_info_from_prompt(prompt: str) -> tuple[Path | None, str | None]
         re.IGNORECASE,
     )
     if skill_match:
-        task_file = _plan_arg_to_path(skill_match.group("plan"))
-        if task_file is None:
-            return None, None
-        return task_file, skill_match.group("task_id")
+        return _resolve_matched_task(skill_match)
+
+    # Pattern 3: bare "<plan-arg>/<task-id>" address, with no /start-task prefix and no
+    # Skill() wrapper. implement-feature/SKILL.md dispatches dh:task-worker with the task
+    # reference as the sub-agent's ENTIRE prompt in this form, so it is matched as a full-string
+    # match (not a substring search like Patterns 1 and 2) to avoid false-positiving on an
+    # address mentioned in passing within a longer, unrelated prompt.
+    bare_match = re.fullmatch(rf"{_PLAN_ARG_RE}/(?P<task_id>{_TASK_ID_RE})", prompt.strip(), re.IGNORECASE)
+    if bare_match:
+        return _resolve_matched_task(bare_match)
 
     return None, None
 

--- a/plugins/development-harness/tests/test_task_status_hook.py
+++ b/plugins/development-harness/tests/test_task_status_hook.py
@@ -201,6 +201,60 @@ def test_extract_task_info_from_prompt_plan_address_not_found() -> None:
 
 
 # ---------------------------------------------------------------------------
+# extract_task_info_from_prompt — bare address form (implement-feature dispatch)
+# ---------------------------------------------------------------------------
+# implement-feature/SKILL.md dispatches dh:task-worker with the task reference as its
+# ENTIRE prompt, in the bare form "{plan_ref}/{task_id}" — no /start-task prefix, no
+# Skill() wrapper.
+
+
+def test_extract_task_info_from_prompt_bare_address_form(tmp_path: Path) -> None:
+    """Bare "{plan_ref}/{task_id}" prompt (implement-feature's dispatch form) resolves."""
+    # Arrange
+    resolved = tmp_path / "Pdec8934d-my-feature.yaml"
+    resolved.touch()
+    prompt = "Pdec8934d/T01"
+
+    # Act
+    with patch.object(_hook_mod, "resolve_plan_address", return_value=resolved) as mock_resolve:
+        task_file, task_id = extract_task_info_from_prompt(prompt)
+
+    # Assert
+    assert task_id == "T01"
+    assert task_file == resolved
+    mock_resolve.assert_called_once_with("Pdec8934d", ANY)
+
+
+def test_extract_task_info_from_prompt_bare_address_form_strips_whitespace(tmp_path: Path) -> None:
+    """Leading/trailing whitespace around the bare address form is tolerated."""
+    # Arrange
+    resolved = tmp_path / "Pdec8934d-my-feature.yaml"
+    resolved.touch()
+    prompt = "  Pdec8934d/T01\n"
+
+    # Act
+    with patch.object(_hook_mod, "resolve_plan_address", return_value=resolved):
+        task_file, task_id = extract_task_info_from_prompt(prompt)
+
+    # Assert
+    assert task_id == "T01"
+    assert task_file == resolved
+
+
+def test_extract_task_info_from_prompt_bare_address_form_embedded_not_matched() -> None:
+    """A plan/task address embedded in a longer prompt is NOT treated as the bare form."""
+    # Arrange
+    prompt = "Please review Pdec8934d/T01 as part of code review."
+
+    # Act
+    task_file, task_id = extract_task_info_from_prompt(prompt)
+
+    # Assert
+    assert task_file is None
+    assert task_id is None
+
+
+# ---------------------------------------------------------------------------
 # extract_task_info_from_prompt — file path form (regression tests)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Part of the #3060 over-orchestration failure, addressed structurally rather than by adding a rule.

`implement-feature`'s Progress Loop previously told the dispatcher to build a delegation prompt containing a skill invocation, and to restate the task's `skills` list inside that prompt. Both write a skill name into free prose. A receiver cannot check the scope of a skill name it is handed against the scope of its own assignment — which is exactly how a plan-level skill reached a task-level agent and made it start dispatching its own workers.

The prescribed prompt is now the task reference alone. `task-worker` already reads the task record to resolve the profile named in its `agent` field, and the task-execution skill it delegates to already loads the task's own `skills` list — so nothing is lost by removing them from the prompt. What is removed is the slot where a skill name could be written.

This does not close the path completely: a dispatcher can still hand-compose whatever prose it likes. #3140 tracks the durable version, where the delegation prompt for a ready task is produced by a tool so no dispatcher composes one at all. This change removes the instruction that told dispatchers to write one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)