### PR TITLE
docs(development-harness): state the artifact consumer invariant

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.9",
+  "version": "10.0.10",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.9",
+  "version": "9.0.10",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.9",
+  "version": "6.0.10",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/dispatch-contract/SKILL.md
+++ b/plugins/development-harness/skills/dispatch-contract/SKILL.md
@@ -9,6 +9,9 @@ user-invocable: false
 This contract governs execution. Follow it whenever you dispatch work in a dh workflow or execute
 a task you were dispatched to run.
 
+Every artifact is consumed as an input by a later step. An artifact no step reads is a missing
+consumer, not a redundant artifact.
+
 ## Dispatch role vocabulary
 
 - Orchestrator — the agent that dispatches. It chooses a dispatch target by fit and passes a task


### PR DESCRIPTION
Adds one sentence, 130 characters:

> Every artifact is consumed as an input by a later step. An artifact no step reads is a missing consumer, not a redundant artifact.

## Why

An audit of the plugin against SAM's stated invariants found this rule stated nowhere in the plugin, in any file, in any form — and it is the one invariant SAM's own source does not state either, so there is no upstream fallback. Every other invariant has at least one correct statement somewhere.

Three separate changes then reasoned from its absence, each concluding that an artifact with no reader should stop being produced: #3145, #3147, and a recommendation to close #3145 in favour of #3147. The correct inference is the opposite — a reader-less artifact means a consumer was never wired up.

## Placement

`skills/dispatch-contract/SKILL.md` is declared in the `skills:` frontmatter of every `dh:` agent that touches SAM or artifact operations, so it reaches an executing agent without anyone choosing to load it. `AGENTS.md` and `CONTEXT.md` are dev-context and invisible once the plugin is installed.

## Known follow-up

That file separately contains an exemption at `:37` that contradicts this invariant, plus four other false claims, and is under review for revert or rewrite. This PR does not address those; it lands the invariant so it exists somewhere regardless of that outcome.