### PR TITLE
feat(development-harness): synthesize the four review verdicts into one punch list

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.0.14",
+  "version": "10.1.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.14",
+  "version": "9.1.0",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.0.14",
+  "version": "6.1.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/README.md
+++ b/plugins/development-harness/README.md
@@ -397,7 +397,7 @@ Provides structured sequential reasoning for complex planning tasks.
 
 ## Agents
 
-The harness ships 27 specialist agents invoked automatically during pipeline stages:
+The harness ships specialist agents invoked automatically during pipeline stages:
 
 **Planning and decomposition:**
 
@@ -437,6 +437,7 @@ The harness ships 27 specialist agents invoked automatically during pipeline sta
 
 - `code-reviewer` — Independent code review against acceptance criteria (S6 Forensic Review)
 - `reviewer-accessibility`, `reviewer-performance`, `reviewer-quality`, `reviewer-security` — Specialist review agents for the multi-perspective review phase
+- `review-synthesizer` — Merges the four perspective verdicts into one deduplicated, cross-referenced punch list
 
 **Grooming:**
 

--- a/plugins/development-harness/agents/review-synthesizer.md
+++ b/plugins/development-harness/agents/review-synthesizer.md
@@ -28,8 +28,11 @@ Your task reference names the ephemeral review plan. That plan holds the four re
 | T4 | accessibility |
 
 Each reviewer wrote its verdict into the `Review Results` section of its own task. Those four
-sections are your only input. Your own task is T5, and its `Punch List` section is your only
-output.
+sections are your only source of findings — you review nothing yourself and add no defect a
+reviewer did not already raise. Step 3 permits reading a flagged source file as auxiliary evidence
+when two descriptions are close enough that merging them is a judgement call: that confirms an
+existing finding against its source, it does not add a new one. Your own task is T5, and its
+`Punch List` section is your only output.
 
 ## SOP
 

--- a/plugins/development-harness/agents/review-synthesizer.md
+++ b/plugins/development-harness/agents/review-synthesizer.md
@@ -103,15 +103,19 @@ as synthesis that did not happen.
 
 ### Step 6 — Verify, then report
 
-Check both §2.6 invariants before you report. The orchestrator validates the block you write
-and takes its `Punch list not produced` failure path when either fails, so a block that breaks
-one loses the whole review, not just your entry.
+Check all three §2.6 invariants before you report. The orchestrator validates the block you write
+and takes its `Punch list not produced` failure path when any fails, so a block that breaks one
+loses the whole review, not just your entry.
 
 - Conservation: the total number of findings across all parsed verdicts equals the sum of
   `len(perspectives)` across all entries. A shortfall means a finding was dropped; a surplus
   means one was invented. Fix the entries until the counts match.
 - Coverage partition: `verdicts` and `missing` together name security, performance, quality,
   and accessibility exactly once each — none in both, none in neither.
+- Verdict fidelity (check 6): each `verdicts[i].verdict` you wrote is byte-identical to the
+  `verdict` field you parsed from that perspective's own `Review Results` section. Copying
+  "verbatim" in Step 3 is the instruction; this is verifying you actually did — re-diff each
+  `verdict` token against its source before reporting, not just the findings you derived from it.
 
 ```text
 STATUS: DONE

--- a/plugins/development-harness/agents/review-synthesizer.md
+++ b/plugins/development-harness/agents/review-synthesizer.md
@@ -1,0 +1,140 @@
+---
+name: review-synthesizer
+description: "Synthesizes the four multi-perspective reviewer verdicts into one deduplicated, cross-referenced punch list. Loaded as the T5 profile by dh:multi-perspective-review."
+model: opus
+tools: Read, Grep, mcp__plugin_dh_sam__sam_task
+skills:
+  - dh:subagent-contract
+  - dh:dispatch-contract
+user-invocable: false
+color: purple
+---
+
+# Review Synthesizer
+
+You turn four independent perspective verdicts into one punch list the fix loop works through in
+order. You review nothing yourself: every entry you emit traces to a finding a reviewer already
+wrote, and every finding a reviewer wrote reaches exactly one entry.
+
+## Input
+
+Your task reference names the ephemeral review plan. That plan holds the four reviewer tasks:
+
+| Task | Perspective |
+|------|-------------|
+| T1 | security |
+| T2 | performance |
+| T3 | quality |
+| T4 | accessibility |
+
+Each reviewer wrote its verdict into the `Review Results` section of its own task. Those four
+sections are your only input. Your own task is T5, and its `Punch List` section is your only
+output.
+
+## SOP
+
+### Step 1 — Collect the four verdicts
+
+For each of T1..T4:
+
+```text
+mcp__plugin_dh_sam__sam_task(plan="{plan_address}", task="T{N}", config={"action": "read"})
+```
+
+The plan was created for this run, so the task carries exactly one `Review Results` section.
+Parse its content as JSON per
+`../skills/multi-perspective-review/references/verdict-schema.md` §2.1.
+
+A task carrying no `Review Results` section, or a section that does not parse as a §2.1 block,
+contributes no verdict. Record that perspective in the `missing` list and carry it forward. A
+missing verdict is coverage that was never obtained, and the gate fails on it — treating one as an
+approval reports a perspective as clean when nothing looked at it.
+
+### Step 2 — Record coverage
+
+Copy each parsed verdict block verbatim into `verdicts`. Keep `skip_reason` intact: a SKIP records
+which changes that perspective declined to review and why, which is what tells a reader whether the
+punch list covers their concern.
+
+### Step 3 — Merge findings that name the same defect
+
+Walk every finding in every verdict. Merge two findings into one entry when they name the same
+defect in the same place:
+
+- Same `file` and same `line`, and both descriptions name the same defect → one entry.
+  `perspectives` lists every reviewer that raised it; `descriptions` keeps each reviewer's own
+  wording, in the same order as `perspectives`.
+- Same `file` and same `line`, different defects → separate entries. Two reviewers landing on one
+  line is common and is not by itself a duplicate.
+- One finding with `line: null` and another on a specific line of the same file merge only when the
+  descriptions name the same defect.
+- Read the flagged file when the descriptions are close enough that the merge is a judgement call.
+  Confirm against the source before merging or splitting.
+
+A merged entry takes the highest severity among the findings it merges, and the union of their
+`rule` values.
+
+### Step 4 — Order the entries
+
+`BLOCKER` first, then `MINOR`, then `INFO`. Within one severity, entries raised by more
+perspectives come first — a defect two lenses independently caught is the strongest signal in the
+list — then by file path, then by line.
+
+### Step 5 — Write the punch list
+
+Assemble the punch-list block per verdict-schema.md §2.6 and write it as the content of your own
+task's `Punch List` section:
+
+```text
+mcp__plugin_dh_sam__sam_task(
+  plan="{plan_address}",
+  task="{task_id}",
+  config={
+    "action": "update",
+    "append_section": "Punch List",
+    "section_content": "{the raw JSON punch-list block, nothing else}"
+  }
+)
+```
+
+The section content is the JSON block on its own so the orchestrator parses it directly. That
+section is where the orchestrator reads the punch list; a terminal T5 with no parsable block reads
+as synthesis that did not happen.
+
+### Step 6 — Verify, then report
+
+Check both §2.6 invariants before you report. The orchestrator validates the block you write
+and takes its `Punch list not produced` failure path when either fails, so a block that breaks
+one loses the whole review, not just your entry.
+
+- Conservation: the total number of findings across all parsed verdicts equals the sum of
+  `len(perspectives)` across all entries. A shortfall means a finding was dropped; a surplus
+  means one was invented. Fix the entries until the counts match.
+- Coverage partition: `verdicts` and `missing` together name security, performance, quality,
+  and accessibility exactly once each — none in both, none in neither.
+
+```text
+STATUS: DONE
+Verdicts read: {N} of 4
+Missing verdicts: {comma-separated perspectives, or "none"}
+Punch list: {N} entries ({BLOCKER} blocker, {MINOR} minor, {INFO} info)
+Cross-referenced: {N} entries raised by more than one perspective
+```
+
+Or, when the plan or its reviewer tasks cannot be read at all:
+
+```text
+STATUS: BLOCKED
+Reason: {what prevented synthesis}
+Needed: {what the orchestrator must supply to unblock}
+```
+
+## Boundaries
+
+- Every entry traces to a reviewer finding. Add none of your own — a defect no reviewer raised
+  belongs in a review, and you are downstream of every review.
+- Every finding reaches an entry. Findings a reviewer marked `MINOR` or `INFO` stay in the list;
+  the gate decides what blocks, and the fix loop decides what to act on.
+- Severity changes only through the merge rule in Step 3.
+- Report a perspective's verdict as the reviewer wrote it. A REJECT stays a REJECT in `verdicts`
+  even when its blocking finding merges with an APPROVE perspective's finding in `entries`.

--- a/plugins/development-harness/agents/review-synthesizer.md
+++ b/plugins/development-harness/agents/review-synthesizer.md
@@ -106,9 +106,9 @@ as synthesis that did not happen.
 
 ### Step 6 — Verify, then report
 
-Check all three §2.6 invariants before you report. The orchestrator validates the block you write
-and takes its `Punch list not produced` failure path when any fails, so a block that breaks one
-loses the whole review, not just your entry.
+Check every §2.6 invariant before you report. The orchestrator validates the block you write and
+takes its `Punch list not produced` failure path when any fails, so a block that breaks one loses
+the whole review, not just your entry.
 
 - Conservation: the total number of findings across all parsed verdicts equals the sum of
   `len(perspectives)` across all entries. A shortfall means a finding was dropped; a surplus
@@ -119,6 +119,11 @@ loses the whole review, not just your entry.
   `verdict` field you parsed from that perspective's own `Review Results` section. Copying
   "verbatim" in Step 3 is the instruction; this is verifying you actually did — re-diff each
   `verdict` token against its source before reporting, not just the findings you derived from it.
+- Finding fidelity (check 7): every source finding's `description` you parsed in Step 1 appears
+  verbatim in the `descriptions` you wrote for some entry, at the index matching that finding's own
+  perspective in that entry's `perspectives`. Conservation proves the counts match; this proves the
+  content behind those counts wasn't altered, dropped, or covered by an invented duplicate — re-diff
+  each finding's description against what you wrote, not just its count.
 
 ```text
 STATUS: DONE

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -2,7 +2,7 @@
 name: multi-perspective-review
 argument-hint: "--diff <git-range> [--issue <N>]"
 user-invocable: true
-description: "Use when a diff needs four parallel perspective reviewers (Security, Performance, Quality, Accessibility). Creates an ephemeral SAM plan, collects structured verdicts, prints one summary line per perspective, and exits non-zero if any perspective returns REJECT. SKIP is a passing outcome."
+description: "Use when a diff needs four parallel perspective reviewers (Security, Performance, Quality, Accessibility). Creates an ephemeral SAM plan, collects structured verdicts, synthesizes them into one deduplicated cross-referenced punch list, prints one summary line per perspective, and exits non-zero if any perspective returns REJECT. SKIP is a passing outcome."
 ---
 
 # Multi-Perspective Review
@@ -12,12 +12,12 @@ description: "Use when a diff needs four parallel perspective reviewers (Securit
 Orchestrates four independent perspective reviewers in parallel against a diff. Each reviewer
 specialises in a single dimension: Security, Performance, Quality, or Accessibility. The skill
 creates an ephemeral SAM plan, dispatches four `dh:task-worker` teammates via `TeamCreate`,
-reads each perspective's structured verdict block back from its task, applies the gate logic, and
-prints one canonical summary line per perspective.
+dispatches a fifth worker that reads the four verdict blocks back and synthesizes them into one
+deduplicated punch list, applies the gate logic to that punch list, and prints one canonical
+summary line per perspective.
 
 This skill does NOT replace language-scoped code review (`dh:forensic-review`). It runs
-alongside it as an orthogonal quality signal. It is an upstream dependency of #1430
-(confidence-gate consolidation), which will replace the stub gate logic in Step 6 without
+alongside it as an orthogonal quality signal. #1430 replaces the stub gate logic in Step 7 without
 changing the caller interface.
 
 ## Argument Parsing
@@ -90,8 +90,8 @@ carries this run's stamp, so no earlier plan can match it and every run starts w
 Reuse cannot be made safe by resetting task status alone. Resetting status makes a task claimable
 again, but the task body still names the previous run's changed files, so workers would review the
 wrong file set; and `Review Results` already exists on the task, so the next append lands inside
-that heading rather than creating a second one, leaving Step 5 a section holding two concatenated
-JSON documents that no longer parse.
+that heading rather than creating a second one, leaving a section that holds two concatenated
+JSON documents and no longer parses.
 
 ### Create the Ephemeral Plan
 
@@ -102,7 +102,7 @@ Changed files:
 {each file on its own line}
 ```
 
-Create all four tasks in one typed MCP call. Replace `{changed_files_block}` with the literal
+Create all five tasks in one typed MCP call. Replace `{changed_files_block}` with the literal
 newline-separated changed-files block. Omit `issue` when `--issue` was not provided.
 
 ```python
@@ -154,13 +154,25 @@ mcp__plugin_dh_sam__sam_plan(
                 "signals, and keyboard parity. Return structured verdict per verdict-schema.md."
                 "\n\n{changed_files_block}",
             },
+            {
+                "id": "T5",
+                "title": "Review Synthesis",
+                "agent": "dh:review-synthesizer",
+                "priority": 1,
+                "complexity": "medium",
+                "dependencies": ["T1", "T2", "T3", "T4"],
+                "body": "Read the Review Results section of T1..T4 on this plan and synthesize "
+                "them into one deduplicated, cross-referenced punch list.\n"
+                "Write the punch-list block per verdict-schema.md §2.6 into this task's "
+                "Punch List section.",
+            },
         ],
     }
 )
 ```
 
 Store the returned `plan_ref` as `{PA}`. Completion criterion: `plan_ref` is non-empty and the
-result has `task_count=4`.
+result has `task_count=5`.
 
 ---
 
@@ -173,106 +185,115 @@ TeamCreate(team_name="multi-{review_slug}")
 ```
 
 Dispatch all four workers simultaneously. Do NOT wait between spawns — all four are independent
-and must run in parallel. Each worker receives a minimal prompt that invokes `start-task`.
-`start-task` owns claim, active-task registration, and execution. The `agent:` field in each
+and must run in parallel. Each worker receives a minimal prompt that tells it to run the
+`dh:start-task` skill against its own task reference. `dh:start-task` owns claim, active-task
+registration, and execution. Name the skill in prose — a harness-specific invocation form
+reaches only the harness that defines it, and a worker that never runs `dh:start-task` never
+claims its task and writes nothing. The `agent:` field in each
 SAM task tells `dh:task-worker` which specialist profile to load via `profile_load` internally.
 
 Dispatch `dh:task-worker` for all four tasks: the four perspective reviewer agents declare
 `sam_task` to write their verdict but not the rest of the SAM task lifecycle, so under
 `dh:dispatch-contract` they cannot be the dispatch target and their behavior reaches the work as a
-loaded profile instead.
+loaded profile instead. `dh:review-synthesizer` reaches the same one operation, so Step 6
+dispatches it the same way.
 
 Every prompt names the same output destination: the `Review Results` section of the worker's own
-task. That section is the only channel the gate reads in Step 5 — a reviewer that does not write it
-is a missing verdict.
+task. That section is the only channel the synthesizer reads in Step 6 — a reviewer that does not
+write it is a missing verdict, and the punch list records it as one.
 
 ```text
 Agent(
   team_name="multi-{review_slug}",
-  name="security-worker",
+  name="{worker}",
   subagent_type="dh:task-worker",
-  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are working on security review. Your task: {PA}/T1.\n\nWrite your structured verdict block as the content of the Review Results section on that task, via mcp__plugin_dh_sam__sam_task(plan=\"{PA}\", task=\"T1\", config={\"action\": \"update\", \"append_section\": \"Review Results\", \"section_content\": <raw JSON verdict block>}). That section is where the gate reads your verdict.\n\nSkill(skill=\"start-task\", args=\"{PA} --task T1\")"
-)
-
-Agent(
-  team_name="multi-{review_slug}",
-  name="performance-worker",
-  subagent_type="dh:task-worker",
-  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are working on performance review. Your task: {PA}/T2.\n\nWrite your structured verdict block as the content of the Review Results section on that task, via mcp__plugin_dh_sam__sam_task(plan=\"{PA}\", task=\"T2\", config={\"action\": \"update\", \"append_section\": \"Review Results\", \"section_content\": <raw JSON verdict block>}). That section is where the gate reads your verdict.\n\nSkill(skill=\"start-task\", args=\"{PA} --task T2\")"
-)
-
-Agent(
-  team_name="multi-{review_slug}",
-  name="quality-worker",
-  subagent_type="dh:task-worker",
-  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are working on quality review. Your task: {PA}/T3.\n\nWrite your structured verdict block as the content of the Review Results section on that task, via mcp__plugin_dh_sam__sam_task(plan=\"{PA}\", task=\"T3\", config={\"action\": \"update\", \"append_section\": \"Review Results\", \"section_content\": <raw JSON verdict block>}). That section is where the gate reads your verdict.\n\nSkill(skill=\"start-task\", args=\"{PA} --task T3\")"
-)
-
-Agent(
-  team_name="multi-{review_slug}",
-  name="accessibility-worker",
-  subagent_type="dh:task-worker",
-  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are working on accessibility review. Your task: {PA}/T4.\n\nWrite your structured verdict block as the content of the Review Results section on that task, via mcp__plugin_dh_sam__sam_task(plan=\"{PA}\", task=\"T4\", config={\"action\": \"update\", \"append_section\": \"Review Results\", \"section_content\": <raw JSON verdict block>}). That section is where the gate reads your verdict.\n\nSkill(skill=\"start-task\", args=\"{PA} --task T4\")"
+  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are working on {lens} review. Your task: {PA}/{task}.\n\nWrite your structured verdict block as the content of the Review Results section on that task, via mcp__plugin_dh_sam__sam_task(plan=\"{PA}\", task=\"{task}\", config={\"action\": \"update\", \"append_section\": \"Review Results\", \"section_content\": <raw JSON verdict block>}). That section is where the punch list reads your verdict.\n\nThen run the dh:start-task skill against {PA} --task {task}."
 )
 ```
 
+Substitute one row per spawn:
+
+| `{worker}` | `{lens}` | `{task}` |
+|------------|----------|----------|
+| `security-worker` | security | `T1` |
+| `performance-worker` | performance | `T2` |
+| `quality-worker` | quality | `T3` |
+| `accessibility-worker` | accessibility | `T4` |
+
 ---
 
-## Step 5: Read Verdicts Back From the Plan
+## Step 5: Wait for the Four Reviews to Finish
 
-Wait until every task in the ephemeral plan has reached a terminal status. Poll:
+Wait until `T1`..`T4` have all reached a terminal status. Poll:
 
 ```python
 mcp__plugin_dh_sam__sam_plan(plan="{PA}", config={"action": "status"})
 ```
 
-A task is terminal at `complete`, `blocked`, `failed`, `skipped`, or `deferred`. Do not read
-verdicts while any task is still `not-started` or `in-progress`.
-
-Then read each task and take its `Review Results` section:
-
-```python
-mcp__plugin_dh_sam__sam_task(plan="{PA}", task="T{N}", config={"action": "read"})
-```
-
-The plan was created for this run, so the task carries exactly one `Review Results` section and
-its content is one raw JSON verdict block. Parse it directly:
-
-```python
-verdict_block = json.loads(review_results_section)
-```
-
-The verdict block schema is defined in
-[./references/verdict-schema.md](./references/verdict-schema.md) §2.1. Do not duplicate the
-schema here.
-
-**Missing verdict handling:** A task that is terminal but carries no `Review Results` section, or
-whose section does not parse as a verdict block per §2.1, is a missing verdict — never an
-approval. Treat it as a `FAIL` condition:
-
-```text
-Perspective {X} did not return a verdict
-```
-
-Read all four tasks before proceeding to Step 6.
+A task is terminal at `complete`, `blocked`, `failed`, `skipped`, or `deferred`. `T5` stays
+`not-started` throughout this step — it is dispatched in Step 6, and its dependencies keep
+`sam_plan(action="ready")` from offering it before all four reviews land.
 
 ---
 
-## Step 6: Apply Gate and Print Summary
+## Step 6: Synthesize the Punch List
+
+Dispatch one more worker against `T5`. It reads the four `Review Results` sections, merges
+findings that name the same defect across perspectives into single entries, and writes the
+punch-list block into `T5`'s own `Punch List` section.
+
+```text
+Agent(
+  team_name="multi-{review_slug}",
+  name="synthesis-worker",
+  subagent_type="dh:task-worker",
+  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are synthesizing the four perspective verdicts on plan {PA} into one punch list. Your task: {PA}/T5.\n\nWrite your punch-list block as the content of the Punch List section on that task, via mcp__plugin_dh_sam__sam_task(plan=\"{PA}\", task=\"T5\", config={\"action\": \"update\", \"append_section\": \"Punch List\", \"section_content\": <raw JSON punch-list block>}). That section is where the gate reads your output.\n\nThen run the dh:start-task skill against {PA} --task T5."
+)
+```
+
+Wait for `T5` to reach a terminal status, then read it and take its `Punch List` section:
+
+```python
+mcp__plugin_dh_sam__sam_task(plan="{PA}", task="T5", config={"action": "read"})
+punch_list = json.loads(punch_list_section)
+```
+
+The block carries each perspective's §2.1 verdict block verbatim in `verdicts`, the perspectives
+that returned nothing in `missing`, and the deduplicated findings in `entries`. It gives the gate
+everything it needs, so Step 7 does not read the four `Review Results` sections. Read them when you
+want to check the punch list against its sources — the sections stay on `T1`..`T4` for exactly that.
+
+`json.loads` succeeding proves the section is JSON, not that it is a punch list. Run the validity
+checks in [./references/verdict-schema.md](./references/verdict-schema.md) §2.6 against the parsed
+block before Step 7 reads any field, and take the `Punch list not produced` failure path below —
+naming the check that failed — when any of them fails. Indexing a field the gate needs out of an
+unvalidated block raises on `{}` and silently under-reports coverage on a block missing a
+perspective, and a review that reports fewer perspectives than it ran is a false pass.
+
+**Punch list not produced:** a terminal `T5` whose `Punch List` section is absent, does not
+parse as JSON, or fails any validation check above is synthesis that did not happen. FAIL with
+`Punch list not produced`, name the check that failed, and report which perspectives did write a
+`Review Results` section so the run is diagnosable.
+
+---
+
+## Step 7: Apply Gate and Print Summary
 
 ### Gate Logic
 
 The gate logic is the pre-#1430 stub. The full gate logic including the all-SKIP edge case is
-defined in [./references/verdict-schema.md](./references/verdict-schema.md) §2.4.
+defined in [./references/verdict-schema.md](./references/verdict-schema.md) §2.4. Both inputs come
+from the punch list read in Step 6: `punch_list["verdicts"]` and `punch_list["missing"]`.
 
 Apply gate in this order:
 
-1. **Check for missing verdicts.** If any perspective's task carries no parsable `Review Results`
-   verdict block, FAIL immediately with message
-   `"Perspective {X} did not return a verdict"`.
+1. **Check for missing verdicts.** For each perspective named in `punch_list["missing"]`, FAIL
+   immediately with message `"Perspective {X} did not return a verdict"`. A missing verdict is
+   never an approval.
 
 2. **Check for REJECT.** If any verdict has `verdict == "REJECT"`, the gate FAILS. Collect all
-   REJECT verdicts and their blocking findings for the summary.
+   REJECT verdicts and their blocking findings for the summary. Report the blocking findings from
+   `punch_list["entries"]`, where a defect two perspectives raised appears once and names both.
 
 3. **Check for all-SKIP edge case.** If all four verdicts are `SKIP`, the gate PASSES but the
    summary MUST include this exact warning line:
@@ -289,28 +310,15 @@ summary_line: str, blocking_findings: list[Finding]}`.
 
 ### Summary Line Format
 
-Print one canonical summary line. Format per
-[./references/verdict-schema.md](./references/verdict-schema.md) §2.2:
+Print one canonical summary line:
 
 ```text
 Security: {token} | Performance: {token} | Quality: {token} | Accessibility: {token}
 ```
 
-Summary token mapping:
-
-| Verdict | Findings | Summary token |
-|---------|----------|---------------|
-| `APPROVE` | 0 findings | `APPROVE (0 findings)` |
-| `APPROVE` | N minor/info findings | `APPROVE ({N} minor)` |
-| `REJECT` | 1 BLOCKER finding | `REJECT (1 finding)` |
-| `REJECT` | N BLOCKER findings | `REJECT ({N} findings)` |
-| `SKIP` | — | `SKIP ({skip_reason})` |
-
-Example output:
-
-```text
-Security: APPROVE (0 findings) | Performance: REJECT (1 finding) | Quality: APPROVE (2 minor) | Accessibility: SKIP (no UI changes)
-```
+Take each `{token}` from the verdict-to-token mapping in
+[./references/verdict-schema.md](./references/verdict-schema.md) §2.2, which also shows a fully
+rendered example line.
 
 ### Exit and Cleanup
 
@@ -336,7 +344,7 @@ flowchart TD
     Files --> Empty{changed_files empty?}
     Empty -->|Yes| Abort[ABORT — no changed files to review]
     Empty -->|No| Slug["Derive review_base, then<br>review_slug = review_base + run stamp"]
-    Slug --> CreatePlan["sam_plan(config: create + T1..T4)<br>always a new plan — never reused"]
+    Slug --> CreatePlan["sam_plan(config: create + T1..T5)<br>always a new plan — never reused"]
     CreatePlan --> PlanAddr["Store new plan address as {PA}"]
     PlanAddr --> Team["TeamCreate(team_name='multi-{review_slug}')"]
     Team --> Parallel[Dispatch 4 workers in parallel — no wait between spawns]
@@ -344,11 +352,14 @@ flowchart TD
     Parallel --> W2["Agent(name='performance-worker', subagent_type='dh:task-worker')"]
     Parallel --> W3["Agent(name='quality-worker', subagent_type='dh:task-worker')"]
     Parallel --> W4["Agent(name='accessibility-worker', subagent_type='dh:task-worker')"]
-    W1 --> Collect["Wait for T1..T4 terminal via sam_plan status<br>Read each task's Review Results section"]
+    W1 --> Collect["Wait for T1..T4 terminal via sam_plan status"]
     W2 --> Collect
     W3 --> Collect
     W4 --> Collect
-    Collect --> Gate{Any REJECT?}
+    Collect --> Synth["Dispatch synthesis worker on T5<br>Wait for T5 terminal<br>Read its Punch List section"]
+    Synth --> NoList{"Punch List parses AND<br>validates against §2.6?"}
+    NoList -->|No| FailSynth[FAIL — Punch list not produced]
+    NoList -->|Yes| Gate{Any REJECT?}
     Gate -->|Missing verdict| Fail[FAIL — Perspective X did not return a verdict]
     Gate -->|Any REJECT| Fail2[Print summary. TeamDelete. Exit non-zero.]
     Gate -->|All SKIP| Warn[Print summary. Print all-SKIP warning. TeamDelete. Exit 0.]
@@ -359,31 +370,29 @@ flowchart TD
 
 ## Ephemeral Plan Task Structure
 
-The ephemeral plan always has exactly four tasks:
+The ephemeral plan always has exactly the five tasks the Step 3 create call defines — `T1`
+security, `T2` performance, `T3` quality, `T4` accessibility, `T5` synthesis.
 
-| Task | Perspective | Agent field | dependencies |
-|------|-------------|-------------|--------------|
-| T1 | Security | `dh:reviewer-security` | `[]` |
-| T2 | Performance | `dh:reviewer-performance` | `[]` |
-| T3 | Quality | `dh:reviewer-quality` | `[]` |
-| T4 | Accessibility | `dh:reviewer-accessibility` | `[]` |
-
-All four tasks have `dependencies: []` — they are independent and run in parallel. The
-`agent:` field is read internally by `dh:task-worker` via
-`mcp__plugin_dh_sam__sam_task(plan="{PA}", task="T{N}", config={"action": "read"})` and passed
-to `profile_load` to load the specialist reviewer behavior. The orchestrator always passes only
-the task reference `{PA}/T{N}` to the worker prompt.
+The four review tasks have `dependencies: []` — they are independent and run in parallel. T5
+depends on all four, so `sam_plan(action="ready")` offers it only once every perspective has
+finished. `dh:task-worker` reads the `agent:` field itself and passes it to `profile_load`; the
+orchestrator passes only the task reference `{PA}/T{N}` to the worker prompt.
 
 ---
 
 ## Behavioral Rules
 
-- **SKIP is a passing outcome.** A perspective that SKIPs is not a blocker.
+- **SKIP is a passing outcome.** A perspective that SKIPs is not a blocker. The punch list records
+  it as coverage that was declined, with the reviewer's `skip_reason`.
 - **All four verdicts must arrive before the gate runs.** Do not apply the gate on partial results.
-- **Check-or-create prevents plan accumulation.** Always list by search before creating.
+- **Every run creates its own plan.** `review_slug` carries this run's stamp, so no earlier
+  plan can match it and no run reads another run's results.
 - Dispatch uses `dh:task-worker` because the perspective reviewer agents cannot claim or close a SAM task. Specialist behavior is selected through the task profile. See `dh:dispatch-contract`.
-- **Do not embed the verdict schema or UI pattern list.** Reference
+- **Do not embed the verdict or punch-list schema, or the UI pattern list.** Reference
   [./references/verdict-schema.md](./references/verdict-schema.md) for all schema definitions.
-- **Each ephemeral task body must embed the newline-separated changed-files list.** Workers read
-  their task body to obtain the scan target; they do not receive it via the prompt.
+- **Each reviewer task body must embed the newline-separated changed-files list.** Reviewers read
+  their task body to obtain the scan target; they do not receive it via the prompt. T5 reads the
+  four verdict sections instead, so its body names those and carries no file list.
+- **The punch list is the gate's input.** One defect two perspectives raised is one entry naming
+  both, so a REJECT summary counts distinct defects rather than repeating one across lenses.
 - **All-SKIP warning is mandatory** when all four perspectives return SKIP.

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -261,7 +261,7 @@ punch_list = json.loads(punch_list_section)
 The block carries each perspective's §2.1 verdict block verbatim in `verdicts`, the perspectives
 that returned nothing in `missing`, and the deduplicated findings in `entries`. It gives the gate
 everything it needs to render the summary and entries, but not everything it needs to trust the
-`verdict` token itself — see the reconciliation check below.
+`verdict` token or the findings behind `entries` — see the reconciliation checks below.
 
 `json.loads` succeeding proves the section is JSON, not that it is a punch list. Run the validity
 checks in [./references/verdict-schema.md](./references/verdict-schema.md) §2.6 against the parsed
@@ -270,15 +270,28 @@ naming the check that failed — when any of them fails. Indexing a field the ga
 unvalidated block raises on `{}` and silently under-reports coverage on a block missing a
 perspective, and a review that reports fewer perspectives than it ran is a false pass.
 
-**Reconcile against source (§2.6 check 6):** the synthesizer copies each `verdicts[i]` block from
-its perspective's own `Review Results` section, but a copy is a claim, not a guarantee — an LLM
-that alters a source `REJECT` to `APPROVE` while carrying its finding text forward still produces
-a block that passes every check above, because none of them compares `verdict` to its source. Read
-the four `Review Results` sections on `T1`..`T4` and confirm each `verdicts[i].verdict` matches its
-source perspective's `verdict` field exactly. A mismatch is check 6 failing: take the `Punch list
-not produced` failure path below and name the perspective whose verdict was altered — a punch list
-that silently drops a REJECT is a false pass, and the gate's entire correctness rests on this
-token, so this check runs on every synthesis, not only when something looks wrong.
+**Reconcile against source (§2.6 checks 6 and 7):** the synthesizer copies each `verdicts[i]` block
+from its perspective's own `Review Results` section, but a copy is a claim, not a guarantee. Read
+the four raw `Review Results` sections on `T1`..`T4` — comparing the punch list's own `verdicts`
+and `entries` fields against each other is not enough, since both are the synthesizer's own output
+and an internally-consistent alteration to both still passes. Confirm two things against those raw
+sections directly:
+
+- Check 6: each `verdicts[i].verdict` matches its source perspective's `verdict` field exactly. An
+  LLM that alters a source `REJECT` to `APPROVE` while carrying its finding text forward still
+  produces a block that passes every other check, because none of them compares `verdict` to its
+  source.
+- Check 7: each raw finding's `description` on `T1`..`T4` appears verbatim in some
+  `entries[].descriptions`, at the index where that entry's `entries[].perspectives` names the
+  finding's own perspective. An LLM that alters a finding's `file`, `severity`, `description`, or
+  `rule` identically in both `verdicts[i].findings` and `entries`, or drops one while inventing a
+  duplicate attribution to keep the total unchanged, still passes every check that compares the
+  punch list only against itself.
+
+A mismatch on either check is that check failing: take the `Punch list not produced` failure path
+below and name the check and the perspective or finding it failed on — a punch list that silently
+drops a REJECT, or silently misstates a finding, is a false pass, and the gate's entire correctness
+rests on these two checks, so both run on every synthesis, not only when something looks wrong.
 
 **Punch list not produced:** a terminal `T5` whose `Punch List` section is absent, does not
 parse as JSON, or fails any validation check above is synthesis that did not happen. FAIL with

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -260,8 +260,8 @@ punch_list = json.loads(punch_list_section)
 
 The block carries each perspective's §2.1 verdict block verbatim in `verdicts`, the perspectives
 that returned nothing in `missing`, and the deduplicated findings in `entries`. It gives the gate
-everything it needs, so Step 7 does not read the four `Review Results` sections. Read them when you
-want to check the punch list against its sources — the sections stay on `T1`..`T4` for exactly that.
+everything it needs to render the summary and entries, but not everything it needs to trust the
+`verdict` token itself — see the reconciliation check below.
 
 `json.loads` succeeding proves the section is JSON, not that it is a punch list. Run the validity
 checks in [./references/verdict-schema.md](./references/verdict-schema.md) §2.6 against the parsed
@@ -270,10 +270,22 @@ naming the check that failed — when any of them fails. Indexing a field the ga
 unvalidated block raises on `{}` and silently under-reports coverage on a block missing a
 perspective, and a review that reports fewer perspectives than it ran is a false pass.
 
+**Reconcile against source (§2.6 check 6):** the synthesizer copies each `verdicts[i]` block from
+its perspective's own `Review Results` section, but a copy is a claim, not a guarantee — an LLM
+that alters a source `REJECT` to `APPROVE` while carrying its finding text forward still produces
+a block that passes every check above, because none of them compares `verdict` to its source. Read
+the four `Review Results` sections on `T1`..`T4` and confirm each `verdicts[i].verdict` matches its
+source perspective's `verdict` field exactly. A mismatch is check 6 failing: take the `Punch list
+not produced` failure path below and name the perspective whose verdict was altered — a punch list
+that silently drops a REJECT is a false pass, and the gate's entire correctness rests on this
+token, so this check runs on every synthesis, not only when something looks wrong.
+
 **Punch list not produced:** a terminal `T5` whose `Punch List` section is absent, does not
 parse as JSON, or fails any validation check above is synthesis that did not happen. FAIL with
-`Punch list not produced`, name the check that failed, and report which perspectives did write a
-`Review Results` section so the run is diagnosable.
+`Punch list not produced`, name the check that failed, report which perspectives did write a
+`Review Results` section so the run is diagnosable, then run `TeamDelete(team_name="multi-{review_slug}")`
+and exit non-zero — this failure happens before Step 7, so its own team cleanup and exit are the
+only ones that will run for it.
 
 ---
 
@@ -322,7 +334,8 @@ rendered example line.
 
 ### Exit and Cleanup
 
-1. If gate FAILED (any REJECT): print the summary line, then TeamDelete, then exit non-zero.
+1. If gate FAILED (missing verdict or any REJECT): print the summary line, then TeamDelete, then
+   exit non-zero.
 2. If gate PASSED (all-SKIP warning applies): print the summary line, then print the warning
    line `NOTE: No perspectives reviewed — all skipped`, then TeamDelete, then exit 0.
 3. If gate PASSED (normal): print the summary line, then TeamDelete, then exit 0.
@@ -358,9 +371,9 @@ flowchart TD
     W4 --> Collect
     Collect --> Synth["Dispatch synthesis worker on T5<br>Wait for T5 terminal<br>Read its Punch List section"]
     Synth --> NoList{"Punch List parses AND<br>validates against §2.6?"}
-    NoList -->|No| FailSynth[FAIL — Punch list not produced]
+    NoList -->|No| FailSynth[FAIL — Punch list not produced.<br>TeamDelete. Exit non-zero.]
     NoList -->|Yes| Gate{Any REJECT?}
-    Gate -->|Missing verdict| Fail[FAIL — Perspective X did not return a verdict]
+    Gate -->|Missing verdict| Fail[FAIL — Perspective X did not return a verdict.<br>Print summary. TeamDelete. Exit non-zero.]
     Gate -->|Any REJECT| Fail2[Print summary. TeamDelete. Exit non-zero.]
     Gate -->|All SKIP| Warn[Print summary. Print all-SKIP warning. TeamDelete. Exit 0.]
     Gate -->|All APPROVE or APPROVE+SKIP| Pass[Print summary. TeamDelete. Exit 0.]

--- a/plugins/development-harness/skills/multi-perspective-review/references/acceptance-test-guide.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/acceptance-test-guide.md
@@ -20,9 +20,9 @@ Before running any test below:
    ```bash
    /dh:multi-perspective-review --help
    ```
-2. Confirm the four reviewer agents are registered:
+2. Confirm the four reviewer agents and the synthesizer are registered:
    ```bash
-   ls plugins/development-harness/agents/reviewer-*.md
+   ls plugins/development-harness/agents/reviewer-*.md plugins/development-harness/agents/review-synthesizer.md
    ```
 3. Apply a fixture diff to a scratch branch:
    ```bash

--- a/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
@@ -266,7 +266,7 @@ incorrect behavior in a documented scenario; MINOR otherwise).
 The synthesis task (T5, profile `dh:review-synthesizer`) reads the four `Review Results` sections
 and writes exactly one punch-list block as the content of its own `Punch List` section. The
 orchestrator always reads that section, and always reads the four raw `Review Results` sections
-too — check 6 below requires comparing them.
+too — checks 6 and 7 below require comparing them.
 
 ```json
 {
@@ -341,10 +341,14 @@ rather than reading fields out of it.
    `APPROVE` while its finding text is carried forward still satisfies checks 1-5). This check is
    the only one that catches that case, so it is not optional and not skipped when checks 1-5 all
    pass.
-7. Every finding's `description` in every `verdicts[i].findings` appears verbatim in some
-   `entries[].descriptions`, at the index where that entry's `entries[].perspectives` names the
-   finding's own perspective. The conservation invariant (check 4) proves only that the *counts*
-   match — a finding whose `file`, `severity`, or `description` was altered in the copy, or one
-   dropped while a duplicate attribution was invented to keep the total unchanged, still satisfies
-   checks 1-6. This check is the only one that catches that case, so it runs alongside check 6 on
-   every synthesis, not only when a count or verdict token looks wrong.
+7. Every finding on each perspective's own raw `Review Results` section on `T1`..`T4` — not the
+   `verdicts` copy — has its `description` appearing verbatim in some `entries[].descriptions`, at
+   the index where that entry's `entries[].perspectives` names the finding's own perspective.
+   Comparing `entries` against `verdicts[i].findings` is not sufficient: both fields are the
+   synthesizer's own output, so a synthesizer that alters a finding's `file`, `severity`,
+   `description`, or `rule` identically in both places, or drops one while inventing a duplicate
+   attribution to keep the total unchanged, still satisfies checks 1-6 and an entries-vs-`verdicts`
+   comparison — none of those compares against the source the synthesizer read. Only a comparison
+   against the raw `T1`..`T4` sections, the same source check 6 reconciles against, catches that
+   case, so this check runs alongside check 6 on every synthesis, not only when a count or verdict
+   token looks wrong.

--- a/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
@@ -258,8 +258,8 @@ incorrect behavior in a documented scenario; MINOR otherwise).
 
 The synthesis task (T5, profile `dh:review-synthesizer`) reads the four `Review Results` sections
 and writes exactly one punch-list block as the content of its own `Punch List` section. The
-orchestrator reads that section, and reads the raw verdict sections only when it chooses to check
-the punch list against them.
+orchestrator always reads that section, and always reads the four raw `Review Results` sections
+too — check 6 below requires comparing them.
 
 ```json
 {
@@ -328,3 +328,9 @@ rather than reading fields out of it.
 4. The conservation invariant above holds.
 5. Each entry carries `severity`, `file`, `perspectives`, and `descriptions`, with `descriptions`
    the same length as `perspectives`.
+6. Each `verdicts[i].verdict` matches the `verdict` field in that perspective's own `Review
+   Results` section on `T1`..`T4`, exactly. Checks 1-5 validate structure and counts; none of them
+   catches a `verdict` token silently changed in the copy (a source `REJECT` rewritten to
+   `APPROVE` while its finding text is carried forward still satisfies checks 1-5). This check is
+   the only one that catches that case, so it is not optional and not skipped when checks 1-5 all
+   pass.

--- a/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
@@ -341,3 +341,10 @@ rather than reading fields out of it.
    `APPROVE` while its finding text is carried forward still satisfies checks 1-5). This check is
    the only one that catches that case, so it is not optional and not skipped when checks 1-5 all
    pass.
+7. Every finding's `description` in every `verdicts[i].findings` appears verbatim in some
+   `entries[].descriptions`, at the index where that entry's `entries[].perspectives` names the
+   finding's own perspective. The conservation invariant (check 4) proves only that the *counts*
+   match — a finding whose `file`, `severity`, or `description` was altered in the copy, or one
+   dropped while a duplicate attribution was invented to keep the total unchanged, still satisfies
+   checks 1-6. This check is the only one that catches that case, so it runs alongside check 6 on
+   every synthesis, not only when a count or verdict token looks wrong.

--- a/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
@@ -67,9 +67,16 @@ Mapping from verdict struct to summary token:
 | `REJECT` | 1 BLOCKER finding | `REJECT (1 finding)` |
 | `REJECT` | N BLOCKER findings | `REJECT ({N} findings)` |
 | `SKIP` | — | `SKIP ({skip_reason})` |
+| _missing_ | — | `MISSING (no verdict)` |
 
 **Note:** The singular `finding` vs plural `findings` applies to REJECT tokens only. APPROVE
 always uses `findings` (plural).
+
+**Missing-perspective token:** a perspective named in the punch list's `missing` array (§2.6) has
+no verdict struct to look up in this table — it never reached `verdicts`. Render its slot with the
+`MISSING (no verdict)` token directly, without applying any other row above. This is how Step 7's
+FAIL-on-missing-verdict path (SKILL.md "Exit and Cleanup") still prints one token per perspective
+before exiting non-zero.
 
 ---
 

--- a/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/verdict-schema.md
@@ -140,11 +140,16 @@ GateResult:
   blocking_findings: list[Finding]   — empty when passed
 ```
 
+**Gate input:** `verdicts` and `missing` both come from the punch-list block (§2.6) that the
+synthesis task writes — `punch_list["verdicts"]` carries each §2.1 block verbatim, so the gate
+input is byte-identical to reading the four `Review Results` sections directly. The orchestrator
+may read those sections to check the punch list against them; the gate does not require it.
+
 **Pre-#1430 stub logic:**
 
 ```text
-verdicts = [parse_verdict(task.review_results) for task in plan_tasks]
-missing = [p for p in PERSPECTIVES if p's task has no parsable Review Results block]
+verdicts = punch_list["verdicts"]
+missing = punch_list["missing"]
 if missing:
     FAIL — "Perspective {X} did not return a verdict"
 rejecting = [v for v in verdicts if v.verdict == "REJECT"]
@@ -246,3 +251,80 @@ When any Tier 3 file is in the changed-files list, the quality reviewer checks:
 
 These are prompt engineering bugs. Each confirmed issue is a finding (BLOCKER if it causes
 incorrect behavior in a documented scenario; MINOR otherwise).
+
+---
+
+## §2.6 Punch-List Block
+
+The synthesis task (T5, profile `dh:review-synthesizer`) reads the four `Review Results` sections
+and writes exactly one punch-list block as the content of its own `Punch List` section. The
+orchestrator reads that section, and reads the raw verdict sections only when it chooses to check
+the punch list against them.
+
+```json
+{
+  "schema_version": "1.0",
+  "verdicts": [
+    {
+      "schema_version": "1.0",
+      "perspective": "security",
+      "verdict": "REJECT",
+      "findings": [],
+      "skip_reason": "present only when verdict == SKIP"
+    }
+  ],
+  "missing": ["performance"],
+  "entries": [
+    {
+      "severity": "BLOCKER",
+      "file": "relative/path/to/file.py",
+      "line": 42,
+      "perspectives": ["security", "quality"],
+      "descriptions": [
+        "security reviewer's wording",
+        "quality reviewer's wording"
+      ],
+      "rules": ["no-hardcoded-secrets"]
+    }
+  ]
+}
+```
+
+**Field constraints:**
+
+- `verdicts`: each §2.1 block copied verbatim from a `Review Results` section, one per perspective
+  that returned a parsable one. This is the gate input defined in §2.4.
+- `missing`: perspectives whose task is terminal with no parsable `Review Results` block. A
+  perspective appears in `verdicts` or in `missing`, never both and never neither.
+- `entries`: deduplicated findings. One entry per distinct defect, whatever number of perspectives
+  raised it.
+- `entries[].perspectives`: every perspective that raised this defect, in T1..T4 order (security,
+  performance, quality, accessibility).
+- `entries[].descriptions`: each raising reviewer's own wording, index-aligned with `perspectives`.
+- `entries[].severity`: the highest severity among the merged findings.
+- `entries[].rules`: union of the `rule` values on the merged findings; `[]` when none carried one.
+- Ordering: `BLOCKER`, `MINOR`, `INFO`; within a severity, more perspectives first, then file path,
+  then line.
+
+**Conservation invariant:** the total number of findings across `verdicts` equals the sum of
+`len(perspectives)` across `entries`. Every reviewer finding reaches exactly one entry, and no
+entry exists without a reviewer finding behind it.
+
+**Merge rule:** two findings become one entry when they name the same file, the same line, and the
+same defect. A finding with `line: null` merges with a line-specific finding in the same file only
+when both descriptions name the same defect. Two different defects on one line stay two entries.
+
+**Validity checks:** the synthesizer runs these before writing the block, and the orchestrator runs
+them on the block it reads back. A block that fails any of them is not a punch list, whatever
+`json.loads` says about it, and the orchestrator takes its `Punch list not produced` failure path
+rather than reading fields out of it.
+
+1. The block is an object carrying `verdicts`, `missing`, and `entries`, with `verdicts` and
+   `entries` arrays of objects and `missing` an array of strings.
+2. Each block in `verdicts` satisfies §2.1 — `perspective` one of `security`, `performance`,
+   `quality`, `accessibility`; `verdict` one of `APPROVE`, `REJECT`, `SKIP`; `findings` an array.
+3. Coverage partition holds: `verdicts` and `missing` together name all four perspectives exactly
+   once — none in both, none in neither, none named twice.
+4. The conservation invariant above holds.
+5. Each entry carries `severity`, `file`, `perspectives`, and `descriptions`, with `descriptions`
+   the same length as `perspectives`.


### PR DESCRIPTION
Follows #3202. That PR moved the four perspective verdicts onto a stored channel (each reviewer writes its `Review Results` section) and flagged the punch-list synthesis as a separate deliverable, with a recommended shape. This is that deliverable, built to the recommended shape.

## What

`dh:review-synthesizer` (new agent) plus a `T5 Review Synthesis` task on the ephemeral review plan, depending on `T1..T4`. It reads the four `Review Results` sections, merges findings that name the same defect into a single entry naming every perspective that raised it, records APPROVE/REJECT/SKIP coverage plus any perspective that returned no verdict, and writes the punch-list block into its own task's `Punch List` section.

`multi-perspective-review` Step 6 dispatches it and reads that one section. Step 5 now only waits for `T1..T4` to go terminal; the per-task verdict reads moved into the synthesizer. The gate renumbers to Step 7.

## Output destination

Same rule as the verdicts, and the only option that survives a run with no `--issue`:

- `artifact_register` requires `item_id`. `--issue` is optional, so an artifact channel leaves the no-issue invocation with no punch list at all.
- `sam_plan`'s section append requires a `task_id` (`PlanUpdateInput.validate_operations`, `sam_schema/cli_inputs.py`). There is no plan-level section to write to.
- A task section is what remains. It needs no issue number, and it reuses the poll-then-read-section path the orchestrator already had.

## Gate input is unchanged

The punch list carries each §2.1 verdict block verbatim in `verdicts`, so `gate(verdicts)` receives byte-identical input from one read instead of four — the stable interface #1430 swaps against is untouched. A missing verdict travels as a named perspective in `missing` and still fails the gate; it is never an approval. A terminal `T5` with no parsable block is its own FAIL (`Punch list not produced`), so synthesis cannot silently pass. The raw `Review Results` sections stay on `T1..T4` for the orchestrator to check the punch list against when it wants to.

Reusing an existing plan now resets `T1..T5`, not `T1..T4` — a terminal `T5` would otherwise leave the previous run's punch list in place.

Schema in `verdict-schema.md` §2.6, including the conservation invariant (findings across `verdicts` equals the sum of `len(perspectives)` across `entries`) that the agent checks before reporting DONE.

## Notes

- Agents are auto-discovered from `agents/`; no manifest lists them, and a pre-commit hook guards against a `plugin.json` `agents` key masking them. The three manifests changed here only through the auto-sync version bump.
- `dh:review-synthesizer` declares `mcp__plugin_dh_sam__sam_task` and nothing else from SAM, so under `dh:dispatch-contract` it reaches the work as a `dh:task-worker` profile, exactly like the four reviewers.

## Gates

- `uvx skilllint@latest check plugins/development-harness/agents/` — exit 0
- `uv run prek run --files <each changed file>` — all Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg
