### PR TITLE
docs(development-harness): state the dispatch-prompt rules positively

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.10",
+  "version": "10.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.10",
+  "version": "9.0.11",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.10",
+  "version": "6.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -102,14 +102,11 @@ For each task being dispatched:
 {plan_ref}/{task_id}
 ```
 
-- Do not name a skill in the delegation prompt. A dispatch carries a task reference; the receiver
-  resolves what to load from it. `dh:task-worker` reads the task record, loads the profile named
-  in its `agent` field, and the task-execution skill it delegates to loads the task's own
-  `skills` list; a specialist dispatched directly already carries its own behavior. A skill name
-  written into a dispatch prompt is an instruction whose scope the receiver cannot check against
-  its own — that is the route by which a plan-level workflow reaches a task-level agent.
-- Do not restate the task's `skills` list in the prompt. The receiver reads it from the task
-  record, and task-level skills stay additive to whatever the agent profile declares.
+- The dispatch carries a task reference and the receiver resolves what to load from it.
+  `dh:task-worker` reads the task record, loads the profile named in its `agent` field, and the
+  task-execution skill it delegates to loads the task's own `skills` list; a specialist dispatched
+  directly already carries its own behavior. Task-level skills stay additive to whatever the agent
+  profile declares.
 
 ### Agent Health Check (While Waiting)
 
@@ -342,4 +339,4 @@ If the issue number is not known, skip registration.
 ## Completion Gate
 
 When all tasks show `COMPLETE`, load the `dh:complete-implementation` skill with `{plan_ref}` as
-its argument, in this workflow's own context. Never pass that skill name to a dispatched agent.
+its argument, in this workflow's own context.


### PR DESCRIPTION
Three prohibitions in `implement-feature/SKILL.md`, each already followed by the positive statement it was guarding:

- `Do not name a skill in the delegation prompt.` → the bullet then says the dispatch carries a task reference and the receiver resolves what to load.
- `Do not restate the task's skills list in the prompt.` → the bullet then says the receiver reads it from the task record.
- `Never pass that skill name to a dispatched agent.` → the sentence already says to load it "in this workflow's own context".

Naming a forbidden action puts that action in front of the agent at the moment it decides what to write. The positive statement alone carries the requirement, so the two bullets collapse into one and the completion-gate line drops its trailing ban.

No behavioural change intended — same rules, stated as what to do.

These were written during a rebase conflict resolution on #3148 and are live on main.