### PR TITLE
fix(development-harness): stop execution SKILL banning the write it mandates

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.10",
+  "version": "10.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.10",
+  "version": "9.0.11",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.10",
+  "version": "6.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/execution/SKILL.md
+++ b/plugins/development-harness/skills/execution/SKILL.md
@@ -195,7 +195,7 @@ in parallel if their `parallelize-with` field permits it.
 ## Behavioral Rules
 
 - Never execute a task whose dependencies have not completed
-- Never modify the task file during execution — it is read-only
+- Record execution results only via the Output append operation — the task's requirements and acceptance criteria are fixed input for the duration of execution
 - If the agent cannot complete the task, status is BLOCKED with explanation
 - Quality gate failures must be addressed before marking COMPLETED
 - Report ALL results honestly — do not suppress failures


### PR DESCRIPTION
## Summary

- `plugins/development-harness/skills/execution/SKILL.md`'s Behavioral Rules said "Never modify the task file during execution — it is read-only," while the same skill's Output section (lines 107-115) requires every execution to append an `Execution Results` section to the task via `sam_task(action="update", append_section="Execution Results", ...)`.
- `dh_core/operations.py:update_task_fields` (lines 941-944) confirms `append_section` delegates straight to `backend.append_task_section` — a genuine append (verified in `ContentTaskProvider.append_task_section`, `sam_schema/core/backends/content.py:212-219`), not a read-modify-write or replace of the whole record. So the rule literally banned the skill's own mandated write path.
- `skills/dispatch-contract/SKILL.md` (lines 109-121, 126-130) confirms "task file" is stale terminology across this plugin: tasks are logical records addressed through `sam_task`, and completion explicitly requires "Task state was written back through the SAM task operation, not only described in prose."
- Replaced the negation with the positive constraint it was reaching for: results are recorded only through the Output append operation, and the task's requirements/acceptance criteria are fixed input for the duration of execution (not something an executing agent should revise mid-run). Per repo policy, a prohibition earns its place only when breaking it demonstrably harms the outcome and stating it demonstrably improves compliance — otherwise state the correct process positively, and a negation makes the banned behaviour more available to a model.

### Before / after (exact text, line 198)

```diff
- Never modify the task file during execution — it is read-only
+ Record execution results only via the Output append operation — the task's requirements and acceptance criteria are fixed input for the duration of execution
```

No other line changed in this file besides the automatic plugin-manifest version bump (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`) applied by the pre-commit hook.

### Other Behavioral Rules checked for the same defect

Checked every line under `## Behavioral Rules` (lines 195-201) for a rule that bans a write this same file elsewhere mandates:

- `Never execute a task whose dependencies have not completed` — gates *when* execution starts, not a write ban; consistent with the Dependency Ordering section. No contradiction.
- `If the agent cannot complete the task, status is BLOCKED with explanation` — not a prohibition.
- `Quality gate failures must be addressed before marking COMPLETED` — consistent with Step 6's "return failures to the agent for remediation before collecting results."
- `Report ALL results honestly — do not suppress failures` — no contradiction elsewhere in the file.

Only the fixed line exhibited this defect. Not in scope: `Task file is authoritative` in `## Key Constraints` (line 176) also uses the stale "task file" phrase, but it instructs *following* the task on conflict with the plan, not modifying it — it does not contradict the Output section, so it was left unchanged per the assigned scope (one file, this one contradiction).

## Test plan

- [x] `uvx skilllint@latest check plugins/development-harness/skills/execution` — exit 0
- [x] `uv run prek run --files plugins/development-harness/skills/execution/SKILL.md` — all hooks passed
- [x] `git commit` succeeded with all pre-commit hooks green (Conventional Commit, manifest auto-sync, skill validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)