### PR TITLE
fix(python-engineering): correct #3156's unreachable no-item_id fallback

### DIFF
--- a/plugins/python-engineering/.claude-plugin/plugin.json
+++ b/plugins/python-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python-engineering",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
-  "version": "13.0.2",
+  "version": "13.0.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python-engineering/.codex-plugin/plugin.json
+++ b/plugins/python-engineering/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-engineering",
-  "version": "11.0.2",
+  "version": "11.0.3",
   "description": "Opinionated Python 3.11+ engineering system. Establishes strong defaults (SOLID, typing policy, testing standards, code smell detection) and routes to specialist skills for TDD, CLI, web, data/science, and constrained environments.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/python-engineering/agents/python-cli-design-spec.md
+++ b/plugins/python-engineering/agents/python-cli-design-spec.md
@@ -49,10 +49,11 @@ checks afterwards that the artifact exists. Pass the whole document in `content`
 document into your completion message. Downstream agents retrieve it with
 `artifact_read(item_id=<same item id>, artifact_type="architect")`.
 
-**No backlog `item_id` in your dispatch prompt** (a direct, ad-hoc invocation with no SAM item
-behind it): `artifact_register` has no owner to attach to. Write the spec to
-`plan/architect-{slug}.md` instead and report that path in your completion message — do not call
-`artifact_register` without an `item_id`.
+**No backlog `item_id` in your dispatch prompt**: the dispatching orchestrator resolves one
+before dispatching you (Direct Track and SAM Track both guarantee this — see the orchestration
+guide's `item_id` resolution step). A dispatch that arrives without one is a caller defect, not a
+condition to work around: report `STATUS: BLOCKED — no item_id in dispatch prompt; artifact_register
+has no owner to attach to` rather than guessing an identifier or writing a file.
 
 Read any prior artifacts named in your dispatch prompt through the same boundary — for example
 `artifact_read(item_id=<same item id>, artifact_type="feature-context")`.
@@ -111,8 +112,7 @@ material into the `research` artifact and register the spec again.
 ## Stopping Condition
 
 Stop when the spec is stored — `artifact_register` has returned and the read-back confirms the
-stored spec is complete and contains every section listed above, or, in the no-`item_id` case, the
-file write has completed. Report:
+stored spec is complete and contains every section listed above. Report:
 
 ```text
 STATUS: DONE

--- a/plugins/python-engineering/skills/orchestrate/SKILL.md
+++ b/plugins/python-engineering/skills/orchestrate/SKILL.md
@@ -88,7 +88,7 @@ Agent routing — delegate rather than implement:
 - Python code → subagent_type="python-engineering:python-cli-architect"
 - Tests → subagent_type="python-engineering:python-pytest-architect"
 - Code review → subagent_type="python-engineering:code-reviewer"
-- Architecture design → subagent_type="python-engineering:python-cli-design-spec"
+- Architecture design → subagent_type="python-engineering:python-cli-design-spec" — requires a resolved `item_id` (see below)
 - Task breakdown → subagent_type="dh:swarm-task-planner"
 - Stdlib-only script → Skill(skill: "python-engineering:python3-stdlib-only")
 - CLI/TUI UI design, shape brief, critique, audit, or polish → Skill(skill: "python-engineering:designing-ui-for-cli")
@@ -96,12 +96,24 @@ Agent routing — delegate rather than implement:
 
 Before delegating any non-trivial implementation to `python-cli-architect`, route through `adversarial-solution-design` first. Skip only for one-line fixes where the correct change is unambiguous (typo, wrong variable name, trivial rename).
 
+#### Resolving `item_id` for `python-cli-design-spec`
+
+`python-cli-design-spec` registers its spec as an artifact against a backlog item — it has no
+file-write fallback, so every dispatch, Direct Track included, must resolve an `item_id` first:
+
+1. Task already names a tracked item (`#N` GitHub issue or a Beads ID) → use it as `item_id`.
+2. Otherwise call `mcp__plugin_dh_backlog__backlog_add(title=<task title>, priority=<P0|P1|P2|Ideas>, description=<task description>)` and capture the returned issue number (or backend-native identifier) as `item_id`. Treat an `error` key in the response as a hard stop — report it, do not fall back to a file write.
+
+Pass the resolved `item_id` in the delegation context alongside Outcomes/Constraints/Known
+issues/File paths below.
+
 Each delegation must include:
 
 - Outcomes: what must be true when the agent is done
 - Constraints: user requirements, compatibility, scope boundaries
 - Known issues: error messages already in context (pass-through, not pre-gathered)
 - File paths: where to start looking — not what you found there
+- `item_id`: required for `python-cli-design-spec` dispatches — resolved per the previous section
 
 ### Delegation Hard Rules
 

--- a/plugins/python-engineering/skills/orchestrating-python-development/SKILL.md
+++ b/plugins/python-engineering/skills/orchestrating-python-development/SKILL.md
@@ -32,6 +32,12 @@ Comprehensive guide for orchestrating Python development tasks using specialized
 
 **Context to include in the prompt** means: file paths, outcomes, and user requirements only. Do not pass file contents, summaries, or pre-gathered data — agents discover and read files themselves.
 
+**Design/Architecture steps below dispatch `python-cli-design-spec`**, which registers its spec
+as an artifact against a backlog item and has no file-write fallback. Before any Design or
+Architecture step in the workflows below: use an `item_id` already named by the task (`#N` GitHub
+issue or Beads ID), or call `mcp__plugin_dh_backlog__backlog_add(title=..., priority=..., description=...)`
+and capture the returned issue number as `item_id`. Include `item_id` in that step's Context.
+
 ## Core Workflow Patterns
 
 ### 1. TDD Workflow (Test-Driven Development)
@@ -48,7 +54,7 @@ The adversarial design step reads the actual codebase, not the architecture spec
 
 ```mermaid
 flowchart TD
-    S1["1. Design<br>subagent_type=python-engineering:python-cli-design-spec<br>Context: user requirements, any existing codebase paths<br>Output: component interfaces, module layout, CLI command tree"]
+    S1["1. Design<br>subagent_type=python-engineering:python-cli-design-spec<br>Context: user requirements, any existing codebase paths, item_id<br>Output: architect artifact registered against item_id (interfaces, layout, CLI command tree)"]
     S2["2. Write Tests<br>subagent_type=python-engineering:python-pytest-architect<br>Context: architecture design file path<br>Output: tests/ directory with failing test suite"]
     S3{"3. Implement<br>Default: python-engineering:python-cli-architect<br>Restricted env only: python-engineering:python3-stdlib-only<br>Context: tests/ path, load python-engineering:typer-and-rich for python-cli-demo.py<br>Output: implementation that makes all tests pass"}
     S4["4. Review<br>subagent_type=python-engineering:code-reviewer<br>Context: implementation file paths, tests/ path<br>Output: review findings with file:line references, improvement suggestions"]
@@ -72,8 +78,8 @@ flowchart TD
 User: "Build a CLI tool to process CSV files with progress bars"
 
 1. Task is Design with subagent_type="python-engineering:python-cli-design-spec"
-   Context to include in the prompt: Design architecture for CSV processing CLI with progress tracking
-   Output: Architecture design file with component list, module layout, CLI command tree
+   Context to include in the prompt: Design architecture for CSV processing CLI with progress tracking; item_id resolved per the Delegation Rule above
+   Output: architect artifact registered against item_id — read via artifact_read(item_id, artifact_type="architect")
 
 2. Task is Write Tests with subagent_type="python-engineering:python-pytest-architect"
    Context to include in the prompt: Path to architecture design file from step 1
@@ -102,7 +108,7 @@ Before delegating Requirements Gathering, read `git log --oneline -10` and pass 
 ```mermaid
 flowchart TD
     S1["1. Requirements Gathering<br>subagent_type=spec-analyst<br>Context: codebase path, user request verbatim<br>Output: requirements doc with acceptance criteria"]
-    S2["2. Architecture<br>subagent_type=python-engineering:python-cli-design-spec<br>Context: requirements doc path, existing codebase path<br>Output: design showing integration points with existing code"]
+    S2["2. Architecture<br>subagent_type=python-engineering:python-cli-design-spec<br>Context: requirements doc path, existing codebase path, item_id<br>Output: architect artifact registered against item_id, showing integration points"]
     S3["3. Implementation Planning<br>subagent_type=dh:swarm-task-planner<br>Context: architecture design path, existing test patterns path<br>Output: ordered task list with file targets and acceptance criteria per task"]
     S4{"4. Implement<br>Default: python-engineering:python-cli-architect<br>Restricted env only: python-engineering:python3-stdlib-only<br>Context: task list path, relevant existing file paths<br>Output: new feature implementation in packages/"}
     S5["5. Testing<br>subagent_type=python-engineering:python-pytest-architect<br>Context: new implementation paths, existing test patterns path<br>Output: tests for new feature + integration tests in tests/"]

--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/.codex-plugin/plugin.json
+++ b/plugins/python3-development/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python3-development",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/python3-development/agents/python-cli-design-spec.md
+++ b/plugins/python3-development/agents/python-cli-design-spec.md
@@ -43,10 +43,11 @@ checks afterwards that the artifact exists. Pass the whole document in `content`
 document into your completion message. Downstream agents retrieve it with
 `artifact_read(item_id=<same item id>, artifact_type="architect")`.
 
-**No backlog `item_id` in your dispatch prompt** (a direct, ad-hoc invocation with no SAM item
-behind it): `artifact_register` has no owner to attach to. Write the spec to
-`plan/architect-{slug}.md` instead and report that path in your completion message — do not call
-`artifact_register` without an `item_id`.
+**No backlog `item_id` in your dispatch prompt**: the dispatching orchestrator resolves one
+before dispatching you (Direct Track and SAM Track both guarantee this — see the orchestration
+guide's `item_id` resolution step). A dispatch that arrives without one is a caller defect, not a
+condition to work around: report `STATUS: BLOCKED — no item_id in dispatch prompt; artifact_register
+has no owner to attach to` rather than guessing an identifier or writing a file.
 
 Read any prior artifacts named in your dispatch prompt through the same boundary — for example
 `artifact_read(item_id=<same item id>, artifact_type="feature-context")`.
@@ -105,8 +106,7 @@ material into the `research` artifact and register the spec again.
 ## Stopping Condition
 
 Stop when the spec is stored — `artifact_register` has returned and the read-back confirms the
-stored spec is complete and contains every section listed above, or, in the no-`item_id` case, the
-file write has completed. Report:
+stored spec is complete and contains every section listed above. Report:
 
 ```text
 STATUS: DONE

--- a/plugins/python3-development/skills/orchestrate/SKILL.md
+++ b/plugins/python3-development/skills/orchestrate/SKILL.md
@@ -56,10 +56,21 @@ Agent routing — delegate rather than implement:
 - Python code → subagent_type="python3-development:python-cli-architect"
 - Tests → subagent_type="python3-development:python-pytest-architect"
 - Code review → subagent_type="python3-development:code-reviewer"
-- Architecture design → subagent_type="python3-development:python-cli-design-spec"
+- Architecture design → subagent_type="python3-development:python-cli-design-spec" — requires a resolved `item_id` (see below)
 - Task breakdown → subagent_type="dh:swarm-task-planner"
 - Requirements → subagent_type="spec-analyst"
 - Stdlib-only script → Skill(skill: "python3-development:stdlib-scripting")
+
+#### Resolving `item_id` for `python-cli-design-spec`
+
+`python-cli-design-spec` registers its spec as an artifact against a backlog item — it has no
+file-write fallback, so every dispatch, Direct Track included, must resolve an `item_id` first:
+
+1. Task already names a tracked item (`#N` GitHub issue or a Beads ID) → use it as `item_id`.
+2. Otherwise call `mcp__plugin_dh_backlog__backlog_add(title=<task title>, priority=<P0|P1|P2|Ideas>, description=<task description>)` and capture the returned issue number (or backend-native identifier) as `item_id`. Treat an `error` key in the response as a hard stop — report it, do not fall back to a file write.
+
+Pass the resolved `item_id` in the delegation context alongside Outcomes/Constraints/Known
+issues/File paths below.
 
 Each delegation must include:
 
@@ -67,6 +78,7 @@ Each delegation must include:
 - Constraints: user requirements, compatibility, scope boundaries
 - Known issues: error messages already in context (pass-through, not pre-gathered)
 - File paths: where to start looking — not what you found there
+- `item_id`: required for `python-cli-design-spec` dispatches — resolved per the previous section
 
 Do NOT read source files before delegating. Agents search and read files for themselves — pass file paths, not file contents. Pre-gathering wastes orchestrator context and duplicates work the agent will do anyway.
 

--- a/plugins/python3-development/skills/python3-development/references/python-development-orchestration.md
+++ b/plugins/python3-development/skills/python3-development/references/python-development-orchestration.md
@@ -39,6 +39,12 @@ Comprehensive guide for orchestrating Python development tasks using specialized
 
 **Context to include in the prompt** means: file paths, outcomes, and user requirements only. Do not pass file contents, summaries, or pre-gathered data — agents discover and read files themselves.
 
+**Design/Architecture steps below dispatch `python-cli-design-spec`**, which registers its spec
+as an artifact against a backlog item and has no file-write fallback. Before any Design or
+Architecture step in the workflows below: use an `item_id` already named by the task (`#N` GitHub
+issue or Beads ID), or call `mcp__plugin_dh_backlog__backlog_add(title=..., priority=..., description=...)`
+and capture the returned issue number as `item_id`. Include `item_id` in that step's Context.
+
 ## Core Workflow Patterns
 
 ### 1. TDD Workflow (Test-Driven Development)
@@ -51,12 +57,12 @@ Before the Implement step, check whether the deployment environment is restricte
 
 ```mermaid
 flowchart TD
-    S1["1. Design<br>subagent_type=python3-development:python-cli-design-spec<br>Context: user requirements, any existing codebase paths<br>Output: component interfaces, module layout, CLI command tree"]
+    S1["1. Design<br>subagent_type=python3-development:python-cli-design-spec<br>Context: user requirements, any existing codebase paths, item_id<br>Output: architect artifact registered against item_id (interfaces, layout, CLI command tree)"]
     S2["2. Write Tests<br>subagent_type=python3-development:python-pytest-architect<br>Context: architecture design file path<br>Output: tests/ directory with failing test suite"]
     S3{"3. Implement<br>Default: python3-development:python-cli-architect<br>Restricted env only: python3-development:stdlib-scripting<br>Context: tests/ path, load python3-development:typer-and-rich for python-cli-demo.py<br>Output: implementation that makes all tests pass"}
     S4["4. Review<br>subagent_type=python3-development:code-reviewer<br>Context: implementation file paths, tests/ path<br>Output: review findings with file:line references, improvement suggestions"]
     S5["5. Validate<br>Run: /python3-development:shebangpython on each script<br>Run: Activate holistic-linting skill<br>Run: uv run pytest (verify >80% coverage)<br>Check: CI config for additional validators<br>Pass criteria: all tests green, linting clean, coverage threshold met"]
-    S1 -->|"Output: component interfaces, module layout, CLI command tree"| S2
+    S1 -->|"Output: architect artifact registered against item_id"| S2
     S2 -->|"Output: tests/ with failing test suite"| S3
     S3 -->|"Output: implementation making all tests pass"| S4
     S4 -->|"Output: review findings, improvement list"| S5
@@ -68,8 +74,8 @@ flowchart TD
 User: "Build a CLI tool to process CSV files with progress bars"
 
 1. Task is Design with subagent_type="python3-development:python-cli-design-spec"
-   Context to include in the prompt: Design architecture for CSV processing CLI with progress tracking
-   Output: Architecture design file with component list, module layout, CLI command tree
+   Context to include in the prompt: Design architecture for CSV processing CLI with progress tracking; item_id resolved per the Delegation Rule above
+   Output: architect artifact registered against item_id — read via artifact_read(item_id, artifact_type="architect")
 
 2. Task is Write Tests with subagent_type="python3-development:python-pytest-architect"
    Context to include in the prompt: Path to architecture design file from step 1
@@ -98,7 +104,7 @@ Before delegating Requirements Gathering, read `git log --oneline -10` and pass 
 ```mermaid
 flowchart TD
     S1["1. Requirements Gathering<br>subagent_type=spec-analyst<br>Context: codebase path, user request verbatim<br>Output: requirements doc with acceptance criteria"]
-    S2["2. Architecture<br>subagent_type=python3-development:python-cli-design-spec<br>Context: requirements doc path, existing codebase path<br>Output: design showing integration points with existing code"]
+    S2["2. Architecture<br>subagent_type=python3-development:python-cli-design-spec<br>Context: requirements doc path, existing codebase path, item_id<br>Output: architect artifact registered against item_id, showing integration points"]
     S3["3. Implementation Planning<br>subagent_type=dh:swarm-task-planner<br>Context: architecture design path, existing test patterns path<br>Output: ordered task list with file targets and acceptance criteria per task"]
     S4{"4. Implement<br>Default: python3-development:python-cli-architect<br>Restricted env only: python3-development:stdlib-scripting<br>Context: task list path, relevant existing file paths<br>Output: new feature implementation in packages/"}
     S5["5. Testing<br>subagent_type=python3-development:python-pytest-architect<br>Context: new implementation paths, existing test patterns path<br>Output: tests for new feature + integration tests in tests/"]
@@ -464,8 +470,8 @@ User: "Build a CLI tool to validate YAML configurations"
 
 Orchestrator:
 1. Task is Architecture Design with subagent_type="python3-development:python-cli-design-spec"
-   Context to include in the prompt: Design architecture for YAML validation CLI
-   Output: Architecture file with component list, validation rules, module layout
+   Context to include in the prompt: Design architecture for YAML validation CLI; item_id resolved per the Delegation Rule above
+   Output: architect artifact registered against item_id (component list, validation rules, module layout)
 
 2. Task is Write Tests with subagent_type="python3-development:python-pytest-architect"
    Context to include in the prompt: Architecture design file path from step 1


### PR DESCRIPTION
## Summary

Corrects a defect that shipped to `main` in `877b81a04` (part of merged PR #3156).

#3156 made `python-cli-design-spec` register its architecture spec as a backlog artifact via `artifact_register(item_id=...)`. For the case where no `item_id` is present in the dispatch prompt, it instructed the agent to fall back to writing `plan/architect-{slug}.md` instead. Neither copy of the agent's `tools:` frontmatter grants `Write` (`plugins/python-engineering/agents/python-cli-design-spec.md`, `plugins/python3-development/agents/python-cli-design-spec.md`), so that fallback was structurally unreachable — the agent could report `STATUS: DONE` while writing nothing.

Root cause: Direct Track (`orchestrate/SKILL.md` Step 3B, both plugin copies) and the Design/Architecture steps in the orchestration guides (`orchestrating-python-development/SKILL.md`, `python3-development/references/python-development-orchestration.md`) never supplied an `item_id` when dispatching `python-cli-design-spec` — the only fields supplied were Outcomes/Constraints/Known issues/File paths.

## Changes

- `plugins/python-engineering/skills/orchestrate/SKILL.md` and `plugins/python3-development/skills/orchestrate/SKILL.md` (Step 3B): the `python-cli-design-spec` routing entry now requires a resolved `item_id`; added a step to resolve one (reuse a tracked `#N`/Beads id from the task, or create one via `backlog_add` and capture the returned issue number) before dispatch, and added `item_id` to the "Each delegation must include" contract.
- `plugins/python-engineering/skills/orchestrating-python-development/SKILL.md` and `plugins/python3-development/skills/python3-development/references/python-development-orchestration.md`: the TDD Workflow and Feature Addition Workflow Design/Architecture dispatch templates (mermaid nodes and worked examples) now include `item_id` in Context and describe the Output as an `architect` artifact registration (was stale "architecture design file" language predating #3156's artifact-registration rewrite).
- `plugins/python-engineering/agents/python-cli-design-spec.md` and `plugins/python3-development/agents/python-cli-design-spec.md`: removed the now-unreachable file-write fallback. A dispatch that still arrives without `item_id` is now treated as a caller defect — the agent reports `STATUS: BLOCKED — no item_id in dispatch prompt` instead of guessing an identifier or writing a file. `Write` was **not** added to either agent's tools frontmatter.

I did not find a genuine ownerless invocation shape that cannot resolve an `item_id` — `backlog_add` only requires a title/priority/description, all synthesizable from the dispatching task, so every path can now supply one before calling `python-cli-design-spec`.

## Test plan

- [x] Reproduced: read both agent files and both orchestration doc pairs on `origin/main`, confirmed no `Write` in either agent's `tools:` frontmatter and confirmed no dispatch path (Direct Track routing table, TDD Workflow, Feature Addition Workflow, in both plugin copies) supplied `item_id`.
- [x] `uv run prek run --files <all 6 hand-edited files>` — all hooks pass (markdownlint, skilllint/plugin validation, manifest-sync). No Python touched, so ruff/ty were no-ops (skipped, not failed).
- [x] Read the full Direct Track section of every touched file top-to-bottom for internal consistency after editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XDV8knocaB5yqW2JaC1tv