### PR TITLE
refactor(development-harness): replace plan-file authoring model with the plan and artifact operations

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-analyzer
 description: Explores codebase patterns and writes structured analysis documents. Spawned before planning to understand existing conventions, architecture, and testing patterns. Writes documents directly to reduce orchestrator context load.
-tools: Read, Bash, Grep, Glob, Write, Skill, SendMessage, mcp__git-forensics__analyze_file_changes, mcp__git-forensics__analyze_time_period, mcp__plugin_dh_sequential_thinking__sequentialthinking, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__get_code_context_exa, mcp__plugin_dh_sam, mcp__plugin_dh_backlog
+tools: Read, Bash, Grep, Glob, Write, Skill, SendMessage, mcp__git-forensics__analyze_file_changes, mcp__git-forensics__analyze_time_period, mcp__plugin_dh_sequential_thinking__sequentialthinking, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__get_code_context_exa, mcp__plugin_dh_backlog
 model: haiku
 skills:
   - dh:subagent-contract
@@ -12,7 +12,7 @@ color: cyan
 ---
 
 <role>
-You are a codebase analyzer. You explore the codebase for a specific focus area and write analysis documents via the SAM MCP tool, then register them as artifacts using a logical artifact id (e.g., `codebase-patterns-{slug}`).
+You are a codebase analyzer. You explore the codebase for a specific focus area and register each analysis document as an artifact under a logical artifact id (e.g., `codebase-patterns-{slug}`). Registration is the whole write path — one call carries the document; no plan is created or updated for it.
 
 You are spawned by:
 
@@ -738,7 +738,6 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 - [ ] Focus area identified from input
 - [ ] `issue_number` received from input
 - [ ] Target document determined (PATTERNS.md, ARCHITECTURE.md, TESTING.md, CONVENTIONS.md, or CONCERNS.md)
-- [ ] Document created via `mcp__plugin_dh_sam__sam_plan` (create action) + `mcp__plugin_dh_sam__sam_plan` (update action)
 - [ ] `artifact_register` called with `artifact_type="codebase-analysis"`, `artifact_id="codebase-{focus}-{slug}"`, `status="complete"`, `agent="codebase-analyzer"`
 
 **Level 2: Substantive**

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -640,21 +640,9 @@ For each finding, record:
 - Actual code snippets
 - How it's relevant
 
-## Step 3: Write Document
+## Step 3: Assemble Document
 
-Create the codebase analysis document using the SAM MCP tool. Use the focus-area name (e.g., `codebase-patterns`, `codebase-architecture`) as the slug:
-
-```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "codebase-{focus}", "goal": "Codebase {focus} analysis", "tasks": []})
-```
-
-Then append the document content as a markdown section:
-
-```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "codebase-{focus}", "task_id": null, "section": "{DOCUMENT}", "content": "{document body}"})
-```
-
-Pass the config dict to `sam_plan(action='create')` and receive the plan address back. Do not resolve or pass a file path.
+Fill the output template for the focus area in memory. Nothing is written to disk.
 
 **Document naming:** UPPERCASE focus area name (e.g., PATTERNS, ARCHITECTURE).
 
@@ -665,31 +653,29 @@ Pass the config dict to `sam_plan(action='create')` and receive the plan address
 3. Include actual code snippets from the codebase
 4. Always include file paths with backticks
 
-## Large Document Strategy
-
-Thorough codebase analysis documents -- particularly PATTERNS.md and ARCHITECTURE.md with extensive code examples -- can be large. All content is written via `sam_plan(action='update')` section appends, so there is no single-call size limit to hit, but each `sam_plan(action='update')` call should stay under 25K characters.
-
-**Strategy A -- One document per focus area:**
-If you are writing documents for multiple focus areas in one session, write each as a separate SAM document (slug: `codebase-patterns`, `codebase-architecture`, etc.). Do not combine multiple focus areas into one document.
-
-**Strategy B -- Multiple `sam_plan(action='update')` section appends (when a single document is large):**
-If a single focus area document is large (e.g., a comprehensive PATTERNS.md with many code examples), split the content into logical sections and issue one `sam_plan(action='update')` call per section. Each call appends one section to the document. Keep each call under 25K characters.
-
-```text
-# Example: large PATTERNS.md written in three appends
-mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "codebase-patterns", "task_id": null, "section": "PATTERNS", "content": "## Command Structure\n\n{first section content}"})
-mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "codebase-patterns", "task_id": null, "section": "PATTERNS", "content": "## Shared Options\n\n{second section content}"})
-mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "codebase-patterns", "task_id": null, "section": "PATTERNS", "content": "## Callback Patterns\n\n{third section content}"})
-```
-
-Do not use `Write` or `Edit` for codebase analysis documents -- all content goes through `sam_plan(action='update')`.
+One document per focus area. When covering multiple focus areas in one dispatch, keep each as
+its own document — do not combine them.
 
 ## Step 4: Register Artifact
 
-After `sam_plan(action='create')` + `sam_plan(action='update')` complete, register the artifact
-so it is discoverable via `artifact_list`. Use `artifact_type="codebase-analysis"`,
-`artifact_id="codebase-{focus}-{slug}"` (logical id — no filesystem path), and pass `content=`
-with the full document text so it is retrievable from worktree-isolated environments.
+Register each focus-area document in one call, passing the whole document as `content=` so it
+is retrievable from worktree-isolated environments:
+
+```text
+mcp__plugin_dh_backlog__artifact_register(
+    item_id={item_id},
+    artifact_type="codebase-analysis",
+    artifact_id="codebase-{focus}-{slug}",
+    content="{full document markdown}",
+    agent="codebase-analyzer",
+)
+```
+
+`artifact_id` is a logical identifier, not a filesystem path. Do not use `Write` or `Edit` for
+codebase analysis documents, and do not split one document across several registration calls —
+re-registering the same `artifact_type` and `artifact_id` replaces the stored content rather
+than appending to it. Multiple focus areas mean multiple calls, each with its own
+`artifact_id`.
 
 ## Step 5: Return Confirmation
 

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -19,7 +19,7 @@ You are spawned by:
 - Feature discovery workflows (via feature-discovery skill)
 - Direct Agent tool invocation for feature research
 
-Your job: Produce `feature-context-{slug}.md` documents that capture the user's goal, relevant codebase patterns, identified gaps, and questions requiring resolution.
+Your job: Produce `feature-context` artifacts that capture the user's goal, relevant codebase patterns, identified gaps, and questions requiring resolution.
 
 **Core responsibilities:**
 
@@ -52,7 +52,7 @@ Research value comes from accuracy, not completeness theater. "I couldn't find s
 </core_principle>
 
 <downstream_consumer>
-Your `feature-context-{slug}.md` is consumed by:
+Your registered `feature-context` artifact is consumed by:
 
 1. **RT-ICA skill** (orchestrator) - Uses questions section to assess completeness
 2. **Orchestrator** - Uses questions to ask user via AskUserQuestion
@@ -348,23 +348,29 @@ def generate_slug(input_text: str) -> str:
     # Example: "remote package update" -> "remote-package-update"
 ```
 
-## Step 6: Write Output Document
+## Step 6: Register the Feature Context Artifact
 
-Create the document using the SAM MCP tool:
-
-```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "{slug}", "goal": "Feature context for {feature name}", "tasks": []})
-```
-
-Then append the document content as a markdown section using:
+Assemble the full document in memory using the output format template below, then register it
+in one call:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "{slug}", "task_id": null, "section": "Feature Context", "content": "{document body}"})
+mcp__plugin_dh_backlog__artifact_register(
+    item_id={item_id},
+    artifact_type="feature-context",
+    artifact_id="feature-context-{slug}",
+    content="{full document markdown}",
+    agent="feature-researcher",
+)
 ```
 
-Pass the config dict to `sam_plan(action='create')` and receive the plan address back. Do not resolve or pass a file path.
+`content` carries the whole document. Do not write a file, do not resolve a path, and do not
+split the document across calls — re-registering the same `artifact_type` and `artifact_id`
+replaces the stored content rather than appending to it. If the research genuinely warrants a
+companion document, register it separately as `artifact_type="research"` with its own
+`artifact_id`, and reference it from the feature context by that identifier.
 
-Use the output format template below.
+If `item_id` is absent from your delegation prompt, return STATUS: BLOCKED — you cannot
+register the deliverable without it.
 
 ## Step 7: Return Structured Result
 
@@ -374,7 +380,7 @@ Return DONE or BLOCKED status to orchestrator.
 
 <output>
 
-## feature-context-{slug}.md Structure
+## Feature Context Document Structure
 
 ```markdown
 # Feature Context: {Feature Name}
@@ -497,18 +503,6 @@ After questions are resolved:
 
 </output>
 
-## Large File Write Strategy
-
-Feature context documents with extensive codebase research, multiple use scenarios, and detailed gap analysis can exceed the Write tool's reliable threshold. A single Write call must not exceed approximately 25,000 characters (25K).
-
-**Strategy A -- Multi-file split (when research warrants it):**
-If the feature context document would exceed 25K due to extensive codebase research findings, split the codebase research into a companion file (e.g., `feature-research-{slug}.md`) and reference it from the main `feature-context-{slug}.md`. The main document retains all sections; the companion holds detailed code examples and pattern analysis.
-
-**Strategy B -- Skeleton then Edit-fill (when a single file is required):**
-Write the document skeleton containing metadata, original request, core intent analysis, and placeholder stubs (e.g., `<!-- PENDING: use scenarios -->`) for remaining sections. Then use Edit calls to replace each placeholder with actual content (use scenarios, gap analysis, questions). Each Write or Edit call must stay under 25K characters.
-
-Never write more than 25K characters in a single Write call. Feature context documents with many code references and pattern examples can approach this limit when the codebase is large.
-
 <success_criteria>
 
 ### Discovery Quality (Core Deliverables)
@@ -524,7 +518,7 @@ Never write more than 25K characters in a single Write call. Feature context doc
 
 **Level 1: Existence**
 
-- [ ] Document written to correct path
+- [ ] `feature-context` artifact registered with the full document as `content`
 - [ ] All required sections present
 - [ ] STATUS: DONE or BLOCKED returned to orchestrator
 

--- a/plugins/development-harness/agents/t0-baseline-capture.md
+++ b/plugins/development-harness/agents/t0-baseline-capture.md
@@ -1,6 +1,6 @@
 ---
 name: t0-baseline-capture
-description: Captures baseline state of structured acceptance criteria before implementation begins. Reads acceptance-criteria-structured from a SAM plan file, runs each check_command via Bash, assembles T0 results as YAML in memory, and registers the artifact via artifact_register with content= for MCP-native storage. Non-zero exit codes are expected and are NOT failures — this agent records whatever state exists at T0 time. Requires item_id (GitHub issue number or beads nanoid string like bd-a3f8) as a mandatory input.
+description: Captures baseline state of structured acceptance criteria before implementation begins. Reads acceptance-criteria-structured from the SAM plan via the plan read operation, runs each check_command via Bash, assembles T0 results as YAML in memory, and registers the artifact via artifact_register with content= for MCP-native storage. Non-zero exit codes are expected and are NOT failures — this agent records whatever state exists at T0 time. Requires item_id (GitHub issue number or beads nanoid string like bd-a3f8) as a mandatory input.
 tools: Read, Bash, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_migrate, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
 model: haiku
 skills:
@@ -26,24 +26,29 @@ You are the T0 baseline capture agent. You run before any implementation tasks b
 
 <procedure>
 
-## Step 1: Read Plan File
+## Step 1: Read the Plan
 
-Read the plan file passed to you (the task file for this feature). Extract:
-
-- `feature` field (the slug — used to construct the output path)
-- `acceptance_criteria_structured` list (or `acceptance-criteria-structured` in YAML)
+Your delegation prompt carries a plan address (`P{N}`, or the task address `P{N}/T{M}` whose
+plan component is `P{N}`). Read the plan through it:
 
 ```bash
-# The plan file path is provided in your task delegation prompt.
-# Read it with the Read tool.
-Read(file_path="{plan_file_path}")
+mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action": "read"})
 ```
 
-If `acceptance_criteria_structured` is absent or empty, write a T0 baseline with `criteria_count: 0` and an empty `results: []`, then exit with STATUS: DONE.
+Extract from the response:
+
+- `feature` — the slug, used in the artifact ID
+- `acceptance-criteria-structured` — the list of criteria to execute
+
+Never read a plan by filesystem path. The plan lives in the configured backend, which may be
+remote, and a path read returns nothing in a worktree-isolated dispatch.
+
+If `acceptance-criteria-structured` is absent or empty, assemble a T0 baseline with
+`criteria_count: 0` and an empty `results: []`, register it, then exit with STATUS: DONE.
 
 ## Step 2: Run Each Check Command
 
-For each entry in `acceptance_criteria_structured`:
+For each entry in `acceptance-criteria-structured`:
 
 1. Note the start timestamp (ISO 8601, UTC)
 2. Run the `check_command` via Bash
@@ -158,8 +163,8 @@ NOTES:
 
 Return STATUS: BLOCKED if:
 - `item_id` is not provided in the task delegation prompt
-- Plan file cannot be read
-- `feature` field is absent from plan frontmatter
+- The plan read returns an error or no plan address was provided
+- `feature` is absent from the plan
 - In-memory YAML structure verification fails (criteria_count mismatch or missing fields)
 - `artifact_register` returns an error
 

--- a/plugins/development-harness/agents/t0-baseline-capture.md
+++ b/plugins/development-harness/agents/t0-baseline-capture.md
@@ -1,6 +1,6 @@
 ---
 name: t0-baseline-capture
-description: Captures baseline state of structured acceptance criteria before implementation begins. Reads acceptance-criteria-structured from the SAM plan via the plan read operation, runs each check_command via Bash, assembles T0 results as YAML in memory, and registers the artifact via artifact_register with content= for MCP-native storage. Non-zero exit codes are expected and are NOT failures — this agent records whatever state exists at T0 time. Requires item_id (GitHub issue number or beads nanoid string like bd-a3f8) as a mandatory input.
+description: Captures baseline state of structured acceptance criteria before implementation begins. Reads acceptance-criteria-structured from the SAM plan via the plan read operation, runs each check-command via Bash, assembles T0 results as YAML in memory, and registers the artifact via artifact_register with content= for MCP-native storage. Non-zero exit codes are expected and are NOT failures — this agent records whatever state exists at T0 time. Requires item_id (GitHub issue number or beads nanoid string like bd-a3f8) as a mandatory input.
 tools: Read, Bash, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_migrate, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
 model: haiku
 skills:
@@ -35,23 +35,30 @@ plan component is `P{N}`). Read the plan through it:
 mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action": "read"})
 ```
 
-Extract from the response:
+The response is an envelope: `plan`, `gaps`, `warnings`, `source_format`, `source_path`. Every plan
+field sits inside `plan`, never at the top level. Extract:
 
-- `feature` — the slug, used in the artifact ID
-- `acceptance-criteria-structured` — the list of criteria to execute
+- `plan.feature` — the slug, used in the artifact ID
+- `plan.acceptance-criteria-structured` — the list of criteria to execute
+
+Each criterion in that list carries `criterion-id`, `description`, `check-command`,
+`expected-baseline`, and `expected-final`.
 
 Never read a plan by filesystem path. The plan lives in the configured backend, which may be
 remote, and a path read returns nothing in a worktree-isolated dispatch.
 
-If `acceptance-criteria-structured` is absent or empty, assemble a T0 baseline with
-`criteria_count: 0` and an empty `results: []`, register it, then exit with STATUS: DONE.
+If `plan.acceptance-criteria-structured` is absent or empty, assemble a T0 baseline with
+`criteria_count: 0` and an empty `results: []`, register it, then exit with STATUS: DONE. Reaching
+that branch because the criteria were looked for at the top level of the response instead of inside
+`plan` disables regression coverage for the whole feature — confirm `plan` is empty of them before
+recording a zero-criterion baseline.
 
 ## Step 2: Run Each Check Command
 
-For each entry in `acceptance-criteria-structured`:
+For each entry in `plan.acceptance-criteria-structured`:
 
 1. Note the start timestamp (ISO 8601, UTC)
-2. Run the `check_command` via Bash
+2. Run its `check-command` via Bash
 3. Record: exit code, stdout (full), stderr (full), end timestamp, duration in seconds
 4. Continue to the next criterion regardless of exit code
 
@@ -99,7 +106,7 @@ results:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `feature` | str | The plan's `feature` field (the slug) |
+| `feature` | str | The plan's `plan.feature` value (the slug) |
 | `captured_at` | str (ISO 8601 UTC) | Timestamp when T0 agent ran |
 | `criteria_count` | int | Number of criteria executed |
 | `results` | list | One entry per AcceptanceCriterion |
@@ -164,7 +171,7 @@ NOTES:
 Return STATUS: BLOCKED if:
 - `item_id` is not provided in the task delegation prompt
 - The plan read returns an error or no plan address was provided
-- `feature` is absent from the plan
+- `plan.feature` is absent from the plan read response
 - In-memory YAML structure verification fails (criteria_count mismatch or missing fields)
 - `artifact_register` returns an error
 

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -37,7 +37,7 @@ You need two inputs:
    T0 agent read it
 
 Your delegation prompt carries `item_id` and a plan address (`P{N}`, or the task address
-`P{N}/T{M}` whose plan component is `P{N}`). The slug comes from the plan's `feature` field.
+`P{N}/T{M}` whose plan component is `P{N}`).
 
 ```bash
 mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="T0-baseline")
@@ -45,7 +45,13 @@ mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action": "read"})
 ```
 
 Parse the T0 baseline content returned by `artifact_read` as YAML to extract the T0 results.
-The plan read returns the criteria as structured fields — no parsing needed.
+
+The plan read returns an envelope: `plan`, `gaps`, `warnings`, `source_format`, `source_path`.
+Every plan field sits inside `plan`, never at the top level. Take the criteria from
+`plan.acceptance-criteria-structured` and the slug from `plan.feature`; they are structured
+fields, so no parsing is needed. Each criterion carries `criterion-id`, `description`,
+`check-command`, `expected-baseline`, and `expected-final`. Criteria read as absent because they
+were looked for at the top level would verify nothing while still reporting a passing verdict.
 
 Never read a plan by filesystem path. The plan lives in the configured backend, which may be
 remote, and a path read returns nothing in a worktree-isolated dispatch.
@@ -54,16 +60,16 @@ If `artifact_read` returns an error or empty result for type `T0-baseline`, retu
 
 ## Step 2: Re-Run Each Check Command
 
-For each entry in the plan's `acceptance-criteria-structured` list:
+For each entry in `plan.acceptance-criteria-structured`:
 
 1. Look up the matching T0 result by `criterion-id`
 2. Note the start timestamp (ISO 8601, UTC)
-3. Run the same `check_command` via Bash
+3. Run the same `check-command` via Bash
 4. Record: exit code, stdout (full), stderr (full), end timestamp, duration
 
 ```bash
 # Run each check command. Non-zero exit is expected for pre-existing failures.
-Bash("{check_command}")
+Bash("{check-command}")
 ```
 
 ## Step 3: Compute CriterionStatus

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -28,29 +28,33 @@ You are the TN verification gate agent. You run after all implementation tasks a
 
 <procedure>
 
-## Step 1: Locate Input Files
+## Step 1: Retrieve Both Inputs
 
 You need two inputs:
 
-1. **T0 baseline**: Retrieved via `artifact_read(item_id, "T0-baseline")` — stored by the T0 agent as a GitHub issue comment artifact
-2. **Plan file**: retrieved via `artifact_read(item_id, "task-plan")` — to re-read `acceptance_criteria_structured`
+1. T0 baseline — an artifact registered by the T0 agent, retrieved by owner and type
+2. The plan's `acceptance-criteria-structured` — read from the plan itself, the same way the
+   T0 agent read it
 
-The `item_id` and plan path are provided in your task delegation prompt. The slug is inferred from the T0 baseline's `feature` field after retrieval.
-
-Retrieve T0 baseline and read plan file:
+Your delegation prompt carries `item_id` and a plan address (`P{N}`, or the task address
+`P{N}/T{M}` whose plan component is `P{N}`). The slug comes from the plan's `feature` field.
 
 ```bash
 mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="T0-baseline")
-mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="task-plan")
+mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action": "read"})
 ```
 
-Parse the content returned by `artifact_read` as YAML to extract the T0 results.
+Parse the T0 baseline content returned by `artifact_read` as YAML to extract the T0 results.
+The plan read returns the criteria as structured fields — no parsing needed.
+
+Never read a plan by filesystem path. The plan lives in the configured backend, which may be
+remote, and a path read returns nothing in a worktree-isolated dispatch.
 
 If `artifact_read` returns an error or empty result for type `T0-baseline`, return STATUS: BLOCKED with: "T0 baseline not found — `artifact_read(item_id={item_id}, artifact_type='T0-baseline')` returned no content. T0 agent must run first."
 
 ## Step 2: Re-Run Each Check Command
 
-For each entry in the plan's `acceptance_criteria_structured` list:
+For each entry in the plan's `acceptance-criteria-structured` list:
 
 1. Look up the matching T0 result by `criterion-id`
 2. Note the start timestamp (ISO 8601, UTC)
@@ -213,7 +217,7 @@ NEXT_STEP: /complete-implementation will read TN-verification artifact via artif
 Return STATUS: BLOCKED if:
 - `item_id` is not provided in the delegation prompt
 - `artifact_read(item_id, "T0-baseline")` returns an error or empty result
-- Plan file cannot be read
+- The plan read returns an error or no plan address was provided
 - `artifact_register` call fails
 
 When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.

--- a/plugins/development-harness/skills/context-integration/SKILL.md
+++ b/plugins/development-harness/skills/context-integration/SKILL.md
@@ -127,13 +127,18 @@ Updated `ARTIFACT:PLAN` with the following section appended:
 - Files unchanged — <list>
 ```
 
-Also update the Contextualization Status at the bottom of PLAN.md:
+End the same content with the status marker, so the re-registered `architect` artifact
+records that Stage 3 ran:
 
 ```markdown
 ## Contextualization Status
 
 - [x] Grounded in codebase (completed by Stage 3)
 ```
+
+Both the `## Contextualization` section and this status marker are part of the single
+`content=` string passed to `artifact_register` in Step 4. There is no separate document
+to update.
 
 ## Role Resolution
 

--- a/plugins/development-harness/skills/task-decomposition/SKILL.md
+++ b/plugins/development-harness/skills/task-decomposition/SKILL.md
@@ -29,7 +29,7 @@ flowchart TD
     A4 -->|Yes| CoVe[4a. Add CoVe checks]
     A4 -->|No| A5[4b. Skip CoVe]
     CoVe --> A5[5. Map dependencies]
-    A5 --> A6[6. Assign roles]
+    A5 --> A6[6. Assign agents]
     A6 --> Gate{Evaluate complexity}
     Gate -->|Manageable| Done([Tasks registered in the plan])
     Gate -->|High complexity or novel architecture| Escalate([Human touchpoint — confirm decomposition])
@@ -94,17 +94,28 @@ Build the dependency graph:
 - Identify which tasks can run in parallel (no shared file conflicts)
 - Document WHY parallelization is safe for each parallel group
 
-### Step 6 — Assign Roles
+### Step 6 — Assign Agents
 
-Assign abstract roles, NOT specific agents:
+Classify each task by the role that does its work, then resolve that role to a real agent name
+before writing it into the task's `agent` field:
 
 - `architect` — design decisions, structural changes
-- `implementer` — write production code
+- `design-spec` — interfaces, data models, module boundaries
 - `test-designer` — write tests and fixtures
 - `code-reviewer` — review and quality assessment
-- `docs-writer` — documentation and comments
 
-Role-to-agent resolution happens at execution time via the language manifest.
+Resolve a role through the project's language manifest: detect the language from the project-root
+markers, read the manifest's `Role Fulfillment` section, and take the agent it maps that role to.
+Manifest entries carry a leading `@` — `@python3-development:code-reviewer` — and `agent` stores
+the same name without it. The stored value stays plugin-qualified.
+
+Write no `agent` value at all when the manifest omits that role, no manifest matches the project,
+or the work is production code, documentation, or anything else no role above covers. The
+executing worker then runs the task with no specialist profile, which is the documented fallback.
+
+`agent` is passed verbatim to `profile_load` at execution time. An abstract role name matches no
+agent, and a bare name that two plugins both ship resolves ambiguously; either one ends the task
+blocked before any work starts.
 
 ## Input
 
@@ -177,7 +188,7 @@ rejected — do not invent fields:
 task: T1
 title: <descriptive imperative title>
 status: not-started
-agent: <architect / implementer / test-designer / code-reviewer / docs-writer>
+agent: <plugin-qualified agent resolved from the language manifest — omit when no role applies>
 dependencies: []
 priority: <1-5 based on dependency depth>
 complexity: <low / medium / high>
@@ -266,7 +277,8 @@ flowchart TD
 - Every task must be self-contained — an agent given ONLY that task can execute it
 - Never point at an upstream artifact by "see X" — inline the content the task needs. The
   executing agent has no guaranteed access to the discovery or plan artifact you read
-- Never assign specific agent names — use roles
+- Never write an abstract role name into `agent` — write the plugin-qualified agent the language
+  manifest maps that role to, or omit the field
 - Tasks must not have circular dependencies
 - Each acceptance criterion must be verifiable by the executing agent alone
 
@@ -276,5 +288,5 @@ flowchart TD
 - Every plan component maps to at least one task
 - Dependency graph has no cycles
 - Parallel groups have no shared file conflicts
-- Roles assigned (not agents) for every task
+- Every `agent` value present is plugin-qualified and resolvable by `profile_load`
 - CoVe checks present on medium/high accuracy-risk tasks only

--- a/plugins/development-harness/skills/task-decomposition/SKILL.md
+++ b/plugins/development-harness/skills/task-decomposition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-decomposition
-description: Decomposes a contextualized plan into atomic, independently executable task files with complete embedded context. Use after SAM Stage 3 Context Integration produces the contextualized plan artifact — when the plan is ready for TASK file generation with CLEAR ordering, CoVe checks, and dependency graphs for parallel execution.
+description: Decomposes a contextualized plan into atomic, independently executable tasks with complete embedded context, registered through the plan API. Use after SAM Stage 3 Context Integration produces the contextualized plan artifact — when the plan is ready for task generation with CLEAR ordering, CoVe checks, and dependency graphs for parallel execution.
 user-invocable: false
 ---
 
@@ -31,7 +31,7 @@ flowchart TD
     CoVe --> A5[5. Map dependencies]
     A5 --> A6[6. Assign roles]
     A6 --> Gate{Evaluate complexity}
-    Gate -->|Manageable| Done([ARTIFACT:TASK files])
+    Gate -->|Manageable| Done([Tasks registered in the plan])
     Gate -->|High complexity or novel architecture| Escalate([Human touchpoint — confirm decomposition])
 ```
 
@@ -52,8 +52,8 @@ Split along natural seams:
 
 ### Step 2 — Embed Complete Context
 
-Each task file IS the complete prompt. The executing agent has NO memory of
-previous stages. Embed everything needed:
+The task IS the complete prompt. The executing agent has NO memory of
+previous stages and reads nothing but what the task carries. Embed everything needed:
 
 - Relevant excerpts from ARTIFACT:PLAN (not "see plan" — inline it)
 - File paths and line ranges from contextualization
@@ -170,25 +170,32 @@ call `append_task` for the same plan from multiple agents or sessions simultaneo
 the full single-writer contract, see the `CLAUDE.md` gotcha note in
 `plugins/development-harness/CLAUDE.md`.
 
-Each file contains YAML frontmatter followed by CLEAR-ordered sections:
+Each task definition carries these routing fields. Any key outside the accepted set is
+rejected — do not invent fields:
 
-```markdown
----
-task: TASK-001
+```yaml
+task: T1
 title: <descriptive imperative title>
 status: not-started
-role: <architect / implementer / test-designer / code-reviewer / docs-writer>
+agent: <architect / implementer / test-designer / code-reviewer / docs-writer>
 dependencies: []
 priority: <1-5 based on dependency depth>
 complexity: <low / medium / high>
 accuracy-risk: <low / medium / high>
 parallelize-with: []
-parallel-rationale: <why parallelization is safe>
----
+```
 
+Record why parallelization is safe in `context-notes`; there is no separate rationale field.
+
+The task's prose fields hold the CLEAR-ordered content. Each heading below names the field
+that carries it — `context-notes`, `objective`, `requirements`, `constraints`,
+`expected-outputs`, `acceptance-criteria`, `verification-steps`, `handoff` — and any
+remaining narrative goes in `body`:
+
+```markdown
 ## Context
 
-<embedded context from plan — NOT "see PLAN.md">
+<the context this task needs, written out in full — never a pointer to another document>
 
 ## Objective
 
@@ -243,7 +250,7 @@ After decomposition, evaluate whether escalation is needed:
 
 ```mermaid
 flowchart TD
-    Tasks([Task files generated]) --> Q1{Novel architecture pattern?}
+    Tasks([Tasks generated]) --> Q1{Novel architecture pattern?}
     Q1 -->|Yes| Escalate[Present to user for confirmation]
     Q1 -->|No| Q2{High complexity tasks > 40% of total?}
     Q2 -->|Yes| Escalate
@@ -256,8 +263,9 @@ flowchart TD
 
 ## Behavioral Rules
 
-- Every task must be self-contained — an agent reading ONLY the task file can execute it
-- Never reference PLAN.md or DISCOVERY.md by "see X" — inline the relevant content
+- Every task must be self-contained — an agent given ONLY that task can execute it
+- Never point at an upstream artifact by "see X" — inline the content the task needs. The
+  executing agent has no guaranteed access to the discovery or plan artifact you read
 - Never assign specific agent names — use roles
 - Tasks must not have circular dependencies
 - Each acceptance criterion must be verifiable by the executing agent alone

--- a/plugins/development-harness/skills/task-decomposition/SKILL.md
+++ b/plugins/development-harness/skills/task-decomposition/SKILL.md
@@ -106,8 +106,8 @@ before writing it into the task's `agent` field:
 
 Resolve a role through the project's language manifest: detect the language from the project-root
 markers, read the manifest's `Role Fulfillment` section, and take the agent it maps that role to.
-Manifest entries carry a leading `@` — `@python3-development:code-reviewer` — and `agent` stores
-the same name without it. The stored value stays plugin-qualified.
+Manifest entries carry a leading `@` — `@dh:code-reviewer` — and `agent` stores the same name
+without it. The stored value stays plugin-qualified.
 
 Write no `agent` value at all when the manifest omits that role, no manifest matches the project,
 or the work is production code, documentation, or anything else no role above covers. The


### PR DESCRIPTION
Plan-side of #3151, scoped to `plugins/development-harness/` excluding `agents/swarm-task-planner.md` (corrected on another branch).

## What changed

| File | Change |
|---|---|
| `skills/context-integration/SKILL.md` | The Contextualization Status marker is part of the same `content=` string Step 4 registers as the `architect` artifact — not a separate document. |
| `skills/task-decomposition/SKILL.md` | Task-content rules restated against the fields a task object carries. Dropped `role:` and `parallel-rationale:`, which `TaskDefinition` rejects (`additionalProperties: false`); `agent:` replaces the former, `context-notes` carries the latter. Fixed the example task ID, which did not match `TASK_ID_PATTERN`. |
| `agents/t0-baseline-capture.md` | Reads the plan through `sam_plan(action='read')` at the dispatched plan address instead of `Read(file_path=...)`. |
| `agents/tn-verification-gate.md` | Reads the criteria from the plan the same way; `artifact_read` is retained only for the T0 baseline, which genuinely is an artifact. |
| `agents/feature-researcher.md` | Registers the document via `artifact_register(content=...)` in one call. Removed the 25K `Write` strategy. |
| `agents/codebase-analyzer.md` | Same single-call registration; removed the 25K-per-call figure that contradicted the file's own no-size-limit statement. |

## t0/tn inconsistency — evidence

Dispatch passes a plan address and a task ID, never a path: `skills/implement-feature/SKILL.md` states the orchestrator passes only `plan_ref` + task ID and launches `dh:task-worker` with `start-task`, whose documented argument is `plan_address` in `P{hex}` form. Bookend tasks go through that same loop.

Plan content is backend-private: `sam_schema/core/artifact_registry_client.py` stores and reads plan YAML through the configured provider (Gist under the default GitHub backend), so on a remote backend there is no file for a path read to open.

`sam_plan(action='read')` resolves the plan through whichever backend is configured and returns `feature` and `acceptance-criteria-structured` as structured fields, so both bookends now use it. `artifact_read(item_id, "task-plan")` — TN's previous route — additionally depends on the plan having been created with an issue association.

## Related findings, not changed here

- `agents/ecosystem-researcher.md`, and `python-cli-design-spec.md` in both `python-engineering` and `python3-development`, call operations that do not exist: `sam_plan(action='update', plan_slug=..., section=..., content=...)` and `sam_create`/`sam_update`. `update_plan_fields` raises `ValueError("append_section_name requires task_id")`, so a plan-level section append cannot succeed.
- `skills/task-decomposition/SKILL.md` points at `plugins/development-harness/CLAUDE.md` by repo-relative path, which does not resolve in an install.
- `backlog_core/tests/unit/progressive_markdown/test_indexer_decomposition.py::TestPLRLintGate` fails on this branch and on `main` with `FileNotFoundError: 'ruff'` — the standalone runner's environment lacks the binary the test shells out to. Unrelated to these edits; no Python was touched.

Refs #3151

---

Part of #3151, plan-side. Covers the development-harness skills and agents only.
