### PR TITLE
docs(rules): scope the write strategy by mechanism, not by agent name

### DIFF
--- a/.claude/rules/large-file-write-strategy.md
+++ b/.claude/rules/large-file-write-strategy.md
@@ -21,9 +21,14 @@ flowchart TD
 
 ## Strategy A: Multi-File Split
 
-Do not use Strategy A when a skill, agent, or dispatcher names the exact output path. That path is
-a single-file contract — splitting it leaves its consumer without the artifact it was promised. Use
-Strategy B for it.
+Do not use Strategy A when a skill, agent, or dispatcher names one exact output path and declares
+no split fallback for it. That path is a single-file contract — splitting it leaves its consumer
+without the artifact it was promised. Use Strategy B for it.
+
+When the contract itself declares a split fallback for the over-limit case (an index path plus
+per-part files, used unless the caller explicitly requires a single file), follow that declared
+fallback instead — it already specifies Strategy A's output shape and takes precedence over the
+single-file default.
 
 Otherwise split when the output has natural boundaries (sections, priorities, task groups, modules)
 and consumers load the parts independently. Write an index file that references each part, and
@@ -35,7 +40,11 @@ Use when the output must be a single file and exceeds 25K characters.
 
 ### Step 1: Plan document structure
 
-List all sections, headers, and approximate content size per section. Confirm total exceeds 25K and no individual section exceeds 20K characters (leave margin for Edit overhead).
+List all sections, headers, and approximate content size per section. When the target document has
+a required-sections contract defined elsewhere (a skill's SKILL.md, an agent's output spec), source
+the list from that contract, not from what seems relevant — a self-invented list can silently omit
+a required section. Confirm total exceeds 25K and no individual section exceeds 20K characters
+(leave margin for Edit overhead).
 
 ### Step 2: Write skeleton
 
@@ -62,6 +71,8 @@ Read the completed file. Confirm:
 - Zero `<!-- PENDING:` markers remain
 - All planned sections contain content
 - Document structure matches the Step 1 plan
+- If a required-sections contract exists, every header it requires is present — not only the
+  headers the skeleton happened to include
 
 ## Wrong / Right Examples
 
@@ -90,6 +101,18 @@ Write(
 ## Bus Factor
 
 <!-- PENDING: Contributor ranking and 80% cumulative cutoff -->
+
+## Team Momentum
+
+<!-- PENDING: Commit activity by month in the analysis window -->
+
+## Firefighting Frequency
+
+<!-- PENDING: Revert, hotfix, and rollback commit count and assessment -->
+
+## Recently Added Files
+
+<!-- PENDING: New files introduced in the analysis window -->
 
 ## Recommendations
 

--- a/.claude/rules/large-file-write-strategy.md
+++ b/.claude/rules/large-file-write-strategy.md
@@ -67,51 +67,47 @@ Read the completed file. Confirm:
 
 **Wrong** -- assembling a 40K+ string and issuing a single `Write` call risks truncation or timeout.
 
-**Right** -- Write skeleton (~2K chars), then Edit calls filling each section (3-5K chars each):
+**Right** -- `git-history-recon` names `walkthrough/recon-report.md` as its output, so that path is a single-file contract and Strategy B applies. Write the skeleton (~2K chars), then Edit each section in (3-5K chars each):
 
 ```python
 # Step 2: Write skeleton under 5K chars
 Write(
-    file_path="plan/architect-auth-system.md",
-    content="""---
-title: Auth System Architecture
----
+    file_path="walkthrough/recon-report.md",
+    content="""# Git History Recon Report
 
-# Auth System Architecture
+## Code Hotspots
 
-## Overview
+<!-- PENDING: Files most frequently changed in the analysis window -->
 
-<!-- PENDING: System overview and goals -->
+## Bug Magnets
 
-## Data Model
+<!-- PENDING: Files most associated with fix, bug, revert commits -->
 
-<!-- PENDING: Entity definitions and relationships -->
+## High-Risk Files
 
-## API Design
+<!-- PENDING: Intersection of hotspots and bug magnets -->
 
-<!-- PENDING: Endpoint specifications -->
+## Bus Factor
 
-## Security Model
+<!-- PENDING: Contributor ranking and 80% cumulative cutoff -->
 
-<!-- PENDING: Authentication and authorization flows -->
+## Recommendations
 
-## Error Handling
-
-<!-- PENDING: Error taxonomy and recovery strategies -->
+<!-- PENDING: Prioritized actions derived from the sections above -->
 """,
 )
 
 # Step 3: Fill each section individually — one Edit per section
 Edit(
-    file_path="plan/architect-auth-system.md",
-    old_string="<!-- PENDING: System overview and goals -->",
-    new_string="The auth system provides token-based authentication...",
+    file_path="walkthrough/recon-report.md",
+    old_string="<!-- PENDING: Files most frequently changed in the analysis window -->",
+    new_string="| File | Changes |\n|---|---|\n| src/api/router.py | 84 |",
 )
 
 # ... one Edit per section ...
 
 # Step 4: Read and verify no PENDING markers remain
-Read(file_path="plan/architect-auth-system.md")
+Read(file_path="walkthrough/recon-report.md")
 ```
 
 ## Relationship to No Invented Limits

--- a/.claude/rules/large-file-write-strategy.md
+++ b/.claude/rules/large-file-write-strategy.md
@@ -2,9 +2,11 @@
 
 ## Scope
 
-This policy applies to agents that produce documents exceeding **25,000 characters** in a single output: `swarm-task-planner`, `python-cli-design-spec`, `codebase-analyzer`, `ecosystem-researcher`, and `feature-researcher`. Any agent producing a document that may exceed 25K characters follows this strategy.
+This policy applies to any agent that writes a document to the filesystem with a single `Write` call and may exceed **25,000 characters**. The 25K threshold reflects the practical reliability limit of one `Write` call; beyond it, writes risk truncation, timeout, or silent data loss.
 
-The 25K threshold reflects the practical reliability limit of a single `Write` tool call. Beyond this size, writes risk truncation, timeout, or silent data loss. The strategies below ensure all content reaches disk intact.
+It does not apply to output stored through an MCP operation. An agent that returns its result through a plan, task, or artifact operation writes no file, so no `Write` limit applies to it. Size limits on that path belong to the configured provider, are not 25K, and are not addressed here — check the provider before assuming one exists.
+
+Determine which case applies by reading what the agent's dispatcher instructs it to call, not by the size of what it produces.
 
 ## Decision Flowchart
 
@@ -23,7 +25,7 @@ Use when the output decomposes naturally into multiple files, each under 25K cha
 
 Create an index file that references each part. Each part is a standalone document written with a single `Write` call.
 
-**Canonical example**: The `swarm-task-planner` agent's 500-line progressive disclosure policy already implements Strategy A. Plans under 500 lines produce a single `PLAN.md`. Plans at or above 500 lines produce a `PLAN/` directory with `index.md` and per-priority part files (e.g., `priority-1-foundation.md`, `priority-2-features.md`). Each part stays under the 25K character limit independently.
+**Worked example**: a presentation crosswalk that outgrows one file becomes an index plus one file per section, each written with its own `Write` call and each independently under the limit.
 
 **When to choose Strategy A**:
 

--- a/.claude/rules/large-file-write-strategy.md
+++ b/.claude/rules/large-file-write-strategy.md
@@ -21,17 +21,13 @@ flowchart TD
 
 ## Strategy A: Multi-File Split
 
-Use when the output decomposes naturally into multiple files, each under 25K characters.
+Do not use Strategy A when a skill, agent, or dispatcher names the exact output path. That path is
+a single-file contract — splitting it leaves its consumer without the artifact it was promised. Use
+Strategy B for it.
 
-Create an index file that references each part. Each part is a standalone document written with a single `Write` call.
-
-**Worked example**: a presentation crosswalk that outgrows one file becomes an index plus one file per section, each written with its own `Write` call and each independently under the limit.
-
-**When to choose Strategy A**:
-
-- Output has natural split boundaries (sections, priorities, task groups, modules)
-- Consumers benefit from loading parts independently
-- No external constraint requires a single file path
+Otherwise split when the output has natural boundaries (sections, priorities, task groups, modules)
+and consumers load the parts independently. Write an index file that references each part, and
+write each part with its own `Write` call, each part under 25K characters.
 
 ## Strategy B: Skeleton + Edit-Fill
 

--- a/.claude/rules/scratch-directory.md
+++ b/.claude/rules/scratch-directory.md
@@ -23,6 +23,10 @@ Write findings to .tmp/scratch/reports/YYYYMMDD-<slug>.md
 Return: STATUS: DONE + path to the file
 ```
 
+The returned path is for the requesting agent to read directly. Never pass it on as the input of a
+later step, agent, or gate — anything a subsequent step reads is an inter-step handoff and goes
+through the artifact or plan operations instead.
+
 ## Hard rule
 
 Never write agent output to `.claude/` — every write to that directory triggers a security

--- a/.claude/rules/scratch-directory.md
+++ b/.claude/rules/scratch-directory.md
@@ -23,9 +23,12 @@ Write findings to .tmp/scratch/reports/YYYYMMDD-<slug>.md
 Return: STATUS: DONE + path to the file
 ```
 
-The returned path is for the requesting agent to read directly. Never pass it on as the input of a
-later step, agent, or gate — anything a subsequent step reads is an inter-step handoff and goes
-through the artifact or plan operations instead.
+The returned path is for the requesting agent to read directly. Do not invent an ad hoc handoff by
+passing it to a later step, agent, or gate that the producing workflow does not already define —
+that step reads results through the artifact or plan operations instead. Exception: when a skill's
+own documented pipeline explicitly names a scratch path as the input to its next stage (for example
+passing a change plan or a draft-output path from one stage to a validator or verifier stage within
+that same skill), that skill's stage definitions govern and the handoff is allowed.
 
 ## Hard rule
 


### PR DESCRIPTION
The regenerating source behind the plan-file half of #3151.

`.claude/rules/large-file-write-strategy.md` loads on the relevant edits, so an agent editing planner or researcher content reads it and preserves what it teaches. Two things in it were false.

**The scope list.** It named `swarm-task-planner`, `python-cli-design-spec`, `codebase-analyzer`, `ecosystem-researcher`, and `feature-researcher` as agents producing 25K+ documents in a single `Write`. None of the five can reach a single-`Write` limit — every one returns its output through a plan or artifact operation and writes no file:

- `swarm-task-planner`, `codebase-analyzer`, `feature-researcher` — `sam_plan create` / `artifact_register`
- `ecosystem-researcher` — no `Write` in its documented procedure
- `python-cli-design-spec` (both plugin copies) — registers an `architect` artifact

**The canonical example.** It described the planner's 500-line policy producing a `PLAN.md` or a `PLAN/` directory of per-priority part files. No code path produces either; `task_exports`, the key that policy prescribed, appears elsewhere only in a negative-path fixture whose loader cannot parse it.

So a rule governing how agents write large documents used a non-existent output as its worked illustration, which is how the plan-file model kept regenerating after each prose sweep.

## What changed

Scope is now by mechanism rather than by name: it applies to an agent that writes a file with `Write` and may exceed 25K, and explicitly does not apply to output stored through an MCP operation. It also says provider-side limits on that path are a different question with a different answer — relevant because the one real ceiling found is provider-owned (see #3158), is 64 KiB not 25K, and belongs to a provider that is not the default.

The example is replaced with one that describes something that happens.

## Not deleted

The rule stays. Three project-local skills use it and genuinely write files with `Write`: `prepare-walkthrough-presentation`, `git-history-recon`, and `linear-walkthrough`. The mechanism is live — only its scope and example were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Part of #3151. Corrects the repo rule that was regenerating the plan-file model; the shipped content it taught is corrected in #3137, #3156, and #3159.
