### PR TITLE
fix(backlog-core): thread struck state through progressive disclosure

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.8",
+  "version": "9.0.9",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/content_normalizer.py
+++ b/plugins/development-harness/backlog_core/content_normalizer.py
@@ -21,13 +21,34 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class NormalizedEntry:
-    """One content entry within a section."""
+    """One content entry within a section.
+
+    ``struck`` and ``entry_id`` are REQUIRED (no defaults) by design: a defaulted
+    ``struck=False`` would let a future producer silently report a struck entry
+    as live, reintroducing the exact defect this shape closes (#3187 — the
+    progressive-disclosure read path dropping ``struck``/``id`` so a retracted
+    entry became indistinguishable from live content). There is exactly one
+    production construction site (``_build_entries`` below) and one test-fixture
+    site; the type checker enforces both supply real values.
+    """
 
     index: int
     """0-based position within the parent section."""
 
     content: str
     """Raw markdown text of the entry."""
+
+    struck: bool
+    """``True`` when the entry has been struck (retracted); mirrors
+    ``SectionEntryDict.struck``.  Never inferred or defaulted — always sourced
+    directly from the entry's own record."""
+
+    entry_id: str
+    """Stable identifier for this entry; mirrors ``SectionEntryDict.id``.
+
+    Named ``entry_id`` (not ``id``) to stay unambiguous alongside the ``ordinal``
+    identity fields already present on downstream types (``OrdinalEntry``,
+    ``ResolvedUnit``, ``_SubtreeNode``)."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,8 +145,11 @@ def _build_entries(section: SectionEntryMetadata | GroomedSectionMetadata) -> li
     if not _is_entry_section_metadata(section):
         return []
     # After TypeGuard narrowing, section is SectionEntryMetadata.
-    # section["entries"] is list[SectionEntryDict]; each entry["content"] is str.
-    return [NormalizedEntry(index=i, content=entry["content"]) for i, entry in enumerate(section["entries"])]
+    # section["entries"] is list[SectionEntryDict]; each entry carries content, struck, id.
+    return [
+        NormalizedEntry(index=i, content=entry["content"], struck=entry["struck"], entry_id=entry["id"])
+        for i, entry in enumerate(section["entries"])
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/backlog_core/disclosure_handler.py
+++ b/plugins/development-harness/backlog_core/disclosure_handler.py
@@ -362,6 +362,8 @@ class BacklogViewDisclosureHandler:
                         truncated=bounded.truncated,
                         child_map=bounded.content,
                         has_children=True,
+                        struck=unit.struck,
+                        entry_id=unit.entry_id,
                     )
                 return self._handle_extract(
                     selector, request.navigate_ordinal, request.head_tokens, request.skip_tokens, mapper
@@ -388,8 +390,9 @@ class BacklogViewDisclosureHandler:
 
         Returns:
             ``MapResponse`` with formatted ``map_text``, ``total_sections``
-            (level-1 count), ``total_est_tokens`` (level-1 sum only), and
-            ``over_budget`` flag.
+            (level-1 count), ``total_est_tokens`` (level-1 sum only),
+            ``over_budget`` flag, and ``struck_ordinals`` (#3187) — the
+            ordinals of every struck entry or descendant in the map.
         """
         level1_entries = [e for e in entries if "." not in e.ordinal]
         total_est_tokens = sum(e.est_tokens for e in level1_entries)
@@ -400,6 +403,7 @@ class BacklogViewDisclosureHandler:
             total_est_tokens=total_est_tokens,
             map_text=map_text,
             over_budget=total_est_tokens > TOKEN_BUDGET,
+            struck_ordinals=[e.ordinal for e in entries if e.struck],
         )
 
     def _handle_navigate(self, ordinal: str, mapper: OrdinalPathMapper) -> NavigateResponse:
@@ -422,6 +426,9 @@ class BacklogViewDisclosureHandler:
             - ``has_children=False``, ``content`` set to the full body text or
               raw fence body, ``child_map=None`` for leaves and code blocks.
 
+            Both branches carry ``struck``/``entry_id`` (#3187) mirrored
+            directly from the resolved ``ResolvedUnit``.
+
         Raises:
             OrdinalNotFoundError: When ``ordinal`` is not in the resolution
                 map.  The exception carries ``valid_ordinals`` so callers can
@@ -439,10 +446,18 @@ class BacklogViewDisclosureHandler:
                 truncated=False,
                 child_map=unit.child_map,
                 has_children=True,
+                struck=unit.struck,
+                entry_id=unit.entry_id,
             )
         # Leaf or code-block node: return full content directly.
         return NavigateResponse(
-            ordinal=ordinal, title=unit.title, content=unit.content, total_tokens=unit.total_tokens, truncated=False
+            ordinal=ordinal,
+            title=unit.title,
+            content=unit.content,
+            total_tokens=unit.total_tokens,
+            truncated=False,
+            struck=unit.struck,
+            entry_id=unit.entry_id,
         )
 
     def _handle_extract(
@@ -471,7 +486,10 @@ class BacklogViewDisclosureHandler:
         Returns:
             ``BoundedResponse`` with ``next_call`` populated when truncated,
             ``None`` otherwise.  When the node is a sub-heading parent,
-            ``content`` holds the bounded ``child_map`` text.
+            ``content`` holds the bounded ``child_map`` text.  ``struck``/
+            ``entry_id`` (#3187) are mirrored from the resolved
+            ``ResolvedUnit`` — struck state is metadata, not content, so it
+            survives windowing even when ``content`` is truncated.
 
         Raises:
             OrdinalNotFoundError: When ``ordinal`` is not in the resolution
@@ -496,4 +514,6 @@ class BacklogViewDisclosureHandler:
             returned_tokens=bounded.returned_tokens,
             truncated=bounded.truncated,
             next_call=next_call,
+            struck=unit.struck,
+            entry_id=unit.entry_id,
         )

--- a/plugins/development-harness/backlog_core/disclosure_types.py
+++ b/plugins/development-harness/backlog_core/disclosure_types.py
@@ -9,7 +9,7 @@ value objects or MCP response shapes, not ingress validators).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 
 
@@ -60,6 +60,14 @@ class MapResponse:
     over_budget: bool
     """``True`` when ``total_est_tokens`` exceeds the configured token budget."""
 
+    struck_ordinals: list[str] = field(default_factory=list)
+    """Ordinals of every struck (retracted) entry or descendant in the map (#3187).
+
+    Explicit field rather than requiring callers to parse ``[struck] `` markers
+    out of ``map_text`` — the "No Invented Limits" data-completeness contract
+    this project follows requires struck state to be addressable, not merely
+    visible in formatted text."""
+
 
 @dataclass(frozen=True, slots=True)
 class NavigateResponse:
@@ -109,6 +117,15 @@ class NavigateResponse:
     to a child ordinal rather than using ``content`` directly.
     """
 
+    struck: bool = False
+    """``True`` when the resolved ordinal addresses a struck (retracted) entry,
+    or a descendant of one (#3187).  ``False`` for level-1 section aggregates,
+    which have no single-entry identity."""
+
+    entry_id: str = ""
+    """Stable identifier of the owning entry; ``""`` when the resolved ordinal
+    has no entry identity (level-1 sections)."""
+
 
 @dataclass(frozen=True, slots=True)
 class BoundedResponse:
@@ -138,6 +155,15 @@ class BoundedResponse:
 
     ``None`` when ``truncated`` is ``False``.
     """
+
+    struck: bool = False
+    """``True`` when the resolved ordinal addresses a struck (retracted) entry,
+    or a descendant of one (#3187).  Struck state is metadata, not content, so
+    it survives token-bounded windowing even when ``content`` is truncated."""
+
+    entry_id: str = ""
+    """Stable identifier of the owning entry; ``""`` when the resolved ordinal
+    has no entry identity (level-1 sections)."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/plugins/development-harness/backlog_core/ordinal_mapper.py
+++ b/plugins/development-harness/backlog_core/ordinal_mapper.py
@@ -17,7 +17,7 @@ Does NOT:
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 from progressive_markdown.indexer import MarkdownIndexer
@@ -29,7 +29,7 @@ from backlog_core.disclosure_types import OrdinalNotFoundError
 if TYPE_CHECKING:
     from progressive_markdown.models import CodeBlock, SectionNode
 
-    from backlog_core.content_normalizer import NormalizedSection
+    from backlog_core.content_normalizer import NormalizedEntry, NormalizedSection
 
 # ---------------------------------------------------------------------------
 # Format constants (architect spec §5.5)
@@ -50,6 +50,15 @@ _FENCE_PATTERN: re.Pattern[str] = re.compile(r"```[^\n]*\n.*?```", re.DOTALL)
 # full content is returned, not a child map.
 _MIN_ROOT_SECTIONS_FOR_PARENT: int = 2
 
+# In-band struck markers (#3187). Reuses the ``[code:{ordinal}]`` token
+# convention already established by ``_replace_code_fences_with_tokens``.
+_STRUCK_CONTENT_MARKER: str = "[struck:{entry_id}]"
+"""Prefix inserted before a struck entry's own text in aggregate content
+(``build_map()``'s level-1 join and ``resolve()``'s level-1 aggregate)."""
+
+_STRUCK_MAP_MARKER: str = "[struck] "
+"""Prefix inserted before a struck entry's title in a formatted map line."""
+
 
 # ---------------------------------------------------------------------------
 # Value objects (public)
@@ -69,12 +78,20 @@ class OrdinalEntry:
         first_line_preview: First non-empty, non-heading line of the content;
             max ``_PREVIEW_MAX`` chars; empty string when content has no body
             text.
+        struck: ``True`` when this ordinal addresses a struck (retracted)
+            entry, or a sub-heading/code fence nested inside one (#3187).
+            Defaulted ``False`` — a level-1 section aggregate is never itself
+            struck; only entries and their descendants carry the flag.
+        entry_id: Stable identifier of the owning entry; ``""`` when this
+            ordinal has no entry identity (level-1 sections).
     """
 
     ordinal: str
     title: str
     est_tokens: int
     first_line_preview: str
+    struck: bool = False
+    entry_id: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,6 +115,11 @@ class ResolvedUnit:
         child_map: Pre-rendered listing of direct sub-heading children using
             the same ``format_map_line`` format as MAP responses.  Non-empty
             only when ``has_sub_heading_children`` is ``True``.
+        struck: ``True`` when this ordinal addresses a struck (retracted)
+            entry, or a descendant of one (#3187).  Defaulted ``False`` for
+            level-1 section aggregates, which have no single-entry identity.
+        entry_id: Stable identifier of the owning entry; ``""`` when this
+            ordinal has no entry identity (level-1 sections).
     """
 
     ordinal: str
@@ -109,6 +131,8 @@ class ResolvedUnit:
     child_ordinals: list[str] = field(default_factory=list)
     code_block_ordinals: list[str] = field(default_factory=list)
     child_map: str = ""
+    struck: bool = False
+    entry_id: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +159,11 @@ class _SubtreeNode:
         is_code_block: True iff this ordinal addresses a code fence body.
         child_ordinals: Direct sub-heading child ordinals (document order).
         code_block_ordinals: Direct-body fence ordinals (document order).
+        struck: ``True`` when this node addresses a struck (retracted) entry,
+            or a descendant of one (#3187).  Defaulted ``False`` for level-1
+            section aggregates.
+        entry_id: Stable identifier of the owning entry; ``""`` when this
+            node has no entry identity (level-1 sections).
     """
 
     ordinal: str
@@ -145,11 +174,35 @@ class _SubtreeNode:
     is_code_block: bool
     child_ordinals: list[str]
     code_block_ordinals: list[str]
+    struck: bool = False
+    entry_id: str = ""
 
 
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _entry_block_text(entry: NormalizedEntry) -> str:
+    r"""Return entry content, prefixed with an in-band struck marker when struck.
+
+    This is the AC-4 fix (#3187): the level-1 section aggregate join must not
+    merge struck and live entry text into one indistinguishable string.
+    Prefixing the marker in-band means a caller reading the aggregate
+    ``content`` (e.g. via ``navigate`` on a level-1 ordinal) can still tell
+    which entry was struck, even though the aggregate has no per-entry field.
+
+    Args:
+        entry: The normalized entry to render.
+
+    Returns:
+        ``entry.content`` unchanged when live; ``"{marker}\\n{content}"`` when
+        struck, where the marker is ``_STRUCK_CONTENT_MARKER`` formatted with
+        the entry's ``entry_id``.
+    """
+    if not entry.struck:
+        return entry.content
+    return f"{_STRUCK_CONTENT_MARKER.format(entry_id=entry.entry_id)}\n{entry.content}"
 
 
 def _extract_entry_title(content: str) -> str:
@@ -342,6 +395,14 @@ class OrdinalPathMapper:
         ``valid_ordinals()``.  Calling ``build_map()`` again replaces the
         previous index.
 
+        Struck entries (#3187): the level-1 aggregate content is joined via
+        ``_entry_block_text()``, which prefixes an in-band
+        ``[struck:{entry_id}]`` marker before a struck entry's own text — the
+        aggregate has no per-entry field, so this is the only way a caller
+        reading the merged content can tell struck from live text apart.
+        Level-2 entries and their indexed sub-ordinal subtree inherit the
+        source entry's ``struck``/``entry_id`` directly.
+
         Returns:
             Ordered list of ``OrdinalEntry``.  Within each section, the
             level-1 entry appears first, followed by level-2 entries; each
@@ -355,7 +416,9 @@ class OrdinalPathMapper:
             level1_ordinal = str(section.index)
 
             # Canonical section content: all entry bodies joined by blank lines.
-            section_content = "\n\n".join(e.content for e in section.entries)
+            # _entry_block_text prefixes struck entries with an in-band marker
+            # so the merged aggregate never presents struck text as live (#3187 AC-4).
+            section_content = "\n\n".join(_entry_block_text(e) for e in section.entries)
             section_tokens = len(self._enc.encode(section_content)) if section_content else 0
             level1_preview = _extract_preview(section_content)
 
@@ -392,6 +455,12 @@ class OrdinalPathMapper:
                     level2_ordinal, entry_content
                 )
 
+                # Stamp the source entry's struck/entry_id onto every node in
+                # its indexed subtree — a sub-heading or code fence inside a
+                # struck entry is itself struck (#3187 AC-5 precondition).
+                sub_ents = [replace(e, struck=entry.struck, entry_id=entry.entry_id) for e in sub_ents]
+                sub_idx = {k: replace(v, struck=entry.struck, entry_id=entry.entry_id) for k, v in sub_idx.items()}
+
                 resolution_index[level2_ordinal] = _SubtreeNode(
                     ordinal=level2_ordinal,
                     title=entry_title,
@@ -401,6 +470,8 @@ class OrdinalPathMapper:
                     is_code_block=False,
                     child_ordinals=[],
                     code_block_ordinals=[],
+                    struck=entry.struck,
+                    entry_id=entry.entry_id,
                 )
                 resolution_index.update(sub_idx)
 
@@ -412,6 +483,8 @@ class OrdinalPathMapper:
                             title=entry_title,
                             est_tokens=final_tokens,
                             first_line_preview=final_preview,
+                            struck=entry.struck,
+                            entry_id=entry.entry_id,
                         )
                     )
                     entries.extend(sub_ents)
@@ -425,10 +498,13 @@ class OrdinalPathMapper:
 
         Format::
 
-            {ordinal} {title} ({est_tokens}t) [— "{preview}"]
+            {ordinal} [{struck marker}]{title} ({est_tokens}t) [— "{preview}"]
 
         The em-dash (U+2014) and preview clause are omitted entirely when
-        ``entry.first_line_preview`` is the empty string.
+        ``entry.first_line_preview`` is the empty string.  The struck marker
+        (``"[struck] "``) is emitted immediately before the title, OUTSIDE
+        the title's truncation window, so it can never be eaten by the
+        ellipsis (#3187 §3.3).
 
         Caps enforced:
 
@@ -447,7 +523,8 @@ class OrdinalPathMapper:
         if len(title) > _TITLE_MAX:
             title = title[: _TITLE_MAX - 1] + _ELLIPSIS
 
-        base = f"{entry.ordinal} {title} ({entry.est_tokens}t)"
+        marker = _STRUCK_MAP_MARKER if entry.struck else ""
+        base = f"{entry.ordinal} {marker}{title} ({entry.est_tokens}t)"
 
         if entry.first_line_preview:
             preview = entry.first_line_preview
@@ -491,6 +568,8 @@ class OrdinalPathMapper:
                 child_ordinals=node.child_ordinals,
                 code_block_ordinals=node.code_block_ordinals,
                 child_map=child_map,
+                struck=node.struck,
+                entry_id=node.entry_id,
             )
         raise OrdinalNotFoundError(ordinal, self.valid_ordinals())
 
@@ -527,7 +606,14 @@ class OrdinalPathMapper:
         lines: list[str] = []
         for co in child_ordinals:
             cn = self._resolution_index[co]
-            entry = OrdinalEntry(ordinal=cn.ordinal, title=cn.title, est_tokens=cn.total_tokens, first_line_preview="")
+            entry = OrdinalEntry(
+                ordinal=cn.ordinal,
+                title=cn.title,
+                est_tokens=cn.total_tokens,
+                first_line_preview="",
+                struck=cn.struck,
+                entry_id=cn.entry_id,
+            )
             lines.append(self.format_map_line(entry))
         return "\n".join(lines)
 

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2551,11 +2551,14 @@ async def backlog_view(
 
     Returns:
         When map=True: dict with map_text (ordinal structure, <2,000 tokens), selector,
-        total_sections, total_est_tokens, and over_budget flag.
+        total_sections, total_est_tokens, over_budget flag, and struck_ordinals (every
+        struck/retracted ordinal in the map).
         When navigate=<ordinal> (no head): dict with ordinal, title, content,
-        total_tokens, truncated=False.
+        total_tokens, truncated=False, struck, and entry_id.
         When navigate=<ordinal> + head=N: dict with ordinal, title, content, total_tokens,
-        returned_tokens, truncated, and next_call hint when truncated=True.
+        returned_tokens, truncated, next_call hint when truncated=True, struck, and entry_id.
+        struck/entry_id reflect the addressed entry (or its descendant); False/"" for
+        level-1 section ordinals, which have no single-entry identity.
         When summary=True (default, no disclosure params): compact dict with issue_number,
         title, labels, status, plan_address, sections_index, _summary, _full_chars, and _hint.
         When summary=False: dict with title, priority, issue, plan, file_path, body,

--- a/plugins/development-harness/backlog_core/tests/unit/test_content_normalizer.py
+++ b/plugins/development-harness/backlog_core/tests/unit/test_content_normalizer.py
@@ -14,6 +14,10 @@ Behavioral contract pinned by this file:
    item (#2515) normalizes to a non-empty list, guarding against the gated-path trap.
 4. **Ordinals match position**: ``NormalizedSection.index`` equals its 0-based position
    in the returned list.
+5. **Struck and entry_id preserved** (#3187): ``NormalizedEntry.struck`` and
+   ``NormalizedEntry.entry_id`` are sourced exactly from each ``SectionEntryDict``'s
+   ``struck``/``id`` fields — never inferred or defaulted — and entry count in
+   equals entry count out for a mixed struck/live section.
 
 Implementation note for T12
 ---------------------------
@@ -60,9 +64,13 @@ def _body_sections_block(order: list[tuple[str, int]]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _entry_dict(content: str, entry_id: str = "test-id") -> SectionEntryDict:
-    """Create a minimal SectionEntryDict for test fixtures."""
-    return SectionEntryDict(id=entry_id, struck=False, content=content)
+def _entry_dict(content: str, entry_id: str = "test-id", struck: bool = False) -> SectionEntryDict:
+    """Create a minimal SectionEntryDict for test fixtures.
+
+    ``struck`` defaults to ``False`` (additive parameter, no call-site churn) —
+    callers exercising struck-entry behavior pass ``struck=True`` explicitly.
+    """
+    return SectionEntryDict(id=entry_id, struck=struck, content=content)
 
 
 def _section(contents: list[str]) -> SectionEntryMetadata | GroomedSectionMetadata:
@@ -264,6 +272,58 @@ class TestNormalizedEntryStructure:
         for i, entry in enumerate(tasks_section.entries):
             assert isinstance(entry, NormalizedEntry), f"Entry {i} must be NormalizedEntry; got {type(entry).__name__}."
             assert entry.index == i, f"NormalizedEntry.index must be {i} (0-based within section); got {entry.index}."
+
+
+# ---------------------------------------------------------------------------
+# TC-N6: NormalizedEntry.struck / entry_id sourced exactly from SectionEntryDict (#3187)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizedEntryStruckAndEntryId:
+    """NormalizedEntry.struck and .entry_id are sourced exactly from SectionEntryDict.
+
+    Regression coverage for #3187: the progressive-disclosure read path previously
+    dropped both fields between ``SectionEntryDict`` and downstream consumers, making
+    a retracted (struck) entry indistinguishable from live content.
+    """
+
+    def test_struck_and_live_entries_map_struck_flag_and_entry_id_correctly(self) -> None:
+        """A mixed section's entries map struck=True/False and entry_id exactly (AC-1, AC-2, AC-6)."""
+        entries: list[SectionEntryDict] = [
+            _entry_dict("struck body", entry_id="ts-struck", struck=True),
+            _entry_dict("live body", entry_id="ts-live", struck=False),
+        ]
+        section_meta = SectionEntryMetadata(num_entries=1, num_struck=1, entries=entries)
+        sections: dict[str, SectionEntryMetadata | GroomedSectionMetadata] = {"Mixed": section_meta}
+        body = _body_sections_block([("Mixed", 2)])
+
+        normalized = ItemContentNormalizer().normalize(ViewItemResult(sections=sections, body=body, sections_index=""))
+
+        assert len(normalized) == 1
+        struck_entry, live_entry = normalized[0].entries
+        assert struck_entry.struck is True, f"First entry must report struck=True; got {struck_entry.struck!r}."
+        assert struck_entry.entry_id == "ts-struck", (
+            f"First entry_id must be 'ts-struck'; got {struck_entry.entry_id!r}."
+        )
+        assert live_entry.struck is False, f"Second entry must report struck=False; got {live_entry.struck!r}."
+        assert live_entry.entry_id == "ts-live", f"Second entry_id must be 'ts-live'; got {live_entry.entry_id!r}."
+
+    def test_mixed_section_entry_count_out_equals_entry_count_in(self) -> None:
+        """normalize() must not drop or add entries for a mixed struck/live section (AC-3)."""
+        entries: list[SectionEntryDict] = [
+            _entry_dict("a", entry_id="e0", struck=True),
+            _entry_dict("b", entry_id="e1", struck=False),
+            _entry_dict("c", entry_id="e2", struck=True),
+        ]
+        section_meta = SectionEntryMetadata(num_entries=1, num_struck=2, entries=entries)
+        sections: dict[str, SectionEntryMetadata | GroomedSectionMetadata] = {"Mixed": section_meta}
+        body = _body_sections_block([("Mixed", 3)])
+
+        normalized = ItemContentNormalizer().normalize(ViewItemResult(sections=sections, body=body, sections_index=""))
+
+        assert len(normalized[0].entries) == len(entries), (
+            f"Entry count out ({len(normalized[0].entries)}) must equal entry count in ({len(entries)})."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/backlog_core/tests/unit/test_disclosure_handler.py
+++ b/plugins/development-harness/backlog_core/tests/unit/test_disclosure_handler.py
@@ -107,9 +107,13 @@ def _load_fixture(name: str) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))  # type: ignore[return-value]
 
 
-def _entry_dict(content: str, entry_id: str = "test-id") -> SectionEntryDict:
-    """Minimal SectionEntryDict for test fixtures."""
-    return SectionEntryDict(id=entry_id, struck=False, content=content)
+def _entry_dict(content: str, entry_id: str = "test-id", struck: bool = False) -> SectionEntryDict:
+    """Minimal SectionEntryDict for test fixtures.
+
+    ``struck`` defaults to ``False`` (additive parameter, no call-site churn) —
+    callers exercising struck-entry behavior (#3187) pass ``struck=True`` explicitly.
+    """
+    return SectionEntryDict(id=entry_id, struck=struck, content=content)
 
 
 def _section(contents: list[str]) -> SectionEntryMetadata:
@@ -1038,3 +1042,123 @@ class TestNavigateOnParentResponse:
         assert result.has_children is True, "has_children must be True for sub-heading parent in EXTRACT mode (§4.4)."
         assert result.child_map is not None, "child_map must not be None when has_children=True."
         assert result.truncated is True, "truncated must be True when child_map text exceeds head=1 token (§4.4)."
+
+
+# ---------------------------------------------------------------------------
+# Struck-entry visibility through the disclosure handler (#3187) - TDD RED
+# ---------------------------------------------------------------------------
+#
+# These tests pin the handler-level behavioral contract from the #3187 solution
+# design brief (.tmp/scratch/solution-design-struck-progressive-disclosure-3187.md
+# section 3.4, section 5.2). They are expected to FAIL until a later
+# implementation pass adds ``struck_ordinals`` to ``MapResponse`` and
+# ``struck``/``entry_id`` to ``NavigateResponse``/``BoundedResponse``, and
+# threads them through
+# ``BacklogViewDisclosureHandler._handle_map/_handle_navigate/_handle_extract``.
+#
+# Failures are expected as ``AttributeError`` (the response dataclasses do not
+# carry these fields yet) - the RIGHT reason for this phase.
+
+
+@pytest.fixture
+def struck_view_result() -> ViewItemResult:
+    """Two-entry section where entry 0 is struck and entry 1 is live (#3187 shape).
+
+    Mirrors item #3187's own RT-ICA section: a struck snapshot entry followed by
+    a live final entry, both within one section - the level-2 emission gate fires
+    (entry_count > 1) so both ordinals ("0.0", "0.1") are independently addressable.
+    """
+    sections: dict[str, SectionEntryMetadata | GroomedSectionMetadata] = {
+        "RT-ICA": SectionEntryMetadata(
+            num_entries=1,
+            num_struck=1,
+            entries=[
+                _entry_dict("RT-ICA Snapshot: original assessment.", entry_id="ts-struck", struck=True),
+                _entry_dict("RT-ICA Final: resolved assessment.", entry_id="ts-live", struck=False),
+            ],
+        )
+    }
+    body = _body_sections_block([("RT-ICA", 2)])
+    return ViewItemResult(sections=sections, body=body, sections_index="")
+
+
+class TestMapModeStruckOrdinals:
+    """MAP mode's ``struck_ordinals`` field lists exactly the struck ordinals (AC-1)."""
+
+    @_skip_without_real_enc
+    def test_struck_ordinals_lists_exactly_the_struck_ordinal(
+        self, struck_view_result: ViewItemResult, mocker: MockerFixture
+    ) -> None:
+        """``MapResponse.struck_ordinals`` contains '0.0' and NOT '0.1'."""
+        mocker.patch("backlog_core.operations.view_item", return_value=struck_view_result)
+
+        result = BacklogViewDisclosureHandler().handle("synthetic-selector", DisclosureRequestParser().parse(map=True))
+
+        assert isinstance(result, MapResponse), f"Expected MapResponse; got {type(result).__name__}."
+        assert result.struck_ordinals == ["0.0"], (
+            f"struck_ordinals must list exactly the struck ordinal '0.0'; got {result.struck_ordinals!r}."
+        )
+
+
+class TestNavigateModeStruckAndEntryId:
+    """NAVIGATE on a struck ordinal reports struck=True; its live sibling reports
+    struck=False - both carry their own entry_id (AC-1, AC-2, bidirectional).
+    """
+
+    @_skip_without_real_enc
+    def test_navigate_struck_ordinal_reports_struck_true_with_entry_id(
+        self, struck_view_result: ViewItemResult, mocker: MockerFixture
+    ) -> None:
+        """NAVIGATE on '0.0' (struck) returns struck=True, entry_id='ts-struck'."""
+        mocker.patch("backlog_core.operations.view_item", return_value=struck_view_result)
+
+        result = BacklogViewDisclosureHandler().handle(
+            "synthetic-selector", DisclosureRequestParser().parse(navigate="0.0")
+        )
+
+        assert isinstance(result, NavigateResponse), f"Expected NavigateResponse; got {type(result).__name__}."
+        assert result.struck is True, f"Struck sibling must report struck=True; got {result.struck!r}."
+        assert result.entry_id == "ts-struck", f"entry_id must be 'ts-struck'; got {result.entry_id!r}."
+
+    @_skip_without_real_enc
+    def test_navigate_live_sibling_reports_struck_false_with_entry_id(
+        self, struck_view_result: ViewItemResult, mocker: MockerFixture
+    ) -> None:
+        """NAVIGATE on '0.1' (live) returns struck=False, entry_id='ts-live' - the
+        bidirectional half of AC-2: a live sibling is never reported as struck.
+        """
+        mocker.patch("backlog_core.operations.view_item", return_value=struck_view_result)
+
+        result = BacklogViewDisclosureHandler().handle(
+            "synthetic-selector", DisclosureRequestParser().parse(navigate="0.1")
+        )
+
+        assert isinstance(result, NavigateResponse)
+        assert result.struck is False, f"Live sibling must report struck=False; got {result.struck!r}."
+        assert result.entry_id == "ts-live", f"entry_id must be 'ts-live'; got {result.entry_id!r}."
+
+
+class TestExtractModeStruckSurvivesWindowing:
+    """EXTRACT (``head=N``) on a struck ordinal preserves struck=True across
+    token-bounded windowing (AC-5) - the struck flag is metadata, not content,
+    so truncating the content window must never lose it.
+    """
+
+    @_skip_without_real_enc
+    def test_extract_on_struck_ordinal_preserves_struck_flag(
+        self, struck_view_result: ViewItemResult, mocker: MockerFixture
+    ) -> None:
+        """EXTRACT on '0.0' (struck) with head=1 still returns struck=True, entry_id set."""
+        mocker.patch("backlog_core.operations.view_item", return_value=struck_view_result)
+
+        result = BacklogViewDisclosureHandler().handle(
+            "synthetic-selector", DisclosureRequestParser().parse(navigate="0.0", head=1)
+        )
+
+        assert isinstance(result, BoundedResponse), f"Expected BoundedResponse; got {type(result).__name__}."
+        assert result.struck is True, (
+            f"BoundedResponse for a struck ordinal must report struck=True; got {result.struck!r}."
+        )
+        assert result.entry_id == "ts-struck", (
+            f"entry_id must survive windowing as 'ts-struck'; got {result.entry_id!r}."
+        )

--- a/plugins/development-harness/backlog_core/tests/unit/test_ordinal_mapper.py
+++ b/plugins/development-harness/backlog_core/tests/unit/test_ordinal_mapper.py
@@ -105,6 +105,11 @@ def _load_fixture(name: str) -> dict[str, object]:
 def _make_sections(*specs: tuple[str, list[str]]) -> list[NormalizedSection]:
     """Build ``list[NormalizedSection]`` with correct 0-based index values.
 
+    All entries are live (``struck=False``).  Use ``_make_struck_sections`` for
+    fixtures that need a struck entry — this helper's public signature is left
+    unchanged so its ~50 existing callers are unaffected (#3187 fixture-safety
+    mandate).
+
     Args:
         specs: Sequence of ``(title, [entry_content, ...])`` tuples.
 
@@ -115,7 +120,41 @@ def _make_sections(*specs: tuple[str, list[str]]) -> list[NormalizedSection]:
     for idx, (title, entries) in enumerate(specs):
         out.append(
             NormalizedSection(
-                index=idx, title=title, entries=[NormalizedEntry(index=i, content=c) for i, c in enumerate(entries)]
+                index=idx,
+                title=title,
+                entries=[
+                    NormalizedEntry(index=i, content=c, struck=False, entry_id=f"{idx}-{i}")
+                    for i, c in enumerate(entries)
+                ],
+            )
+        )
+    return out
+
+
+def _make_struck_sections(*specs: tuple[str, list[tuple[str, bool, str]]]) -> list[NormalizedSection]:
+    """Build ``list[NormalizedSection]`` with per-entry struck flags and entry IDs.
+
+    Separate helper (not an overload of ``_make_sections``) so struck-specific
+    fixtures are explicit at the call site without touching the ~50 existing
+    ``_make_sections`` callers (#3187 fixture-safety mandate).
+
+    Args:
+        specs: Sequence of ``(title, [(entry_content, struck, entry_id), ...])`` tuples.
+
+    Returns:
+        Ordered list where each section's ``index`` equals its position, and each
+        entry carries the exact ``struck``/``entry_id`` values supplied.
+    """
+    out: list[NormalizedSection] = []
+    for idx, (title, entries) in enumerate(specs):
+        out.append(
+            NormalizedSection(
+                index=idx,
+                title=title,
+                entries=[
+                    NormalizedEntry(index=i, content=content, struck=struck, entry_id=entry_id)
+                    for i, (content, struck, entry_id) in enumerate(entries)
+                ],
             )
         )
     return out
@@ -1211,3 +1250,170 @@ class TestOrdinalGeneratorValidatorAgreement:
         """A code-fence ordinal, attached to the root or any nested heading, matches the regex."""
         ordinal = _entry_ordinal_for_code(parent, k)
         assert _ORDINAL_PATTERN.fullmatch(ordinal), f"{ordinal!r} does not match _ORDINAL_PATTERN"
+
+
+# ---------------------------------------------------------------------------
+# Struck-entry marking through progressive disclosure (#3187) — TDD RED
+# ---------------------------------------------------------------------------
+#
+# These tests pin the behavioral contract from the #3187 solution design brief
+# (.tmp/scratch/solution-design-struck-progressive-disclosure-3187.md §3.3, §5.2).
+# They are expected to FAIL until a later implementation pass:
+#
+# - Adds ``struck``/``entry_id`` (defaulted) to ``OrdinalEntry`` and ``ResolvedUnit``.
+# - Adds the ``_entry_block_text()`` helper and ``_STRUCK_CONTENT_MARKER`` /
+#   ``_STRUCK_MAP_MARKER`` constants.
+# - Changes ``build_map()``'s level-1 content join to use ``_entry_block_text``.
+# - Stamps struck/entry_id onto level-2 ``OrdinalEntry``/``_SubtreeNode`` and their
+#   indexed sub-heading subtree via ``dataclasses.replace``.
+# - Changes ``format_map_line()`` to prefix a struck marker before the title.
+#
+# Until then, failures are expected in one of two forms — both are the RIGHT
+# reason (feature not yet implemented downstream of NormalizedEntry):
+#
+# - ``AttributeError`` — accessing ``.struck``/``.entry_id`` on ``OrdinalEntry``/
+#   ``ResolvedUnit``, which do not carry those fields yet.
+# - ``AssertionError`` — the struck marker is absent from map/content text because
+#   ``build_map()``'s section-content join and ``format_map_line()`` do not emit it yet.
+
+
+class TestBuildMapLevelOneAggregateMarksStruckEntries:
+    """``build_map()``'s level-1 aggregate content must flag struck entries in-band (AC-4).
+
+    This is the row the #3187 brief calls the gate: a half-fix that only adds
+    fields to ``NormalizedEntry`` and the response types, without also changing
+    the level-1 content join, still merges struck and live text into one
+    indistinguishable string here.
+    """
+
+    def test_level1_content_contains_marker_before_struck_entry_not_before_live(self) -> None:
+        """resolve('0').content must contain '[struck:{entry_id}]' immediately before the
+        struck entry's text, and must NOT contain a marker anywhere near the live entry.
+        """
+        sections = _make_struck_sections((
+            "Mixed",
+            [("Struck body text.", True, "id-struck"), ("Live body text.", False, "id-live")],
+        ))
+        mapper = OrdinalPathMapper(sections)
+        mapper.build_map()
+        resolved = mapper.resolve("0")
+
+        assert "[struck:id-struck]" in resolved.content, (
+            f"Level-1 aggregate content must carry the struck marker for the struck entry; got: {resolved.content!r}"
+        )
+        marker_pos = resolved.content.index("[struck:id-struck]")
+        body_pos = resolved.content.index("Struck body text.")
+        assert marker_pos < body_pos, "Struck marker must precede the struck entry's own text."
+        assert "[struck:id-live]" not in resolved.content, (
+            "The live entry must never be marked struck — no marker keyed to its entry_id."
+        )
+        assert "Live body text." in resolved.content, "Live entry text must still be present, unmarked."
+
+
+class TestFormatMapLineStruckMarker:
+    """``format_map_line()`` must prefix a struck marker before the title (§3.3).
+
+    The marker sits outside the 50-char title truncation window so a long
+    struck title's ellipsis can never eat it.
+    """
+
+    def test_struck_level2_entry_emits_marker_before_truncated_title(self) -> None:
+        """A struck level-2 entry's map line starts with '{ordinal} [struck] ', and the
+        title is still truncated with an ellipsis when it exceeds 50 chars.
+        """
+        long_title = "A" * 80
+        sections = _make_struck_sections((
+            "Sec",
+            [(f"# {long_title}\nbody one", True, "ts-struck"), ("second entry body", False, "ts-live")],
+        ))
+        mapper = OrdinalPathMapper(sections)
+        entries = mapper.build_map()
+
+        struck_entry = next(e for e in entries if e.ordinal == "0.0")
+        live_entry = next(e for e in entries if e.ordinal == "0.1")
+
+        # AttributeError expected here until OrdinalEntry carries a struck field.
+        assert struck_entry.struck is True, (
+            f"Level-2 OrdinalEntry for the struck source entry must report struck=True; got {struck_entry!r}."
+        )
+        assert live_entry.struck is False, (
+            f"Level-2 OrdinalEntry for the live source entry must report struck=False; got {live_entry!r}."
+        )
+
+        struck_line = mapper.format_map_line(struck_entry)
+        live_line = mapper.format_map_line(live_entry)
+
+        assert struck_line.startswith("0.0 [struck] "), (
+            f"Struck marker must precede the (possibly truncated) title; got {struck_line!r}."
+        )
+        assert "…" in struck_line, f"Long title must still be truncated with an ellipsis; got {struck_line!r}."
+        assert "[struck] " not in live_line, f"Live entry's map line must carry no struck marker; got {live_line!r}."
+
+
+class TestResolveSubHeadingInsideStruckEntryInheritsStruckState:
+    """A sub-heading node inside a struck entry inherits the parent's struck flag
+    and entry_id (AC-5 precondition — the actual EXTRACT/head windowing test lives
+    in ``test_disclosure_handler.py`` and ``test_struck_progressive_disclosure.py``).
+    """
+
+    def test_level3_sub_heading_resolves_struck_true_with_parent_entry_id(self) -> None:
+        """resolve('0.0.0') on a sub-heading inside a struck entry returns struck=True
+        and entry_id equal to the parent entry's entry_id — not the sub-heading's own
+        (sub-headings have no independent entry identity).
+        """
+        content = "### First\n\nFirst body.\n\n### Second\n\nSecond body.\n"
+        # Two entries in the section (not one) so the level-2 emission gate
+        # (entry_count > 1) fires and level-3 sub-ordinals are indexed — mirrors
+        # the module's own structured_entry_doc fixture convention.
+        sections = _make_struck_sections((
+            "Groomed",
+            [(content, True, "ts-parent"), ("Second entry.", False, "ts-sibling")],
+        ))
+        mapper = OrdinalPathMapper(sections)
+        mapper.build_map()
+        assert "0.0.0" in mapper.valid_ordinals(), (
+            "Precondition: entry content with 2+ root headings must index a level-3 sub-ordinal '0.0.0'. "
+            f"Valid ordinals: {mapper.valid_ordinals()}"
+        )
+
+        unit = mapper.resolve("0.0.0")
+
+        assert unit.struck is True, (  # AttributeError expected until ResolvedUnit carries struck
+            f"Sub-heading inside a struck entry must resolve struck=True; got {unit!r}."
+        )
+        assert unit.entry_id == "ts-parent", (
+            f"Sub-heading must inherit the parent entry's entry_id 'ts-parent'; got {unit.entry_id!r}."
+        )
+
+
+class TestZeroStruckSectionMapOutputUnchanged:
+    """Regression guard (AC-7): a section with no struck entries produces identical
+    map output regardless of which fixture builder constructed it — proving the
+    struck-marker machinery introduces nothing for an all-live section.
+
+    Unlike the tests above, this class is expected to PASS in both the RED and the
+    GREEN phase: it protects an invariant that must never change.
+    """
+
+    def test_all_live_section_output_identical_via_either_builder(self) -> None:
+        """A section built via ``_make_sections`` and the same content built via
+        ``_make_struck_sections`` with ``struck=False`` on every entry must produce
+        byte-identical ordinal, title, est_tokens, and preview for every map entry.
+        """
+        plain = _make_sections(("Live", ["first live entry", "second live entry"]))
+        struck_free = _make_struck_sections((
+            "Live",
+            [("first live entry", False, "ts-1"), ("second live entry", False, "ts-2")],
+        ))
+
+        plain_entries = OrdinalPathMapper(plain).build_map()
+        struck_free_entries = OrdinalPathMapper(struck_free).build_map()
+
+        plain_shape = [(e.ordinal, e.title, e.est_tokens, e.first_line_preview) for e in plain_entries]
+        struck_free_shape = [(e.ordinal, e.title, e.est_tokens, e.first_line_preview) for e in struck_free_entries]
+
+        assert plain_shape == struck_free_shape, (
+            f"All-live section map output must be identical regardless of builder.\n"
+            f"Via _make_sections:        {plain_shape}\n"
+            f"Via _make_struck_sections: {struck_free_shape}"
+        )

--- a/plugins/development-harness/backlog_core/tests/unit/test_struck_progressive_disclosure.py
+++ b/plugins/development-harness/backlog_core/tests/unit/test_struck_progressive_disclosure.py
@@ -1,0 +1,218 @@
+"""End-to-end reproduction test for #3187 — struck state through progressive disclosure.
+
+**TDD state (RED)**: This module pins the item's own reproduction verbatim, built
+through the REAL production pipeline — ``entry_blocks.wrap_entry_with_timestamp`` →
+``entry_blocks.strike_entry`` → ``entry_blocks.parse_entries`` → ``SectionEntryDict``
+list → ``ViewItemResult`` → ``ItemContentNormalizer`` → ``OrdinalPathMapper`` →
+``BacklogViewDisclosureHandler``. The only thing bypassed is the backend fetch
+(``operations.view_item``, patched with a hand-built ``ViewItemResult``) — nothing
+under test is mocked.
+
+Bug being reproduced: the progressive-disclosure read path (``backlog_view`` with
+``map=``/``navigate=``) silently dropped each entry's ``struck``/``id`` fields — a
+retracted (struck) entry was indistinguishable from live content by the time it
+reached a caller. Item #3187's own ``RT-ICA`` section is the canonical live
+reproduction (see the solution design brief §2 for the captured baseline):
+
+- ``16.0`` — RT-ICA Snapshot, ``struck: true``
+- ``16.1`` — RT-ICA Final, live
+
+This file rebuilds that exact shape synthetically (ordinal ``"0.0"``/``"0.1"``
+instead of ``"16.0"``/``"16.1"`` — this is a fresh single-section document, not
+item #3187 itself) so the test is self-contained and does not depend on live
+backend state.
+
+Until the fix lands, failures below are expected in one of two forms — both are
+the RIGHT reason (feature not yet implemented downstream of ``NormalizedEntry``):
+
+- ``AttributeError`` — accessing ``.struck``/``.entry_id``/``.struck_ordinals`` on
+  types that do not carry those fields yet (``OrdinalEntry``, ``ResolvedUnit``,
+  ``MapResponse``, ``NavigateResponse``, ``BoundedResponse``).
+- ``AssertionError`` — the in-band ``[struck:{entry_id}]`` marker is absent from
+  aggregate content because ``build_map()``'s section-content join does not emit
+  it yet.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from backlog_core.content_normalizer import ItemContentNormalizer
+from backlog_core.disclosure_handler import BacklogViewDisclosureHandler, DisclosureRequestParser
+from backlog_core.disclosure_types import MapResponse
+from backlog_core.entry_blocks import parse_entries, strike_entry, wrap_entry_with_timestamp
+from backlog_core.models import Entry, SectionEntryDict, SectionEntryMetadata, ViewItemResult
+from backlog_core.ordinal_mapper import OrdinalPathMapper
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+try:
+    from progressive_markdown.list_navigator import ENCODING as _ENCODING
+
+    _ENCODING_AVAILABLE: bool = _ENCODING is not None
+except (ImportError, OSError):
+    _ENCODING_AVAILABLE = False
+
+_skip_without_real_enc = pytest.mark.skipif(
+    not _ENCODING_AVAILABLE, reason="cl100k_base encoding unavailable (offline environment)."
+)
+
+# ---------------------------------------------------------------------------
+# Reproduction builder — the item's own repro steps, verbatim
+# ---------------------------------------------------------------------------
+
+_STRUCK_TS = "2026-08-23T11:49:14.766159Z"
+_LIVE_TS = "2026-08-23T12:00:00.000000Z"
+_STRUCK_CONTENT = "RT-ICA Snapshot: original assessment, since superseded."
+_LIVE_CONTENT = "RT-ICA Final: resolved assessment."
+
+
+def _build_mixed_struck_view_result() -> tuple[ViewItemResult, str, str]:
+    """Build a real ``ViewItemResult`` with one struck and one live entry.
+
+    Reproduces item #3187's RT-ICA section shape via the real entry pipeline:
+    ``wrap_entry_with_timestamp`` → ``strike_entry`` → ``parse_entries(show="all")``
+    → ``SectionEntryDict`` list → ``ViewItemResult``. Only ``operations.view_item``
+    (the backend fetch) is ever bypassed by callers of this helper.
+
+    Returns:
+        Tuple of ``(ViewItemResult, struck_entry_id, live_entry_id)``.
+    """
+    struck_block_raw = wrap_entry_with_timestamp(_STRUCK_CONTENT, _STRUCK_TS)
+    struck_block = strike_entry(struck_block_raw, reason="superseded by final assessment")
+    live_block = wrap_entry_with_timestamp(_LIVE_CONTENT, _LIVE_TS)
+
+    section_body = f"{struck_block}\n\n{live_block}"
+    entries: list[Entry] = parse_entries(section_body, show="all")
+    assert len(entries) == 2, f"Precondition: reproduction must parse exactly 2 entries; got {len(entries)}."
+    assert entries[0].struck is True, "Precondition: first parsed entry must be struck (the Snapshot)."
+    assert entries[1].struck is False, "Precondition: second parsed entry must be live (the Final)."
+
+    entry_dicts: list[SectionEntryDict] = [
+        SectionEntryDict(id=e.id, struck=e.struck, content=e.content) for e in entries
+    ]
+    section_meta = SectionEntryMetadata(num_entries=1, num_struck=1, entries=entry_dicts)
+    body = "## Sections\n[0] RT-ICA (2 entries)\n"
+    result = ViewItemResult(sections={"RT-ICA": section_meta}, body=body, sections_index="")
+    return result, entries[0].id, entries[1].id
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the real pipeline threads struck/entry_id into NormalizedEntry
+# ---------------------------------------------------------------------------
+
+
+class TestReproductionNormalizesStruckAndEntryId:
+    """The real entry_blocks → normalizer pipeline preserves struck/entry_id.
+
+    This class is expected to PASS already — it only exercises
+    ``ItemContentNormalizer``, which the RED-phase dataclass change already wires
+    correctly. It anchors that the reproduction builder itself is sound before the
+    downstream (ordinal_mapper / disclosure_handler) RED assertions below.
+    """
+
+    def test_normalized_entries_carry_struck_and_entry_id(self) -> None:
+        """NormalizedEntry.struck/.entry_id exactly mirror the parsed Entry objects."""
+        result, struck_id, live_id = _build_mixed_struck_view_result()
+
+        normalized = ItemContentNormalizer().normalize(result)
+
+        assert len(normalized) == 1, f"Expected exactly 1 section; got {len(normalized)}."
+        struck_entry, live_entry = normalized[0].entries
+        assert struck_entry.struck is True, f"First entry must be struck; got {struck_entry.struck!r}."
+        assert struck_entry.entry_id == struck_id, (
+            f"First entry_id must be {struck_id!r}; got {struck_entry.entry_id!r}."
+        )
+        assert live_entry.struck is False, f"Second entry must be live; got {live_entry.struck!r}."
+        assert live_entry.entry_id == live_id, f"Second entry_id must be {live_id!r}; got {live_entry.entry_id!r}."
+
+
+# ---------------------------------------------------------------------------
+# RED: the AC-4 gate — build_map()'s level-1 aggregate must not merge struck
+# and live content into one indistinguishable string
+# ---------------------------------------------------------------------------
+
+
+class TestReproductionBuildMapLevelOneAggregateFlagsStruckContent:
+    """AC-4 gate row: a half-fix that only adds fields to ``NormalizedEntry`` and
+    the response types — without also changing ``build_map()``'s level-1 content
+    join — still reproduces the exact defect: ``navigate="0"`` (item #3187's
+    ``navigate="16"``) returns struck+live text merged with no marker anywhere.
+    """
+
+    @_skip_without_real_enc
+    def test_level1_aggregate_content_marks_struck_and_not_live(self) -> None:
+        """resolve('0').content must carry '[struck:{struck_id}]' immediately before
+        the Snapshot text, and no marker anywhere near the Final text.
+        """
+        result, struck_id, live_id = _build_mixed_struck_view_result()
+        normalized = ItemContentNormalizer().normalize(result)
+        mapper = OrdinalPathMapper(normalized)
+        mapper.build_map()
+
+        resolved = mapper.resolve("0")
+
+        marker = f"[struck:{struck_id}]"
+        assert marker in resolved.content, (
+            f"Level-1 aggregate content must carry the struck marker for the struck entry; got: {resolved.content!r}"
+        )
+        assert resolved.content.index(marker) < resolved.content.index(_STRUCK_CONTENT), (
+            "Struck marker must precede the struck entry's own text."
+        )
+        assert f"[struck:{live_id}]" not in resolved.content, (
+            "The live entry must never be marked struck — no marker keyed to its entry_id."
+        )
+        assert _LIVE_CONTENT in resolved.content, "Live entry text must still be present, unmarked."
+
+
+# ---------------------------------------------------------------------------
+# RED: AC-1 — both entries independently addressable and oppositely flagged
+# ---------------------------------------------------------------------------
+
+
+class TestReproductionBothVariantsIndependentlyAddressableAndOppositelyFlagged:
+    """Both AC-1 variants ('16.0'/'16.1' in the live item, '0.0'/'0.1' here) are
+    present, independently addressable, and oppositely flagged — the core claim
+    of the bug report: a caller can no longer confuse the two.
+    """
+
+    @_skip_without_real_enc
+    def test_level2_entries_are_independently_and_oppositely_flagged(self) -> None:
+        """build_map() emits '0.0' (struck=True) and '0.1' (struck=False) — never
+        the same flag value for both.
+        """
+        result, struck_id, live_id = _build_mixed_struck_view_result()
+        normalized = ItemContentNormalizer().normalize(result)
+        mapper = OrdinalPathMapper(normalized)
+        entries = mapper.build_map()
+
+        by_ordinal = {e.ordinal: e for e in entries}
+        assert "0.0" in by_ordinal, f"Level-2 ordinal '0.0' must be addressable. Got: {sorted(by_ordinal)}"
+        assert "0.1" in by_ordinal, f"Level-2 ordinal '0.1' must be addressable. Got: {sorted(by_ordinal)}"
+
+        struck_entry = by_ordinal["0.0"]
+        live_entry = by_ordinal["0.1"]
+
+        # AttributeError expected here until OrdinalEntry carries a struck field.
+        assert struck_entry.struck is True, f"'0.0' (Snapshot) must report struck=True; got {struck_entry!r}."
+        assert live_entry.struck is False, f"'0.1' (Final) must report struck=False; got {live_entry!r}."
+        assert struck_entry.entry_id == struck_id
+        assert live_entry.entry_id == live_id
+
+    @_skip_without_real_enc
+    def test_handler_map_mode_reports_struck_ordinals_for_the_reproduction(self, mocker: MockerFixture) -> None:
+        """End to end through the handler: MAP mode's struck_ordinals contains
+        exactly the struck level-2 ordinal from the reproduction.
+        """
+        result, _struck_id, _live_id = _build_mixed_struck_view_result()
+        mocker.patch("backlog_core.operations.view_item", return_value=result)
+
+        response = BacklogViewDisclosureHandler().handle("#repro-3187", DisclosureRequestParser().parse(map=True))
+
+        assert isinstance(response, MapResponse), f"Expected MapResponse; got {type(response).__name__}."
+        assert response.struck_ordinals == ["0.0"], (
+            f"struck_ordinals must list exactly '0.0'; got {response.struck_ordinals!r}."
+        )

--- a/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
+++ b/plugins/development-harness/docs/mcp-progressive-disclosure-contract.md
@@ -95,6 +95,8 @@ Navigate to the ordinal in each token to retrieve the raw fence body.
 | `truncated`    | `bool`        | Always `False` for navigate-without-head responses.                                     |
 | `child_map`    | `str \| None` | Formatted listing of direct sub-heading children. `None` for leaves and code blocks.    |
 | `has_children` | `bool`        | `True` iff the node has sub-heading children (ADR-4). `False` for code-only nodes.      |
+| `struck`       | `bool`        | `True` iff the ordinal addresses a struck (retracted) entry, or a descendant of one.    |
+| `entry_id`     | `str`         | Stable identifier of the owning entry. `""` for level-1 section ordinals (no dot).      |
 
 ---
 
@@ -118,6 +120,8 @@ NavigateResponse:
   truncated:     false
   has_children:  true
   child_map:     "4.0.0 | Overview | ~45 tokens\n4.0.1 | Steps | ~120 tokens\n..."
+  struck:        false
+  entry_id:      "2026-08-23T11:49:14.766159Z"
 ```
 
 Read `child_map` to discover child ordinals, then navigate to a specific child.
@@ -142,6 +146,8 @@ NavigateResponse:
   truncated:     <true if child_map exceeds head= budget>
   has_children:  true
   child_map:     "4.0.0 | Overview | ~45 tokens\n4.0.1 | Steps | ~120 tokens\n..."
+  struck:        false
+  entry_id:      "2026-08-23T11:49:14.766159Z"
 ```
 
 ### Leaf node (`has_children=False`, not a code block)
@@ -159,6 +165,8 @@ NavigateResponse:
   truncated:     false
   has_children:  false
   child_map:     null
+  struck:        false
+  entry_id:      "2026-08-23T11:49:14.766159Z"
 ```
 
 ### Code-block node (`has_children=False`, code fence body)
@@ -176,7 +184,63 @@ NavigateResponse:
   truncated:     false
   has_children:  false
   child_map:     null
+  struck:        false
+  entry_id:      "2026-08-23T11:49:14.766159Z"
 ```
+
+---
+
+## Struck Entries
+
+A struck (retracted) entry is never omitted from progressive disclosure and never presented as
+indistinguishable from live content. Every response carries an explicit, out-of-band flag, and
+aggregate content that merges multiple entries into one string carries an additional in-band
+marker so the flag is never lost when entry boundaries collapse.
+
+### Out-of-band fields
+
+| Response        | Fields                              | Meaning                                                              |
+|------------------|--------------------------------------|------------------------------------------------------------------------|
+| `MapResponse`    | `struck_ordinals: list[str]`        | Every ordinal (level-2 entry or deeper) whose node is struck.        |
+| `NavigateResponse` | `struck: bool`, `entry_id: str`   | Whether the resolved node is struck, and its owning entry's id.      |
+| `BoundedResponse`  | `struck: bool`, `entry_id: str`   | Same, surviving `head=`/`skip_tokens=` token-window truncation — struck state is metadata, not content, so it is never truncated away. |
+
+`struck`/`entry_id` are `False`/`""` for level-1 section ordinals (no dot) — a section
+aggregate has no single-entry identity. A sub-heading or code fence nested inside a struck
+entry inherits that entry's `struck`/`entry_id`.
+
+### In-band markers
+
+Two response bodies merge multiple entries' text into one string with no per-entry field to
+attach to — a map line's title, and a level-1 section's aggregate `content` (all entry bodies
+joined). Both carry a literal marker so the merged text itself remains unambiguous:
+
+| Context                                   | Marker                    | Position                                            |
+|--------------------------------------------|----------------------------|------------------------------------------------------|
+| Formatted map line (`format_map_line()`)   | `"[struck] "`              | Immediately before the title, outside the 50-char truncation window — a long struck title's ellipsis can never eat the marker. |
+| Level-1 aggregate content (`build_map()`'s section-content join) | `"[struck:{entry_id}]"` | Immediately before the struck entry's own text, inside the joined aggregate. |
+
+Example — `map=true` on an item whose section `16` has a struck entry `16.0` and a live
+entry `16.1`:
+
+```text
+16 RT-ICA (1003t) — "..."
+16.0 [struck] RT-ICA Snapshot: ... (357t) — "..."
+16.1 RT-ICA Final: ... (645t) — "..."
+```
+
+```text
+MapResponse.struck_ordinals == ["16.0"]
+```
+
+`navigate="16"` (the level-1 aggregate spanning both entries):
+
+```text
+content: "[struck:2026-08-23T11:49:14.766159Z]\nRT-ICA Snapshot: ...\n\nRT-ICA Final: ..."
+```
+
+The marker precedes only the struck entry's own text — the live entry's text carries no marker
+anywhere.
 
 ---
 

--- a/plugins/development-harness/skills/backlog/SKILL.md
+++ b/plugins/development-harness/skills/backlog/SKILL.md
@@ -103,9 +103,10 @@ Returns `{title, priority, issue, plan, file_path, body, groomed, messages, warn
 `{title, priority, issue, plan, file_path, groomed, sections_metadata, messages, warnings}` where
 `sections_metadata` is a list of `{name, num_entries, num_struck}` dicts — no `body` or `sections` keys.
 
-With `map=True`, returns `{selector, total_sections, total_est_tokens, map_text, over_budget}`.
-With `navigate` alone, returns `{ordinal, title, content, total_tokens, truncated, child_map, has_children}`.
-With `navigate` plus `head`, returns `{ordinal, title, content, total_tokens, returned_tokens, truncated, next_call}`.
+With `map=True`, returns `{selector, total_sections, total_est_tokens, map_text, over_budget, struck_ordinals}`.
+With `navigate` alone, returns `{ordinal, title, content, total_tokens, truncated, child_map, has_children, struck, entry_id}`.
+With `navigate` plus `head`, returns `{ordinal, title, content, total_tokens, returned_tokens, truncated, next_call, struck, entry_id}`.
+`struck`/`entry_id` reflect the addressed entry (or its descendant); `""`/`False` for level-1 section ordinals, which have no single-entry identity. `struck_ordinals` lists every struck ordinal in the map.
 
 Before fetching a large item to read one part of it — one acceptance-criteria block, one code
 fence, one sub-heading — read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,24 @@ too-many-positional-arguments = "warn" # runtime-injected modules (e.g. backlog 
 unresolved-import = "warn"             # TDD red-state: test files import classes not yet implemented
 
 [[tool.ty.overrides]]
+# TDD RED-phase temporary exception (#3187 struck-progressive-disclosure): these three
+# files intentionally assert on fields (struck, entry_id, struck_ordinals) not yet added
+# to OrdinalEntry / ResolvedUnit / MapResponse / NavigateResponse / BoundedResponse — the
+# same "TDD red-state" category as the unresolved-import warn above, but "warn" alone does
+# not suppress ty's non-zero exit for warning-level diagnostics, so these specific files
+# need "ignore" instead. Remove this override once the GREEN-phase implementation pass
+# (backlog_core/ordinal_mapper.py, disclosure_types.py, disclosure_handler.py) adds the
+# fields — at that point the diagnostics disappear and the override becomes a no-op.
+include = [
+    "plugins/development-harness/backlog_core/tests/unit/test_ordinal_mapper.py",
+    "plugins/development-harness/backlog_core/tests/unit/test_disclosure_handler.py",
+    "plugins/development-harness/backlog_core/tests/unit/test_struck_progressive_disclosure.py",
+]
+
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
+
+[[tool.ty.overrides]]
 # pytest.skip is decorated with @_with_exception which ty 0.0.17 miscounts as a bound
 # method expecting 0 positional args (counting self). Both positional and keyword forms
 # trigger false positives. Suppress for the three reader test files that use this pattern.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,24 +183,6 @@ too-many-positional-arguments = "warn" # runtime-injected modules (e.g. backlog 
 unresolved-import = "warn"             # TDD red-state: test files import classes not yet implemented
 
 [[tool.ty.overrides]]
-# TDD RED-phase temporary exception (#3187 struck-progressive-disclosure): these three
-# files intentionally assert on fields (struck, entry_id, struck_ordinals) not yet added
-# to OrdinalEntry / ResolvedUnit / MapResponse / NavigateResponse / BoundedResponse — the
-# same "TDD red-state" category as the unresolved-import warn above, but "warn" alone does
-# not suppress ty's non-zero exit for warning-level diagnostics, so these specific files
-# need "ignore" instead. Remove this override once the GREEN-phase implementation pass
-# (backlog_core/ordinal_mapper.py, disclosure_types.py, disclosure_handler.py) adds the
-# fields — at that point the diagnostics disappear and the override becomes a no-op.
-include = [
-    "plugins/development-harness/backlog_core/tests/unit/test_ordinal_mapper.py",
-    "plugins/development-harness/backlog_core/tests/unit/test_disclosure_handler.py",
-    "plugins/development-harness/backlog_core/tests/unit/test_struck_progressive_disclosure.py",
-]
-
-[tool.ty.overrides.rules]
-unresolved-attribute = "ignore"
-
-[[tool.ty.overrides]]
 # pytest.skip is decorated with @_with_exception which ty 0.0.17 miscounts as a bound
 # method expecting 0 positional args (counting self). Both positional and keyword forms
 # trigger false positives. Suppress for the three reader test files that use this pattern.


### PR DESCRIPTION
## Summary

- Resolves #3187 (P0): the progressive-disclosure read path (`backlog_view` with `map=`/`navigate=`) silently dropped each entry's `struck`/`id` fields even though they're already present at the `SectionEntryDict` layer — a retracted (struck) entry was indistinguishable from live content by the time it reached a calling agent.
- `NormalizedEntry` now carries required `struck: bool` + `entry_id: str`, threaded through `ordinal_mapper.py`'s internal types and every downstream progressive-disclosure response shape (`MapResponse.struck_ordinals`, `NavigateResponse`/`BoundedResponse` `struck`/`entry_id`), plus an in-band `[struck:{id}]` marker in `build_map()`'s level-1 aggregate join — the one place a flag alone can't help, since struck and live entry text get concatenated into one string before ordinal work.
- Design and implementation followed this repo's TDD-mandated track for this area given four stacked regressions here in the last two days: `python-engineering:adversarial-solution-design` → RED-phase tests (`python-pytest-architect`) → GREEN-phase implementation (`python-cli-architect`), all in one worktree, three commits.
- Docs updated (`docs/mcp-progressive-disclosure-contract.md`, `skills/backlog/SKILL.md`) to keep the documented response-shape field lists current.

Note: intentionally not using a `Fixes #3187` auto-close keyword — this repo's convention routes issue closure through the backlog quality-gate workflow, not GitHub's merge auto-close.

## Test plan

- [x] `uv run pytest plugins/development-harness/backlog_core -q` — 610 passed, 0 failed (includes all ~50 pre-existing `test_ordinal_mapper.py` methods unmodified)
- [x] `uv run pytest plugins/development-harness/ -q` — 5203 passed, 1 pre-existing unrelated failure (reproduced identically against the RED-phase commit alone, not a regression from this change)
- [x] `uv run ruff check` / `ruff format` — clean
- [x] `uv run ty check plugins/development-harness/backlog_core/` — clean (temporary RED-phase override removed)
- [x] Live MCP round-trip against real items `#3187` and `#3060` (no mocks) — struck entries correctly flagged at map/navigate/EXTRACT depth, zero-struck sections byte-identical to pre-change baseline
- [x] `uv run prek run` on all touched files — clean, no `--no-verify`

## Known follow-up (not in scope here)

- `skills/backlog/references/progressive-disclosure.md` describes response shapes in prose but wasn't in this task's file list — doesn't state anything incorrect, but doesn't mention the new struck/entry_id fields either. Worth a follow-up pass.
- The pre-existing 17.x/19.x duplicate-ordinal defect visible in `map=true` output is a separate root cause, tracked as #3196.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018XDV8knocaB5yqW2JaC1tv