### PR TITLE
fix(backlog-core): let artifact_get address one artifact by its id

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.10",
+  "version": "10.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.10",
+  "version": "9.0.11",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.10",
+  "version": "6.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -3444,16 +3444,28 @@ async def artifact_get(
         ),
     ],
     artifact_type: Annotated[str, Field(description="Artifact type to retrieve")],
+    artifact_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Logical identifier of the specific artifact to return. Omit to return every "
+                "artifact registered under this type."
+            )
+        ),
+    ] = None,
 ) -> dict:
-    """Return metadata for a specific artifact type registered on a backlog item.
+    """Return metadata for artifacts registered on a backlog item under one type.
 
-    If multiple artifacts of the same type exist (e.g. multiple
-    codebase-analysis files), all are returned.
+    Omitting ``artifact_id`` returns every entry of the type (e.g. multiple
+    codebase-analysis files). Supplying it returns the single addressed entry, matching
+    ``dh_core.operations.artifact_get`` and the ``artifact get --artifact-id`` CLI option,
+    so both surfaces can address an artifact the same way.
 
     Returns:
         Dict with artifacts (list of dicts), count (int), and output
-        messages/warnings. Returns error key when type is not found — an absent
-        artifact is data, not a failed call.
+        messages/warnings. Returns error key when the type is not found, or when a supplied
+        ``artifact_id`` matches no entry of that type — an absent artifact is data, not a
+        failed call.
 
     Raises:
         ValueError: ``artifact_type`` is not an ``ArtifactType`` member.
@@ -3467,11 +3479,15 @@ async def artifact_get(
         def _run() -> list[dict]:
             manifest = _load_manifest(provider, item_id)
             entries = _artifact_registry.get_by_type(manifest, type_enum)
+            _require_artifact_entries(entries, f"No artifacts of type '{artifact_type}' found for item #{item_id}")
+            if artifact_id is not None:
+                entries = [entry for entry in entries if entry.artifact_id == artifact_id]
+                _require_artifact_entries(
+                    entries, f"No artifact with id '{artifact_id}' of type '{artifact_type}' found for item #{item_id}"
+                )
             return [e.model_dump(mode="json") for e in entries]
 
         artifacts = await asyncio.to_thread(_run)
-        if not artifacts:
-            return {"error": f"No artifacts of type '{artifact_type}' found for item #{item_id}", **out.to_dict()}
         return {"artifacts": artifacts, "count": len(artifacts), **out.to_dict()}
     except BacklogError as e:
         return {"error": str(e), **out.to_dict()}

--- a/plugins/development-harness/dh_core/operations.py
+++ b/plugins/development-harness/dh_core/operations.py
@@ -1955,8 +1955,12 @@ def artifact_list(item_id: int | str, artifact_type: str | None = None) -> dict[
 def artifact_get(item_id: int | str, artifact_type: str, artifact_id: str | None = None) -> dict[str, Any]:
     """Return metadata for artifacts of a specific type on a backlog item.
 
+    Omitting ``artifact_id`` returns every entry of the type; supplying it returns the single
+    addressed entry.
+
     Returns:
-        Dict with ``artifacts`` (list of dicts), ``count``, or ``error``.
+        Dict with ``artifacts`` (list of dicts), ``count``, or ``error`` when the type has no
+        entries or a supplied ``artifact_id`` matches none of them.
     """
     out = Output()
     try:
@@ -1964,11 +1968,16 @@ def artifact_get(item_id: int | str, artifact_type: str, artifact_id: str | None
         type_enum = ArtifactType(artifact_type)
         manifest = _load_manifest(provider, item_id)
         entries = _artifact_registry.get_by_type(manifest, type_enum)
+        if not entries:
+            return {"error": f"No artifacts of type '{artifact_type}' found for item #{item_id}", **out.to_dict()}
         if artifact_id is not None:
             entries = [entry for entry in entries if entry.artifact_id == artifact_id]
+            if not entries:
+                return {
+                    "error": f"No artifact with id '{artifact_id}' of type '{artifact_type}' found for item #{item_id}",
+                    **out.to_dict(),
+                }
         artifacts = [e.model_dump(mode="json") for e in entries]
-        if not artifacts:
-            return {"error": f"No artifacts of type '{artifact_type}' found for item #{item_id}", **out.to_dict()}
         return {"artifacts": artifacts, "count": len(artifacts), **out.to_dict()}
     except (ValueError, KeyError) as exc:
         return {"error": f"Invalid parameter: {exc}", **out.to_dict()}

--- a/plugins/development-harness/tests/test_artifact_content_storage.py
+++ b/plugins/development-harness/tests/test_artifact_content_storage.py
@@ -815,17 +815,89 @@ async def test_artifact_read_reports_an_unmatched_artifact_id() -> None:
     assert "plan/absent.md" in result["error"]
 
 
-async def test_artifact_read_mcp_surface_matches_the_operations_signature() -> None:
-    """The MCP tool must accept the same addressing parameters as its operations counterpart.
+async def test_artifact_get_by_artifact_id_returns_only_the_addressed_entry() -> None:
+    """artifact_id narrows the metadata read to one entry instead of the whole type.
+
+    Tests: artifact_get MCP tool — addressing by logical identifier.
+    How: Two research entries; get the older one by id and assert it is the only result.
+    Why: An identifier assigned on registration that no MCP metadata read accepts makes every
+    such read a category read, so a caller holding an id cannot ask which row it names.
+    """
+    older_entry = ArtifactEntry(
+        artifact_type=ArtifactType.RESEARCH,
+        artifact_id="plan/r-old.md",
+        status=ArtifactStatus.CURRENT,
+        created_at="2026-01-01T10:00:00Z",
+    )
+    newer_entry = ArtifactEntry(
+        artifact_type=ArtifactType.RESEARCH,
+        artifact_id="plan/r-new.md",
+        status=ArtifactStatus.CURRENT,
+        created_at="2026-06-01T10:00:00Z",
+    )
+    mock_manifest = ArtifactManifest(issue_number=42, artifacts=[older_entry, newer_entry])
+    mock_provider = MagicMock(spec=ContentProvider)
+    mock_provider.get_content.return_value = _manifest_record(mock_manifest)
+
+    with (
+        patch("backlog_core.server._get_artifact_provider", return_value=mock_provider),
+        patch("backlog_core.server._artifact_registry") as mock_registry,
+    ):
+        mock_registry.get_by_type.return_value = [older_entry, newer_entry]
+        # Act
+        result = await _call(
+            "artifact_get", {"item_id": 42, "artifact_type": "research", "artifact_id": "plan/r-old.md"}
+        )
+
+    # Assert: the addressed entry is the only one returned
+    assert result.get("error") is None
+    assert result["count"] == 1
+    assert result["artifacts"][0]["artifact_id"] == "plan/r-old.md"
+
+
+async def test_artifact_get_reports_an_unmatched_artifact_id() -> None:
+    """An artifact_id matching no entry names the id rather than the type.
+
+    Reporting "no artifacts of type research" while research entries do exist points the
+    caller at the wrong correction.
+    """
+    entry = ArtifactEntry(
+        artifact_type=ArtifactType.RESEARCH,
+        artifact_id="plan/r-new.md",
+        status=ArtifactStatus.CURRENT,
+        created_at="2026-06-01T10:00:00Z",
+    )
+    mock_manifest = ArtifactManifest(issue_number=42, artifacts=[entry])
+    mock_provider = MagicMock(spec=ContentProvider)
+    mock_provider.get_content.return_value = _manifest_record(mock_manifest)
+
+    with (
+        patch("backlog_core.server._get_artifact_provider", return_value=mock_provider),
+        patch("backlog_core.server._artifact_registry") as mock_registry,
+    ):
+        mock_registry.get_by_type.return_value = [entry]
+        # Act
+        result = await _call(
+            "artifact_get", {"item_id": 42, "artifact_type": "research", "artifact_id": "plan/absent.md"}
+        )
+
+    # Assert
+    assert "plan/absent.md" in result["error"]
+
+
+@pytest.mark.parametrize("tool_name", ["artifact_register", "artifact_list", "artifact_get", "artifact_read"])
+async def test_artifact_mcp_surface_matches_the_operations_signature(tool_name: str) -> None:
+    """Each MCP tool must accept the same parameters as its operations counterpart.
 
     Two surfaces over one operation that disagree on which parameters exist force callers
-    onto the richer surface for no functional reason.
+    onto the richer surface for no functional reason. Parametrised over every artifact tool
+    because the divergence this pins was introduced one tool at a time.
     """
     tools = await mcp.list_tools()
-    parameters = next(tool.parameters for tool in tools if tool.name == "artifact_read")
-    operations_parameters = set(inspect.signature(dh_operations.artifact_read).parameters)
+    parameters = next(tool.parameters for tool in tools if tool.name == tool_name)
+    operations_parameters = set(inspect.signature(getattr(dh_operations, tool_name)).parameters)
 
     assert set(parameters["properties"]) == operations_parameters, (
-        "artifact_read's MCP parameters diverge from dh_core.operations.artifact_read: "
+        f"{tool_name}'s MCP parameters diverge from dh_core.operations.{tool_name}: "
         f"MCP has {sorted(parameters['properties'])}, operations has {sorted(operations_parameters)}"
     )

--- a/plugins/development-harness/tests_backlog/test_local_content_backends.py
+++ b/plugins/development-harness/tests_backlog/test_local_content_backends.py
@@ -310,3 +310,33 @@ def test_local_content_backends_have_no_yaml_or_file_cache_import_boundary() -> 
     } | {node.module for tree in trees for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module}
 
     assert not {name for name in imports if "file_cache" in name.casefold() or "yaml_io" in name.casefold()}
+
+
+@pytest.mark.unit
+def test_artifact_get_addresses_one_entry_and_names_an_unmatched_id(
+    local_provider: InMemoryBackend | SQLiteBackend | BeadsBackend,
+) -> None:
+    """The CLI-facing operation narrows to one entry by id and reports a miss by that id.
+
+    An identifier assigned at registration is only useful if a read accepts it; reporting a
+    miss as "no artifacts of type research" while research entries exist names the wrong
+    correction.
+    """
+    set_config(BacklogConfig(backend=local_provider))
+    try:
+        # Given: two artifacts of one type on one item.
+        operations.artifact_register("item-2", "research", "report-old", "body-old")
+        operations.artifact_register("item-2", "research", "report-new", "body-new")
+
+        # When: one is addressed by id.
+        addressed = operations.artifact_get("item-2", "research", "report-old")
+
+        # Then: only that entry comes back.
+        assert addressed.get("error") is None
+        assert addressed["count"] == 1
+        assert addressed["artifacts"][0]["artifact_id"] == "report-old"
+
+        # And: an id matching no entry is reported by id, not by type.
+        assert "absent" in operations.artifact_get("item-2", "research", "absent")["error"]
+    finally:
+        reset_config()


### PR DESCRIPTION
## Problem

An artifact's `artifact_id` is assigned on registration, but MCP `artifact_get` accepted only a
type — so a caller holding an id could not ask which row it named, and every metadata read was a
category read.

The gap was one parameter on one tool, not the three the issue described:

| Surface | `register` | `list` | `get` | `read` |
|---|---|---|---|---|
| MCP `backlog_core/server.py` | `artifact_id` | — | **absent** | `artifact_id` |
| `dh_core/operations.py` | `artifact_id` | — | `artifact_id` | `artifact_id` |
| CLI `sam_schema/artifacts.py` | `--artifact-id` | — | `--artifact-id` | `--artifact-id` |

`9e235a326` (#3174) added `artifact_id` to MCP `artifact_read` and edited MCP `artifact_get`'s
docstring in the same hunk range without adding the parameter there. `artifact_read`'s docstring
on `main` already states MCP/CLI parity as the intent, so this was an omission, not a deliberate
asymmetry.

`artifact_list` is untouched: it is type-filter-only on all three surfaces, so adding an id there
would create an asymmetry rather than remove one.

## Change

- MCP `artifact_get` takes `artifact_id: str | None = None`. Supplied, it returns that entry or
  reports the id as unmatched, mirroring `artifact_read`. Omitted, behaviour is unchanged: every
  entry of the type, same error envelope when the type has none. Existing type-only callers are
  unaffected.
- `dh_core.operations.artifact_get` reported an unmatched id as `No artifacts of type 'X' found`
  while entries of that type existed — the wrong correction, on the surface the CLI shows. It now
  checks type-emptiness first and reports a miss by id. Which artifact is selected does not change.
- The existing single-tool MCP/operations parity test is parametrised over all four artifact
  tools. The divergence it now catches was introduced one tool at a time, which a single-tool test
  cannot see.

## Tests

Written first and run red, then green.

New:

- `tests/test_artifact_content_storage.py::test_artifact_get_by_artifact_id_returns_only_the_addressed_entry`
  — two `research` entries on one item, the older addressed by id, asserted as the only result.
- `tests/test_artifact_content_storage.py::test_artifact_get_reports_an_unmatched_artifact_id`
- `tests/test_artifact_content_storage.py::test_artifact_mcp_surface_matches_the_operations_signature`
  — parametrised over `artifact_register`, `artifact_list`, `artifact_get`, `artifact_read`.
- `tests_backlog/test_local_content_backends.py::test_artifact_get_addresses_one_entry_and_names_an_unmatched_id`
  — same behaviour through `dh_core.operations` against real memory/sqlite/beads backends.

Affected suites (`test_artifact_content_storage`, `test_artifact_tool_input_contract`,
`test_artifact_provider`, `test_local_content_backends`, `test_mcp_call_shape_drift`):
`118 passed`.

Full plugin suites: `1 failed, 3461 passed, 39 skipped, 5 xfailed`. The failure is
`test_github_sync_provider.py::test_github_content_provider_replay_preserves_concurrent_remote_revision`,
confirmed pre-existing — it fails identically on clean `main` with this branch's changes stashed,
and does not touch artifact addressing.

## Branch-on-read finding (no behaviour changed)

`codebase-analysis` has six producers registering against one item under the same type with
different ids (`code-reviewer`, `codebase-analyzer`, `reviewer-quality`, `reviewer-performance`,
`reviewer-accessibility`, `reviewer-security`) — legal per `ArtifactRegistry.register`'s own
docstring. Four consumers read it with no id and branch on the result: `complete-implementation`'s
quality gate (AGENTS.md:160), `forensic-review`, `add-new-feature`, and `codebase-analyzer`'s own
completion check. Newest-wins there was not the intent; the surrounding prose treats the read as
returning a single verdict.

This overlaps #3147, which splits the code-review verdict onto its own type. The two are
complementary — a type split removes one collision, id addressing lets a caller name one entry
whenever a type is legitimately multi-entry. No file collision with #3147: its only `server.py`
hunk edits `artifact_register`'s type description string, which `main` has since replaced with an
`ArtifactType` enum annotation.

`T0-baseline`/`TN-verification` reads branch on existence only (safe), but the content compared
afterwards is newest-wins and `T0-baseline-{slug}` ids make multiple baselines per item
expressible. `research` reads are plausibly intended to mean "latest", but nothing states it.

No agent or skill markdown was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg
