### PR TITLE
fix(agent-orchestration): add DELIVERY field to local delegation template

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -31,6 +31,9 @@ DEFINITION OF SUCCESS:
 - [Acceptance criteria]
 - [Verification method]
 
+DELIVERY:
+- [The channel that reaches the dispatcher, and where any longer artifact is written]
+
 CONTEXT:
 - Location: [Where to look]
 - Scope: [Boundaries]
@@ -52,6 +55,7 @@ YOUR TASK:
 
 - **OBSERVATIONS**: Pass-through only — data already in your context (user messages, prior agent reports, command outputs you already received). Include file:line references if already known. Include verbatim error messages, not paraphrased. Do NOT pre-gather data for the agent (e.g., don't run `ruff check .` before delegating to a linting agent). Do NOT read, grep, or glob files to find context for the agent — the agent has full tool access and an empty context window; it does its own discovery. No interpretations ("I think"), no assumptions ("probably"). SOURCE: [agent-orchestration SKILL.md](./../../../plugins/agent-orchestration/skills/agent-orchestration/SKILL.md) — Pre-Delegation Verification Checklist section.
 - **DEFINITION OF SUCCESS**: The "WHAT". Measurable outcomes the agent can verify. When the agent will produce more than ~1 line of output, instruct it to write results to a file and return only the path — this keeps orchestrator context lean. Example: `Write findings to .claude/reports/NAME-YYYYMMDD.md. Return: STATUS: DONE + file path.`
+- **DELIVERY**: State the delivery channel explicitly. The channel that carries an agent's final response back to its dispatcher differs between harnesses. Name the channel this dispatch expects, and name the artifact fallback: the full result written to a file whose path the agent returns. A result that exists only in the agent's final response text may never be read. Do not assume the dispatcher receives anything the prompt did not ask the agent to send.
 - **CONTEXT**: The "WHERE" and "WHY". Location narrows scope; constraints bound the solution space.
 
 ---
@@ -67,6 +71,7 @@ Check before sending:
 | **Constraints OK** | DO tell agent _constraints_ (e.g., "Must use the 'requests' library")                    |
 | **No Assumptions** | Do NOT say "The issue is probably..."                                                    |
 | **Full Scope**     | If code smell found, instruct agent to audit _entire pattern_, not single instance       |
+| **Stated Delivery** | Every prompt names how the result reaches the dispatcher                                |
 
 ---
 
@@ -77,3 +82,4 @@ Check before sending:
 - [ ] No assumptions stated as facts
 - [ ] Defines WHAT and WHY, not HOW
 - [ ] Lists resources without prescribing tools
+- [ ] Names the delivery channel and where any longer artifact is written


### PR DESCRIPTION
## Summary
- The local `.claude/skills/delegate/SKILL.md` delegation template had no field naming how a dispatched agent's result reaches its dispatcher, unlike the plugin-side `plugins/agent-orchestration/skills/delegate/SKILL.md`, which already carries a `DELIVERY:` field and authoring guidance for it.
- Adds the same `DELIVERY:` field to the local template, matching authoring guidance in the same voice as the existing field entries, plus corresponding rows in the Delegation Rules table and Quick Checklist for consistency with the plugin skill.

## Test plan
- [x] `uv run prek run --files .claude/skills/delegate/SKILL.md` passes (markdownlint-cli2, skill validator, and all other applicable hooks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg