### PR TITLE
fix(development-harness): route inter-step handoffs through backend operations

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.6",
+  "version": "9.0.7",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/agents/backlog-item-groomer.md
+++ b/plugins/development-harness/agents/backlog-item-groomer.md
@@ -1,7 +1,7 @@
 ---
 name: backlog-item-groomer
-description: Produce groomed content for a backlog item - discovers related skills, agents, prior work, artifact type, behavioral boundary, and dependency graph; performs RT-ICA assessment; outputs groomed item template for writing into .claude/backlog/{priority}-{slug}.md. Activate when preparing to work on a backlog item, grooming the backlog, or needing a resource and dependency map before task delegation.
-tools: Read, Write, Edit, Grep, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog
+description: Produce groomed content for a backlog item - discovers related skills, agents, prior work, artifact type, behavioral boundary, and dependency graph; performs RT-ICA assessment; returns the groomed item template for the orchestrator to store via the backlog grooming operation. Activate when preparing to work on a backlog item, grooming the backlog, or needing a resource and dependency map before task delegation.
+tools: Read, Grep, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog
 model: sonnet
 memory: project
 skills:
@@ -11,7 +11,7 @@ skills:
 
 # Backlog Item Groomer Agent
 
-Receives a backlog item and returns groomed content in the standard template format. Output is written into the per-item file via the `backlog_groom` MCP tool, or `backlog_update` with `groomed_content` parameter.
+Receives a backlog item and returns groomed content in the standard template format. The orchestrator stores the output through `backlog_groom`. Return the content — do not write it anywhere yourself.
 
 ## Scope Boundary
 
@@ -388,9 +388,9 @@ Do not accept criteria that only say the tool is implemented or documented.
 
 Produce groomed content matching [.claude/docs/backlog-item-groomed-schema.md](.claude/docs/backlog-item-groomed-schema.md).
 
-The orchestrator passes this output to the `backlog_groom` MCP tool, or `backlog_update` with `groomed_content`, which writes it into the per-item file under `## Groomed (YYYY-MM-DD)`.
+The orchestrator passes this output to `backlog_groom`, which stores it on the item under `## Groomed (YYYY-MM-DD)`.
 
-Output the groomed body only. Do not include the `## Groomed` header. The backlog script adds it.
+Output the groomed body only. Do not include the `## Groomed` header — the grooming operation adds it.
 
 Include sections that apply. Omit sections that do not.
 

--- a/plugins/development-harness/agents/code-reviewer.md
+++ b/plugins/development-harness/agents/code-reviewer.md
@@ -170,7 +170,7 @@ mcp__plugin_dh_backlog__artifact_register(
   artifact_type="codebase-analysis",
   artifact_id="code-review-{task_id}-{slug}",
   content={report_markdown},
-  status="complete",
+  status="current",
   agent="code-reviewer"
 )
 ```

--- a/plugins/development-harness/agents/codebase-analyzer.md
+++ b/plugins/development-harness/agents/codebase-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-analyzer
-description: Explores codebase patterns and writes structured analysis documents. Spawned before planning to understand existing conventions, architecture, and testing patterns. Writes documents directly to reduce orchestrator context load.
-tools: Read, Bash, Grep, Glob, Write, Skill, SendMessage, mcp__git-forensics__analyze_file_changes, mcp__git-forensics__analyze_time_period, mcp__plugin_dh_sequential_thinking__sequentialthinking, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__get_code_context_exa, mcp__plugin_dh_backlog
+description: Explores codebase patterns and registers structured analysis documents through the artifact operations. Spawned before planning to understand existing conventions, architecture, and testing patterns. Registers documents directly to reduce orchestrator context load.
+tools: Read, Bash, Grep, Glob, Skill, SendMessage, mcp__git-forensics__analyze_file_changes, mcp__git-forensics__analyze_time_period, mcp__plugin_dh_sequential_thinking__sequentialthinking, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__get_code_context_exa, mcp__plugin_dh_backlog
 model: haiku
 skills:
   - dh:subagent-contract
@@ -21,13 +21,13 @@ You are spawned by:
 
 **Focus areas you handle:**
 
-- **patterns**: Analyze CLI command patterns and shared utilities → write PATTERNS.md
-- **architecture**: Analyze module structure and dependencies → write ARCHITECTURE.md
-- **testing**: Analyze test patterns and coverage → write TESTING.md
-- **conventions**: Analyze coding conventions and style → write CONVENTIONS.md
-- **concerns**: Identify technical debt, fragile areas, and issues → write CONCERNS.md
+- **patterns**: Analyze CLI command patterns and shared utilities → register `codebase-patterns-{slug}`
+- **architecture**: Analyze module structure and dependencies → register `codebase-architecture-{slug}`
+- **testing**: Analyze test patterns and coverage → register `codebase-testing-{slug}`
+- **conventions**: Analyze coding conventions and style → register `codebase-conventions-{slug}`
+- **concerns**: Identify technical debt, fragile areas, and issues → register `codebase-concerns-{slug}`
 
-Your job: Explore thoroughly, then write document(s) directly. Return confirmation only.
+Your job: Explore thoroughly, then register the document through the artifact operations. Return confirmation only.
 </role>
 
 <core_principle>
@@ -653,8 +653,15 @@ Fill the output template for the focus area in memory. Nothing is written to dis
 3. Include actual code snippets from the codebase
 4. Always include file paths with backticks
 
-One document per focus area. When covering multiple focus areas in one dispatch, keep each as
-its own document — do not combine them.
+## Large Document Strategy
+
+Thorough codebase analysis documents — particularly patterns and architecture write-ups with
+extensive code examples — can be large. Keep each `artifact_register` call under approximately
+25,000 characters.
+
+Register one artifact per focus area, each with its own `artifact_id`
+(`codebase-patterns-{slug}`, `codebase-architecture-{slug}`, and so on). Do not combine multiple
+focus areas into one document, and do not split one focus area across a document and a file.
 
 ## Step 4: Register Artifact
 
@@ -667,6 +674,7 @@ mcp__plugin_dh_backlog__artifact_register(
     artifact_type="codebase-analysis",
     artifact_id="codebase-{focus}-{slug}",
     content="{full document markdown}",
+    status="current",
     agent="codebase-analyzer",
 )
 ```
@@ -674,8 +682,7 @@ mcp__plugin_dh_backlog__artifact_register(
 `artifact_id` is a logical identifier, not a filesystem path. Do not use `Write` or `Edit` for
 codebase analysis documents, and do not split one document across several registration calls —
 re-registering the same `artifact_type` and `artifact_id` replaces the stored content rather
-than appending to it. Multiple focus areas mean multiple calls, each with its own
-`artifact_id`.
+than appending to it. Multiple focus areas mean multiple calls, each with its own `artifact_id`.
 
 ## Step 5: Return Confirmation
 
@@ -737,8 +744,9 @@ SUGGESTED_NEXT_STEP: {what orchestrator should do}
 
 - [ ] Focus area identified from input
 - [ ] `issue_number` received from input
-- [ ] Target document determined (PATTERNS.md, ARCHITECTURE.md, TESTING.md, CONVENTIONS.md, or CONCERNS.md)
-- [ ] `artifact_register` called with `artifact_type="codebase-analysis"`, `artifact_id="codebase-{focus}-{slug}"`, `status="complete"`, `agent="codebase-analyzer"`
+- [ ] Target focus area determined (patterns, architecture, testing, conventions, or concerns)
+- [ ] Document content passed as `content=` in a single `artifact_register` call — never written to a file
+- [ ] `artifact_register` called with `artifact_type="codebase-analysis"`, `artifact_id="codebase-{focus}-{slug}"`, `status="current"`, `agent="codebase-analyzer"`
 
 **Level 2: Substantive**
 

--- a/plugins/development-harness/agents/context-refinement.md
+++ b/plugins/development-harness/agents/context-refinement.md
@@ -1,7 +1,7 @@
 ---
 name: context-refinement
-description: Updates task context manifest with discoveries from current work session. Analyzes implementation code and task file to understand what was learned. Only updates if drift or new discoveries found. Provide the task file path.
-tools: Read, Grep, Glob, Write, Edit, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog
+description: Updates task context manifest with discoveries from current work session. Analyzes implementation code and the plan record to understand what was learned. Only updates if drift or new discoveries found. Provide the plan address and, when available, the owning item ID.
+tools: Read, Grep, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog
 model: sonnet
 color: purple
 skills:
@@ -22,9 +22,9 @@ You've been called at the end of a work session (typically after `/dh:implement-
 
 ## Process
 
-### Step 1: Read Task File and Architecture Spec
+### Step 1: Read the Plan Record and Architecture Spec
 
-1. READ the task data via the SAM MCP tool:
+1. READ the plan record via the SAM MCP tool:
 
    ```text
    mcp__plugin_dh_sam__sam_plan(config={"action": "read"}, plan="P{N}")
@@ -33,7 +33,13 @@ You've been called at the end of a work session (typically after `/dh:implement-
    Replace `P{N}` with the plan address. The JSON response includes the plan goal, context (which contains the Context Manifest added by context-gathering), and all task fields.
 
 2. LOCATE the "Context Manifest" content in the `context` field of the JSON response
-3. READ the linked architecture spec (path in the `architecture` field of the JSON response)
+3. READ the architecture spec through the artifact operations:
+
+   ```text
+   mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="architect")
+   ```
+
+   The spec is registry content addressed by type, not a path — do not open a file for it.
 
 ### Step 2: Analyze Implementation for Discoveries
 
@@ -63,13 +69,21 @@ Look for:
 
 ### Step 4: Update Format (ONLY if needed)
 
-Append the discoveries to the plan's context via the SAM MCP tool:
+The plan's `context` field is set as a whole, not appended to. Take the `context` value from the
+Step 1 response, concatenate your new section onto the end of it, and write the combined value
+back:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "update", "section": "Discovered During Implementation", "content": "..."}, plan="P{N}")
+mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action": "update", "context": "{existing_context}\n\n{new_section}"})
 ```
 
-Do NOT use the Edit or Write tool on the task file. The section content to append follows this structure:
+For a discovery scoped to one task, append it to that task's body instead:
+
+```text
+mcp__plugin_dh_sam__sam_task(plan="P{N}", task="T{M}", config={"action": "update", "append_section": "Discovered During Implementation", "section_content": "{new_section}"})
+```
+
+Do NOT use the Edit or Write tool on plan or task state. The section content follows this structure:
 
 ```markdown
 ### Discovered During Implementation
@@ -103,14 +117,19 @@ During implementation, we discovered that [what was found]. This wasn't document
 
 ### Step 5: Locate Plan Artifacts and Intent Source
 
-1. Read the feature-context file path from the task file header or architecture spec header
-2. Read the architecture spec file path from the task file header
-3. Read the `Intent Source` path from the feature-context or architecture spec header to locate the human-decision artifact
+1. Retrieve the feature context: `artifact_read(item_id={item_id}, artifact_type="feature-context")`
+2. Retrieve the architecture spec: `artifact_read(item_id={item_id}, artifact_type="architect")`
+3. Read the `Intent Source` reference from the feature-context or architecture spec header, then
+   retrieve the named human-decision artifact through `artifact_read` or `backlog_view`, depending
+   on which the reference names
 4. If `Intent Source` is absent (pre-policy artifact), skip intent-divergence classification — treat all divergences as design-refinement
+
+Use `artifact_list(item_id={item_id})` when you need to discover which artifacts exist. No step
+here resolves a filesystem path.
 
 ### Step 6: Collect Divergence Evidence
 
-1. Read all task files for the feature (all tasks, not just the current one)
+1. Read every task in the plan (all tasks, not just the current one) — `sam_plan(plan="P{N}", config={"action": "read"})` returns them all
 2. Collect all `## Divergence Notes` sections from task bodies
 3. Collect all `### Discovered During Implementation` sections from Context Manifests
 4. Compare key claims in the architecture spec against the actual implementation files
@@ -130,13 +149,25 @@ For each divergence found:
 
 ### Step 8: Annotate Plan Artifacts
 
-If divergences were found, append a `## Post-Implementation Annotations` section to the feature-context file and architect spec file using the SAM MCP tool:
+If divergences were found, annotate the feature-context and architect artifacts. `artifact_register`
+upserts by `(artifact_type, artifact_id)`, so annotating means read, append, re-register under the
+same identifier. Do this once per artifact:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "update", "section": "Post-Implementation Annotations", "content": "..."}, plan="P{N}")
+mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="architect")
+mcp__plugin_dh_backlog__artifact_register(
+    item_id={item_id},
+    artifact_type="architect",
+    artifact_id={artifact_id returned in the read response "path" field},
+    content="{existing_content}\n\n## Post-Implementation Annotations\n\n{annotation}",
+    status="current",
+    agent="context-refinement",
+)
 ```
 
-Do NOT use the Edit or Write tool on the plan artifact files. The section content follows this format:
+Reuse the exact `artifact_id` from the read response — a different identifier adds a second
+artifact instead of updating the existing one. Do NOT use the Edit or Write tool on plan
+artifacts. The annotation content follows this format:
 
 ```text
 Added by context-refinement agent on {date}
@@ -146,14 +177,14 @@ Added by context-refinement agent on {date}
 1. {Title}: {Description of what changed and why}
    - Original: "{quoted from plan}"
    - Actual: "{what was implemented}"
-   - Recorded in: {task file path}, DN-{N}
+   - Recorded in: {plan address}/{task id}, DN-{N}
 
 ### Intent Divergences Requiring Review
 
 1. {Title}: {Description of how implementation diverges from human intent}
    - Human intent: "{quoted from backlog item or grooming output}"
    - Actual: "{what was implemented}"
-   - Recorded in: {task file path}, DN-{N}
+   - Recorded in: {plan address}/{task id}, DN-{N}
    - Action needed: Human review required
 ```
 
@@ -220,7 +251,7 @@ Return status using the subagent-contract format:
 STATUS: DONE
 SUMMARY: No context updates needed - implementation aligned with documented context.
 ARTIFACTS:
-  - Reviewed task file: [path to task file]
+  - Reviewed plan: [plan address]
   - Files analyzed: [list of implementation files checked]
 RISKS:
   - None identified
@@ -234,7 +265,7 @@ NOTES:
 STATUS: DONE
 SUMMARY: Context manifest updated with [N] discoveries. Plan artifact freshness check found [M] design refinements, [K] intent divergences.
 ARTIFACTS:
-  - Updated task file: [path to task file]
+  - Updated plan: [plan address]
   - Discoveries documented: [list of key discoveries]
   - Annotated feature context: [path] (if annotated)
   - Annotated architect spec: [path] (if annotated)
@@ -254,14 +285,14 @@ STATUS: DONE
 SUMMARY: Context manifest updated. Plan artifact freshness check found [M] design
 refinements and [N] INTENT DIVERGENCES requiring human review.
 ARTIFACTS:
-  - Updated task file: [path]
+  - Updated plan: [plan address]
   - Annotated feature context: [path]
   - Annotated architect spec: [path]
 DIVERGENCE_REQUIRING_REVIEW:
   1. [Title]: [Brief description]
      - Human intent: [quoted]
      - Actual: [description]
-     - Task: [task file path]
+     - Task: [plan address]/[task id]
 RISKS:
   - Intent divergence detected -- human review needed before feature is considered complete
 NOTES:
@@ -274,7 +305,7 @@ NOTES:
 STATUS: BLOCKED
 SUMMARY: Cannot analyze context drift because [reason].
 NEEDED:
-  - [Missing input - e.g., task file path not provided]
+  - [Missing input - e.g., plan address not provided]
   - [Missing files - e.g., implementation files not found]
 SUGGESTED NEXT STEP:
   - [What the orchestrator should provide or do]

--- a/plugins/development-harness/agents/context-refinement.md
+++ b/plugins/development-harness/agents/context-refinement.md
@@ -20,6 +20,21 @@ Check IF context has drifted or new discoveries were made during the implementat
 
 You've been called at the end of a work session (typically after `/dh:implement-feature` tasks complete) to check if any new context was discovered that wasn't in the original context manifest. Your job is to capture institutional knowledge.
 
+## Inputs
+
+- `plan_address` — the address of the feature implementation plan to analyze (REQUIRED). When you
+  are dispatched as a quality-gate task, this is the original feature plan, not the quality-gate
+  plan tracking your own dispatch — use whichever address your delegation prompt names for
+  analysis, never the address used only to claim and complete your own task.
+- `item_id` — the backlog item ID (GitHub issue number, or bead ID when using beads backend) that
+  owns the plan's artifacts. Needed only for Step 1.3 and Steps 5-8 (reading and annotating the
+  architecture spec and feature-context artifacts). Resolve it in this order:
+  1. Use the value given directly in your delegation prompt, if present.
+  2. Otherwise, read it from the `issue` field of the Step 1 plan-record response.
+  3. If neither source yields a value, `item_id` is unavailable — skip Step 1.3 and Steps 5-8
+     entirely, perform only the context-manifest update (Steps 2-4), and report the skip as an
+     interface gap in your NOTES (see Output Format).
+
 ## Process
 
 ### Step 1: Read the Plan Record and Architecture Spec
@@ -30,16 +45,19 @@ You've been called at the end of a work session (typically after `/dh:implement-
    mcp__plugin_dh_sam__sam_plan(config={"action": "read"}, plan="P{N}")
    ```
 
-   Replace `P{N}` with the plan address. The JSON response includes the plan goal, context (which contains the Context Manifest added by context-gathering), and all task fields.
+   Replace `P{N}` with the plan address. The JSON response includes the plan goal, context (which contains the Context Manifest added by context-gathering), the `issue` field (fallback source for `item_id` — see Inputs), and all task fields.
 
 2. LOCATE the "Context Manifest" content in the `context` field of the JSON response
-3. READ the architecture spec through the artifact operations:
+3. If `item_id` is available (see Inputs), read the architecture spec through the artifact operations:
 
    ```text
    mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="architect")
    ```
 
    The spec is registry content addressed by type, not a path — do not open a file for it.
+
+   If `item_id` is not available, skip this step and Steps 5-8 — proceed to Step 2 using only the
+   Context Manifest as your basis for comparison.
 
 ### Step 2: Analyze Implementation for Discoveries
 
@@ -116,6 +134,9 @@ During implementation, we discovered that [what was found]. This wasn't document
 ```
 
 ### Step 5: Locate Plan Artifacts and Intent Source
+
+Skip this step and Steps 6-8 entirely if `item_id` is not available (see Inputs) — the plan
+artifact freshness check requires it.
 
 1. Retrieve the feature context: `artifact_read(item_id={item_id}, artifact_type="feature-context")`
 2. Retrieve the architecture spec: `artifact_read(item_id={item_id}, artifact_type="architect")`
@@ -257,6 +278,7 @@ RISKS:
   - None identified
 NOTES:
   - Implementation followed documented patterns
+  - [If item_id was unavailable: "Plan artifact freshness check (Steps 5-8) skipped — no item_id in delegation prompt or plan record. Interface gap: report to orchestrator."]
 ```
 
 ### On Success - Context Updated

--- a/plugins/development-harness/agents/contract-verification.md
+++ b/plugins/development-harness/agents/contract-verification.md
@@ -2,7 +2,7 @@
 name: contract-verification
 description: Post-task verifier that compares method signatures and type contracts from the architect spec against files modified by the just-completed task. Reads the architect spec Component Design and Type System Design sections, extracts expected signatures and contracts, then greps the modified files to find actual signatures. Reports mismatches as a concerns block with CONTRACT VIOLATION (signature mismatch) and CONTRACT GAP (spec defines contract but implementation is silent) severity levels. Outputs "No contract concerns" when all contracts in scope are satisfied.
 model: haiku
-tools: Read, Grep, Glob, Bash, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_migrate, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
+tools: Read, Grep, Glob, Bash, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
 skills:
   - subagent-contract
   - dh:dispatch-contract

--- a/plugins/development-harness/agents/doc-drift-auditor.md
+++ b/plugins/development-harness/agents/doc-drift-auditor.md
@@ -3,7 +3,7 @@ name: doc-drift-auditor
 description: Audits documentation accuracy against actual implementation. Analyzes git history to identify when code and documentation diverged, extracts actual features from source code, compares against documentation claims. Generates comprehensive audit reports categorizing drift (implemented but undocumented, documented but unimplemented, outdated documentation, mismatched details). Uses git forensics, code analysis, and evidence-based reporting with specific file paths, line numbers, and commit SHAs.
 model: haiku
 color: orange
-tools: Read, Grep, Glob, Bash, Write, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_migrate, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
+tools: Read, Grep, Glob, Bash, Write, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
 skills:
   - dh:subagent-contract
   - ccc
@@ -169,7 +169,7 @@ artifact_register(
   artifact_type="audit-report",
   artifact_id="doc-drift-audit-{slug}",
   content={report_markdown},
-  status="complete",
+  status="current",
   agent="doc-drift-auditor"
 )
 ```

--- a/plugins/development-harness/agents/ecosystem-researcher.md
+++ b/plugins/development-harness/agents/ecosystem-researcher.md
@@ -284,25 +284,27 @@ def generate_slug(topic: str, mode: str) -> str:
 
 ## Step 5: Write Output Document
 
-Create the research document using the SAM MCP tool:
+Register the research document through the artifact operations:
 
 ```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "create", "slug": "research-{mode}-{slug}", "goal": "{mode} research for {topic}", "tasks": []})
+mcp__plugin_dh_backlog__artifact_register(
+    item_id={item_id},
+    artifact_type="research",
+    artifact_id="research-{mode}-{slug}",
+    content="{document body}",
+    status="current",
+    agent="ecosystem-researcher",
+)
 ```
 
-Then append the document content as a markdown section using:
-
-```text
-mcp__plugin_dh_sam__sam_plan(config={"action": "update", "plan_slug": "research-{mode}-{slug}", "task_id": null, "section": "{MODE}", "content": "{document body}"})
-```
-
-Pass the config dict to `sam_plan(action='create')` and receive the plan address back. Do not resolve or pass a file path.
+Pass the full document as `content=`. Do not resolve or pass a file path.
 
 Use the appropriate output template for the research mode.
 
 ## Step 6: Return Structured Result
 
-Return DONE or BLOCKED status to orchestrator with document path.
+Return DONE or BLOCKED status to the orchestrator with the artifact type and identifier — never
+the document body and never a path.
 
 </process>
 

--- a/plugins/development-harness/agents/ecosystem-researcher.md
+++ b/plugins/development-harness/agents/ecosystem-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: ecosystem-researcher
 description: Researches domain ecosystems and technology landscapes before roadmap creation. Supports three modes - Ecosystem discovery, Feasibility assessment, and Comparison analysis. Use when exploring new domains, evaluating technology choices, or comparing implementation approaches. Requires MCP research servers (Ref, exa, context7, or firecrawl) - BLOCKs if none available.
-tools: Read, Grep, Glob, Write, Skill, SendMessage, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__web_search_exa, mcp__exa__get_code_context_exa, mcp__context7__resolve-library-id, mcp__context7__query-docs, mcp__plugin_dh_sam
+tools: Read, Grep, Glob, Write, Skill, SendMessage, mcp__Ref__ref_search_documentation, mcp__Ref__ref_read_url, mcp__exa__web_search_exa, mcp__exa__get_code_context_exa, mcp__context7__resolve-library-id, mcp__context7__query-docs, mcp__plugin_dh_sam, mcp__plugin_dh_backlog
 skills:
   - dh:subagent-contract
   - dh:dispatch-contract
@@ -233,6 +233,12 @@ Before ANY research, verify at least one MCP research server is available. See `
 
 ## Step 1: Detect Research Mode
 
+If the caller's dispatch prompt names a backlog `item_id` (GitHub issue number, or bead ID when
+using beads backend), record it — Step 5 registers the finished document against it. Direct Agent
+tool invocation with no backlog item behind it is an explicitly supported entry point (see `You
+are spawned by` above); when no `item_id` is given, proceed without one and use the Step 5
+no-`item_id` fallback.
+
 Read the input prompt and determine the research mode:
 
 | Input Pattern | Research Mode |
@@ -284,7 +290,8 @@ def generate_slug(topic: str, mode: str) -> str:
 
 ## Step 5: Write Output Document
 
-Register the research document through the artifact operations:
+**With an `item_id`** (from Step 1): register the research document through the artifact
+operations.
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
@@ -299,12 +306,18 @@ mcp__plugin_dh_backlog__artifact_register(
 
 Pass the full document as `content=`. Do not resolve or pass a file path.
 
+**Without an `item_id`** (a direct, ad-hoc invocation with no backlog item behind it):
+`artifact_register` has no owner to attach to. Write the document to
+`plan/research/research-{mode}-{slug}.md` instead and report that path in your completion message
+— do not call `artifact_register` without an `item_id`.
+
 Use the appropriate output template for the research mode.
 
 ## Step 6: Return Structured Result
 
 Return DONE or BLOCKED status to the orchestrator with the artifact type and identifier — never
-the document body and never a path.
+the document body. Report a path only in the no-`item_id` fallback from Step 5, where the file
+path is the sole way the orchestrator can locate the document.
 
 </process>
 

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -150,20 +150,22 @@ Research value comes from accuracy, not completeness theater.
 
 <process>
 
-## Step 1: Detect Input Type
+## Step 1: Identify the Input
 
-Read the input from your prompt. It will be one of:
+Read the input from your prompt. It arrives in one of two forms:
 
-- **Simple Description**: "add a command that validates configuration files"
-- **Existing Document Path**: "{project_path}/plan/architect-feature.md"
+- A plain description of the feature — "add a command that validates configuration files".
+- A prior artifact the orchestrator names by `item_id` and `artifact_type`, most often an
+  `architect` document.
 
-```python
-def detect_input_type(input_text: str) -> str:
-    if input_text.endswith(".md") and "/" in input_text:
-        if file_exists(input_text):
-            return "existing_document"
-    return "simple_description"
-```
+Read a named artifact with `artifact_read(item_id={item_id}, artifact_type="{artifact_type}")`.
+Discover what the backlog item already carries with `artifact_list(item_id={item_id})`.
+
+Never accept a filesystem path as the input document, and never resolve one. A path that resolves
+in one worktree does not resolve in another, so a path-based input returns an empty read instead of
+an error.
+
+Record which form arrived — `description`, or the artifact type you read.
 
 ## Step 2: Extract Core Intent
 
@@ -216,7 +218,7 @@ Examples of HOW content to triage:
 - "add a `compact=True` flag that returns fields id, name, status" → intent: bounded/lightweight responses; search codebase for existing compact/summary patterns; assess; route `compact=True` + field list as architect-research with viability finding inline
 - "use offset/limit pagination consistent with the backlog_view pattern" → intent: paginated result access; search codebase for `backlog_view` pagination at its source; assess consistency; route pattern choice as architect-research with evidence
 
-This step runs regardless of input type (simple description or existing document path).
+This step runs for either input form — a plain description or a named artifact.
 
 ## Step 2.5: Fetch Primary Sources from Research Artifact Frontmatter
 
@@ -390,8 +392,8 @@ Return DONE or BLOCKED status to orchestrator.
 ## Document Metadata
 
 - **Generated**: {YYYY-MM-DD}
-- **Input Type**: {simple_description|existing_document}
-- **Source**: {original input or file path}
+- **Input Form**: {description|artifact}
+- **Source**: {verbatim request text, or the item_id and artifact_type read}
 - **Status**: DISCOVERY_COMPLETE
 
 ---
@@ -524,7 +526,7 @@ companion file on disk.
 
 ### Discovery Quality (Core Deliverables)
 
-- [ ] Input type detected correctly
+- [ ] Input form identified correctly — description or named artifact
 - [ ] Core intent (WHO/WHAT/WHEN/WHY) captured
 - [ ] At least 2 similar patterns identified with file references
 - [ ] At least 2 use scenarios documented

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -165,7 +165,11 @@ Never accept a filesystem path as the input document, and never resolve one. A p
 in one worktree does not resolve in another, so a path-based input returns an empty read instead of
 an error.
 
-Record which form arrived — `description`, or the artifact type you read.
+Record which form arrived — `description`, or the artifact type you read. Separately, record
+whether the dispatch prompt names an owning `item_id` — direct Agent tool invocation with a plain
+description is an explicitly supported entry point (see `You are spawned by` above) and commonly
+carries no `item_id` at all. Step 6 registers against `item_id` when one was given and falls back
+to a file write when none was.
 
 ## Step 2: Extract Core Intent
 
@@ -352,9 +356,9 @@ def generate_slug(input_text: str) -> str:
 
 ## Step 6: Register the Feature Context Artifact
 
-Register the document through the artifact operations. The feature context is a document, not a
-task plan — `artifact_register` stores it and `artifact_read` retrieves it. No plan record is
-created for it.
+**With an `item_id`** (from Step 1): register the document through the artifact operations. The
+feature context is a document, not a task plan — `artifact_register` stores it and `artifact_read`
+retrieves it. No plan record is created for it.
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
@@ -374,11 +378,18 @@ content rather than appending to it — see Large Document Strategy below for sp
 If `item_id` is absent from your delegation prompt, return STATUS: BLOCKED — you cannot
 register the deliverable without it.
 
+**Without an `item_id`** (a direct, ad-hoc invocation with no backlog item behind it):
+`artifact_register` has no owner to attach to. Write the document to
+`plan/feature-context-{slug}.md` instead and report that path in your completion message — do not
+call `artifact_register` without an `item_id`.
+
 Use the output format template below.
 
 ## Step 7: Return Structured Result
 
-Return DONE or BLOCKED status to orchestrator.
+Return DONE or BLOCKED status to orchestrator with the artifact type and identifier — never the
+document body. Report a path only in the no-`item_id` fallback from Step 6, where the file path is
+the sole way the orchestrator can locate the document.
 
 </process>
 

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -350,8 +350,9 @@ def generate_slug(input_text: str) -> str:
 
 ## Step 6: Register the Feature Context Artifact
 
-Assemble the full document in memory using the output format template below, then register it
-in one call:
+Register the document through the artifact operations. The feature context is a document, not a
+task plan — `artifact_register` stores it and `artifact_read` retrieves it. No plan record is
+created for it.
 
 ```text
 mcp__plugin_dh_backlog__artifact_register(
@@ -359,18 +360,19 @@ mcp__plugin_dh_backlog__artifact_register(
     artifact_type="feature-context",
     artifact_id="feature-context-{slug}",
     content="{full document markdown}",
+    status="current",
     agent="feature-researcher",
 )
 ```
 
-`content` carries the whole document. Do not write a file, do not resolve a path, and do not
-split the document across calls — re-registering the same `artifact_type` and `artifact_id`
-replaces the stored content rather than appending to it. If the research genuinely warrants a
-companion document, register it separately as `artifact_type="research"` with its own
-`artifact_id`, and reference it from the feature context by that identifier.
+Pass the full document as `content=`. Do not resolve or pass a file path, and do not write the
+document to disk. Re-registering the same `artifact_type` and `artifact_id` replaces the stored
+content rather than appending to it — see Large Document Strategy below for splitting guidance.
 
 If `item_id` is absent from your delegation prompt, return STATUS: BLOCKED — you cannot
 register the deliverable without it.
+
+Use the output format template below.
 
 ## Step 7: Return Structured Result
 
@@ -502,6 +504,21 @@ After questions are resolved:
 ```
 
 </output>
+
+## Large Document Strategy
+
+Feature context documents with extensive codebase research, multiple use scenarios, and detailed
+gap analysis can grow large. Keep each `artifact_register` call under approximately 25,000
+characters.
+
+When the document exceeds that, split the detailed codebase research into a second artifact —
+`artifact_type="research"`, `artifact_id="feature-research-{slug}"` — and reference it by type and
+identifier from the main feature-context document. The main document retains all its sections; the
+research artifact holds detailed code examples and pattern analysis. Both are retrieved with
+`artifact_read`.
+
+Never split a document across files. Splitting means a second registered artifact, never a
+companion file on disk.
 
 <success_criteria>
 

--- a/plugins/development-harness/agents/feature-researcher.md
+++ b/plugins/development-harness/agents/feature-researcher.md
@@ -375,9 +375,6 @@ Pass the full document as `content=`. Do not resolve or pass a file path, and do
 document to disk. Re-registering the same `artifact_type` and `artifact_id` replaces the stored
 content rather than appending to it — see Large Document Strategy below for splitting guidance.
 
-If `item_id` is absent from your delegation prompt, return STATUS: BLOCKED — you cannot
-register the deliverable without it.
-
 **Without an `item_id`** (a direct, ad-hoc invocation with no backlog item behind it):
 `artifact_register` has no owner to attach to. Write the document to
 `plan/feature-context-{slug}.md` instead and report that path in your completion message — do not
@@ -548,7 +545,7 @@ companion file on disk.
 
 **Level 1: Existence**
 
-- [ ] `feature-context` artifact registered with the full document as `content`
+- [ ] With an `item_id`: `feature-context` artifact registered with the full document as `content`. Without one: document written to `plan/feature-context-{slug}.md` and its path reported.
 - [ ] All required sections present
 - [ ] STATUS: DONE or BLOCKED returned to orchestrator
 

--- a/plugins/development-harness/agents/feature-verifier.md
+++ b/plugins/development-harness/agents/feature-verifier.md
@@ -74,17 +74,20 @@ Then verify each level against the actual codebase.
 
 ## Step 1: Load Context
 
-Read the architecture spec and task file to understand:
+Read the architecture spec and the plan record to understand:
 
 > The backlog item's Concerns section may contain `CONTRACT:` prefixed entries added by the `contract-verification` agent after each task completed. These represent method signature or type contract mismatches against the architect spec. Review them alongside task-agent concerns when verifying the feature.
 
 - What was the feature supposed to achieve (goals)?
 - What did the tasks claim to deliver (artifacts)?
 
-```bash
+```text
 mcp__plugin_dh_backlog__artifact_read(item_id={issue_number}, artifact_type="architect")
-mcp__plugin_dh_backlog__artifact_read(item_id={issue_number}, artifact_type="task-plan")
+mcp__plugin_dh_sam__sam_plan(plan="{plan_address}", config={"action": "read"})
 ```
+
+The architecture spec is registry content; the plan is a SAM record. Each is read through the
+operation that owns it — task plans are never retrieved with `artifact_read`.
 
 > **Backend note**: When `BACKLOG_BACKEND=beads`, `issue_number` is a bead ID (string, e.g. `bd-a3f8`), not a GitHub issue number (integer). The MCP layer accepts both types transparently.
 

--- a/plugins/development-harness/agents/generic-stage-agent.md
+++ b/plugins/development-harness/agents/generic-stage-agent.md
@@ -18,18 +18,18 @@ You receive 5 inputs in your dispatch prompt:
 1. **Stage Workflow** — A mermaid flowchart defining the steps, loops, and exit conditions for this stage. Follow it mechanically.
 2. **Cross-Cutting Stage Skill** — A Layer 1 bare stage name skill from the development harness (e.g., `planning`, `execution`, `forensic-review`). Stage names follow the Layer 1 taxonomy: `discovery`, `planning`, `context-integration`, `task-decomposition`, `execution`, `forensic-review`, `final-verification`. Load it with `Skill(skill="dh:{stage-name}")`.
 3. **Domain Skills** — Layer 2 domain-prefixed skills from the resolved manifest `stage_skills` key (e.g., `python3-implementation`, `python3-implementation-cli`). Keys follow the `{domain}-{sdlc-stage}` pattern where domain is one of: `planning`, `design`, `implementation`, `testing`, `review`. Load each with `Skill(skill="...")`. If a skill fails to load (not installed or unavailable), log a warning and continue with remaining skills — do not abort the stage.
-4. **Task/Artifact File** — The input artifact from the previous stage. Read it to understand what you are working on.
+4. **Task Address** — The plan address and task ID identifying your work. Read it with `sam_task(plan=..., task=..., config={"action": "read"})`; the response carries plan-level context and every task field. When the dispatch prompt also names an artifact produced by an earlier stage, retrieve it with `artifact_read(item_id=..., artifact_type=...)`. Both addresses are logical identifiers — never open them as filesystem paths.
 5. **Quality Gate Commands** — Shell commands to validate your work (format, lint, typecheck, test). Run ALL of them before declaring completion. Commands containing `{files}` use Python `str.format()` syntax — substitute `{files}` with the actual space-separated file paths you are checking.
 
 ## Execution Protocol
 
 1. Load all skills specified in inputs 2 and 3
-2. Read the task/artifact file (input 4)
+2. Read the task at the address in input 4
 3. Follow the stage workflow mermaid (input 1) step by step
 4. Apply domain knowledge from loaded skills at each step
 5. Run quality gate commands (input 5) before completing
 6. If any quality gate fails, fix the issues and re-run
-7. Write your output artifact to the path specified in the dispatch prompt
+7. Register your output through the operation named in the dispatch prompt — `artifact_register` with `content=` for a stage document, or `sam_task(config={"action": "update", "append_section": ..., "section_content": ...})` for task-scoped results
 
 ## Constraints
 
@@ -37,6 +37,6 @@ You receive 5 inputs in your dispatch prompt:
 - Domain skills provide the knowledge — you provide the execution
 - Quality gates are mandatory — never skip them
 - If a step is unclear, read the loaded skill documentation before proceeding
-- Write output artifacts as files, not conversation responses
+- Pass no data to a later stage through a file. Every input arrives from a read operation and every output leaves through a register or update operation. The `Write` tool is for source, tests, and documentation that land in the repository — nothing else
 
 When operating as a **teammate** (spawned via `TeamCreate`), send your completion status to the team lead via `SendMessage(to="team-lead", summary="[brief summary]", message="[your full completion status]")`.

--- a/plugins/development-harness/agents/integration-checker.md
+++ b/plugins/development-harness/agents/integration-checker.md
@@ -73,10 +73,10 @@ The orchestrator aggregates your findings. Use consistent format with categorize
 
 For each module in the feature, extract what it provides and what it should consume.
 
-**From task file, extract:**
+Read the plan record through the plan operations — task plans are SAM state, not registry content:
 
-```bash
-mcp__plugin_dh_backlog__artifact_read(item_id={issue_number}, artifact_type="task-plan")
+```text
+mcp__plugin_dh_sam__sam_plan(plan="{plan_address}", config={"action": "read"})
 ```
 
 > **Backend note**: When `BACKLOG_BACKEND=beads`, `issue_number` is a bead ID (string, e.g. `bd-a3f8`), not a GitHub issue number (integer). The MCP layer accepts both types transparently.

--- a/plugins/development-harness/agents/reviewer-accessibility.md
+++ b/plugins/development-harness/agents/reviewer-accessibility.md
@@ -139,7 +139,7 @@ mcp__plugin_dh_backlog__artifact_register(
   artifact_type="codebase-analysis",
   artifact_id="code-review-accessibility-{issue_number}",
   content={verdict_block_json},
-  status="complete",
+  status="current",
   agent="reviewer-accessibility"
 )
 ```

--- a/plugins/development-harness/agents/reviewer-performance.md
+++ b/plugins/development-harness/agents/reviewer-performance.md
@@ -132,7 +132,7 @@ mcp__plugin_dh_backlog__artifact_register(
   artifact_type="codebase-analysis",
   artifact_id="code-review-performance-{issue_number}",
   content={structured_verdict_json},
-  status="complete",
+  status="current",
   agent="reviewer-performance"
 )
 ```

--- a/plugins/development-harness/agents/reviewer-quality.md
+++ b/plugins/development-harness/agents/reviewer-quality.md
@@ -128,7 +128,7 @@ mcp__plugin_dh_backlog__artifact_register(
   artifact_type="codebase-analysis",
   artifact_id="code-review-quality-{issue_number}",
   content={verdict_block_json},
-  status="complete",
+  status="current",
   agent="reviewer-quality"
 )
 ```

--- a/plugins/development-harness/agents/swarm-task-planner.md
+++ b/plugins/development-harness/agents/swarm-task-planner.md
@@ -191,7 +191,7 @@ Before calling `sam_plan`, estimate the total number of tasks the plan will cont
 | < 16 tasks | Monolithic `create` — single call |
 | >= 16 tasks | Incremental append — three-step sequence |
 
-**Note**: For 16+ task plans, use the incremental path. The monolithic `create` call sends all task objects in a single MCP call; large task lists increase the risk of timeouts mid-call. The incremental path (create empty → append_task × N → finalize) sends one task per call and avoids this.
+**Note**: For 16+ task plans, use the incremental path. The monolithic `create` call sends all task objects in a single MCP call; large task lists increase the risk of timeouts mid-call. The incremental path (create empty → append_task × N → finalize) sends one task per call and avoids this. Keep every individual `sam_plan`/`sam_task` call under approximately 25,000 characters regardless of path — if a single task's content would exceed that on its own, patch its large fields after creation (see below) instead of inflating the `create`/`append_task` payload.
 
 #### Path A — Monolithic create (< 16 tasks)
 

--- a/plugins/development-harness/agents/t0-baseline-capture.md
+++ b/plugins/development-harness/agents/t0-baseline-capture.md
@@ -1,7 +1,7 @@
 ---
 name: t0-baseline-capture
 description: Captures baseline state of structured acceptance criteria before implementation begins. Reads acceptance-criteria-structured from the SAM plan via the plan read operation, runs each check-command via Bash, assembles T0 results as YAML in memory, and registers the artifact via artifact_register with content= for MCP-native storage. Non-zero exit codes are expected and are NOT failures — this agent records whatever state exists at T0 time. Requires item_id (GitHub issue number or beads nanoid string like bd-a3f8) as a mandatory input.
-tools: Read, Bash, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_migrate, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
+tools: Read, Bash, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
 model: haiku
 skills:
   - dh:subagent-contract
@@ -29,7 +29,8 @@ You are the T0 baseline capture agent. You run before any implementation tasks b
 ## Step 1: Read the Plan
 
 Your delegation prompt carries a plan address (`P{N}`, or the task address `P{N}/T{M}` whose
-plan component is `P{N}`). Read the plan through it:
+plan component is `P{N}`). Read the plan through it — it is a logical identifier, not a
+filesystem path, so never open it with a file read:
 
 ```bash
 mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action": "read"})
@@ -138,7 +139,7 @@ mcp__plugin_dh_backlog__artifact_register(
     artifact_type="T0-baseline",
     artifact_id="T0-baseline-{slug}",
     content={yaml_string},
-    status="complete",
+    status="current",
     agent="t0-baseline-capture"
 )
 ```

--- a/plugins/development-harness/agents/tn-verification-gate.md
+++ b/plugins/development-harness/agents/tn-verification-gate.md
@@ -1,7 +1,7 @@
 ---
 name: tn-verification-gate
 description: Verification gate that runs after all implementation tasks complete. Re-runs acceptance-criteria-structured check commands, compares results against T0 baseline, computes CriterionStatus per criterion, and registers a TN-verification artifact via MCP with a verdict of PASS or FAIL. FAIL blocks /complete-implementation if any criterion regressed.
-tools: Read, Bash, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_migrate, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
+tools: Read, Bash, Glob, Skill, SendMessage, mcp__plugin_dh_sam, mcp__plugin_dh_backlog__artifact_get, mcp__plugin_dh_backlog__artifact_list, mcp__plugin_dh_backlog__artifact_read, mcp__plugin_dh_backlog__artifact_register
 model: haiku
 skills:
   - dh:subagent-contract
@@ -30,11 +30,11 @@ You are the TN verification gate agent. You run after all implementation tasks a
 
 ## Step 1: Retrieve Both Inputs
 
-You need two inputs:
+You need two inputs, each from the operation that owns it:
 
-1. T0 baseline — an artifact registered by the T0 agent, retrieved by owner and type
-2. The plan's `acceptance-criteria-structured` — read from the plan itself, the same way the
-   T0 agent read it
+1. T0 baseline — an artifact registered by the T0 agent, retrieved through the artifact operations
+2. Plan record — SAM-owned state, retrieved through the plan operations to re-read
+   `acceptance-criteria-structured`, the same way the T0 agent read it
 
 Your delegation prompt carries `item_id` and a plan address (`P{N}`, or the task address
 `P{N}/T{M}` whose plan component is `P{N}`).
@@ -43,6 +43,9 @@ Your delegation prompt carries `item_id` and a plan address (`P{N}`, or the task
 mcp__plugin_dh_backlog__artifact_read(item_id={item_id}, artifact_type="T0-baseline")
 mcp__plugin_dh_sam__sam_plan(plan="P{N}", config={"action": "read"})
 ```
+
+Task plans are SAM records, never artifact-registry content. Do not attempt
+`artifact_read(item_id, "task-plan")` — nothing registers that type, and the call returns no content.
 
 Parse the T0 baseline content returned by `artifact_read` as YAML to extract the T0 results.
 
@@ -153,7 +156,7 @@ mcp__plugin_dh_backlog__artifact_register(
     artifact_type="TN-verification",
     artifact_id="TN-verification-{slug}",
     content={yaml_string},
-    status="complete",
+    status="current",
     agent="tn-verification-gate"
 )
 ```

--- a/plugins/development-harness/docs/poc-validation-guide.md
+++ b/plugins/development-harness/docs/poc-validation-guide.md
@@ -125,8 +125,11 @@ The five inputs are:
 1. **Stage workflow skill** — the dh skill that owns this stage's process steps
 2. **Cross-cutting stage skill** — optional dh skill applying SDLC-level guidance
 3. **Domain skills** — from `manifest.stage_skills[stage]`
-4. **Task/artifact file path** — the file the agent reads for task context
+4. **Task address** — the plan address and task ID the agent reads through the task operations
 5. **Quality gate commands** — from `manifest.quality_gates`
+
+No stage hands data to a later stage through a file. Inputs are addresses resolved by read
+operations; outputs are registered through the artifact operations.
 
 Run the following from the `plugins/development-harness/scripts/` directory:
 
@@ -143,10 +146,13 @@ manifest = load_manifest(
 prompt = build_dispatch_prompt(
     stage="planning-context-integration",
     manifest=manifest,
-    task_file=".planning/harness/plan-my-feature.md",
+    plan="P1-my-feature",
+    task="T1",
     stage_workflow_skill="dh:context-integration",
     cross_cutting_skill="dh:planning",
-    output_artifact_path=Path(".planning/harness/context-my-feature.md"),
+    item_id=1770,
+    artifact_type="architect",
+    artifact_id="context-my-feature",
 )
 print(prompt)
 EOF
@@ -169,8 +175,11 @@ This provides SDLC-stage-level guidance applicable across all languages.
 ## Input 3: Domain Skills
 - Load: `Skill(skill="python3-implementation")`
 
-## Input 4: Task/Artifact File
-Read this file for your task context: `.planning/harness/plan-my-feature.md`
+## Input 4: Task Address
+Read your task context through the task operations:
+`sam_task(plan="P1-my-feature", task="T1", config={"action": "read"})`
+Plan-level context and every task field arrive in that response. The address is a
+logical identifier — do not treat it as a filesystem path.
 
 ## Input 5: Quality Gates
 Run ALL of these before declaring completion:
@@ -185,41 +194,40 @@ use Python `str.format()` syntax. Substitute `{files}` with the actual
 space-separated file paths you are checking before running the command.
 
 ## Output Artifact
-Write your output artifact to: `.planning/harness/context-my-feature.md`
+Register your output through the artifact operations:
+`artifact_register(item_id=1770, artifact_type="architect", artifact_id="context-my-feature", content=<full document>)`
+Report only the artifact type and identifier. Do not write the document to a file.
 ```
 
 **What to verify:**
 
 - Input 3 lists `python3-implementation` — the domain skill mapped to
   `planning-context-integration` in the manifest
-- Input 5 lists all five quality gates
-- The output artifact path matches what you passed as `output_artifact_path`
+- Input 5 lists every quality gate configured in the manifest
+- The artifact registration call carries the `item_id`, `artifact_type`, and `artifact_id`
+  you passed, and no filesystem path appears anywhere in the prompt
 
 ---
 
 ## Expected Output
 
-The planning stage (S2/S3 in the SAM pipeline) produces a **PLAN artifact** or **CONTEXT
-artifact** written to `.planning/harness/` in the project root.
+The planning stage (S2/S3 in the SAM pipeline) produces a PLAN artifact or CONTEXT artifact,
+registered through the artifact operations. Nothing is written to the filesystem.
 
 Per [artifact-conventions.md](../skills/development-harness/references/artifact-conventions.md):
 
-- **S2 Planning artifact** — `plan-{feature-slug}.md`
+- S2 Planning artifact — `artifact_id="plan-{feature-slug}"`
   - Token: `ARTIFACT:PLAN({feature-slug})`
   - Contains: RT-ICA gap analysis, task graph with dependencies, task skeletons with
     acceptance criteria, quality gate schedule
 
-- **S3 Context Integration artifact** — `context-{feature-slug}.md`
+- S3 Context Integration artifact — `artifact_id="context-{feature-slug}"`
   - Token: `ARTIFACT:CONTEXT({feature-slug})`
   - Amends S2 — contains validation results, codebase discrepancies, plan amendments,
     confirmed integration points
 
-**Example paths for a feature slug `my-feature`:**
-
-```text
-.planning/harness/plan-my-feature.md
-.planning/harness/context-my-feature.md
-```
+Retrieve either with `artifact_read(item_id={item_id}, artifact_type={type})`. The identifiers
+above are logical, not filesystem paths.
 
 Each artifact includes a YAML frontmatter header linking it to predecessor and successor
 artifacts:

--- a/plugins/development-harness/scripts/dispatch_helper.py
+++ b/plugins/development-harness/scripts/dispatch_helper.py
@@ -4,9 +4,13 @@ The generic stage agent receives:
 1. Stage workflow skill (from dh)
 2. Cross-cutting SDLC stage skill (from dh)
 3. Domain skills (from resolved manifest stage_skills)
-4. Task/artifact file path
+4. Task address (plan address plus task ID, read through the task operations)
 5. Quality gate commands (from resolved manifest quality_gates)
-6. Output artifact path (where to write results)
+6. Output artifact target (registered through the artifact operations)
+
+No stage passes data to a later stage through a file. Inputs are read and outputs
+are registered through the backend operations, so the addresses below are logical
+identifiers, never filesystem paths.
 """
 
 from __future__ import annotations
@@ -15,8 +19,6 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from manifest_schema import LanguageManifest
 
 
@@ -62,29 +64,45 @@ def _format_skill_loads(skills: list[str]) -> str:
 def build_dispatch_prompt(
     stage: str,
     manifest: LanguageManifest,
-    task_file: str,
+    plan: str,
+    task: str,
     stage_workflow_skill: str,
     cross_cutting_skill: str | None,
-    output_artifact_path: Path | None = None,
+    item_id: int | str | None = None,
+    artifact_type: str | None = None,
+    artifact_id: str | None = None,
 ) -> str:
     """Build the dispatch prompt for a generic stage agent.
 
-    Assembles all 5 inputs (plus output path) into a structured prompt
-    that the generic stage agent can follow mechanically.
+    Assembles all 5 inputs (plus the output artifact target) into a structured
+    prompt that the generic stage agent can follow mechanically.
 
     Args:
         stage: The SDLC stage identifier (e.g., "implementation").
         manifest: The fully resolved language manifest.
-        task_file: Path to the task/artifact file.
+        plan: Plan address holding the task (e.g., "P123-my-feature").
+        task: Task ID within the plan (e.g., "T1").
         stage_workflow_skill: Skill name for the stage workflow (e.g., "development-harness:execution").
         cross_cutting_skill: Optional cross-cutting SDLC skill name.
-        output_artifact_path: Where the agent should write its output artifact.
-            If None, the agent writes output next to the task file.
+        item_id: Backlog item identifier the output artifact is registered against.
+        artifact_type: Artifact type string for the stage output.
+        artifact_id: Logical artifact identifier for the stage output.
 
     Returns:
         Formatted dispatch prompt string.
     """
     domain_skills = manifest.stage_skills.get(stage, [])
+    output_section = (
+        dedent(f"""\
+            Register your output through the artifact operations:
+            `artifact_register(item_id={item_id!r}, artifact_type="{artifact_type}", artifact_id="{artifact_id}", content=<full document>)`
+            Report only the artifact type and identifier. Do not write the document to a file.""")
+        if item_id is not None and artifact_type and artifact_id
+        else dedent("""\
+            Append your output to the task body:
+            `sam_task(plan=..., task=..., config={"action": "update", "append_section": <heading>, "section_content": <body>})`
+            Do not write the output to a file.""")
+    )
 
     cross_cutting_section = (
         dedent(f"""\
@@ -97,29 +115,34 @@ def build_dispatch_prompt(
             No cross-cutting skill for this stage.""")
     )
 
-    return dedent(f"""\
-        # Stage Dispatch: {stage}
-        **Language:** {manifest.language} | **Stack:** {manifest.stack or "base"} | **Manifest:** {manifest.name}
+    # Written flush-left: interpolated sections are already dedented, so an indented
+    # template plus dedent() would leave their continuation lines ragged.
+    return f"""\
+# Stage Dispatch: {stage}
+**Language:** {manifest.language} | **Stack:** {manifest.stack or "base"} | **Manifest:** {manifest.name}
 
-        ## Input 1: Stage Workflow
-        Load the stage workflow skill: `Skill(skill="{stage_workflow_skill}")`
-        Follow the workflow mermaid from this skill step by step.
+## Input 1: Stage Workflow
+Load the stage workflow skill: `Skill(skill="{stage_workflow_skill}")`
+Follow the workflow mermaid from this skill step by step.
 
-        {cross_cutting_section}
+{cross_cutting_section}
 
-        ## Input 3: Domain Skills
-        {_format_skill_loads(domain_skills)}
+## Input 3: Domain Skills
+{_format_skill_loads(domain_skills)}
 
-        ## Input 4: Task/Artifact File
-        Read this file for your task context: `{task_file}`
+## Input 4: Task Address
+Read your task context through the task operations:
+`sam_task(plan="{plan}", task="{task}", config={{"action": "read"}})`
+Plan-level context and every task field arrive in that response. The address is a
+logical identifier — do not treat it as a filesystem path.
 
-        ## Input 5: Quality Gates
-        Run ALL of these before declaring completion:
-        {_format_quality_gates(manifest)}
+## Input 5: Quality Gates
+Run ALL of these before declaring completion:
+{_format_quality_gates(manifest)}
 
-        **Note on `{{files}}` in quality gate commands**: Commands containing `{{files}}`
-        use Python `str.format()` syntax. Substitute `{{files}}` with the actual
-        space-separated file paths you are checking before running the command.
+**Note on `{{files}}` in quality gate commands**: Commands containing `{{files}}`
+use Python `str.format()` syntax. Substitute `{{files}}` with the actual
+space-separated file paths you are checking before running the command.
 
-        ## Output Artifact
-        Write your output artifact to: `{output_artifact_path or "next to the task file"}`""")
+## Output Artifact
+{output_section}"""

--- a/plugins/development-harness/skills/complete-implementation/SKILL.md
+++ b/plugins/development-harness/skills/complete-implementation/SKILL.md
@@ -432,7 +432,8 @@ mcp__plugin_dh_sam__sam_plan(
                  "body": "Audit documentation for drift in {slug} (work item {item_ref}). item_id={item_ref} (REQUIRED — register the audit-report artifact against it; block if absent). project_root is the repository root (your current working directory)."},
                 {"id": "T5", "title": "Documentation Update",     "agent": "service-docs-maintainer","dependencies": ["T4"],"priority": 1, "complexity": "low",
                  "body": "Update documentation to resolve the drift found in T4 for {slug} (work item {item_ref}). item_id={item_ref} (read the audit-report artifact registered against it). project_root is the repository root (your current working directory)."},
-                {"id": "T6", "title": "Context Refinement",       "agent": "context-refinement","dependencies": ["T5"],    "priority": 1, "complexity": "medium"}
+                {"id": "T6", "title": "Context Refinement",       "agent": "context-refinement","dependencies": ["T5"],    "priority": 1, "complexity": "medium",
+                 "body": "Refine context and audit plan artifacts for {slug} (work item {item_ref}). plan_address={plan_address} (REQUIRED — this is the original feature plan to analyze; the address used to dispatch this task is a separate quality-gate plan used only to claim and complete your own task). item_id={item_ref} (needed only to read and annotate the architect and feature-context artifacts — if empty, skip that part and report it as a gap)."}
             ]}
 )
 ```

--- a/plugins/development-harness/skills/complete-implementation/SKILL.md
+++ b/plugins/development-harness/skills/complete-implementation/SKILL.md
@@ -590,7 +590,7 @@ If the T6 (Context Refinement) sub-agent output contained a `DIVERGENCE_REQUIRIN
 
 ```text
 Plan artifacts have intent divergences requiring your review.
-See: [annotated artifact paths from agent output]
+See: [annotated artifact types and identifiers from agent output]
 Divergences:
   [list from DIVERGENCE_REQUIRING_REVIEW block]
 ```

--- a/plugins/development-harness/skills/complete-implementation/SKILL.md
+++ b/plugins/development-harness/skills/complete-implementation/SKILL.md
@@ -426,8 +426,10 @@ mcp__plugin_dh_sam__sam_plan(
             "tasks": [
                 {"id": "T0", "title": "Multi-Perspective Review", "agent": "task-worker",     "dependencies": [],           "priority": 1, "complexity": "high"},
                 {"id": "T1", "title": "Code Review",              "agent": "code-reviewer",   "dependencies": [],           "priority": 1, "complexity": "medium"},
-                {"id": "T2", "title": "Feature Verification",     "agent": "feature-verifier","dependencies": ["T1"],       "priority": 1, "complexity": "medium"},
-                {"id": "T3", "title": "Integration Check",        "agent": "integration-checker","dependencies": ["T2"],   "priority": 1, "complexity": "medium"},
+                {"id": "T2", "title": "Feature Verification",     "agent": "feature-verifier","dependencies": ["T1"],       "priority": 1, "complexity": "medium",
+                 "body": "Verify goal achievement for {slug} (work item {item_ref}). plan_address={plan_address} (REQUIRED — this is the original feature plan to read for goals, tasks, and artifacts; the address used to dispatch this task is a separate quality-gate plan used only to claim and complete your own task). item_id={item_ref} (needed to read the architect artifact)."},
+                {"id": "T3", "title": "Integration Check",        "agent": "integration-checker","dependencies": ["T2"],   "priority": 1, "complexity": "medium",
+                 "body": "Verify cross-module integration for {slug} (work item {item_ref}). plan_address={plan_address} (REQUIRED — this is the original feature plan to read for exports, imports, and data flows; the address used to dispatch this task is a separate quality-gate plan used only to claim and complete your own task). item_id={item_ref}."},
                 {"id": "T4", "title": "Documentation Drift Audit","agent": "doc-drift-auditor","dependencies": ["T3"],     "priority": 1, "complexity": "low",
                  "body": "Audit documentation for drift in {slug} (work item {item_ref}). item_id={item_ref} (REQUIRED — register the audit-report artifact against it; block if absent). project_root is the repository root (your current working directory)."},
                 {"id": "T5", "title": "Documentation Update",     "agent": "service-docs-maintainer","dependencies": ["T4"],"priority": 1, "complexity": "low",

--- a/plugins/development-harness/skills/complete-implementation/references/migration-fidelity-gate.md
+++ b/plugins/development-harness/skills/complete-implementation/references/migration-fidelity-gate.md
@@ -15,7 +15,7 @@ flowchart TD
     D2 --> D3["For each task in the plan, call<br>sam_task(plan='{plan_id}', task='{task_id}', config={action:'read'})<br>and check acceptance_criteria field<br>for: 'delete', 'remove source',<br>'after migration complete', 'drop the source'<br>Note: acceptance_criteria is a direct str field on Task model"]
     D3 --> Signal{"Any migration signal found<br>across issue title, body, or task criteria?"}
     Signal -->|"No signal found"| Skip(["Skip gate — proceed to Artifact Discovery"])
-    Signal -->|"Signal found — gate activates"| Fid1{"Evidence exists (file path or commit SHA)<br>that fidelity check ran on REAL production records<br>(not only synthetic fixtures) with zero data loss?"}
+    Signal -->|"Signal found — gate activates"| Fid1{"Evidence exists (verification summary or commit SHA)<br>that fidelity check ran on REAL production records<br>(not only synthetic fixtures) with zero data loss?"}
     Fid1 -->|"Confirmed"| Fid2
     Fid1 -->|"Unconfirmed"| CollectF1["Record: Fidelity check on real data — unconfirmed"]
     CollectF1 --> Fid2
@@ -32,7 +32,7 @@ flowchart TD
     Fid4 -->|"Unconfirmed"| CollectF4["Record: Deletion deferred or confirmed — unconfirmed"]
     CollectF4 --> AllConfirmed
     AllConfirmed -->|"No — all confirmed"| Proceed(["Proceed to Artifact Discovery"])
-    AllConfirmed -->|"Yes — unconfirmed items remain"| Blocked["COMPLETION BLOCKED — Migration Fidelity Gate<br>List each unconfirmed item<br>To unblock: run verify_migration_fidelity.py against real production data<br>OR provide a commit SHA showing completeness assertion ran on real files<br>Do NOT build QG plan, dispatch T1, or apply SAM state until resolved"]
+    AllConfirmed -->|"Yes — unconfirmed items remain"| Blocked["COMPLETION BLOCKED — Migration Fidelity Gate<br>List each unconfirmed item<br>To unblock: run verify_migration_fidelity.py against real production data<br>and read the verdict from its JSON summary, never from a report path<br>OR provide a commit SHA showing completeness assertion ran on real files<br>Do NOT build QG plan, dispatch T1, or apply SAM state until resolved"]
 ```
 
 ## On-Block Output
@@ -45,11 +45,14 @@ COMPLETION BLOCKED — Migration Fidelity Gate
 Unconfirmed items:
 - [list each unchecked item]
 
-To unblock: run `uv run plugins/development-harness/scripts/verify_migration_fidelity.py`
-against real production data and provide the path to the generated report in
-`.tmp/scratch/reports/`. A passing report (zero data loss, all sections preserved) confirms
-items 1 and 2. Alternatively, a commit SHA showing the completeness assertion was run on
+To unblock: run `uv run "${CLAUDE_PLUGIN_ROOT}/scripts/verify_migration_fidelity.py"` against real
+production data and report its JSON summary. A pass — `classification_counts.CONTENT_LOSS` of 0 and `errors` of 0, exit status 0 —
+confirms items 1 and 2. Alternatively, a commit SHA showing the completeness assertion was run on
 real files is accepted.
+
+Read the verdict from that summary. Do not accept a filesystem path to a report as the evidence,
+and do not open one: a path that resolves where the script ran does not resolve here, so the gate
+reads nothing and passes on an empty file.
 ```
 
 Do NOT build the QG plan, dispatch T1, or apply any SAM state until all items above are confirmed.

--- a/plugins/development-harness/skills/dispatch/SKILL.md
+++ b/plugins/development-harness/skills/dispatch/SKILL.md
@@ -92,7 +92,10 @@ When all workers return:
 3. Run verification (tests, linter) across the full changeset
 4. Relay synthesis findings to user or feed into next wave
 
-File pointer pattern: instruct workers to write findings to `.tmp/scratch/reports/` and return the path, or register artifacts via `artifact_register` and return the artifact type. Read reports, not inline summaries, to keep orchestrator context lean.
+Artifact pointer pattern: instruct workers to register findings via `artifact_register` with the
+full text as `content=`, and to return only the artifact type and identifier. Retrieve each with
+`artifact_read` when you need the detail. This keeps orchestrator context lean without any worker
+writing a file for another step to read.
 
 ### 6 — Clean Up
 

--- a/plugins/development-harness/skills/groom-milestone/SKILL.md
+++ b/plugins/development-harness/skills/groom-milestone/SKILL.md
@@ -27,7 +27,7 @@ All items in the milestone are groomed, dependency-analyzed, and conflict-groupe
 - A dependency graph (item-to-item) is produced with conflict groups identified
 - Any items recommended for splitting have been split (user-approved)
 - Any items recommended for addition have been added (user-approved)
-- Dispatch plan file written at `plan/milestone-{N}-dispatch.yaml`
+- Dispatch plan stored via `dispatch_create_plan(milestone_number={N}, ...)` and retrievable with `dispatch_read({N})`
 
 ## Workflow
 
@@ -105,7 +105,7 @@ The dispatch plan is persisted via the `dispatch_create_plan` MCP tool, which va
 - No items in milestone: report, suggest running `/group-items-to-milestone` first
 - Grooming agent fails for an item: log the error, continue grooming remaining items, report all failures at the end
 - Impact Radius missing after grooming: re-trigger groom for that item once; if still missing, flag as BLOCKED in the report
-- Wave ordering or dependency reference errors found during plan build: fix before writing the plan file and calling `dispatch_wave_start`
+- Wave ordering or dependency reference errors found during plan build: fix before calling `dispatch_create_plan` and `dispatch_wave_start`
 
 ## Backend Requirements
 

--- a/plugins/development-harness/skills/groom-milestone/references/dispatch-plan-schema.md
+++ b/plugins/development-harness/skills/groom-milestone/references/dispatch-plan-schema.md
@@ -159,10 +159,10 @@ Use the `dispatch_create_plan` MCP tool (on the backlog server) to create or upd
 
 **Parameters:**
 
-- `milestone_number` — GitHub milestone number; the tool writes to `plan/milestone-{N}-dispatch.yaml`
+- `milestone_number` — GitHub milestone number; the tool stores the plan under a provider-owned reference keyed by it. Retrieve it with `dispatch_read(milestone_number)`, never by opening a path
 - `plan` — typed DispatchPlan object containing the full dispatch plan (accepts both kebab-case and snake_case keys)
-- `overwrite` — Allow replacing an existing plan file; set to `True` when re-grooming (default: `False`)
-- `validate` — Run `validate_plan_integrity()` after writing and include results in response (default: `True`)
-- `issue` — Optional GitHub issue number; when provided, auto-registers the plan file as a `dispatch-plan` artifact
+- `overwrite` — Allow replacing an existing stored plan; set to `True` when re-grooming (default: `False`)
+- `validate` — Run `validate_plan_integrity()` after storing and include results in response (default: `True`)
+- `issue` — Optional GitHub issue number; when provided, auto-registers the plan as a `dispatch-plan` artifact
 
 **Response:** Returns `milestone_number`, `wave_count`, `item_count`, `is_valid`, `errors`, `warnings`, and `messages`. On error, the response contains an `error` key with a description.

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/work/plan.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/work/plan.md
@@ -54,7 +54,7 @@ flowchart TD
     Q2 -->|"Yes"| Found
     Q2 -->|"No — still not found"| Warn["Log warning: Plan not found for {title}<br>Skip backlog_update<br>Proceed to Step 4.4"]
     Found --> Update["CLI: backlog update<br>--selector={title} --plan=P{id}"]
-    Update --> RecordIssue["If item has Issue: #N,<br>record it in plan file header comment"]
+    Update --> RecordIssue["If item has Issue = #N,<br>set it on the plan record via sam_plan update"]
     RecordIssue --> Done([Step 4.3 complete])
     Warn --> Done
 ```
@@ -67,10 +67,11 @@ flowchart TD
 
 ### 4.3.2: Record Issue Number
 
-If the backlog item body contains `**Issue**: #N`, write a comment in the plan file header:
+If the backlog item body contains `**Issue**: #N`, record the association on the plan record
+itself. The plan is backend state, not a file — there is no header to comment on:
 
-```yaml
-# Issue: #N
+```text
+mcp__plugin_dh_sam__sam_plan(plan="P{id}", config={"action": "update", "set_fields_json": {"issue": N}})
 ```
 
 **Constraint:** Do NOT include `Fixes #N`, `Closes #N`, or `Resolves #N` in task-level commit messages. Issue closure is handled exclusively by `/dh:complete-implementation` in its final commit step.

--- a/plugins/development-harness/tests/test_dispatch_helper.py
+++ b/plugins/development-harness/tests/test_dispatch_helper.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from dispatch_helper import build_dispatch_prompt
 from manifest_schema import LanguageManifest, ProjectDetection, QualityGates
 
@@ -26,7 +24,8 @@ class TestBuildDispatchPrompt:
         prompt = build_dispatch_prompt(
             stage="implementation",
             manifest=manifest,
-            task_file="plan/tasks-1-auth/T1.md",
+            plan="P123-auth",
+            task="T1",
             stage_workflow_skill="development-harness:execution",
             cross_cutting_skill="development-harness:implementation",
         )
@@ -36,7 +35,7 @@ class TestBuildDispatchPrompt:
         assert "development-harness:implementation" in prompt
         assert "python3-implementation" in prompt
         assert "python3-implementation-cli" in prompt
-        assert "plan/tasks-1-auth/T1.md" in prompt
+        assert 'sam_task(plan="P123-auth", task="T1"' in prompt
         assert "uv run ruff format" in prompt
         assert "uv run ruff check" in prompt
         assert "uv run pytest" in prompt
@@ -53,7 +52,8 @@ class TestBuildDispatchPrompt:
         prompt = build_dispatch_prompt(
             stage="discovery",
             manifest=manifest,
-            task_file="plan/task.md",
+            plan="P123-auth",
+            task="T1",
             stage_workflow_skill="development-harness:discovery",
             cross_cutting_skill=None,
         )
@@ -76,14 +76,15 @@ class TestBuildDispatchPrompt:
         prompt = build_dispatch_prompt(
             stage="discovery",
             manifest=manifest,
-            task_file="plan/task.md",
+            plan="P123-auth",
+            task="T1",
             stage_workflow_skill="development-harness:discovery",
             cross_cutting_skill=None,
         )
-        assert "plan/task.md" in prompt
+        assert 'sam_task(plan="P123-auth", task="T1"' in prompt
 
-    def test_output_artifact_path_included(self) -> None:
-        """I5: Dispatch prompt should include the output artifact path."""
+    def test_output_artifact_target_included(self) -> None:
+        """I5: Dispatch prompt routes stage output through artifact_register, not a file path."""
         manifest = LanguageManifest(
             name="python3",
             language="python",
@@ -94,12 +95,18 @@ class TestBuildDispatchPrompt:
         prompt = build_dispatch_prompt(
             stage="implementation",
             manifest=manifest,
-            task_file="plan/task.md",
+            plan="P123-auth",
+            task="T1",
             stage_workflow_skill="development-harness:execution",
             cross_cutting_skill=None,
-            output_artifact_path=Path("plan/output/T1-result.md"),
+            item_id=1770,
+            artifact_type="architect",
+            artifact_id="architect-auth",
         )
-        assert "plan/output/T1-result.md" in prompt
+        assert "artifact_register(item_id=1770" in prompt
+        assert 'artifact_type="architect"' in prompt
+        assert 'artifact_id="architect-auth"' in prompt
+        assert ".md" not in prompt
 
     def test_files_template_variable_documented(self) -> None:
         """N5: Dispatch prompt should document {files} template variable contract."""
@@ -113,7 +120,8 @@ class TestBuildDispatchPrompt:
         prompt = build_dispatch_prompt(
             stage="implementation",
             manifest=manifest,
-            task_file="plan/task.md",
+            plan="P123-auth",
+            task="T1",
             stage_workflow_skill="development-harness:execution",
             cross_cutting_skill=None,
         )
@@ -133,7 +141,8 @@ class TestBuildDispatchPrompt:
         prompt = build_dispatch_prompt(
             stage="implementation",
             manifest=manifest,
-            task_file="plan/task.md",
+            plan="P123-auth",
+            task="T1",
             stage_workflow_skill="development-harness:execution",
             cross_cutting_skill="development-harness:implementation",
         )

--- a/plugins/development-harness/tests/test_proof_of_concept.py
+++ b/plugins/development-harness/tests/test_proof_of_concept.py
@@ -103,7 +103,8 @@ class TestProofOfConcept:
         prompt = build_dispatch_prompt(
             stage="implementation",
             manifest=manifest,
-            task_file="plan/tasks-1-my-cli/T1-add-cli-entrypoint.md",
+            plan="P1-my-cli",
+            task="T1",
             stage_workflow_skill="development-harness:execution",
             cross_cutting_skill="development-harness:implementation",
         )
@@ -119,8 +120,8 @@ class TestProofOfConcept:
         assert "python3-implementation" in prompt
         assert "python3-implementation-cli" in prompt
 
-        # Input 4: Task file
-        assert "plan/tasks-1-my-cli/T1-add-cli-entrypoint.md" in prompt
+        # Input 4: Task address, read through the task operations
+        assert 'sam_task(plan="P1-my-cli", task="T1"' in prompt
 
         # Input 5: Quality gates
         assert "uv run ruff format" in prompt
@@ -152,7 +153,8 @@ class TestProofOfConcept:
         prompt = build_dispatch_prompt(
             stage="implementation",
             manifest=manifest,
-            task_file="plan/task.md",
+            plan="P1-my-lib",
+            task="T1",
             stage_workflow_skill="development-harness:execution",
             cross_cutting_skill=None,
         )


### PR DESCRIPTION
Audit of `plugins/development-harness/` for the invariant: **a workflow step must not pass data to a later step through a file.** Reports, plans, tasks, artifacts, and handoffs go through the DH CLI or MCP operations into the configured backend.

The discriminator applied throughout is the **consumer**, not the location and not the tool: is a later step, agent, or gate instructed to READ this file? If yes it is an inter-step handoff, even at a scratch path. If no it is a scratch/working file, even when written with the same call.

## Inventory — INTER-STEP HANDOFF (violations, all fixed)

| File | What it said | Correct operation |
|---|---|---|
| `scripts/dispatch_helper.py` | `build_dispatch_prompt(task_file=..., output_artifact_path=...)` emitted "Read this file for your task context: `{path}`" and "Write your output artifact to: `{path}`" | `sam_task(plan=, task=, config={"action":"read"})` for input; `artifact_register(content=)` for output |
| `agents/generic-stage-agent.md` | Input 4 "Task/Artifact File — the input artifact from the previous stage. Read it"; step 7 "Write your output artifact to the path specified"; constraint "Write output artifacts as files" | Same pair — consumer of the prompt above, corrected with it |
| `docs/poc-validation-guide.md` | Documented the same file-based dispatch, incl. `.planning/harness/plan-my-feature.md` → `context-my-feature.md` chain | Rewritten to the address/artifact form; expected-output block regenerated from actual verified output |
| `agents/t0-baseline-capture.md` | "Read the plan file passed to you … `Read(file_path="{plan_file_path}")`" | `sam_plan(plan=, config={"action":"read"})` |
| `agents/tn-verification-gate.md` | "Plan file: retrieved via `artifact_read(item_id, "task-plan")`" | `sam_plan(action="read")` — nothing registers `task-plan`; the call returned no content |
| `agents/feature-verifier.md` | `artifact_read(item_id, artifact_type="task-plan")` | `sam_plan(action="read")` |
| `agents/integration-checker.md` | "From task file, extract: `artifact_read(… "task-plan")`" | `sam_plan(action="read")` |
| `agents/context-refinement.md` | Step 1 "READ the linked architecture spec (path in the `architecture` field)"; Step 5 "Read the feature-context file path from the task file header", "Read the architecture spec file path"; Step 6 "Read all task files for the feature"; Step 8 "append … to the feature-context file and architect spec file" | `artifact_read` / `artifact_list` for documents; `sam_plan(action="read")` for tasks; read-append-re-register under the same `artifact_id` for annotation |
| `skills/dispatch/SKILL.md` | "File pointer pattern: instruct workers to write findings to `.tmp/scratch/reports/` and return the path … Read reports" | `artifact_register(content=)` + `artifact_read` — the orchestrator is instructed to read these, so the scratch path does not make it a working file |
| `agents/swarm-task-planner.md` | §4.2 Task Prompt Export Mode — "export per-task worker prompts … one file per task: `TASK/<task-id>-<slug>.md`" for worker agents to read | Task record fields (`context-notes`, `objective`, `requirements`, `constraints`, `expected-outputs`, `acceptance-criteria`, `verification-steps`, `handoff`) read via `sam_task(action="read")` |
| `skills/work-backlog-item/references/workflows/work/plan.md` | Step 4.3.2 "write a comment in the plan file header: `# Issue: #N`" | `sam_plan(config={"action":"update","set_fields_json":{"issue": N}})` |
| `agents/backlog-item-groomer.md` | Description: "outputs groomed item template for writing into `.claude/backlog/{priority}-{slug}.md`" | `backlog_groom` (already used in the body; the description leaked the cache path) |

### Invented parameter shapes found while fixing the above

Every call written was checked against `sam_schema/core/action_models.py` and `backlog_core/server.py`. Four pre-existing classes of invalid call were found and corrected:

| Problem | Where | Effect |
|---|---|---|
| `sam_plan(action="update", section=, content=, plan_slug=)` | `context-refinement`, `feature-researcher`, `codebase-analyzer`, `ecosystem-researcher` | `UpdatePlanConfig` has `append_section_name`/`section_content`/`task_id` and no `section`/`content`/`plan_slug`. Pydantic's default `extra="ignore"` drops them — the call succeeds and writes nothing. Silent data loss. |
| `status="complete"` on `artifact_register` | 8 agents | `ArtifactStatus` is `draft\|current\|superseded\|archived`; `ArtifactStatus("complete")` raises `ValueError`, returning `{"error": "Invalid parameter: …"}`. Every such registration failed. Changed to `"current"`. |
| `mcp__plugin_dh_backlog__artifact_migrate` in `tools:` frontmatter | 8 agents | No such tool exists (`tests_backlog/test_high_level_storage_boundaries.py` asserts its absence). |
| `backlog_update(groomed_content=…)` | `backlog-item-groomer` | No such parameter on `backlog_update`. |

Three research agents (`feature-researcher`, `codebase-analyzer`, `ecosystem-researcher`) additionally used `sam_plan` create+update to store *documents*, which `artifact-conventions.md` explicitly forbids ("Task plans are SAM-owned records… never register or read task-plan content with `artifact_register`" — and the converse: documents are not plans). Since each already called `artifact_register(content=)` in a later step, the plan dance was both broken and redundant; it is removed.

Two agents that no longer write anything to the repo had `Write`/`Edit` dropped from their `tools:` list, making the constraint observable rather than advisory: `context-refinement`, `codebase-analyzer`, `backlog-item-groomer`.

## Inventory — SCRATCH / WORKING FILE (not violations, left alone)

| File | What it says | Why it passes |
|---|---|---|
| `agents/swarm-task-planner.md` §4 | `PLAN.md` / `PLAN/` progressive disclosure | The file itself states validators and downstream agents read the SAM plan ID, "never from the filesystem"; disk output is a human-readable summary no step reads. Wording tightened to say so explicitly. |
| `skills/complete-implementation/references/migration-fidelity-gate.md` | "provide the path to the generated report in `.tmp/scratch/reports/`" | Report produced by a script for a human to cite when unblocking a gate; a commit SHA is an accepted alternative. Human-in-the-loop, not a step-to-step handoff. |
| `agents/impact-analyst.md`, `service-docs-maintainer.md`, `fact-checker.md` | "Write to it directly with the Write tool" under `.claude/agent-memory/` | Platform-provided per-agent memory. No later step reads it. |
| `skills/multi-perspective-review/references/acceptance-test-guide.md` | `.tmp/test-fixtures/*.diff` | Test fixtures applied with `git apply` by the same procedure. |
| `docs/graph-schema.md`, `docs/plans/prd-workflow-extractor.md` | `.tmp/fragments/`, `.tmp/extraction-misses/` | Ephemeral extraction-tooling output, explicitly "not committed". |

## Inventory — BACKEND INTERNAL (left, prose corrected where it read as an agent instruction)

| File | What it said | Action |
|---|---|---|
| `skills/groom-milestone/references/dispatch-plan-schema.md` | "the tool writes to `plan/milestone-{N}-dispatch.yaml`" | `_dispatch_reference()` builds a `ContentRef(kind=DISPATCH_PLAN, …)` — provider-owned, not a repo path. Reworded to name `dispatch_read(milestone_number)` as the retrieval route. |
| `skills/groom-milestone/SKILL.md` | "Dispatch plan file written at `plan/milestone-{N}-dispatch.yaml`" | Same; reworded. |
| `skills/implementation-manager/SKILL.md` | `~/.dh/projects/{slug}/context/active-task-{session_id}.json` | Written and read by the hooks themselves, not by an agent. Left as-is. |
| `skills/backlog/references/item-schema.md`, `README.md` | `~/.dh/projects/{slug}/backlog/{priority}-{slug}.md` | Documents the backend's own storage layout. Left as-is. |

## COMMITTED DELIVERABLE (left)

`skills/setup-skill-discovery/SKILL.md` writing `.dh/skill_discovery.yaml` — a project config file the wizard produces for the repo, not a step output. `agents/dh-context-gathering.md` reading `.planning/codebase/*.md` and `STATE.md`/`ROADMAP.md` — inputs from *external* frameworks (GSD/BMAD) under an explicit interoperability section, not DH step outputs. `skills/interop/SKILL.md` taking a Superpowers plan file path as `$ARGUMENTS` — same, an external artifact entering the pipeline.

## AMBIGUOUS

| Entry | What would decide it |
|---|---|
| `agents/workflow-extractor-reducer.md` — `fragment_output_path`, `miss_log_path`; a later pipeline stage (`scripts/merge_layer.py`) reads the fragment JSON | Whether the graph-extraction pipeline counts as a DH workflow. Its consumer is a Python ETL script whose input contract *is* a filesystem path, orchestrated by `dh-extract-file.js`, and it has no backlog item to register an artifact against — `artifact_register` requires `item_id`. **Left unfixed and reported as a gap**: this is a genuine handoff with no operation that can carry it, and inventing one would break the pipeline. |
| `artifact_id` style — `add-new-feature` uses path-shaped ids (`plan/feature-context-{slug}.md`), `create-artifact` recommends logical ids (`feature-context-{slug}`) | Both are sanctioned by `artifact_register`'s own docstring. Not a data-flow violation (content still travels through the operation), so left alone. Would need a product decision to unify. |

## Could not fix

One: the `workflow-extractor-reducer` fragment/miss-log handoff above. The artifact operations key on a backlog `item_id`; the extraction pipeline is repo-maintenance tooling with no owning item, and its consumer is a script, not an agent. Reported rather than papered over with a plausible-looking call.

## Is the violation confined to pre-contract content?

**Confined to pre-contract content — no new violations are being introduced.** Basis:

- The correct pattern is already stated canonically and correctly in `skills/development-harness/references/artifact-conventions.md` ("These artifacts are the only communication channel between stages… No stage reads or writes filesystem paths directly") and in `skills/create-artifact/SKILL.md`.
- The most recently reworked content is already compliant: `skills/add-new-feature/SKILL.md` uses `artifact_register(content=)`/`artifact_read` throughout; `agents/plan-validator.md` carries an explicit correction ("Do NOT attempt to read the file at the literal path — it is not repo-relative"); `agents/dh-context-gathering.md` and `agents/tn-verification-gate.md` already forbid `Write`/`Edit` on task state and `~/.dh/` paths.
- Every violation found sits in content that shows the *older* mechanic, and several are half-migrated — the `sam_plan(section=, content=)` calls are visibly an attempted migration off file writes that used a parameter shape the model does not have. That is the signature of a completed-but-unverified migration pass, not of ongoing authoring against the old pattern.

The one caveat: the half-migrated calls fail silently (`extra="ignore"` drops unknown keys; the invalid `status` returns an error dict rather than raising). Nothing in the test suite or the runtime surfaces an agent instructed with a wrong parameter shape, so a future migration can repeat the same class of error undetected.

## Verification

- `uv run pytest plugins/development-harness/tests/` — 2861 passed, 39 skipped, 5 xfailed
- `uv run prek run --files <28 changed files>` — all hooks pass (ruff, ty, markdownlint, skilllint, manifest sync)
- `build_dispatch_prompt` output regenerated and inspected; the docs' expected-output block is copied from the verified run, not written from memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Part of #3151. Routes twelve inter-step handoffs through backend operations; the file-based language those handoffs used is corrected separately in #3137, #3156, #3159, and #3161.
