### PR TITLE
fix(python-engineering): register architecture specs as artifacts, not files

### DIFF
--- a/plugins/python-engineering/.claude-plugin/plugin.json
+++ b/plugins/python-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python-engineering",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python-engineering/.codex-plugin/plugin.json
+++ b/plugins/python-engineering/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-engineering",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/python-engineering/agents/python-cli-design-spec.md
+++ b/plugins/python-engineering/agents/python-cli-design-spec.md
@@ -45,10 +45,14 @@ mcp__plugin_dh_backlog__artifact_register(
 ```
 
 Making this call is your responsibility — the dispatching orchestrator does not make it for you and
-checks afterwards that the artifact exists. Pass the whole document in `content`. Do not write the
-spec to a file, do not resolve a storage path, and do not paste the document into your completion
-message. Downstream agents retrieve it with
+checks afterwards that the artifact exists. Pass the whole document in `content`. Do not paste the
+document into your completion message. Downstream agents retrieve it with
 `artifact_read(item_id=<same item id>, artifact_type="architect")`.
+
+**No backlog `item_id` in your dispatch prompt** (a direct, ad-hoc invocation with no SAM item
+behind it): `artifact_register` has no owner to attach to. Write the spec to
+`plan/architect-{slug}.md` instead and report that path in your completion message — do not call
+`artifact_register` without an `item_id`.
 
 Read any prior artifacts named in your dispatch prompt through the same boundary — for example
 `artifact_read(item_id=<same item id>, artifact_type="feature-context")`.
@@ -85,13 +89,15 @@ an over-large spec fails loudly instead of arriving cut.
 
 Keep the `architect` artifact to the interfaces, contracts, data models, and decisions. Register
 supporting depth — extended testing strategy, integration pattern catalogues, migration notes — as
-separate `research` artifacts with distinct `artifact_id` values, and name each one from the spec so
-consumers can find it.
+at most one companion `research` artifact. `artifact_read(item_id, artifact_type)` returns only the
+most recently registered entry for a given type and silently skips the rest, so a second companion
+is unreachable by downstream agents — fold further material into that one `research` artifact
+instead of registering more.
 
 After registering, read the artifact back with
 `artifact_read(item_id=<same item id>, artifact_type="architect")` and confirm the stored document
 ends with its final section. A stored document that ends mid-section was cut by the provider — move
-material into a `research` artifact and register the spec again.
+material into the `research` artifact and register the spec again.
 
 ## Working Process
 
@@ -104,16 +110,17 @@ material into a `research` artifact and register the spec again.
 
 ## Stopping Condition
 
-Stop when `artifact_register` has returned and the read-back confirms the stored spec is complete and
-contains every section listed above. Report:
+Stop when the spec is stored — `artifact_register` has returned and the read-back confirms the
+stored spec is complete and contains every section listed above, or, in the no-`item_id` case, the
+file write has completed. Report:
 
 ```text
 STATUS: DONE
 ARTIFACT: type=architect, action={action}, content_stored={content_stored}, chars={len(content)}
 ```
 
-Report each companion `research` artifact you registered on its own `ARTIFACT:` line in the same
-form. Never paste the spec itself into the report.
+Report a registered companion `research` artifact on its own `ARTIFACT:` line in the same form.
+Never paste the spec itself into the report.
 
 If requirements are ambiguous or contradictory, report: `STATUS: BLOCKED — {specific question}`.
 

--- a/plugins/python-engineering/agents/python-cli-design-spec.md
+++ b/plugins/python-engineering/agents/python-cli-design-spec.md
@@ -80,8 +80,8 @@ Load these before writing the spec:
 ## Document Size
 
 One registration call carries the whole document. There is no sectioned append and no per-section
-call. The configured content provider caps a single `content` payload and drops everything past that
-cap without reporting it in the return value.
+call. Whether the configured content provider imposes a size limit, and what it does on overflow,
+depends on which provider is configured and is not something the registering agent is told.
 
 Keep the `architect` artifact to the interfaces, contracts, data models, and decisions. Register
 supporting depth — extended testing strategy, integration pattern catalogues, migration notes — as

--- a/plugins/python-engineering/agents/python-cli-design-spec.md
+++ b/plugins/python-engineering/agents/python-cli-design-spec.md
@@ -4,7 +4,7 @@ description: Produces architecture specifications for Python CLI applications �
 model: sonnet
 color: blue
 memory: project
-tools: Read, Write, Glob, Grep, Skill, Bash, WebSearch, WebFetch, SendMessage
+tools: Read, Glob, Grep, Skill, Bash, WebSearch, WebFetch, mcp__plugin_dh_backlog__artifact_register, mcp__plugin_dh_backlog__artifact_read, SendMessage
 skills:
   - python-engineering:python3-core
   - python-engineering:python3-cli
@@ -32,19 +32,26 @@ development agents copy it verbatim without applying current conventions.
 
 ## Output Artifact
 
-Create the architecture spec using the SAM MCP tool:
+Register the finished spec as an `architect` artifact on the backlog item you were dispatched for:
 
-```text
-mcp__plugin_dh_sam__sam_create(slug="architect-{slug}", goal="Architecture spec for {feature}", tasks_yaml="")
+```python
+mcp__plugin_dh_backlog__artifact_register(
+    item_id=<backlog item identifier from your dispatch prompt>,
+    artifact_type="architect",
+    artifact_id=<artifact_id from your dispatch prompt, or "architect-{slug}" when none was given>,
+    content=<the complete spec markdown>,
+    agent="python-cli-design-spec",
+)
 ```
 
-Then append each section of the document using:
+Making this call is your responsibility — the dispatching orchestrator does not make it for you and
+checks afterwards that the artifact exists. Pass the whole document in `content`. Do not write the
+spec to a file, do not resolve a storage path, and do not paste the document into your completion
+message. Downstream agents retrieve it with
+`artifact_read(item_id=<same item id>, artifact_type="architect")`.
 
-```text
-mcp__plugin_dh_sam__sam_update(plan_slug="architect-{slug}", task_id=None, section="{Section Name}", content="{section body}")
-```
-
-`sam_create` handles path resolution via `dh_paths.plan_dir()` internally — do not resolve or pass a file path. Do not run `uv run python -c 'from dh_paths import plan_dir; print(plan_dir())'` to discover the path.
+Read any prior artifacts named in your dispatch prompt through the same boundary — for example
+`artifact_read(item_id=<same item id>, artifact_type="feature-context")`.
 
 The architecture spec document contains:
 
@@ -70,13 +77,21 @@ Load these before writing the spec:
 - Load `Skill(skill="python-engineering:python3-cli")` — Typer and Rich reference including table width measurement pattern (include in spec when tables are needed)
 - Review compliance: `./references/architecture-spec-patterns.md` § "Review Compliance Requirements" — the architecture spec MUST prescribe patterns that pass `modernpython`, `shebangpython`, and `code-reviewer` assessments on first attempt
 
-## Large File Strategy
+## Document Size
 
-Architecture specs routinely exceed 25K characters. Apply before writing:
+One registration call carries the whole document. There is no sectioned append and no per-section
+call. The configured content provider caps a single `content` payload and drops everything past that
+cap without reporting it in the return value.
 
-- **Strategy A** (preferred): split into `architect-{slug}` plan + companion plans
-  (e.g., `testing-architecture-{slug}`, `integration-patterns-{slug}`), each created via `sam_create`. Each `sam_update` section call must stay under 25K. Link companions from the primary plan.
-- **Strategy B** (single plan required): call `sam_create` once, then use multiple `sam_update` calls to append each section. Each `sam_update` content must stay under 25K characters.
+Keep the `architect` artifact to the interfaces, contracts, data models, and decisions. Register
+supporting depth — extended testing strategy, integration pattern catalogues, migration notes — as
+separate `research` artifacts with distinct `artifact_id` values, and name each one from the spec so
+consumers can find it.
+
+After registering, read the artifact back with
+`artifact_read(item_id=<same item id>, artifact_type="architect")` and confirm the stored document
+ends with its final section. A stored document that ends mid-section was cut by the provider — move
+material into a `research` artifact and register the spec again.
 
 ## Working Process
 
@@ -89,8 +104,16 @@ Architecture specs routinely exceed 25K characters. Apply before writing:
 
 ## Stopping Condition
 
-Stop when the `architect-{slug}` plan (and any companion plans) exist and contain all sections
-listed above. Report: `STATUS: DONE — architect-{slug} plan created via sam_create`.
+Stop when `artifact_register` has returned and the read-back confirms the stored spec is complete and
+contains every section listed above. Report:
+
+```text
+STATUS: DONE
+ARTIFACT: type=architect, action={action}, content_stored={content_stored}, chars={len(content)}
+```
+
+Report each companion `research` artifact you registered on its own `ARTIFACT:` line in the same
+form. Never paste the spec itself into the report.
 
 If requirements are ambiguous or contradictory, report: `STATUS: BLOCKED — {specific question}`.
 

--- a/plugins/python-engineering/agents/python-cli-design-spec.md
+++ b/plugins/python-engineering/agents/python-cli-design-spec.md
@@ -80,8 +80,8 @@ Load these before writing the spec:
 ## Document Size
 
 One registration call carries the whole document. There is no sectioned append and no per-section
-call. Whether the configured content provider imposes a size limit, and what it does on overflow,
-depends on which provider is configured and is not something the registering agent is told.
+call. The provider rejects an oversized record before any network call rather than truncating it, so
+an over-large spec fails loudly instead of arriving cut.
 
 Keep the `architect` artifact to the interfaces, contracts, data models, and decisions. Register
 supporting depth — extended testing strategy, integration pattern catalogues, migration notes — as

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/.codex-plugin/plugin.json
+++ b/plugins/python3-development/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python3-development",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/python3-development/agents/python-cli-design-spec.md
+++ b/plugins/python3-development/agents/python-cli-design-spec.md
@@ -39,10 +39,14 @@ mcp__plugin_dh_backlog__artifact_register(
 ```
 
 Making this call is your responsibility — the dispatching orchestrator does not make it for you and
-checks afterwards that the artifact exists. Pass the whole document in `content`. Do not write the
-spec to a file, do not resolve a storage path, and do not paste the document into your completion
-message. Downstream agents retrieve it with
+checks afterwards that the artifact exists. Pass the whole document in `content`. Do not paste the
+document into your completion message. Downstream agents retrieve it with
 `artifact_read(item_id=<same item id>, artifact_type="architect")`.
+
+**No backlog `item_id` in your dispatch prompt** (a direct, ad-hoc invocation with no SAM item
+behind it): `artifact_register` has no owner to attach to. Write the spec to
+`plan/architect-{slug}.md` instead and report that path in your completion message — do not call
+`artifact_register` without an `item_id`.
 
 Read any prior artifacts named in your dispatch prompt through the same boundary — for example
 `artifact_read(item_id=<same item id>, artifact_type="feature-context")`.
@@ -79,13 +83,15 @@ an over-large spec fails loudly instead of arriving cut.
 
 Keep the `architect` artifact to the interfaces, contracts, data models, and decisions. Register
 supporting depth — extended testing strategy, integration pattern catalogues, migration notes — as
-separate `research` artifacts with distinct `artifact_id` values, and name each one from the spec so
-consumers can find it.
+at most one companion `research` artifact. `artifact_read(item_id, artifact_type)` returns only the
+most recently registered entry for a given type and silently skips the rest, so a second companion
+is unreachable by downstream agents — fold further material into that one `research` artifact
+instead of registering more.
 
 After registering, read the artifact back with
 `artifact_read(item_id=<same item id>, artifact_type="architect")` and confirm the stored document
 ends with its final section. A stored document that ends mid-section was cut by the provider — move
-material into a `research` artifact and register the spec again.
+material into the `research` artifact and register the spec again.
 
 ## Working Process
 
@@ -98,15 +104,16 @@ material into a `research` artifact and register the spec again.
 
 ## Stopping Condition
 
-Stop when `artifact_register` has returned and the read-back confirms the stored spec is complete and
-contains every section listed above. Report:
+Stop when the spec is stored — `artifact_register` has returned and the read-back confirms the
+stored spec is complete and contains every section listed above, or, in the no-`item_id` case, the
+file write has completed. Report:
 
 ```text
 STATUS: DONE
 ARTIFACT: type=architect, action={action}, content_stored={content_stored}, chars={len(content)}
 ```
 
-Report each companion `research` artifact you registered on its own `ARTIFACT:` line in the same
-form. Never paste the spec itself into the report.
+Report a registered companion `research` artifact on its own `ARTIFACT:` line in the same form.
+Never paste the spec itself into the report.
 
 If requirements are ambiguous or contradictory, report: `STATUS: BLOCKED — {specific question}`.

--- a/plugins/python3-development/agents/python-cli-design-spec.md
+++ b/plugins/python3-development/agents/python-cli-design-spec.md
@@ -74,8 +74,8 @@ Load these before writing the spec:
 ## Document Size
 
 One registration call carries the whole document. There is no sectioned append and no per-section
-call. The configured content provider caps a single `content` payload and drops everything past that
-cap without reporting it in the return value.
+call. Whether the configured content provider imposes a size limit, and what it does on overflow,
+depends on which provider is configured and is not something the registering agent is told.
 
 Keep the `architect` artifact to the interfaces, contracts, data models, and decisions. Register
 supporting depth — extended testing strategy, integration pattern catalogues, migration notes — as

--- a/plugins/python3-development/agents/python-cli-design-spec.md
+++ b/plugins/python3-development/agents/python-cli-design-spec.md
@@ -74,8 +74,8 @@ Load these before writing the spec:
 ## Document Size
 
 One registration call carries the whole document. There is no sectioned append and no per-section
-call. Whether the configured content provider imposes a size limit, and what it does on overflow,
-depends on which provider is configured and is not something the registering agent is told.
+call. The provider rejects an oversized record before any network call rather than truncating it, so
+an over-large spec fails loudly instead of arriving cut.
 
 Keep the `architect` artifact to the interfaces, contracts, data models, and decisions. Register
 supporting depth — extended testing strategy, integration pattern catalogues, migration notes — as

--- a/plugins/python3-development/agents/python-cli-design-spec.md
+++ b/plugins/python3-development/agents/python-cli-design-spec.md
@@ -1,7 +1,7 @@
 ---
 name: python-cli-design-spec
 description: Use when designing a Python CLI tool's architecture before implementation — command interfaces, technology stack selection, data models, and contracts. Activates on architecture planning requests for new CLI tools or major feature additions. Produces WHAT to build (interfaces, schemas, contracts); python-cli-architect handles the HOW (implementation).
-tools: Read, Write, Edit, Glob, Grep, TodoWrite, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__web_search_exa, mcp__exa__get_code_context_exa, mcp__plugin_python3-development_sequential_thinking__sequentialthinking, SendMessage
+tools: Read, Glob, Grep, TodoWrite, mcp__plugin_dh_backlog__artifact_register, mcp__plugin_dh_backlog__artifact_read, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__web_search_exa, mcp__exa__get_code_context_exa, mcp__plugin_python3-development_sequential_thinking__sequentialthinking, SendMessage
 skills:
   - python3-development:python-cli-architect
 ---
@@ -26,19 +26,26 @@ development agents copy it verbatim without applying current conventions.
 
 ## Output Artifact
 
-Create the architecture spec using the SAM MCP tool:
+Register the finished spec as an `architect` artifact on the backlog item you were dispatched for:
 
-```text
-mcp__plugin_dh_sam__sam_create(slug="architect-{slug}", goal="Architecture spec for {feature}", tasks_yaml="")
+```python
+mcp__plugin_dh_backlog__artifact_register(
+    item_id=<backlog item identifier from your dispatch prompt>,
+    artifact_type="architect",
+    artifact_id=<artifact_id from your dispatch prompt, or "architect-{slug}" when none was given>,
+    content=<the complete spec markdown>,
+    agent="python-cli-design-spec",
+)
 ```
 
-Then append each section of the document using:
+Making this call is your responsibility — the dispatching orchestrator does not make it for you and
+checks afterwards that the artifact exists. Pass the whole document in `content`. Do not write the
+spec to a file, do not resolve a storage path, and do not paste the document into your completion
+message. Downstream agents retrieve it with
+`artifact_read(item_id=<same item id>, artifact_type="architect")`.
 
-```text
-mcp__plugin_dh_sam__sam_update(plan_slug="architect-{slug}", task_id=None, section="{Section Name}", content="{section body}")
-```
-
-`sam_create` handles path resolution via `dh_paths.plan_dir()` internally — do not resolve or pass a file path. Do not run `uv run python -c 'from dh_paths import plan_dir; print(plan_dir())'` to discover the path.
+Read any prior artifacts named in your dispatch prompt through the same boundary — for example
+`artifact_read(item_id=<same item id>, artifact_type="feature-context")`.
 
 The architecture spec document contains:
 
@@ -64,13 +71,21 @@ Load these before writing the spec:
 - Load `Skill(skill="python3-development:typer-and-rich")` — Typer and Rich reference including table width measurement pattern (include in spec when tables are needed)
 - Review compliance: `./references/architecture-spec-patterns.md` § "Review Compliance Requirements" — the architecture spec MUST prescribe patterns that pass `modernpython`, `shebangpython`, and `code-reviewer` assessments on first attempt
 
-## Large File Strategy
+## Document Size
 
-Architecture specs routinely exceed 25K characters. Apply before writing:
+One registration call carries the whole document. There is no sectioned append and no per-section
+call. The configured content provider caps a single `content` payload and drops everything past that
+cap without reporting it in the return value.
 
-- **Strategy A** (preferred): split into `architect-{slug}` plan + companion plans
-  (e.g., `testing-architecture-{slug}`, `integration-patterns-{slug}`), each created via `sam_create`. Each `sam_update` section call must stay under 25K. Link companions from the primary plan.
-- **Strategy B** (single plan required): call `sam_create` once, then use multiple `sam_update` calls to append each section. Each `sam_update` content must stay under 25K characters.
+Keep the `architect` artifact to the interfaces, contracts, data models, and decisions. Register
+supporting depth — extended testing strategy, integration pattern catalogues, migration notes — as
+separate `research` artifacts with distinct `artifact_id` values, and name each one from the spec so
+consumers can find it.
+
+After registering, read the artifact back with
+`artifact_read(item_id=<same item id>, artifact_type="architect")` and confirm the stored document
+ends with its final section. A stored document that ends mid-section was cut by the provider — move
+material into a `research` artifact and register the spec again.
 
 ## Working Process
 
@@ -83,7 +98,15 @@ Architecture specs routinely exceed 25K characters. Apply before writing:
 
 ## Stopping Condition
 
-Stop when the `architect-{slug}` plan (and any companion plans) exist and contain all sections
-listed above. Report: `STATUS: DONE — architect-{slug} plan created via sam_create`.
+Stop when `artifact_register` has returned and the read-back confirms the stored spec is complete and
+contains every section listed above. Report:
+
+```text
+STATUS: DONE
+ARTIFACT: type=architect, action={action}, content_stored={content_stored}, chars={len(content)}
+```
+
+Report each companion `research` artifact you registered on its own `ARTIFACT:` line in the same
+form. Never paste the spec itself into the report.
 
 If requirements are ambiguous or contradictory, report: `STATUS: BLOCKED — {specific question}`.


### PR DESCRIPTION
Plan-side work on #3151 — the cross-plugin half.

## What was wrong

Both copies of `python-cli-design-spec` (in `python-engineering` and `python3-development`) instructed a skeleton-then-fill write strategy against `sam_create` and `sam_update`. Neither tool exists — the SAM server exposes `sam_plan`, `sam_task`, `sam_active_task`, and the artifact operations live on the backlog server.

Worse than stale prose: neither copy declared any `mcp__plugin_dh_backlog__*` tool. `add-new-feature` Phase 3 loads this agent as a profile through `dh:task-worker`, which carries the operations — but three skills in `python-engineering` dispatch it directly as a `subagent_type`, and on that path the registration call was unavailable regardless of what the body said.

The spec is an `architect` artifact registered through the content provider. Confirmed against `create-artifact`'s type table, `add-new-feature` Phase 3's delegation prompt, `docs/workflow-layers/G2-artifacts.json` (`"storage": "provider_artifact"`), and `scripts/migrate_plan_artifacts.py`.

## The real size constraint is not 25K

`backlog_core/artifact_provider.py` sets `_GITHUB_COMMENT_MAX_CHARS = 65_536` and truncates a longer payload, appending an HTML warning into the stored body. Nothing is added to the returned `warnings` — **truncation is invisible to the calling agent**. There is no sectioned append for artifacts; registration replaces.

So the guidance is now: one call carries the whole document, keep the spec to interfaces and contracts, register supporting depth as separate `research` artifacts, and read the artifact back to confirm it ends with its final section.

## Drift between the two copies

Not byte-identical. Different `description`, different tool lists (disjoint), different `skills:` frontmatter, and `model`/`color`/`memory` present in one and absent in the other. Same correction applied to both; the divergence itself is worth a decision about whether two copies should exist.

## Left alone deliberately

`plugins/python3-development/planning/sse-gap-analysis.md` states the planner produces `PLAN.md` and `TASK/` files. It is a dated point-in-time assessment (2026-01-29, "Review Complete") with a companion forensic verification document auditing its own claims, nothing loads it, and most components it reviews no longer exist in the plugin. Correcting its facts would rewrite what was assessed in January into what is true now and break its pairing with the audit. Its own redesign document already schedules `planning/` for deletion — that is the correct disposition, not in-place edits.

## Found, not fixed

- `python-engineering/agents/code-reviewer.md` and `python3-development/agents/code-reviewer.md` both instruct `sam_create` with a `tasks_yaml` payload; the second also reads plan/task files from disk under `~/.dh/projects/{slug}/plan/`.
- `python-engineering/skills/orchestrate/SKILL.md` references `sam_create` and `sam_update`.
- `create-artifact` prescribes `artifact_id` as `architect-{slug}` while `add-new-feature` Phase 3 passes `plan/architect-{slug}.md`. The corrected agents defer to the dispatch prompt, which is correct under both; the disagreement is for the development-harness half.
- `.claude/rules/large-file-write-strategy.md` names `python-cli-design-spec` as subject to the 25K `Write` threshold. That is now inconsistent with these agents, and is repo configuration rather than plugin content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Part of #3151, plan-side. Covers the two python-cli-design-spec copies only.
