### PR TITLE
fix(backlog-core): honor the documented entry_id contract on the live write path, and keep one resolution rule

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/entry_blocks.py
+++ b/plugins/development-harness/backlog_core/entry_blocks.py
@@ -508,6 +508,47 @@ def _rewrite_replace(
     return "\n\n".join(parts)
 
 
+def resolve_entry_id(stored_ids: list[str], entry_id: str) -> int:
+    """Return the index *entry_id* targets, after positional collision resolution.
+
+    Applies :func:`_resolve_duplicate_ids` to a throwaway id-only copy of
+    *stored_ids*, so a caller-supplied ``-N``-suffixed id -- the form
+    backlog_view returns when two entries in one section share a stored id --
+    resolves to the correct position instead of matching nothing. This is the
+    single implementation of "which entry does this id target": both
+    :func:`_rewrite_by_entry_id` (indexing ``spans``) and
+    ``operations._resolve_section_entry`` (indexing a ``Section``'s
+    ``entries``) resolve against *this* function rather than each keeping a
+    private copy of the resolution loop.
+
+    Because *stored_ids* is copied 1:1 into the throwaway ``Entry`` list
+    below, the returned index always aligns positionally with *stored_ids*
+    itself -- and with any other list built from the same source in the same
+    order (e.g. ``spans`` or a ``Section``'s ``entries``). No further
+    positional pairing (``zip`` or otherwise) is needed or correct at the
+    call site.
+
+    Args:
+        stored_ids: A section's entry ids, in storage order.
+        entry_id: The id to resolve, as returned by backlog_view.
+
+    Returns:
+        Index into *stored_ids* that *entry_id* targets.
+
+    Raises:
+        EntryNotFoundError: When ``entry_id`` matches neither a raw id nor a
+            collision-resolved id. Names every id backlog_view would show for
+            *stored_ids*.
+    """
+    id_entries = [Entry(id=stored_id, content="") for stored_id in stored_ids]
+    _resolve_duplicate_ids(id_entries)
+    resolved_ids = [e.id for e in id_entries]
+    for idx, resolved_id in enumerate(resolved_ids):
+        if resolved_id == entry_id:
+            return idx
+    raise EntryNotFoundError(entry_id, resolved_ids)
+
+
 def _rewrite_by_entry_id(
     existing_body: str, spans: list[EntrySpan], is_legacy: bool, new_content: str | None, entry_id: str, added_date: str
 ) -> str:
@@ -523,14 +564,9 @@ def _rewrite_by_entry_id(
             raise EntryNotFoundError(entry_id, [legacy_ts])
         result_parts.append(wrap_entry(new_content) if new_content else "")
     else:
-        id_entries = [Entry(id=s.entry_id, content="") for s in spans]
-        _resolve_duplicate_ids(id_entries)
-        available = [e.id for e in id_entries]
-        if entry_id not in available:
-            raise EntryNotFoundError(entry_id, available)
-
-        for span, id_entry in zip(spans, id_entries, strict=False):
-            if id_entry.id == entry_id:
+        target_idx = resolve_entry_id([s.entry_id for s in spans], entry_id)
+        for idx, span in enumerate(spans):
+            if idx == target_idx:
                 if new_content:
                     result_parts.append(wrap_entry_with_timestamp(new_content, span.entry_id))
             else:

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -27,7 +27,7 @@ from typing_extensions import TypedDict
 from . import models as _models
 from .backend_protocol import get_config
 from .backend_types import ContentProvider, GitHubExtras, IssueCommentNode, IssueNode, MilestoneFullNode, SyncProvider
-from .entry_blocks import _render_entry_raw, _resolve_duplicate_ids, find_entry_spans, parse_entries
+from .entry_blocks import _render_entry_raw, find_entry_spans, parse_entries, resolve_entry_id
 from .models import (
     ITEM_TYPE_ALIASES,
     VALID_CLOSE_REASONS,
@@ -842,11 +842,10 @@ def _extract_subsection_body(body: str, section_name: str) -> str:
 def _resolve_section_entry(entries: list[Entry], entry_id: str) -> Entry:
     """Locate the entry that *entry_id* targets, resolving stored-id collisions positionally.
 
-    Applies the same positional collision resolution backlog_view uses
-    (:func:`~.entry_blocks._resolve_duplicate_ids`) to a throwaway copy of
-    *entries*' ids, so a caller-supplied ``-N``-suffixed id -- the form
-    backlog_view returns when two entries in one section share a stored id --
-    resolves to the correct entry instead of matching nothing.
+    Thin wrapper around :func:`~.entry_blocks.resolve_entry_id` -- the single
+    positional collision-resolution implementation, shared with
+    :func:`~.entry_blocks._rewrite_by_entry_id` so backlog_view's read path
+    and this write path always agree on which entry a given id targets.
 
     Args:
         entries: A section's entry list, in storage order.
@@ -857,17 +856,12 @@ def _resolve_section_entry(entries: list[Entry], entry_id: str) -> Entry:
         callers mutate it in place.
 
     Raises:
-        EntryNotFoundError: When ``entry_id`` matches neither a raw id nor a
-            collision-resolved id. Names every id backlog_view would show for
-            *entries*, so a stale or mistyped id fails loudly instead of
-            silently creating a duplicate entry.
+        EntryNotFoundError: When ``entry_id`` matches no entry in *entries*,
+            even after collision resolution. Names every id backlog_view
+            would show for *entries*, so a stale or mistyped id fails loudly
+            instead of silently creating a duplicate entry.
     """
-    id_entries = [Entry(id=e.id, content="") for e in entries]
-    _resolve_duplicate_ids(id_entries)
-    for entry, id_entry in zip(entries, id_entries, strict=True):
-        if id_entry.id == entry_id:
-            return entry
-    raise EntryNotFoundError(entry_id, [e.id for e in id_entries])
+    return entries[resolve_entry_id([e.id for e in entries], entry_id)]
 
 
 def _apply_groomed_entries(

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -27,7 +27,7 @@ from typing_extensions import TypedDict
 from . import models as _models
 from .backend_protocol import get_config
 from .backend_types import ContentProvider, GitHubExtras, IssueCommentNode, IssueNode, MilestoneFullNode, SyncProvider
-from .entry_blocks import _render_entry_raw, find_entry_spans, parse_entries
+from .entry_blocks import _render_entry_raw, _resolve_duplicate_ids, find_entry_spans, parse_entries
 from .models import (
     ITEM_TYPE_ALIASES,
     VALID_CLOSE_REASONS,
@@ -41,6 +41,7 @@ from .models import (
     ContentUnavailableError,
     DuplicateItemError,
     Entry,
+    EntryNotFoundError,
     GroomedData,
     GroomedSectionMetadata,
     IssueLocalFields,
@@ -838,6 +839,37 @@ def _extract_subsection_body(body: str, section_name: str) -> str:
     return sub_match.group(1).strip()
 
 
+def _resolve_section_entry(entries: list[Entry], entry_id: str) -> Entry:
+    """Locate the entry that *entry_id* targets, resolving stored-id collisions positionally.
+
+    Applies the same positional collision resolution backlog_view uses
+    (:func:`~.entry_blocks._resolve_duplicate_ids`) to a throwaway copy of
+    *entries*' ids, so a caller-supplied ``-N``-suffixed id -- the form
+    backlog_view returns when two entries in one section share a stored id --
+    resolves to the correct entry instead of matching nothing.
+
+    Args:
+        entries: A section's entry list, in storage order.
+        entry_id: The id to resolve, as returned by backlog_view.
+
+    Returns:
+        The matching :class:`Entry` object, by identity, from *entries* --
+        callers mutate it in place.
+
+    Raises:
+        EntryNotFoundError: When ``entry_id`` matches neither a raw id nor a
+            collision-resolved id. Names every id backlog_view would show for
+            *entries*, so a stale or mistyped id fails loudly instead of
+            silently creating a duplicate entry.
+    """
+    id_entries = [Entry(id=e.id, content="") for e in entries]
+    _resolve_duplicate_ids(id_entries)
+    for entry, id_entry in zip(entries, id_entries, strict=True):
+        if id_entry.id == entry_id:
+            return entry
+    raise EntryNotFoundError(entry_id, [e.id for e in id_entries])
+
+
 def _apply_groomed_entries(
     section: Section,
     groomed_content: str,
@@ -862,6 +894,10 @@ def _apply_groomed_entries(
 
     Raises:
         ValueError: When ``replace_section`` is ``True`` but ``reason`` is empty.
+        EntryNotFoundError: When ``entry_id`` is set but matches no entry in
+            ``section`` (see :func:`_resolve_section_entry`). backlog_update
+            and backlog_groom document this as the contract: an id matching no
+            entry is an error naming the available ids, never a silent no-op.
     """
     if append:
         section.entries.append(Entry(id=now_iso(), content=groomed_content))
@@ -879,11 +915,8 @@ def _apply_groomed_entries(
         section.entries.append(Entry(id=now_iso(), content=groomed_content))
         return
     if entry_id:
-        for entry in section.entries:
-            if entry.id == entry_id:
-                entry.content = groomed_content
-                return
-        section.entries.append(Entry(id=entry_id, content=groomed_content))
+        target = _resolve_section_entry(section.entries, entry_id)
+        target.content = groomed_content
         return
     # Default: append only when content is non-empty and not already present.
     # Identical content in any existing unstruck entry is treated as idempotent.
@@ -3653,7 +3686,10 @@ def strike_entry(
 
     Raises:
         ItemNotFoundError: If item cannot be found.
-        ValueError: If entry_id not found in the item body.
+        EntryNotFoundError: If entry_id matches no entry in any section
+            searched (see :func:`_resolve_section_entry` — resolution is
+            collision-aware, matching what backlog_view returns for a
+            section holding two entries with the same stored id).
     """
     out = output or Output()
     items = get_config().backend.list_work_items()
@@ -3666,24 +3702,22 @@ def strike_entry(
         raise BacklogError(msg)
 
     struck_at = now_iso()
-    found = False
+    target: Entry | None = None
+    available: list[str] = []
     for section_name, section_data in item.sections.items():
         if not isinstance(section_data, Section) or (section and section_name.lower() != section.lower()):
             continue
-        for entry in section_data.entries:
-            if entry.id == entry_id:
-                entry.struck = True
-                entry.struck_at = struck_at
-                entry.struck_reason = reason
-                found = True
-                break
-        if found:
-            break
-    if not found:
-        msg = f"Entry '{entry_id}' not found in item '{item.title}'"
-        if section:
-            msg += f" section '{section}'"
-        raise ValueError(msg)
+        try:
+            target = _resolve_section_entry(section_data.entries, entry_id)
+        except EntryNotFoundError as exc:
+            available.extend(exc.available)
+            continue
+        break
+    if target is None:
+        raise EntryNotFoundError(entry_id, available)
+    target.struck = True
+    target.struck_at = struck_at
+    target.struck_reason = reason
 
     backend = get_config().backend
     backend.put_work_item(item)

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -2584,8 +2584,14 @@ class TestStrikeEntryOperation:
         assert "based on training data" in body
 
     def test_strike_entry_not_found_raises(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        """strike_entry raises ValueError when entry_id doesn't exist."""
-        from backlog_core.models import Output
+        """strike_entry raises EntryNotFoundError, naming available ids, when entry_id doesn't exist.
+
+        backlog_strike_entry's server.py tool description documents that "An id
+        matching no entry is an error naming the available ids, never a silent
+        no-op" -- EntryNotFoundError.__str__ is the mechanism that names them
+        (see backlog_core.models.EntryNotFoundError).
+        """
+        from backlog_core.models import EntryNotFoundError, Output
 
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
 
@@ -2595,8 +2601,46 @@ class TestStrikeEntryOperation:
         _write_item(backlog_dir, title="No Entry", priority="P1", topic="no-entry")
 
         out = Output()
-        with pytest.raises(ValueError, match=r"Entry.*not found"):
+        with pytest.raises(EntryNotFoundError, match=r"No entry with id"):
             ops.strike_entry(selector="No Entry", entry_id="2099-01-01T00:00:00Z", reason="test", output=out)
+
+    def test_strike_entry_resolves_collision_suffixed_id(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """A '-N'-suffixed entry_id must strike the correct colliding entry.
+
+        When two entries in one section share a stored id, backlog_view resolves
+        them positionally (entry_blocks._resolve_duplicate_ids) and returns the
+        second one suffixed as f"{id}-1". strike_entry compared entry_id against
+        each raw, still-colliding entry.id directly, so the suffixed id it
+        advertised as the way to target a collision matched neither entry and
+        struck nothing.
+        """
+        from backlog_core.backend_protocol import get_config
+        from backlog_core.models import Output
+
+        mocker.patch("backlog_core.operations.try_get_github", return_value=None)
+
+        import backlog_core.models as _m
+
+        backlog_dir = _m.get_backlog_dir()
+        filepath = _write_item_yaml(backlog_dir, title="Collision Test", priority="P1", topic="collision-test")
+
+        shared_id = "2026-01-01T00:00:00Z"
+        item = _stored_item(filepath)
+        item.sections["log"] = Section(
+            entries=[Entry(id=shared_id, content="first"), Entry(id=shared_id, content="second")]
+        )
+        get_config().backend.put_work_item(item)
+
+        out = Output()
+        result = ops.strike_entry(
+            selector="Collision Test", entry_id=f"{shared_id}-1", reason="test reason", output=out
+        )
+        assert "error" not in result
+        assert result["struck"] is True
+
+        updated_section = cast("Section", _stored_item(filepath).sections["log"])
+        assert updated_section.entries[0].struck is False, "the first colliding entry must remain unstruck"
+        assert updated_section.entries[1].struck is True, "the second colliding entry (id-1) must be struck"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests/test_epoch_timestamp_bug.py
+++ b/plugins/development-harness/tests/test_epoch_timestamp_bug.py
@@ -380,6 +380,54 @@ def test_apply_groomed_entries_collision_suffixed_id_updates_correct_entry() -> 
 
 
 # ---------------------------------------------------------------------------
+# Finding 7c — the entry_blocks.rewrite_section path and the
+# operations._apply_groomed_entries path must resolve an identical
+# stored-id collision to the identical target entry (#3183 consolidation)
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_section_and_apply_groomed_entries_resolve_same_collision_id() -> None:
+    """Both entry-id resolution call sites must agree on which entry a suffixed id targets.
+
+    entry_blocks._rewrite_by_entry_id (used by rewrite_section, the markdown-body
+    path) and operations._apply_groomed_entries (used by backlog_update/
+    backlog_groom, the live Section path) both resolve entry_id through the single
+    shared implementation, entry_blocks.resolve_entry_id. This test is the
+    regression guard for that consolidation: if a future edit reintroduces a
+    second, independent resolution implementation in either caller, this test
+    fails as soon as the two disagree on which entry a collision-suffixed id
+    targets.
+    """
+    from backlog_core.entry_blocks import rewrite_section, wrap_entry_with_timestamp
+
+    shared_id = "2026-01-01T00:00:00Z"
+    target_id = f"{shared_id}-1"
+
+    # entry_blocks path: rewrite_section replaces the entry the suffixed id targets.
+    body = f"{wrap_entry_with_timestamp('first', shared_id)}\n\n{wrap_entry_with_timestamp('second', shared_id)}"
+    rewritten = rewrite_section(body, new_content="REPLACED", entry_id=target_id)
+    rewritten_entries = parse_entries(rewritten, show="all")
+    assert [e.content for e in rewritten_entries] == ["first", "REPLACED"], (
+        "rewrite_section must resolve the '-1' suffix to the SECOND colliding entry"
+    )
+
+    # operations path: _apply_groomed_entries updates the entry the same suffixed id targets.
+    section = Section(entries=[Entry(id=shared_id, content="first"), Entry(id=shared_id, content="second")])
+    _apply_groomed_entries(
+        section,
+        "REPLACED",
+        append=False,
+        replace_section=False,
+        reason=None,
+        entry_id=target_id,
+        added_date="0000-00-00",
+    )
+    assert [e.content for e in section.entries] == ["first", "REPLACED"], (
+        "_apply_groomed_entries must resolve the '-1' suffix to the SAME (second) colliding entry"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Regression — since filtering must use datetime comparison, not string comparison
 # ---------------------------------------------------------------------------
 

--- a/plugins/development-harness/tests/test_epoch_timestamp_bug.py
+++ b/plugins/development-harness/tests/test_epoch_timestamp_bug.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import re
 
+import pytest
 from backlog_core.entry_blocks import parse_entries, wrap_entry_with_timestamp
-from backlog_core.models import Entry, Section
+from backlog_core.models import Entry, EntryNotFoundError, Section
 from backlog_core.operations import _apply_groomed_entries
 from backlog_core.timestamps import now_iso
 
@@ -304,6 +305,78 @@ def test_apply_groomed_entries_empty_content_on_empty_section_adds_no_entries() 
     assert len(section.entries) == 0, (
         f"Empty groomed_content on an empty section must not add any entry. Got {len(section.entries)} entries."
     )
+
+
+# ---------------------------------------------------------------------------
+# Finding 7a — an entry_id matching no entry must raise, not silently append (P1, #3183)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_groomed_entries_unknown_entry_id_raises_instead_of_appending() -> None:
+    """entry_id matching no stored entry must raise EntryNotFoundError, not append.
+
+    backlog_update and backlog_groom both delegate to this function. Their
+    server.py tool descriptions document that "An id matching no entry is an
+    error naming the available ids, never a silent no-op" -- but the pre-fix
+    entry_id branch fell through to ``section.entries.append(Entry(id=entry_id,
+    ...))`` on a miss, silently creating an extra entry and reporting success.
+    An agent that supplies a stale or mistyped id (e.g. one it read from an
+    earlier backlog_view call against a since-changed section) gets a
+    duplicated entry instead of the update it asked for, with no error at all.
+    """
+    section = Section(entries=[Entry(id="2026-01-01T00:00:00Z", content="original")])
+
+    with pytest.raises(EntryNotFoundError):
+        _apply_groomed_entries(
+            section,
+            "new content",
+            append=False,
+            replace_section=False,
+            reason=None,
+            entry_id="2026-01-01T00:00:00Z-1",  # matches nothing in this section
+            added_date="0000-00-00",
+        )
+
+    assert len(section.entries) == 1, (
+        f"A miss must not mutate the section. Expected 1 entry, got {len(section.entries)}."
+    )
+    assert section.entries[0].content == "original"
+
+
+# ---------------------------------------------------------------------------
+# Finding 7b — a collision-suffixed entry_id must resolve positionally, matching
+# the same resolution backlog_view applies (P1, #3183)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_groomed_entries_collision_suffixed_id_updates_correct_entry() -> None:
+    """A '-N'-suffixed entry_id must target the correct colliding entry in place.
+
+    When two entries in one section share a stored id, backlog_view resolves
+    them positionally with entry_blocks._resolve_duplicate_ids and returns the
+    second one suffixed as f"{id}-1". Passing that exact id back must update
+    the second entry in place -- not compare literally against the still-raw,
+    still-colliding stored ids (which matches neither) and append a third,
+    unrelated entry.
+    """
+    shared_id = "2026-01-01T00:00:00Z"
+    section = Section(entries=[Entry(id=shared_id, content="first"), Entry(id=shared_id, content="second")])
+
+    _apply_groomed_entries(
+        section,
+        "updated second",
+        append=False,
+        replace_section=False,
+        reason=None,
+        entry_id=f"{shared_id}-1",
+        added_date="0000-00-00",
+    )
+
+    assert len(section.entries) == 2, (
+        f"A collision-suffixed id must update in place, not append. Expected 2 entries, got {len(section.entries)}."
+    )
+    assert section.entries[0].content == "first", "the first colliding entry must be untouched"
+    assert section.entries[1].content == "updated second", "the second colliding entry (id-1) must be updated"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/tests/test_epoch_timestamp_bug.py
+++ b/plugins/development-harness/tests/test_epoch_timestamp_bug.py
@@ -308,7 +308,7 @@ def test_apply_groomed_entries_empty_content_on_empty_section_adds_no_entries() 
 
 
 # ---------------------------------------------------------------------------
-# Finding 7a — an entry_id matching no entry must raise, not silently append (P1, #3183)
+# Finding 7a — an entry_id matching no entry must raise, not silently append (P1)
 # ---------------------------------------------------------------------------
 
 
@@ -345,7 +345,7 @@ def test_apply_groomed_entries_unknown_entry_id_raises_instead_of_appending() ->
 
 # ---------------------------------------------------------------------------
 # Finding 7b — a collision-suffixed entry_id must resolve positionally, matching
-# the same resolution backlog_view applies (P1, #3183)
+# the same resolution backlog_view applies (P1)
 # ---------------------------------------------------------------------------
 
 
@@ -382,7 +382,7 @@ def test_apply_groomed_entries_collision_suffixed_id_updates_correct_entry() -> 
 # ---------------------------------------------------------------------------
 # Finding 7c — the entry_blocks.rewrite_section path and the
 # operations._apply_groomed_entries path must resolve an identical
-# stored-id collision to the identical target entry (#3183 consolidation)
+# stored-id collision to the identical target entry
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## What this fixes

PR #3160 added `EntryNotFoundError` and collision-aware positional entry resolution, and documented both on the MCP surface — `backlog_update`, `backlog_groom` and `backlog_strike_entry` all tell callers that "an id matching no entry is an error naming the available ids, never a silent no-op", and that a collision-suffixed `-N` id is the form that targets a colliding entry.

Neither was true of the code the MCP tools actually call. Both lived only in `entry_blocks.rewrite_section`, which has no non-test caller. The live write path — `operations._apply_groomed_entries` and `operations.strike_entry` — compared `entry_id` against each raw, still-colliding `Entry.id` directly.

Two defects followed:

1. An unknown or stale `entry_id` passed to `backlog_update`/`backlog_groom` silently appended a new duplicate entry and reported success. Not a silent no-op — a silent wrong write.
2. A collision-suffixed id — the exact form `backlog_view` hands the caller — matched nothing on either path. `backlog_strike_entry` raised "not found" for the id its own description tells callers to use.

## Reproductions, run before the fix

Against `d9757efa1` (this branch's base), with the post-fix test files copied in:

```
tests/test_epoch_timestamp_bug.py::test_apply_groomed_entries_unknown_entry_id_raises_instead_of_appending
  E   Failed: DID NOT RAISE EntryNotFoundError

tests/test_epoch_timestamp_bug.py::test_apply_groomed_entries_collision_suffixed_id_updates_correct_entry
  E   AssertionError: A collision-suffixed id must update in place, not append. Expected 2 entries, got 3.

tests/test_backlog_core_operations.py::TestStrikeEntryOperation::test_strike_entry_resolves_collision_suffixed_id
  E   ValueError: Entry '2026-01-01T00:00:00Z-1' not found in item 'Collision Test'

tests/test_backlog_core_operations.py::TestStrikeEntryOperation::test_strike_entry_not_found_raises
  E   ValueError: Entry '2099-01-01T00:00:00Z' not found in item 'No Entry'
```

All four pass on this branch.

The fourth is a pre-existing test that was strengthened rather than added. It asserted `ValueError` with a message naming no available ids, which did not match the contract `server.py` already documented. It now asserts `EntryNotFoundError`, whose message reads `No entry with id ... Available ids: ...`.

## Two commits

`ccd4dfba9` wires the live write path to the documented contract. `strike_entry` accumulates available ids across the sections it searches and raises `EntryNotFoundError` only when no section matched.

`ca265a393` collapses the resolution rule into one implementation. The first commit introduced a second private copy of "which entry does this id target" — `entry_blocks._rewrite_by_entry_id` already contained the same sequence. That is the same shape as the defect #3160 and #3165 existed to remove: five private answers to "where does an entry end", disagreeing with each other. Two copies that agree today diverge the first time one is touched, and these two already disagreed on `zip(strict=...)`.

Both call sites now resolve through public `entry_blocks.resolve_entry_id(stored_ids, entry_id) -> int`. Indexing rather than object identity, so `_rewrite_by_entry_id` indexes `spans` and `operations._resolve_section_entry` indexes a `Section`'s `entries` without either keeping its own loop. The `strict=` question is gone rather than settled: the index is built 1:1 from `stored_ids`, so no positional pairing of two lists remains at either call site. `operations` imports the public name — the private cross-module import is gone.

## Regression guard

`test_rewrite_section_and_apply_groomed_entries_resolve_same_collision_id` drives the identical stored-id collision through both paths and asserts both resolve `-1` to the second entry.

Verified as a real guard, not a test that merely passes: injecting a divergent private resolution into `operations._resolve_section_entry` (resolve any suffixed id to entry 0) fails it with `assert ['REPLACED', 'second'] == ['first', 'REPLACED']`. The probe was reverted and the tree confirmed clean.

## Verification

Full plugin suite, run independently of the implementing agent: `3471 passed, 39 skipped, 5 xfailed` in 85.58s, zero failures. `ruff check` and `ty check` clean on `backlog_core/` and on each touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XDV8knocaB5yqW2JaC1tv
