### PR TITLE
fix(development-harness): reject invalid MCP call shapes instead of accepting them silently

### DIFF
--- a/plugins/agentskill-kaizen/.claude-plugin/plugin.json
+++ b/plugins/agentskill-kaizen/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentskill-kaizen",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "description": "Analyze Claude Code agent session transcripts to identify inefficiencies, anti-patterns, repeated mistakes, and missing tooling opportunities for continuous improvement",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/agentskill-kaizen/.codex-plugin/plugin.json
+++ b/plugins/agentskill-kaizen/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentskill-kaizen",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "description": "Analyze Claude Code agent session transcripts to identify inefficiencies, anti-patterns, repeated mistakes, and missing tooling opportunities for continuous improvement",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/agentskill-kaizen/skills/transcript-analysis/references/session-log-schema.md
+++ b/plugins/agentskill-kaizen/skills/transcript-analysis/references/session-log-schema.md
@@ -356,7 +356,7 @@ Appears in **assistant** records. Records a tool call made by the model.
 }
 ```
 
-`name` is the tool name — e.g., `Bash`, `Read`, `mcp__plugin_dh_sam__sam_ready`.
+`name` is the tool name — e.g., `Bash`, `Read`, `mcp__plugin_dh_sam__sam_plan`.
 
 ### `tool_result`
 

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -3318,15 +3318,7 @@ async def artifact_register(
             description="Backlog item identifier — GitHub issue number (int) or beads nanoid string (e.g. 'bd-a3f8')"
         ),
     ],
-    artifact_type: Annotated[
-        str,
-        Field(
-            description=(
-                "Artifact type: feature-context, architect, task-plan, T0-baseline, TN-verification, "
-                "codebase-analysis, research"
-            )
-        ),
-    ],
+    artifact_type: Annotated[ArtifactType, Field(description="Artifact type registered against the work item")],
     artifact_id: Annotated[
         str,
         Field(
@@ -3344,7 +3336,7 @@ async def artifact_register(
             description="Artifact body written through the selected content provider before its manifest registration.",
         ),
     ],
-    status: Annotated[str, Field(description="Lifecycle status: draft, current, superseded, archived")] = "current",
+    status: Annotated[ArtifactStatus, Field(description="Lifecycle status of the artifact")] = ArtifactStatus.CURRENT,
     agent: Annotated[str, Field(description="Name of the producing agent")] = "",
 ) -> dict:
     """Upsert an artifact entry in provider-owned logical content.
@@ -3358,20 +3350,18 @@ async def artifact_register(
 
     Returns:
         Dict with registered (bool), artifact_count (int), action (str),
-        content_stored (bool), and output messages/warnings. On error, dict
-        contains an error key.
+        content_stored (bool), and output messages/warnings.
+
+    Raises:
+        BacklogError: The selected backend could not store the artifact or its manifest.
     """
     out = Output()
     try:
-        if not content:
-            return {"error": "Artifact content must not be empty.", **out.to_dict()}
         provider = _get_artifact_provider()
-        artifact_type_enum = ArtifactType(artifact_type)
-        status_enum = ArtifactStatus(status)
         entry = ArtifactEntry(
-            artifact_type=artifact_type_enum,
+            artifact_type=artifact_type,
             artifact_id=artifact_id,
-            status=status_enum,
+            status=status,
             created_at=_datetime.now(UTC).isoformat(),
             agent=agent,
         )
@@ -3388,8 +3378,6 @@ async def artifact_register(
 
         result = await asyncio.to_thread(_run)
         return {**result.model_dump(), **out.to_dict()}
-    except (ValueError, KeyError) as e:
-        return {"error": f"Invalid parameter: {e}", **out.to_dict()}
     except BacklogError as e:
         return {"error": str(e), **out.to_dict()}
 
@@ -3415,7 +3403,11 @@ async def artifact_list(
 
     Returns:
         Dict with artifacts (list of dicts), count (int), and output
-        messages/warnings. On error, dict contains an error key.
+        messages/warnings.
+
+    Raises:
+        ValueError: ``artifact_type`` is not an ``ArtifactType`` member.
+        BacklogError: The selected backend could not resolve the manifest.
     """
     out = Output()
     try:
@@ -3432,8 +3424,6 @@ async def artifact_list(
 
         artifacts = await asyncio.to_thread(_run)
         return {"artifacts": artifacts, "count": len(artifacts), **out.to_dict()}
-    except (ValueError, KeyError) as e:
-        return {"error": f"Invalid parameter: {e}", **out.to_dict()}
     except BacklogError as e:
         return {"error": str(e), **out.to_dict()}
 
@@ -3459,7 +3449,12 @@ async def artifact_get(
 
     Returns:
         Dict with artifacts (list of dicts), count (int), and output
-        messages/warnings. Returns error key when type is not found.
+        messages/warnings. Returns error key when type is not found — an absent
+        artifact is data, not a failed call.
+
+    Raises:
+        ValueError: ``artifact_type`` is not an ``ArtifactType`` member.
+        BacklogError: The selected backend could not resolve the manifest.
     """
     out = Output()
     try:
@@ -3475,8 +3470,6 @@ async def artifact_get(
         if not artifacts:
             return {"error": f"No artifacts of type '{artifact_type}' found for item #{item_id}", **out.to_dict()}
         return {"artifacts": artifacts, "count": len(artifacts), **out.to_dict()}
-    except (ValueError, KeyError) as e:
-        return {"error": f"Invalid parameter: {e}", **out.to_dict()}
     except BacklogError as e:
         return {"error": str(e), **out.to_dict()}
 
@@ -3494,16 +3487,35 @@ async def artifact_read(
         ),
     ],
     artifact_type: Annotated[str, Field(description="Artifact type whose content to read")],
+    artifact_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Logical identifier of the specific artifact to read. Omit to read the most "
+                "recently registered artifact of this type."
+            )
+        ),
+    ] = None,
 ) -> dict:
     """Read provider-owned logical content for a registered artifact.
 
     The selected ContentProvider resolves the artifact by owner, type, and
     logical identifier. This layer does not access local artifact files.
 
+    Omitting ``artifact_id`` returns the most recently registered entry of the type.
+    Supplying it addresses one specific entry, matching
+    ``dh_core.operations.artifact_read`` and the ``artifact read --artifact-id`` CLI
+    option, so both surfaces can address an artifact the same way.
+
     Returns:
         Dict with type (str), path (str), content (str), status (str), and
         output messages/warnings. Returns error key on type-not-found or when
-        the selected provider has no matching content.
+        the selected provider has no matching content — an absent artifact is
+        data, not a failed call.
+
+    Raises:
+        ValueError: ``artifact_type`` is not an ``ArtifactType`` member.
+        BacklogError: The selected backend could not resolve the manifest.
     """
     out = Output()
     try:
@@ -3514,6 +3526,11 @@ async def artifact_read(
             manifest = _load_manifest(provider, item_id)
             entries = _artifact_registry.get_by_type(manifest, type_enum)
             _require_artifact_entries(entries, f"No artifacts of type '{artifact_type}' found for item #{item_id}")
+            if artifact_id is not None:
+                entries = [entry for entry in entries if entry.artifact_id == artifact_id]
+                _require_artifact_entries(
+                    entries, f"No artifact with id '{artifact_id}' of type '{artifact_type}' found for item #{item_id}"
+                )
             # Sort by created_at desc so the most recently registered entry comes first.
             # Entries without a timestamp sort last (empty string is smallest; stable sort
             # preserves insertion order among multiple undated entries).
@@ -3533,8 +3550,6 @@ async def artifact_read(
 
         result = await asyncio.to_thread(_run)
         return {**result.model_dump(mode="json"), **out.to_dict()}
-    except (ValueError, KeyError) as e:
-        return {"error": f"Invalid parameter: {e}", **out.to_dict()}
     except BacklogError as e:
         return {"error": str(e), **out.to_dict()}
 

--- a/plugins/development-harness/docs/TASK_FILE_FORMAT.md
+++ b/plugins/development-harness/docs/TASK_FILE_FORMAT.md
@@ -121,20 +121,22 @@ mcp__plugin_dh_sam__sam_active_task(config={"action":"clear"})
 
 #### Deprecated Tools (migration reference only)
 
-The following 8 tools are replaced by the 3-tool interface above. They return a
-`ToolError` when called and must not appear in new agent code or skill files.
+The tools named below are replaced by the 3-tool interface above. They return a
+`ToolError` when called and must not appear in new agent code or skill files. The deprecated
+column names them without call syntax deliberately — writing a removed name in call form is the
+instruction shape this table exists to retire.
 
 | Deprecated tool | Replaced by |
 |---|---|
-| `sam_read(plan, task)` | `sam_task(plan, task, config={"action":"read"})` |
-| `sam_claim(plan, task)` | `sam_task(plan, task, config={"action":"claim"})` |
-| `sam_state(plan, task, status)` | `sam_task(plan, task, config={"action":"state","status":...})` |
-| `sam_update(plan, context)` | `sam_plan(plan, config={"action":"update","context":...})` |
-| `sam_update(plan, task, ...)` | `sam_task(plan, task, config={"action":"update",...})` |
-| `sam_ready(plan)` | `sam_plan(plan, config={"action":"ready"})` |
-| `sam_status(plan)` | `sam_plan(plan, config={"action":"status"})` |
-| `sam_list(...)` | `sam_plan(config={"action":"list",...})` |
-| `sam_create(...)` | `sam_plan(config={"action":"create",...})` |
+| `sam_read` | `sam_task(plan, task, config={"action":"read"})` |
+| `sam_claim` | `sam_task(plan, task, config={"action":"claim"})` |
+| `sam_state` | `sam_task(plan, task, config={"action":"state","status":...})` |
+| `sam_update`, plan-level | `sam_plan(plan, config={"action":"update","context":...})` |
+| `sam_update`, task-level | `sam_task(plan, task, config={"action":"update",...})` |
+| `sam_ready` | `sam_plan(plan, config={"action":"ready"})` |
+| `sam_status` | `sam_plan(plan, config={"action":"status"})` |
+| `sam_list` | `sam_plan(config={"action":"list",...})` |
+| `sam_create` | `sam_plan(config={"action":"create",...})` |
 
 ### DH CLI Adapter
 

--- a/plugins/development-harness/sam_schema/core/action_models.py
+++ b/plugins/development-harness/sam_schema/core/action_models.py
@@ -31,9 +31,17 @@ class _ActionConfigBase(BaseModel):
 
     Sets ``populate_by_name=True`` once so every subclass inherits it without
     repeating the ``model_config = ConfigDict(populate_by_name=True)`` line.
+
+    ``extra="forbid"`` closes every config branch. The enclosing tool schema already
+    emits ``additionalProperties: false`` at its top level, but each branch published
+    nothing, so a parameter that does not exist on the selected action was dropped and
+    the call reported success having written nothing — the mechanism behind the invented
+    ``plan_slug``/``section``/``content`` plan update (#3162). Forbidding extras rejects
+    such a call and, just as importantly, advertises the closed key set in the schema the
+    calling agent reads before composing the call.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
 __all__ = [

--- a/plugins/development-harness/sam_schema/tests/test_action_models.py
+++ b/plugins/development-harness/sam_schema/tests/test_action_models.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-import pytest
-from pydantic import ValidationError
+import inspect
 
-from sam_schema.core.action_models import CreatePlanConfig, TaskDefinition
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from sam_schema.cli_inputs import CreatePlanInput
+from sam_schema.core import action_models
+from sam_schema.core.action_models import CreatePlanConfig, TaskDefinition, UpdatePlanConfig
 
 
 def test_create_plan_schema_describes_provider_neutral_identity() -> None:
@@ -65,3 +69,66 @@ def test_task_definition_rejects_id_not_matching_task_id_pattern() -> None:
     """An ID outside TASK_ID_PATTERN is still rejected after widening to the canonical pattern."""
     with pytest.raises(ValidationError, match="id"):
         TaskDefinition.model_validate({"id": "invalid-id", "title": "Implement"})
+
+
+# ---------------------------------------------------------------------------
+# Closed-object contract on every action config (#3162)
+# ---------------------------------------------------------------------------
+
+
+def _action_config_models() -> list[type[BaseModel]]:
+    """Return every concrete action-config model exposed on the SAM tool surface."""
+    base = action_models._ActionConfigBase
+    return [
+        member
+        for _, member in inspect.getmembers(action_models, inspect.isclass)
+        if issubclass(member, base) and member is not base
+    ]
+
+
+def test_plan_update_config_rejects_parameters_that_do_not_exist() -> None:
+    """A plan-level section append was instructed for months and silently wrote nothing.
+
+    ``plan_slug``, ``section`` and ``content`` are not ``UpdatePlanConfig`` fields. While
+    the config accepted unknown keys the call returned success having applied no patch,
+    so the agent's output was lost with no signal at the call site (#3162).
+    """
+    with pytest.raises(ValidationError, match="plan_slug"):
+        UpdatePlanConfig.model_validate({
+            "action": "update",
+            "plan_slug": "auth-system",
+            "section": "Findings",
+            "content": "Research output",
+        })
+
+
+@pytest.mark.parametrize("model", _action_config_models(), ids=lambda m: m.__name__)
+def test_action_config_schema_advertises_a_closed_object(model: type[BaseModel]) -> None:
+    """Each config branch must publish ``additionalProperties: false``.
+
+    The enclosing tool schema already closes its top level, but a calling agent reads the
+    branch schema to learn which keys exist. A branch that advertises nothing invites the
+    invented parameter and then discards it.
+    """
+    assert model.model_json_schema().get("additionalProperties") is False, (
+        f"{model.__name__} does not advertise a closed object, so an unknown key on this "
+        "action is neither rejected nor visible as invalid in the published schema."
+    )
+
+
+def test_cli_create_plan_passes_no_keys_the_config_forbids() -> None:
+    """``plan create`` re-validates its own dump, so a stray key would break the CLI.
+
+    ``sam_plan.create`` builds the action config from ``CreatePlanInput.to_config()``'s
+    dump plus ``owner_reference``. Closing the model turns any key outside the field set
+    into a hard CLI failure, so the round trip is asserted directly.
+    """
+    config = CreatePlanInput(slug="auth-system", goal="Ship auth", tasks=[], context=None, issue=None).to_config()
+
+    payload = {**config.model_dump(), "owner_reference": None}
+
+    assert set(payload) <= set(CreatePlanConfig.model_fields), (
+        "plan create would pass keys the closed config rejects: "
+        f"{sorted(set(payload) - set(CreatePlanConfig.model_fields))}"
+    )
+    assert CreatePlanConfig.model_validate(payload).slug == "auth-system"

--- a/plugins/development-harness/skills/complete-implementation/references/final-handoff.md
+++ b/plugins/development-harness/skills/complete-implementation/references/final-handoff.md
@@ -53,7 +53,7 @@ flowchart TD
     Fetch["backlog_list(title='{slug}')<br>Slug-filtered search — mandatory, not substitutable"] --> ItemFound{"First result returned<br>(item found)?"}
     ItemFound -->|"No — zero results"| NothingQueued["Clear context and run:<br>/dh:work-backlog-item — nothing queued —"]
     ItemFound -->|"Yes"| PlanSet{"item.plan set and non-empty?<br>(boolean check only)"}
-    PlanSet -->|"Yes — plan is set"| ResolvePlan["sam_list(search='{slug}')<br>Use returned plan address (full stem)<br>Do NOT pass item.plan directly to SAM"]
+    PlanSet -->|"Yes — plan is set"| ResolvePlan["sam_plan(config={'action':'list','search':'{slug}'})<br>Use returned plan address (full stem)<br>Do NOT pass item.plan directly to SAM"]
     PlanSet -->|"No — plan not set"| WorkItem["Clear context and run:<br>/dh:work-backlog-item {item.title}"]
     ResolvePlan --> ImplementFeature["Clear context and run:<br>/dh:implement-feature {plan_address}"]
     ImplementFeature --> Done([Handoff complete])

--- a/plugins/development-harness/skills/execution/SKILL.md
+++ b/plugins/development-harness/skills/execution/SKILL.md
@@ -107,10 +107,10 @@ collecting results.
 Execution results stored via SAM:
 
 ```text
-sam_plan(
-    address="{plan_address}/T{NNN}",
-    append_section="Execution Results",
-    section_content="{execution markdown below}"
+sam_task(
+    plan="{plan_address}",
+    task="T{NNN}",
+    config={"action": "update", "append_section": "Execution Results", "section_content": "{execution markdown below}"}
 )
 ```
 

--- a/plugins/development-harness/tests/fixtures/mcp_call_shape_known_defects.json
+++ b/plugins/development-harness/tests/fixtures/mcp_call_shape_known_defects.json
@@ -1,0 +1,93 @@
+{
+  "_purpose": "Known-defect specimens for the #3162 MCP call-shape guards. Each must_flag entry is one live defect class frozen from the shipped file named in frozen_from; each must_not_flag entry is a shape that resembles a defect and is correct. Mutation tests copy frozen_from into tmp_path, append markdown, and assert the guard's verdict, so a guard that cannot fail is itself a test failure.",
+  "must_flag": [
+    {
+      "id": "grant-nonexistent-backlog-tool",
+      "guard": "tool_grant",
+      "frozen_from": "plugins/development-harness/agents/t0-baseline-capture.md",
+      "markdown": "tools: mcp__plugin_dh_backlog__artifact_register, mcp__plugin_dh_backlog__artifact_migrate\n",
+      "expect_contains": "mcp__plugin_dh_backlog__artifact_migrate"
+    },
+    {
+      "id": "grant-nonexistent-sam-tool",
+      "guard": "tool_grant",
+      "frozen_from": "plugins/development-harness/agents/swarm-task-planner.md",
+      "markdown": "tools: mcp__plugin_dh_sam__sam_create, mcp__plugin_dh_sam__sam_update\n",
+      "expect_contains": "mcp__plugin_dh_sam__sam_create"
+    },
+    {
+      "id": "grant-tool-under-wrong-server-prefix",
+      "guard": "tool_grant",
+      "frozen_from": "plugins/development-harness/agents/swarm-task-planner.md",
+      "markdown": "tools: mcp__plugin_dh_sam__backlog_add\n",
+      "expect_contains": "granted under the sam prefix"
+    },
+    {
+      "id": "call-nonexistent-tool-bare-name",
+      "guard": "tool_call",
+      "frozen_from": "plugins/development-harness/docs/TASK_FILE_FORMAT.md",
+      "markdown": "Register the plan with `sam_create(slug='x', goal='y')`.\n",
+      "expect_contains": "sam_create("
+    },
+    {
+      "id": "call-nonexistent-tool-in-mermaid-node",
+      "guard": "tool_call",
+      "frozen_from": "plugins/development-harness/skills/complete-implementation/references/final-handoff.md",
+      "markdown": "```mermaid\nflowchart TD\n    A --> B[\"sam_list(search='{slug}')\"]\n```\n",
+      "expect_contains": "sam_list("
+    },
+    {
+      "id": "call-nonexistent-tool-with-server-prefix",
+      "guard": "tool_call",
+      "frozen_from": "plugins/development-harness/agents/contract-verification.md",
+      "markdown": "Call `mcp__plugin_dh_backlog__artifact_migrate(item_id=1)` to move it.\n",
+      "expect_contains": "artifact_migrate("
+    },
+    {
+      "id": "enum-invalid-artifact-status",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/agents/t0-baseline-capture.md",
+      "markdown": "```python\nartifact_register(\n    item_id=1,\n    artifact_type=\"T0-baseline\",\n    artifact_id=\"T0-baseline-x\",\n    content=\"y\",\n    status=\"complete\",\n)\n```\n",
+      "expect_contains": "status=\"complete\""
+    },
+    {
+      "id": "enum-invalid-artifact-type",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/agents/tn-verification-gate.md",
+      "markdown": "Read it with `artifact_read(item_id=1, artifact_type=\"task-plan-v2\")`.\n",
+      "expect_contains": "artifact_type=\"task-plan-v2\""
+    }
+  ],
+  "must_not_flag": [
+    {
+      "id": "python-attribute-call-is-not-a-tool-call",
+      "frozen_from": "plugins/development-harness/docs/TASK_FILE_FORMAT.md",
+      "markdown": "The path is resolved via `dh_paths.backlog_dir()` at import time.\n"
+    },
+    {
+      "id": "wildcard-grant-names-no-specific-tool",
+      "frozen_from": "plugins/development-harness/agents/t0-baseline-capture.md",
+      "markdown": "tools: mcp__plugin_dh_backlog__*, mcp__plugin_dh_sam__*\n"
+    },
+    {
+      "id": "status-outside-an-artifact-call-has-its-own-value-domain",
+      "frozen_from": "plugins/development-harness/agents/swarm-task-planner.md",
+      "markdown": "Call `backlog_update(selector='x', status=\"in-progress\")` and `sam_task(plan='P1', task='T1', config={\"action\":\"state\",\"status\":\"complete\"})`.\n"
+    },
+    {
+      "id": "task-plan-is-a-registered-artifact-type",
+      "frozen_from": "plugins/development-harness/agents/tn-verification-gate.md",
+      "markdown": "Read it with `artifact_read(item_id=1, artifact_type=\"task-plan\")`.\n"
+    },
+    {
+      "id": "placeholder-literals-are-not-values",
+      "frozen_from": "plugins/development-harness/agents/t0-baseline-capture.md",
+      "markdown": "Call `artifact_register(item_id={id}, artifact_type=\"<type>\", artifact_id='x', content='y', status=\"{status}\")`.\n"
+    },
+    {
+      "id": "live-tool-names-and-enum-values-are-accepted",
+      "frozen_from": "plugins/development-harness/agents/contract-verification.md",
+      "markdown": "Call `mcp__plugin_dh_backlog__artifact_register(item_id=1, artifact_type=\"T0-baseline\", artifact_id='t0-x', content='y', status=\"current\")` then `sam_plan(config={\"action\":\"list\"})`.\n"
+    }
+  ]
+}

--- a/plugins/development-harness/tests/mcp_call_shape_guards.py
+++ b/plugins/development-harness/tests/mcp_call_shape_guards.py
@@ -1,0 +1,265 @@
+"""Pure detection functions for MCP call-shape drift in shipped markdown (#3162).
+
+Shipped agent and skill markdown instructs MCP calls in prose. A wrong tool name or a
+wrong enum literal reads as correct to an author and a reviewer because the surrounding
+tool is real; only calling it reveals the shape. These functions resolve every instructed
+name against the servers' live tool listing and against the real ``ArtifactType`` /
+``ArtifactStatus`` members, so drift fails a test instead of failing at dispatch time.
+
+Detection is deliberately narrow. A general keyword-argument parser was built, measured
+against the whole shipped corpus, and rejected: it reached only 78.5% of call sites and
+produced a 34.7% false-positive rate. These three checks target names with a closed,
+mechanically resolvable value domain, which is why they carry no false positives.
+
+The functions are pure ``(text) -> list[Defect]`` so the same code path runs against the
+real corpus and against injected mutations under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+__all__ = [
+    "Defect",
+    "DefectKind",
+    "ToolSurface",
+    "find_artifact_enum_defects",
+    "find_tool_call_defects",
+    "find_tool_grant_defects",
+    "load_tool_surface",
+]
+
+# Server key used in the ``mcp__plugin_dh_<server>__<tool>`` grant token.
+_BACKLOG_SERVER: Final = "backlog"
+_SAM_SERVER: Final = "sam"
+
+# Which guard produced a defect. Closed set — a new value means a new guard, not a new string.
+DefectKind: TypeAlias = Literal["tool_grant", "tool_call", "artifact_enum"]
+
+_GRANT_RE: Final = re.compile(r"mcp__plugin_dh_(backlog|sam)__([A-Za-z0-9_]+)")
+
+# An instructed call: an optionally server-prefixed tool name followed by "(".
+# The prefix alternative must be tried first — a word-boundary anchor cannot match
+# after the "_" that ends the prefix, which silently skipped every prefixed site in
+# an earlier probe of this same corpus.
+#
+# The lookbehind also excludes a preceding "." — an MCP tool is always invoked as a bare
+# name, so an attribute call such as ``dh_paths.backlog_dir()`` is Python, not an
+# instructed tool call.
+_NOT_AN_IDENTIFIER_TAIL: Final = r"(?<![A-Za-z0-9_.])"
+
+_CALL_RE: Final = re.compile(
+    _NOT_AN_IDENTIFIER_TAIL + r"(?:mcp__plugin_dh_(?:backlog|sam)__)?"
+    r"((?:sam|artifact|backlog|dispatch|profile)_[A-Za-z0-9_]+)\s*\("
+)
+
+_ARTIFACT_CALL_RE: Final = re.compile(
+    _NOT_AN_IDENTIFIER_TAIL + r"(?:mcp__plugin_dh_backlog__)?(artifact_[A-Za-z0-9_]+)\s*\("
+)
+
+_ARTIFACT_TYPE_KWARG_RE: Final = re.compile(r"""artifact_type\s*=\s*["']([^"']*)["']""")
+_STATUS_KWARG_RE: Final = re.compile(r"""status\s*=\s*["']([^"']*)["']""")
+
+# Characters that mark a literal as an authoring placeholder rather than a real value.
+_PLACEHOLDER_CHARS: Final = frozenset("{}<>$|")
+
+# How far past a call opener to keep scanning for its arguments when the parentheses
+# never balance — prose call sites are routinely truncated or wrapped mid-argument.
+_MAX_CALL_SPAN: Final = 600
+
+
+class ToolSurface(BaseModel):
+    """The tool names each dh MCP server actually exposes at runtime."""
+
+    model_config = ConfigDict(frozen=True)
+
+    backlog: frozenset[str] = Field(description="Tool names exposed by the backlog server.")
+    sam: frozenset[str] = Field(description="Tool names exposed by the SAM server.")
+
+    @property
+    def all_names(self) -> frozenset[str]:
+        """Every tool name exposed by either server."""
+        return self.backlog | self.sam
+
+    def server_for(self, server_key: str) -> frozenset[str]:
+        """Return the tool names for a ``mcp__plugin_dh_<server_key>__`` prefix.
+
+        Args:
+            server_key: The server segment of a grant token — ``backlog`` or ``sam``.
+
+        Returns:
+            The tool names that server exposes.
+
+        Raises:
+            KeyError: ``server_key`` names no dh server. Resolving an unrecognised prefix to
+                a default listing would let a whole prefix go unchecked without saying so.
+        """
+        return {_BACKLOG_SERVER: self.backlog, _SAM_SERVER: self.sam}[server_key]
+
+
+class Defect(BaseModel):
+    """One instructed call shape that does not exist at runtime."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: DefectKind = Field(description="Which guard produced this defect.")
+    found: str = Field(description="The literal name or value as written in the markdown.")
+    detail: str = Field(description="Why it is wrong, naming the values that would be accepted.")
+
+    def __str__(self) -> str:
+        """Render as a single line for a pytest assertion message."""
+        return f"[{self.kind}] {self.found}: {self.detail}"
+
+
+def load_tool_surface() -> ToolSurface:
+    """Read the live tool listing from both dh MCP servers.
+
+    Importing the server modules registers their tools; ``list_tools`` reports what a
+    calling agent can actually reach, so the guards resolve against the runtime surface
+    rather than a hand-maintained list that can drift from it.
+
+    Returns:
+        The tool names exposed by the backlog and SAM servers.
+    """
+    import backlog_core.server as backlog_server
+    import sam_schema.server as sam_server
+
+    async def _listings() -> tuple[frozenset[str], frozenset[str]]:
+        backlog_tools = await backlog_server.mcp.list_tools()
+        sam_tools = await sam_server.mcp.list_tools()
+        return frozenset(t.name for t in backlog_tools), frozenset(t.name for t in sam_tools)
+
+    backlog_names, sam_names = asyncio.run(_listings())
+    return ToolSurface(backlog=backlog_names, sam=sam_names)
+
+
+def _is_placeholder(value: str) -> bool:
+    """Report whether a literal is an authoring placeholder rather than a real value."""
+    return (
+        not value
+        or "..." in value
+        or any(char in _PLACEHOLDER_CHARS for char in value)
+        or not any(char.isalpha() for char in value)
+    )
+
+
+def find_tool_grant_defects(text: str, surface: ToolSurface) -> list[Defect]:
+    """Flag ``mcp__plugin_dh_*__`` tokens that name no tool on the server they address.
+
+    A frontmatter grant for a tool that does not exist is dropped silently and the rest of
+    the grant survives, so the agent starts without the capability its own file claims.
+    The same token in prose instructs a call that cannot dispatch. Wildcard grants
+    (``mcp__plugin_dh_backlog__*``) name no specific tool and are not checked.
+
+    Args:
+        text: Full markdown text of one shipped file.
+        surface: The live tool listing from both servers.
+
+    Returns:
+        One defect per token naming a tool absent from the server it addresses.
+    """
+    defects: list[Defect] = []
+    for match in _GRANT_RE.finditer(text):
+        server_key, tool_name = match.group(1), match.group(2)
+        if tool_name in surface.server_for(server_key):
+            continue
+        other_server = _SAM_SERVER if server_key == _BACKLOG_SERVER else _BACKLOG_SERVER
+        detail = (
+            f"names no tool on the {server_key} server"
+            if tool_name not in surface.all_names
+            else f"is a {other_server} server tool, granted under the {server_key} prefix"
+        )
+        defects.append(Defect(kind="tool_grant", found=match.group(0), detail=detail))
+    return defects
+
+
+def find_tool_call_defects(text: str, surface: ToolSurface) -> list[Defect]:
+    """Flag instructed ``tool(...)`` calls whose tool name is absent from both servers.
+
+    Args:
+        text: Full markdown text of one shipped file.
+        surface: The live tool listing from both servers.
+
+    Returns:
+        One defect per call site naming a tool neither server exposes.
+    """
+    live = surface.all_names
+    return [
+        Defect(kind="tool_call", found=f"{match.group(1)}(", detail="names no tool on either dh MCP server")
+        for match in _CALL_RE.finditer(text)
+        if match.group(1) not in live
+    ]
+
+
+def _call_span(text: str, start: int) -> str:
+    """Return the argument text of a call whose opening paren sits at ``start``.
+
+    Stops at the matching close paren, at a blank line, or after ``_MAX_CALL_SPAN``
+    characters — prose call sites are frequently wrapped or truncated mid-argument, so a
+    strictly balanced scan would silently skip them.
+    """
+    depth = 0
+    for index in range(start, min(len(text), start + _MAX_CALL_SPAN)):
+        char = text[index]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+        elif text.startswith("\n\n", index):
+            return text[start:index]
+    return text[start : start + _MAX_CALL_SPAN]
+
+
+def _artifact_call_spans(text: str) -> Iterator[str]:
+    """Yield the argument text of every instructed ``artifact_*`` call."""
+    for match in _ARTIFACT_CALL_RE.finditer(text):
+        yield _call_span(text, match.end() - 1)
+
+
+def find_artifact_enum_defects(
+    text: str, artifact_types: frozenset[str], artifact_statuses: frozenset[str]
+) -> list[Defect]:
+    """Flag ``artifact_type=`` and ``status=`` literals that are not enum members.
+
+    ``artifact_type=`` is checked wherever it appears — that keyword is unique to the
+    artifact tools. ``status=`` is checked only inside an ``artifact_*`` call span,
+    because the same keyword carries an unrelated value domain on the backlog and task
+    tools.
+
+    Args:
+        text: Full markdown text of one shipped file.
+        artifact_types: Valid ``ArtifactType`` values.
+        artifact_statuses: Valid ``ArtifactStatus`` values.
+
+    Returns:
+        One defect per literal outside its enum.
+    """
+    defects: list[Defect] = [
+        Defect(
+            kind="artifact_enum",
+            found=f'artifact_type="{value}"',
+            detail=f"is not an ArtifactType; valid values are {sorted(artifact_types)}",
+        )
+        for value in _ARTIFACT_TYPE_KWARG_RE.findall(text)
+        if not _is_placeholder(value) and value not in artifact_types
+    ]
+    defects.extend(
+        Defect(
+            kind="artifact_enum",
+            found=f'status="{value}"',
+            detail=f"is not an ArtifactStatus; valid values are {sorted(artifact_statuses)}",
+        )
+        for span in _artifact_call_spans(text)
+        for value in _STATUS_KWARG_RE.findall(span)
+        if not _is_placeholder(value) and value not in artifact_statuses
+    )
+    return defects

--- a/plugins/development-harness/tests/test_artifact_content_storage.py
+++ b/plugins/development-harness/tests/test_artifact_content_storage.py
@@ -16,6 +16,7 @@ All GitHub API calls are mocked at the ``_graphql_request`` boundary
 from __future__ import annotations
 
 import hashlib
+import inspect
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -47,6 +48,7 @@ from backlog_core.models import (
     ContentUnavailableError,
 )
 from backlog_core.server import mcp
+from dh_core import operations as dh_operations
 from fastmcp.exceptions import ToolError
 from graphql_factories import (
     make_issue_by_number_response,
@@ -590,21 +592,19 @@ async def test_artifact_register_rejects_empty_content_before_provider_mutation(
     mock_provider.put_content.assert_not_called()
 
 
-async def test_artifact_register_with_invalid_type_returns_error() -> None:
-    """Verify artifact_register returns an error for unknown artifact types.
+async def test_artifact_register_with_invalid_type_raises() -> None:
+    """Verify artifact_register fails the call for unknown artifact types.
 
     Tests: artifact_register MCP tool — invalid type validation.
-    How: Pass artifact_type not in ArtifactType enum, verify error key present.
-    Why: Input validation must reject garbage types before touching GitHub.
+    How: Pass artifact_type not in ArtifactType enum, verify the call errors.
+    Why: An invalid type returned inside a successful response let a caller that does not
+    inspect the payload continue as though the artifact was stored (#3162).
     """
-    # Arrange / Act
-    result = await _call(
-        "artifact_register",
-        {"item_id": 42, "artifact_type": "not-a-real-type", "artifact_id": "plan/foo.md", "content": "# Content"},
-    )
-
-    # Assert
-    assert "error" in result
+    with pytest.raises(ToolError):
+        await _call(
+            "artifact_register",
+            {"item_id": 42, "artifact_type": "not-a-real-type", "artifact_id": "plan/foo.md", "content": "# Content"},
+        )
 
 
 async def test_artifact_read_returns_configured_provider_content() -> None:
@@ -665,8 +665,8 @@ async def test_artifact_read_returns_error_when_type_not_found() -> None:
     """
     # Arrange
     mock_manifest = ArtifactManifest(issue_number=42, artifacts=[])
-    mock_provider = MagicMock()
-    mock_provider.get_manifest.return_value = mock_manifest
+    mock_provider = MagicMock(spec=ContentProvider)
+    mock_provider.get_content.return_value = _manifest_record(mock_manifest)
 
     with (
         patch("backlog_core.server._get_artifact_provider", return_value=mock_provider),
@@ -680,18 +680,16 @@ async def test_artifact_read_returns_error_when_type_not_found() -> None:
     assert "error" in result
 
 
-async def test_artifact_read_returns_error_for_invalid_type() -> None:
-    """Verify artifact_read returns an error for unknown artifact types.
+async def test_artifact_read_raises_for_invalid_type() -> None:
+    """Verify artifact_read fails the call for unknown artifact types.
 
     Tests: artifact_read MCP tool — invalid type validation.
     How: Pass artifact_type not in ArtifactType enum.
-    Why: Input validation must reject invalid types before touching GitHub.
+    Why: An invalid type is a caller error, not an absent artifact, and must not be
+    reported through the same channel as a legitimate absence (#3162).
     """
-    # Arrange / Act
-    result = await _call("artifact_read", {"item_id": 42, "artifact_type": "not-real"})
-
-    # Assert
-    assert "error" in result
+    with pytest.raises(ToolError):
+        await _call("artifact_read", {"item_id": 42, "artifact_type": "not-real"})
 
 
 async def test_artifact_read_multi_entry_returns_most_recent_and_warns() -> None:
@@ -739,3 +737,95 @@ async def test_artifact_read_multi_entry_returns_most_recent_and_warns() -> None
     assert len(warnings) == 1
     assert "plan/r-old.md" in warnings[0]
     assert "2" in warnings[0]  # "Multiple … found (2)"
+
+
+async def test_artifact_read_by_artifact_id_returns_the_addressed_entry_not_the_newest() -> None:
+    """artifact_id addresses one entry, overriding the newest-wins default.
+
+    Tests: artifact_read MCP tool — addressing by logical identifier.
+    How: Two research entries; read the older one by id and assert its content is returned.
+    Why: The MCP tool previously exposed no artifact_id while dh_core.operations.artifact_read
+    and ``artifact read --artifact-id`` both did, so an agent on MCP could not address a
+    specific artifact and recovery work had to be written in CLI form.
+    """
+    # Arrange: two research entries — the wanted one is NOT the most recent
+    older_entry = ArtifactEntry(
+        artifact_type=ArtifactType.RESEARCH,
+        artifact_id="plan/r-old.md",
+        status=ArtifactStatus.CURRENT,
+        created_at="2026-01-01T10:00:00Z",
+    )
+    newer_entry = ArtifactEntry(
+        artifact_type=ArtifactType.RESEARCH,
+        artifact_id="plan/r-new.md",
+        status=ArtifactStatus.CURRENT,
+        created_at="2026-06-01T10:00:00Z",
+    )
+    mock_manifest = ArtifactManifest(issue_number=42, artifacts=[older_entry, newer_entry])
+    mock_provider = MagicMock(spec=ContentProvider)
+    mock_provider.get_content.side_effect = [
+        _manifest_record(mock_manifest),
+        _artifact_record(42, "research", "plan/r-old.md", "# Older content"),
+    ]
+
+    with (
+        patch("backlog_core.server._get_artifact_provider", return_value=mock_provider),
+        patch("backlog_core.server._artifact_registry") as mock_registry,
+    ):
+        mock_registry.get_by_type.return_value = [older_entry, newer_entry]
+        # Act
+        result = await _call(
+            "artifact_read", {"item_id": 42, "artifact_type": "research", "artifact_id": "plan/r-old.md"}
+        )
+
+    # Assert: the addressed entry wins, and no ambiguity warning is emitted
+    assert result.get("error") is None
+    assert result["path"] == "plan/r-old.md"
+    assert result["content"] == "# Older content"
+    assert result.get("warnings", []) == []
+
+
+async def test_artifact_read_reports_an_unmatched_artifact_id() -> None:
+    """An artifact_id matching no entry of the type is reported, not silently ignored.
+
+    Falling back to the newest entry would hand the caller a different artifact than the
+    one it addressed — the ambiguity this parameter exists to remove.
+    """
+    entry = ArtifactEntry(
+        artifact_type=ArtifactType.RESEARCH,
+        artifact_id="plan/r-new.md",
+        status=ArtifactStatus.CURRENT,
+        created_at="2026-06-01T10:00:00Z",
+    )
+    mock_manifest = ArtifactManifest(issue_number=42, artifacts=[entry])
+    mock_provider = MagicMock(spec=ContentProvider)
+    mock_provider.get_content.return_value = _manifest_record(mock_manifest)
+
+    with (
+        patch("backlog_core.server._get_artifact_provider", return_value=mock_provider),
+        patch("backlog_core.server._artifact_registry") as mock_registry,
+    ):
+        mock_registry.get_by_type.return_value = [entry]
+        # Act
+        result = await _call(
+            "artifact_read", {"item_id": 42, "artifact_type": "research", "artifact_id": "plan/absent.md"}
+        )
+
+    # Assert
+    assert "plan/absent.md" in result["error"]
+
+
+async def test_artifact_read_mcp_surface_matches_the_operations_signature() -> None:
+    """The MCP tool must accept the same addressing parameters as its operations counterpart.
+
+    Two surfaces over one operation that disagree on which parameters exist force callers
+    onto the richer surface for no functional reason.
+    """
+    tools = await mcp.list_tools()
+    parameters = next(tool.parameters for tool in tools if tool.name == "artifact_read")
+    operations_parameters = set(inspect.signature(dh_operations.artifact_read).parameters)
+
+    assert set(parameters["properties"]) == operations_parameters, (
+        "artifact_read's MCP parameters diverge from dh_core.operations.artifact_read: "
+        f"MCP has {sorted(parameters['properties'])}, operations has {sorted(operations_parameters)}"
+    )

--- a/plugins/development-harness/tests/test_artifact_tool_input_contract.py
+++ b/plugins/development-harness/tests/test_artifact_tool_input_contract.py
@@ -1,0 +1,115 @@
+"""The artifact tools must advertise their value domain and reject anything outside it (#3162).
+
+``artifact_register`` declared ``artifact_type`` and ``status`` as bare strings, so the
+published schema named no allowed values and a calling agent had nothing to check its
+literal against. The invalid literal then raised inside the handler, where a broad
+``except (ValueError, KeyError)`` turned it into a success envelope carrying an ``error``
+key — an agent that does not inspect the payload continues as though its artifact was
+stored. These tests pin both halves: the schema advertises the enums, and an invalid
+literal produces a genuine error response rather than a successful one.
+
+The contract matches the one already documented for ``sam_schema/server.py``: handlers let
+exceptions propagate and FastMCP converts them into ``isError=true``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import pytest
+from backlog_core.models import ArtifactStatus, ArtifactType
+from backlog_core.server import mcp
+from fastmcp.exceptions import ToolError
+
+from tests.helpers import call_mcp_tool
+
+_VALID_REGISTER_ARGS: Final = {
+    "item_id": 42,
+    "artifact_type": "T0-baseline",
+    "artifact_id": "T0-baseline-x",
+    "content": "# baseline",
+}
+
+
+async def _register_schema() -> dict[str, Any]:
+    """Return the published input schema of ``artifact_register``.
+
+    Returns:
+        The JSON Schema an MCP client receives for the tool's parameters.
+    """
+    tools = await mcp.list_tools()
+    return next(tool.parameters for tool in tools if tool.name == "artifact_register")
+
+
+def _advertised_enum(schema: dict[str, Any], property_name: str) -> set[str]:
+    """Return the enum values a schema publishes for one property.
+
+    Pydantic emits an enum-typed field either inline or as a ``$ref`` into ``$defs``,
+    optionally wrapped in ``allOf`` when the field also carries a default. All three shapes
+    are equivalent to a client, so all three are resolved here.
+
+    Args:
+        schema: The tool's full input schema.
+        property_name: Name of the parameter to inspect.
+
+    Returns:
+        The advertised values, or an empty set when the property advertises none.
+    """
+    fragment: dict[str, Any] = schema["properties"][property_name]
+    candidates: list[dict[str, Any]] = [fragment, *fragment.get("allOf", []), *fragment.get("anyOf", [])]
+    for candidate in candidates:
+        if "enum" in candidate:
+            return set(candidate["enum"])
+        ref = candidate.get("$ref")
+        if ref:
+            definition = schema.get("$defs", {}).get(ref.rsplit("/", 1)[-1], {})
+            if "enum" in definition:
+                return set(definition["enum"])
+    return set()
+
+
+async def test_artifact_register_schema_advertises_the_artifact_type_enum() -> None:
+    """The schema must name every valid artifact type, not just describe them in prose."""
+    schema = await _register_schema()
+
+    assert _advertised_enum(schema, "artifact_type") == {member.value for member in ArtifactType}, (
+        "artifact_type advertises no enum, so a calling agent has no machine-readable list "
+        f"of allowed values to check its literal against: {schema['properties']['artifact_type']!r}"
+    )
+
+
+async def test_artifact_register_schema_advertises_the_artifact_status_enum() -> None:
+    """The schema must name every valid lifecycle status."""
+    schema = await _register_schema()
+
+    assert _advertised_enum(schema, "status") == {member.value for member in ArtifactStatus}, (
+        f"status advertises no enum, so 'complete' reads as acceptable to an author: {schema['properties']['status']!r}"
+    )
+
+
+@pytest.mark.parametrize("invalid_status", ["complete", "done", "COMPLETE"])
+async def test_artifact_register_rejects_a_status_outside_the_enum(invalid_status: str) -> None:
+    """An invalid status must produce an error response, not a success envelope.
+
+    ``status="complete"`` was instructed across eight shipped agent files. Each of those
+    registrations reported success and stored nothing.
+    """
+    with pytest.raises(ToolError):
+        await call_mcp_tool(mcp, "artifact_register", {**_VALID_REGISTER_ARGS, "status": invalid_status})
+
+
+async def test_artifact_register_rejects_an_artifact_type_outside_the_enum() -> None:
+    """An invalid artifact type must produce an error response, not a success envelope."""
+    with pytest.raises(ToolError):
+        await call_mcp_tool(mcp, "artifact_register", {**_VALID_REGISTER_ARGS, "artifact_type": "not-a-real-type"})
+
+
+async def test_artifact_read_raises_rather_than_returning_an_error_envelope() -> None:
+    """An unknown artifact type on a read must surface as a failed call.
+
+    A read that returns ``{"error": ...}`` inside a successful response is indistinguishable
+    from a legitimately absent artifact to an agent that only checks whether the call
+    succeeded.
+    """
+    with pytest.raises(ToolError):
+        await call_mcp_tool(mcp, "artifact_read", {"item_id": 42, "artifact_type": "not-a-real-type"})

--- a/plugins/development-harness/tests/test_mcp_call_shape_drift.py
+++ b/plugins/development-harness/tests/test_mcp_call_shape_drift.py
@@ -1,0 +1,212 @@
+"""Guards shipped markdown against MCP call shapes that do not exist at runtime (#3162).
+
+Three checks run over every shipped ``.md`` file: server-prefixed tool grants, instructed
+tool calls, and artifact enum literals. Each resolves against the servers' live
+``list_tools()`` output and the real ``ArtifactType`` / ``ArtifactStatus`` members, so a
+tool rename or an enum change fails here instead of failing at dispatch time.
+
+A corpus check alone is not enough. The guard this replaces passed while the defect it
+targeted was live, because its regex silently matched nothing. Every guard here is
+therefore also driven by ``fixtures/mcp_call_shape_known_defects.json``: each specimen is
+injected into a copy of a real shipped file under ``tmp_path`` and the guard must flag it,
+and each near-miss specimen is injected the same way and the guard must stay silent.
+"""
+
+from __future__ import annotations
+
+import json
+import operator
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+import pytest
+from backlog_core.models import ArtifactStatus, ArtifactType
+
+from tests.mcp_call_shape_guards import (
+    Defect,
+    ToolSurface,
+    find_artifact_enum_defects,
+    find_tool_call_defects,
+    find_tool_grant_defects,
+    load_tool_surface,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+_PLUGIN_ROOT: Final = Path(__file__).resolve().parent.parent
+_REPO_ROOT: Final = _PLUGIN_ROOT.parent.parent
+_FIXTURE: Final = Path(__file__).resolve().parent / "fixtures" / "mcp_call_shape_known_defects.json"
+
+_ARTIFACT_TYPES: Final = frozenset(member.value for member in ArtifactType)
+_ARTIFACT_STATUSES: Final = frozenset(member.value for member in ArtifactStatus)
+
+_KNOWN_DEFECTS: Final = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _corpus_root() -> Path:
+    """Return the directory holding shipped markdown.
+
+    The defect classes span every plugin that instructs a dh MCP call, so the whole
+    ``plugins/`` tree is in scope. A standalone plugin bundle has no such tree; there the
+    plugin's own root is the entire shipped corpus.
+    """
+    plugins_dir = _REPO_ROOT / "plugins"
+    return plugins_dir if plugins_dir.is_dir() else _PLUGIN_ROOT
+
+
+def _iter_shipped_markdown(root: Path) -> Iterator[Path]:
+    """Yield every shipped markdown file under ``root``.
+
+    ``graphify-out/`` holds generated graph output, not authored instructions.
+    """
+    for path in sorted(root.rglob("*.md")):
+        if "graphify-out" not in path.parts:
+            yield path
+
+
+@pytest.fixture(scope="session")
+def tool_surface() -> ToolSurface:
+    """The live tool listing from both dh MCP servers."""
+    return load_tool_surface()
+
+
+def _grant_guard(text: str, surface: ToolSurface) -> list[Defect]:
+    return find_tool_grant_defects(text, surface)
+
+
+def _call_guard(text: str, surface: ToolSurface) -> list[Defect]:
+    return find_tool_call_defects(text, surface)
+
+
+def _enum_guard(text: str, _surface: ToolSurface) -> list[Defect]:
+    return find_artifact_enum_defects(text, _ARTIFACT_TYPES, _ARTIFACT_STATUSES)
+
+
+_GUARDS: Final[dict[str, Callable[[str, ToolSurface], list[Defect]]]] = {
+    "tool_grant": _grant_guard,
+    "tool_call": _call_guard,
+    "artifact_enum": _enum_guard,
+}
+
+
+def _scan_corpus(guard: Callable[[str, ToolSurface], list[Defect]], surface: ToolSurface) -> list[str]:
+    """Run one guard over every shipped markdown file, returning one line per defect."""
+    root = _corpus_root()
+    return [
+        f"{path.relative_to(root.parent)}: {defect}"
+        for path in _iter_shipped_markdown(root)
+        for defect in guard(path.read_text(encoding="utf-8"), surface)
+    ]
+
+
+def _mutate(tmp_path: Path, specimen: dict[str, str]) -> tuple[str, str]:
+    """Copy the specimen's origin file into ``tmp_path`` and append its markdown.
+
+    Returns:
+        The clean text and the mutated text, so a caller can compare defect sets and
+        attribute a new flag to the injected markdown rather than to the origin file.
+    """
+    origin = _REPO_ROOT / specimen["frozen_from"]
+    if not origin.is_file():
+        pytest.skip(f"origin file not present in this checkout: {specimen['frozen_from']}")
+    target = tmp_path / origin.name
+    shutil.copyfile(origin, target)
+    clean = target.read_text(encoding="utf-8")
+    mutated = clean + "\n" + specimen["markdown"]
+    target.write_text(mutated, encoding="utf-8")
+    return clean, mutated
+
+
+def _injected_defects(
+    guard: Callable[[str, ToolSurface], list[Defect]], clean: str, mutated: str, surface: ToolSurface
+) -> list[str]:
+    """Return the defect lines the mutation introduced, ignoring any already present."""
+    baseline = [str(defect) for defect in guard(clean, surface)]
+    after = [str(defect) for defect in guard(mutated, surface)]
+    for line in baseline:
+        if line in after:
+            after.remove(line)
+    return after
+
+
+@pytest.mark.parametrize("specimen", _KNOWN_DEFECTS["must_flag"], ids=operator.itemgetter("id"))
+def test_guard_flags_each_known_defect_class(
+    specimen: dict[str, str], tmp_path: Path, tool_surface: ToolSurface
+) -> None:
+    """Injecting a known defect into a real shipped file must produce a flag.
+
+    This is the check the guard being replaced lacked. Without it a regex that matches
+    nothing reports a clean corpus and passes forever.
+    """
+    guard = _GUARDS[specimen["guard"]]
+    clean, mutated = _mutate(tmp_path, specimen)
+
+    introduced = _injected_defects(guard, clean, mutated, tool_surface)
+
+    assert any(specimen["expect_contains"] in line for line in introduced), (
+        f"Guard {specimen['guard']!r} did not flag the injected defect {specimen['id']!r}. "
+        f"Expected a flag containing {specimen['expect_contains']!r}; got {introduced!r}. "
+        "A guard that cannot fail on a live defect class is not a guard."
+    )
+
+
+@pytest.mark.parametrize("specimen", _KNOWN_DEFECTS["must_not_flag"], ids=operator.itemgetter("id"))
+def test_guards_ignore_each_known_correct_shape(
+    specimen: dict[str, str], tmp_path: Path, tool_surface: ToolSurface
+) -> None:
+    """Injecting a correct shape that resembles a defect must produce no flag.
+
+    Each specimen is a shape a coarser check would flag — a Python attribute call, a
+    wildcard grant, ``status=`` on a non-artifact tool, an authoring placeholder. A false
+    positive here is what gets a guard switched off.
+    """
+    clean, mutated = _mutate(tmp_path, specimen)
+
+    introduced = [line for guard in _GUARDS.values() for line in _injected_defects(guard, clean, mutated, tool_surface)]
+
+    assert not introduced, (
+        f"Correct shape {specimen['id']!r} was flagged as a defect: {introduced!r}. "
+        "A guard that flags valid instructions is a guard authors will disable."
+    )
+
+
+def test_shipped_markdown_grants_only_live_dh_tools(tool_surface: ToolSurface) -> None:
+    """Every ``mcp__plugin_dh_*__`` token must name a tool its server actually exposes.
+
+    A grant for a tool that does not exist is dropped silently while the rest of the grant
+    survives, so the agent starts without the capability its own frontmatter claims.
+    """
+    defects = _scan_corpus(_grant_guard, tool_surface)
+
+    assert not defects, (
+        "Shipped markdown grants or names dh MCP tools that do not exist on the server "
+        "addressed by their prefix. Correct the token, or drop it if the capability was "
+        "removed: " + "\n".join(defects)
+    )
+
+
+def test_shipped_markdown_calls_only_live_dh_tools(tool_surface: ToolSurface) -> None:
+    """Every instructed ``tool(...)`` call must name a tool one of the servers exposes."""
+    defects = _scan_corpus(_call_guard, tool_surface)
+
+    assert not defects, (
+        "Shipped markdown instructs calls to dh MCP tools that no server exposes, so an "
+        "agent following the instruction cannot dispatch. Replace each with its live "
+        "equivalent: " + "\n".join(defects)
+    )
+
+
+def test_shipped_markdown_uses_valid_artifact_enum_literals(tool_surface: ToolSurface) -> None:
+    """Every instructed artifact enum literal must be a member of its enum.
+
+    An invalid literal is rejected inside the handler, so the artifact is never stored and
+    a later read of it is indistinguishable from a legitimate absence.
+    """
+    defects = _scan_corpus(_enum_guard, tool_surface)
+
+    assert not defects, (
+        "Shipped markdown instructs artifact calls with enum literals that are not members "
+        "of ArtifactType/ArtifactStatus, so the registration never happens: " + "\n".join(defects)
+    )

--- a/plugins/development-harness/tests_backlog/test_artifact_provider.py
+++ b/plugins/development-harness/tests_backlog/test_artifact_provider.py
@@ -902,54 +902,53 @@ class TestMCPToolArtifactRegister:
         assert data["action"] == "updated"
         assert data["artifact_count"] == 1  # Still one entry
 
-    async def test_artifact_register_invalid_type_returns_error(self, patched_mcp_server: Any) -> None:
-        """artifact_register returns error dict for an unknown artifact_type value.
+    async def test_artifact_register_invalid_type_fails_the_call(self, patched_mcp_server: Any) -> None:
+        """artifact_register fails the call for an unknown artifact_type value.
 
         Tests: Input validation error handling in artifact_register
-        How: Pass an unknown artifact type string; assert 'error' key in response.
-        Why: Callers must receive an informative error, not an unhandled exception.
+        How: Pass an unknown artifact type string; assert the call errors.
+        Why: An error returned inside a successful response reads as success to a caller
+        that does not inspect the payload, so nothing was stored and nothing said so
+        (#3162).
         """
         from fastmcp.client import Client
+        from fastmcp.exceptions import ToolError
 
-        # Arrange / Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool(
-                "artifact_register",
-                {
-                    "item_id": 100,
-                    "artifact_type": "not-a-real-type",
-                    "artifact_id": "plan/something.md",
-                    "content": "irrelevant — invalid type is rejected before content is used",
-                },
-            )
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "artifact_register",
+                    {
+                        "item_id": 100,
+                        "artifact_type": "not-a-real-type",
+                        "artifact_id": "plan/something.md",
+                        "content": "irrelevant — invalid type is rejected before content is used",
+                    },
+                )
 
-        # Assert
-        assert "error" in result.data
-
-    async def test_artifact_register_invalid_status_returns_error(self, patched_mcp_server: Any) -> None:
-        """artifact_register returns error dict for an unknown status value.
+    async def test_artifact_register_invalid_status_fails_the_call(self, patched_mcp_server: Any) -> None:
+        """artifact_register fails the call for an unknown status value.
 
         Tests: Status value validation in artifact_register
-        How: Pass an unknown status string; assert 'error' key in response.
-        Why: Invalid status values must produce an error, not silently default.
+        How: Pass an unknown status string; assert the call errors.
+        Why: ``status="complete"`` was instructed across shipped agent files and each such
+        registration reported success while storing nothing (#3162).
         """
         from fastmcp.client import Client
+        from fastmcp.exceptions import ToolError
 
-        # Arrange / Act
         async with Client(patched_mcp_server) as client:
-            result = await client.call_tool(
-                "artifact_register",
-                {
-                    "item_id": 100,
-                    "artifact_type": "architect",
-                    "artifact_id": "plan/architect-foo.md",
-                    "content": "irrelevant — invalid status is rejected before content is used",
-                    "status": "not-a-real-status",
-                },
-            )
-
-        # Assert
-        assert "error" in result.data
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "artifact_register",
+                    {
+                        "item_id": 100,
+                        "artifact_type": "architect",
+                        "artifact_id": "plan/architect-foo.md",
+                        "content": "irrelevant — invalid status is rejected before content is used",
+                        "status": "not-a-real-status",
+                    },
+                )
 
 
 class TestMCPToolArtifactList:

--- a/plugins/plugin-creator/skills/claude-session-data-schema-reference/references/schema.md
+++ b/plugins/plugin-creator/skills/claude-session-data-schema-reference/references/schema.md
@@ -363,7 +363,7 @@ Appears in **assistant** records. Records a tool call made by the model.
 }
 ```
 
-`name` is the tool name — e.g., `Bash`, `Read`, `mcp__plugin_dh_sam__sam_ready`.
+`name` is the tool name — e.g., `Bash`, `Read`, `mcp__plugin_dh_sam__sam_plan`.
 
 ### `tool_result`
 

--- a/plugins/plugin-creator/skills/hooks-guide/references/claude-session-log-schema-reference.md
+++ b/plugins/plugin-creator/skills/hooks-guide/references/claude-session-log-schema-reference.md
@@ -354,7 +354,7 @@ Appears in **assistant** records. Records a tool call made by the model.
 }
 ```
 
-`name` is the tool name — e.g., `Bash`, `Read`, `mcp__plugin_dh_sam__sam_ready`.
+`name` is the tool name — e.g., `Bash`, `Read`, `mcp__plugin_dh_sam__sam_plan`.
 
 ### `tool_result`
 

--- a/plugins/python-engineering/agents/code-reviewer.md
+++ b/plugins/python-engineering/agents/code-reviewer.md
@@ -4,7 +4,7 @@ description: Performs holistic code review after feature implementation. Checks 
 model: sonnet
 color: yellow
 memory: project
-tools: Read, Write, Glob, Grep, Skill, Bash, SendMessage
+tools: Read, Write, Glob, Grep, Skill, Bash, SendMessage, mcp__plugin_dh_sam__sam_plan
 skills:
   - python-engineering:python3-core
   - python-engineering:python3-testing
@@ -138,7 +138,7 @@ invoking the Skill tool, which would terminate your flow prematurely.
 
 ### Step 7: Create Follow-up Tasks
 
-For each significant issue found (including HIGH/MEDIUM priority issues from the automated analysis), create a follow-up plan file using `mcp__plugin_dh_sam__sam_create` as
+For each significant issue found (including HIGH/MEDIUM priority issues from the automated analysis), create a follow-up plan using `mcp__plugin_dh_sam__sam_plan` as
 described in the Task File Format section.
 </workflow>
 
@@ -162,69 +162,48 @@ perceived impact large enough to warrant its own grooming?
 - Has perceived impact large enough to warrant its own grooming, research, and architecture decision
 - Involves changing a shared component in a way that affects multiple features
 
-**Required output format**: Every follow-up task file must include:
-1. Top-level `scope:` YAML field: `scope: in-scope` or `scope: out-of-scope`
-2. A `## Scope` section in the task body with the classification value
-3. A `## Scope Rationale` section with at least one sentence explaining the classification
+Required output format: every follow-up task must carry the classification in its `body`, as a
+`## Scope` section holding the classification value and a `## Scope Rationale` section holding at
+least one sentence explaining it. The task model has no `scope` field; a task submitted with one
+is rejected.
 
 ## Task File Format
 
-### Creating Follow-up Files with SAM
+### Creating Follow-up Plans with SAM
 
-Use `mcp__plugin_dh_sam__sam_create` to create follow-up task files. This produces a versioned YAML plan file
-in `~/.dh/projects/{slug}/plan/` with an auto-assigned plan number (`plan/P{NNN}-{slug}.yaml` relative to the dh state root).
+Use `mcp__plugin_dh_sam__sam_plan` with the `create` action. The plan is stored by the configured
+backend and addressed logically — no filesystem path is returned or needed.
 
-**CRITICAL: Task identifier key is `task:` — NEVER use `id:`.**
-
-The tasks_yaml passed to `sam_create` MUST use `task:` as the identifier field. Using `id:` is
-wrong and will produce a malformed plan.
-
-**Correct tasks_yaml structure:**
-
-```yaml
-tasks:
-  - task: T1
-    title: "Brief title of the fix"
-    status: not-started
-    agent: python-cli-architect
-    dependencies: []
-    priority: 2
-    complexity: low
-    skills: []
-    scope: in-scope
-    body: |
-      ## Objective
-      Describe what needs to be done.
-
-      ## Acceptance Criteria
-      - Criterion 1
-```
-
-**Command:**
+Each entry in `tasks` is a task definition. Its identifier key is `task` (`id` is also accepted);
+`title` is required. `agent`, `dependencies`, `priority`, `complexity`, `skills`, and `body` are
+optional. Any other key is rejected, so classification and detail belong inside `body`.
 
 ```text
-mcp__plugin_dh_sam__sam_create(
-  slug="{feature-slug}-followup-{issue-number}",
-  goal="{one-sentence goal describing the fix}",
-  tasks_yaml="tasks:\n  - task: T1\n    title: \"{Brief Title}\"\n    status: not-started\n    agent: python-cli-architect\n    dependencies: []\n    priority: 2\n    complexity: low\n    skills: []\n    scope: in-scope\n    body: |\n      ## Objective\n      {describe the fix needed}\n"
-)
+mcp__plugin_dh_sam__sam_plan(config={
+  "action": "create",
+  "slug": "{feature-slug}-followup-{issue-number}",
+  "goal": "{one-sentence goal describing the fix}",
+  "tasks": [
+    {
+      "task": "T1",
+      "title": "{Brief Title}",
+      "status": "not-started",
+      "agent": "python-cli-architect",
+      "dependencies": [],
+      "priority": 2,
+      "complexity": "low",
+      "body": "## Objective\n{describe the fix needed}\n\n## Scope\nin-scope\n\n## Scope Rationale\n{one sentence}\n\n## Acceptance Criteria\n- {criterion}\n"
+    }
+  ]
+})
 ```
 
-**Output:** JSON with the created file path:
+Output: the created plan's logical address. Use that address in your ARTIFACTS `Task files:` list.
 
-```json
-{"path": "plan/P005-{feature-slug}-followup-{issue-number}.yaml", "plan_number": 5, "task_count": 1}
-```
+To determine the slug: take the feature slug from the plan the review covers (e.g.
+`data-validation`) and pass `{feature-slug}-followup-{issue-number}`.
 
-**To determine the slug:**
-
-1. READ the original task file path (e.g., `~/.dh/projects/{slug}/plan/P004-data-validation.yaml`)
-2. EXTRACT the feature slug (e.g., `data-validation`)
-3. PASS `{feature-slug}-followup-{issue-number}` as the slug argument
-
-**Priority values:** 1 (critical) through 5 (low). Complexity: `low`, `medium`, or `high` (lowercase).
-
-**IMPORTANT:** Use the `path` value from the JSON output in your ARTIFACTS `Task files:` list.
+Priority values: 1 (critical) through 5 (low). Complexity: `low`, `medium`, or `high` (lowercase).
 
 ## Output Format (MANDATORY)
 

--- a/plugins/python-engineering/skills/orchestrate/SKILL.md
+++ b/plugins/python-engineering/skills/orchestrate/SKILL.md
@@ -55,21 +55,20 @@ flowchart TD
 
 ### SAM task creation format (when creating tasks directly)
 
-When `mcp__plugin_dh_sam__sam_create` is called directly (e.g., from `create-feature-task`):
+When `mcp__plugin_dh_sam__sam_plan` is called directly with the `create` action (e.g., from
+`create-feature-task`), each entry in `tasks` carries:
 
 ```yaml
+task: "<task id, e.g. T1>"
 title: "<short imperative title>"
-description: |
+body: |
   <what must be true when this task is done>
-acceptance_criteria:
+
+  ## Acceptance Criteria
   - Given <context>, when <action>, then <observable result>
-phases:
-  - name: <phase name>
-    tasks:
-      - <concrete subtask>
 ```
 
-Update task status with `mcp__plugin_dh_sam__sam_update` as phases complete.
+Update task status with `mcp__plugin_dh_sam__sam_task(plan="{plan}", task="{task}", config={"action": "state", "status": "complete"})` as phases complete.
 
 ## Step 3B — Direct Track
 


### PR DESCRIPTION
## What this fixes

Three mechanisms let an MCP call that cannot work report success. All three are closed here.

1. `_ActionConfigBase` set only `populate_by_name=True`. The SAM tool's top-level schema emits `additionalProperties: false`, but each config branch emitted nothing — so an unknown key on a config was dropped and the call returned success having written nothing. `extra="forbid"` closes every branch and publishes the closed key set in the schema a calling agent reads before composing the call.
2. `artifact_register` declared `artifact_type` and `status` as bare strings, so the schema advertised no allowed values. Both are now enum-typed.
3. The four `artifact_*` handlers caught `(ValueError, KeyError)` and returned `{"error": ...}` inside a *successful* response. Those clauses are removed; the exceptions propagate and FastMCP marks the response `isError`, matching the contract already documented for `sam_schema/server.py`. The `BacklogError` envelope is kept — an absent artifact is data, not a failed call.

`Closes #3162`

## Behavioural proof

`artifact_register` with the shape eight shipped agent files instructed, run through `fastmcp call` against the live server script.

Before:

```text
{
  "error": "Invalid parameter: 'complete' is not a valid ArtifactStatus",
  "messages": [],
  "warnings": [],
  "errors": []
}
```

After:

```text
Error: 1 validation error for call[artifact_register]
status
  Input should be 'draft', 'current', 'superseded' or 'archived' [type=enum,
input_value='complete', input_type=str]
```

`sam_plan` with the invented plan-update parameters, same transport.

Before — the three keys pass validation, are discarded, and execution proceeds into backend plan loading. In-process, the same payload:

```text
ACCEPTED, keys retained: ['action']
schema additionalProperties: None
```

After:

```text
Error: 3 validation errors for call[sam_plan]
config.update.plan_slug
  Extra inputs are not permitted [type=extra_forbidden, input_value='x', input_type=str]
config.update.section
  Extra inputs are not permitted [type=extra_forbidden, input_value='S', input_type=str]
config.update.content
  Extra inputs are not permitted [type=extra_forbidden, input_value='C', input_type=str]
```

```text
REJECTED: 3 errors: [('plan_slug',), ('section',), ('content',)]
schema additionalProperties: False
```

The T0/TN pair against a scratch item, register then read back. Before — the register reports an error inside a successful response and the TN read finds nothing:

```text
T0 register, shape the agents instructed (status='complete'):
  {'error': "Invalid parameter: 'complete' is not a valid ArtifactStatus", ...}
TN read of the baseline after that register:
  {'error': "No artifacts of type 'T0-baseline' found for item #9001", ...}
```

After — the register fails the call outright, so the loss is visible at the call site:

```text
T0 register, shape the agents instructed (status='complete'):
  TOOL ERROR: 1 validation error for call[artifact_register]
  status
    Input should be 'draft', 'current', 'superseded' or 'archived'
TN read of the baseline after that register:
  {'error': "No artifacts of type 'T0-baseline' found for item #9001", ...}
T0 register, corrected shape (status='current'):
  {'registered': True, 'artifact_count': 1, 'action': 'added', 'content_stored': True, ...}
TN read of the baseline after the corrected register:
  {'artifact_type': 'T0-baseline', 'path': 'T0-baseline-9001', 'content': 'criteria:\n  - id: AC1\n    exit_code: 1\n', 'status': 'current', ...}
```

## `CreatePlanConfig` extras risk — checked, clear

`sam_plan.create` builds its action config from `CreatePlanInput.to_config()`'s own dump plus `owner_reference`. `to_config()` returns a `CreatePlanConfig`, so the dump's keys are exactly that model's fields and `owner_reference` is one of them. No extras, no caller change needed. `test_cli_create_plan_passes_no_keys_the_config_forbids` pins it so a future field added to the CLI input path cannot reintroduce the risk.

## Guards

Three narrow checks over every shipped `.md` file, resolving each instructed name against the servers' live `list_tools()` output and the real `ArtifactType` / `ArtifactStatus` members: prefixed tool grants, instructed tool calls, artifact enum literals.

The general keyword-argument parser was built, measured, and rejected before this — it reached only 78.5% of call sites and produced a 34.7% false-positive rate.

The defect under repair is "a guard that passes while the defect it targets is live", so a corpus check alone is not enough. The earlier artifact-ownership guard passed against live defects because a word boundary cannot match after the `_` that ends the `mcp__plugin_dh_*__` prefix, silently skipping 22% of call sites. Every guard here is therefore driven by `fixtures/mcp_call_shape_known_defects.json`: each known defect class is injected into a copy of a real shipped file under `tmp_path` and the guard must flag it, and each near-miss shape (a Python attribute call, a wildcard grant, `status=` on a non-artifact tool, an authoring placeholder, a valid call) is injected the same way and the guard must stay silent.

Red-first, on the unmodified tree: 3 corpus guards failed listing 40 defects across 20 files; 14 mutation and near-miss tests passed. Green after the sweep: 17 passed.

## Markdown sweep

Closing the config branches turns each wrong instruction from a silent no-op into a hard failure, so the shipped instructions are corrected in the same change rather than left to fail at dispatch.

`feature-researcher`, `ecosystem-researcher`, `codebase-analyzer` and both `python-cli-design-spec` copies instructed a plan-level section append, which does not exist — a section append requires a `task_id`. Each now registers its deliverable through `artifact_register` with `content=`, the documented mechanism for a document artifact and the one their own downstream steps already assumed. `ecosystem-researcher` and both design-spec copies gain the grant and the `create-artifact` skill they need to reach it; `ecosystem-researcher` had neither, so correcting its prose alone would not have been enough.

Also corrected: `status="complete"` (not an `ArtifactStatus`) in eight agent files, four `artifact_migrate` grants for a tool that does not exist, `sam_list`/`sam_create`/`sam_update` written in call form, `sam_plan(address=, append_section=, section_content=)` in `execution/SKILL.md`, and python-engineering's `code-reviewer` building follow-up plans through `sam_create` with a `tasks_yaml` string and a `scope:` key the task model does not have.

## Separate change — `artifact_read` parameter parity

Not part of #3162; included because it lands in the same function.

`dh_core.operations.artifact_read(item_id, artifact_type, artifact_id=None)` accepts an artifact id and `artifact read --artifact-id` exposes it, but the MCP tool did not — so an agent on MCP could only read by type, which returns the newest entry, while an agent on the CLI could address a specific artifact. That asymmetry already forced recovery work onto the CLI purely because the MCP tool could not address an artifact by id, and reading by type alone is exactly the ambiguity that lets one artifact silently displace another for a consumer gating on it.

The MCP tool now takes the same optional `artifact_id`, with the same semantics. Behaviour when it is absent is unchanged — newest wins. Tests cover reading the older of two entries by id, and reporting an id that matches nothing rather than falling back to the newest.

## Verification

- `uv run pytest` — 5237 passed, 42 skipped, 5 xfailed
- `uv run ruff check` / `ruff format` / `uv run ty check` — clean
- `uv run prek run --files <changed>` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
