### PR TITLE
docs(development-harness): defer the dispatch target to dh:dispatch-contract

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/development-harness/references/role-resolution-protocol.md
+++ b/plugins/development-harness/skills/development-harness/references/role-resolution-protocol.md
@@ -99,7 +99,7 @@ Parse the manifest's Role Fulfillment section and map each abstract role to a co
 
 **Dispatch routing rule:**
 
-Regardless of what role resolves to, the orchestrator always dispatches `subagent_type="dh:task-worker"`. The resolved agent name is recorded in the task's `agent:` field. `task-worker` reads this field via SAM MCP and calls `profile_load(agent_name=...)` to load specialist behavior internally. The orchestrator passes only the task reference; specialist behavior is selected by the worker's internal profile loading.
+Record the resolved agent name in the task's `agent:` field, then choose the dispatch target with the decision in `dh:dispatch-contract`. The orchestrator passes only the task reference.
 
 **Agent reference format in manifests:**
 


### PR DESCRIPTION
Part of #3113

## What

`role-resolution-protocol.md` carried a universal under `**Dispatch routing rule:**`: regardless of
what a role resolves to, the orchestrator always dispatches `subagent_type="dh:task-worker"`.

Replaced with: record the resolved agent name in the task's `agent:` field, then choose the dispatch
target with the decision in `dh:dispatch-contract`.

## Why the universal is the wrong half

Verified against source on `main`, not taken from the audit report:

- `main` contradicts its own universal in four places — `skills/forensic-review/SKILL.md` dispatches
  `dh:code-reviewer`, `skills/implement-feature/SKILL.md` dispatches `dh:contract-verification`,
  `skills/groom-backlog-item/references/groomer-agent.md` and
  `work-backlog-item/references/workflows/groom/swarm.md` dispatch `dh:backlog-item-groomer`,
  `skills/backlog-tools-administrator/SKILL.md` dispatches
  `python3-development:python-cli-architect` and `plugin-creator:ai-doc-optimizer`. Direct specialist
  dispatch predates the dispatch-contract skill.
- Scoping the rule by originating plugin would be wrong. `plugins/python3-development/skills/python3-development/references/language-manifest.md`
  declares `- code-reviewer: @dh:code-reviewer`, and `language-manifest-schema.md` validates
  `@plugin:agent` syntax only — never that the plugin differs from `dh`. A project-local
  `.claude/language-manifest.md` override can name any installed agent. The discriminator is the
  resolved agent's declared capability, which is what `dh:dispatch-contract` already decides.

The adjacent `**Resolution rules:**` block is untouched. It maps abstract roles to agent names, a
different operation, and it remains correct.

## Ordering dependency

`dh:dispatch-contract` does not exist on `main` yet — it ships in #3134, which already carries this
exact one-line replacement. Merge #3134 first, or merge this and accept the pointer resolving only
once #3134 lands. If #3134 merges first this PR becomes a no-op and can be closed.

## Out of scope, found while verifying

`skills/add-new-feature/SKILL.md` states "Phase 3 always dispatches `subagent_type=\"dh:task-worker\"`".
That is a phase-specific decision rather than the universal fixed here, and #3134 does not touch that
file either. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)