### PR TITLE
docs(agentskills): sync content against upstream and fix reference-link format

### DIFF
--- a/plugins/plugin-creator/.claude-plugin/plugin.json
+++ b/plugins/plugin-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creator",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
-  "version": "14.5.19",
+  "version": "14.5.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/plugin-creator/.codex-plugin/plugin.json
+++ b/plugins/plugin-creator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-creator",
-  "version": "14.5.8",
+  "version": "14.5.9",
   "description": "Complete plugin development toolkit for creating, refactoring, and validating Claude Code plugins and agents. Use when creating new plugins/skills/agents, refactoring existing plugins/skills, validating frontmatter, or restructuring plugin components. Includes specialized agents for assessment, planning, execution, and validation workflows.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/plugin-creator/skills/agentskills/SKILL.md
+++ b/plugins/plugin-creator/skills/agentskills/SKILL.md
@@ -184,7 +184,7 @@ Place user-facing docs (README, CHANGELOG, INSTALLATION_GUIDE), setup procedures
 
 ## Validation
 
-For skill-complexity and frontmatter checks in this repository, run `uvx skilllint@latest check <skill-path>` first — it is bundled, requires no install, and is this repo's standard validator (see AGENTS.md).
+For quick complexity and frontmatter checks, `uvx skilllint@latest check <skill-path>` is available via `uvx` (resolves the package from PyPI on first run — needs network access, is not bundled with this skill) and is faster than installing `skills-ref`.
 
 For deeper agentskills.io open-standard compliance checks not covered by `skilllint` (e.g. cross-client portability rules), use the `skills-ref` reference library:
 

--- a/plugins/plugin-creator/skills/agentskills/SKILL.md
+++ b/plugins/plugin-creator/skills/agentskills/SKILL.md
@@ -6,11 +6,11 @@ user-invocable: true
 
 # Agent Skills Open Standard
 
-The Agent Skills format is an open standard for extending AI agent capabilities with specialized knowledge and workflows. Originally developed by Anthropic, adopted by 25+ agent products.
+The Agent Skills format is an open standard for extending AI agent capabilities with specialized knowledge and workflows. Originally developed by Anthropic, released as an open standard, and adopted by a growing number of agent products.
 
 **Source:** <https://agentskills.io>
 
-**When to use this skill:** Before creating any skill that should be portable across multiple agent products. For Claude Code-specific features (hooks, context fork, model selection, invocation control), see `../claude-skills-overview-2026/SKILL.md` instead.
+**When to use this skill:** Before creating any skill that should be portable across multiple agent products. For Claude Code-specific features (hooks, context fork, model selection, invocation control), use the `plugin-creator:claude-skills-overview-2026` skill instead.
 
 ---
 
@@ -93,7 +93,7 @@ description: Helps with PDFs.
 Skills use three-level loading to manage context efficiently:
 
 1. **Metadata** (~100 tokens): `name` + `description` loaded at startup for all skills
-2. **Instructions** (<5000 tokens recommended): Full SKILL.md body loaded on activation
+2. **Instructions** (<5000 tokens recommended, and ideally under 500 lines): Full SKILL.md body loaded on activation
 3. **Resources** (as needed): Files in `scripts/`, `references/`, `assets/` loaded on demand
 
 **Keep SKILL.md body lean.** Move detailed reference material to separate files. Run `uvx skilllint@latest check <skill-path>` after writing and follow its guidance on token-based sizing.
@@ -159,7 +159,7 @@ Static resources used in output (templates, images, data files). Not loaded into
 
 ## Authoring Best Practices
 
-For the complete Anthropic authoring guide, see `references/best-practices.md`.
+For the complete Anthropic authoring guide, see [references/best-practices.md](./references/best-practices.md).
 
 Key principles:
 
@@ -184,7 +184,9 @@ Place user-facing docs (README, CHANGELOG, INSTALLATION_GUIDE), setup procedures
 
 ## Validation
 
-Use the `skills-ref` reference library to validate:
+For skill-complexity and frontmatter checks in this repository, run `uvx skilllint@latest check <skill-path>` first — it is bundled, requires no install, and is this repo's standard validator (see AGENTS.md).
+
+For deeper agentskills.io open-standard compliance checks not covered by `skilllint` (e.g. cross-client portability rules), use the `skills-ref` reference library:
 
 ```bash
 # Validate a skill directory
@@ -210,6 +212,8 @@ prompt = to_prompt([Path("skill-a"), Path("skill-b")])
 
 Install: `pip install -e .` from the [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) directory.
 
+> **Note:** `skills-ref` is intended for demonstration purposes only and is not meant to be used in production — treat it as a reference implementation, not a hardened validation gate.
+
 ---
 
 ## Portable vs Claude Code-Specific
@@ -234,20 +238,22 @@ The open standard defines a **portable subset**. Claude Code extends it with add
 
 **For portable skills:** Use only the open standard fields. Other agents will ignore unknown fields, but keeping frontmatter clean improves compatibility.
 
-**For Claude Code skills:** See `../claude-skills-overview-2026/SKILL.md` for the full extended schema.
+**Claude Code-specific validation:** Claude Code additionally rejects `name` or `description` values containing XML tags, and rejects `name` values containing the reserved words `anthropic` or `claude` — a stricter check than the open standard's own name/description rules above. This constraint is Claude Code-specific and not part of the agentskills.io specification.
+
+**For Claude Code skills:** Use the `plugin-creator:claude-skills-overview-2026` skill for the full extended schema.
 
 ---
 
 ## Detailed References
 
-- **Full specification details**: See `references/specification.md`
-- **Authoring best practices**: See `references/best-practices.md`
-- **Agent integration guide**: See `references/integration.md`
+- **Full specification details**: See [references/specification.md](./references/specification.md)
+- **Authoring best practices**: See [references/best-practices.md](./references/best-practices.md)
+- **Agent integration guide**: See [references/integration.md](./references/integration.md)
 
 ## External Links
 
-- Specification: <https://agentskills.io/specification>
-- Best practices: <https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices>
-- Example skills: <https://github.com/anthropics/skills>
-- Reference library: <https://github.com/agentskills/agentskills/tree/main/skills-ref>
-- GitHub org: <https://github.com/agentskills/agentskills>
+- Specification: <https://agentskills.io/specification> (accessed 2026-08-24)
+- Best practices: <https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices> (accessed 2026-08-24)
+- Example skills: <https://github.com/anthropics/skills> (accessed 2026-08-24)
+- Reference library: <https://github.com/agentskills/agentskills/tree/main/skills-ref> (accessed 2026-08-24)
+- GitHub org: <https://github.com/agentskills/agentskills> (accessed 2026-08-24) — Apache-2.0 (code) + CC-BY-4.0 (spec text)

--- a/plugins/plugin-creator/skills/agentskills/references/best-practices.md
+++ b/plugins/plugin-creator/skills/agentskills/references/best-practices.md
@@ -139,7 +139,7 @@ description: Generate descriptive commit messages by analyzing git diffs. Use wh
 
 ### Progressive Disclosure Patterns
 
-Keep SKILL.md body lean. Split content into separate files when the validator warns. Run `uvx skilllint@latest check <skill-path>` after writing and follow its guidance on token-based sizing.
+Keep SKILL.md body lean — aim for under 500 lines, in addition to the token-based limit. Split content into separate files when the validator warns. Run `uvx skilllint@latest check <skill-path>` after writing and follow its guidance on token-based sizing.
 
 **Pattern 1 — High-level guide with references:**
 
@@ -279,7 +279,7 @@ description: >-
 
 Apply this check before sharing or publishing a skill that targets multiple clients.
 
-SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-04-23)
+SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-08-24)
 
 ---
 

--- a/plugins/plugin-creator/skills/agentskills/references/integration.md
+++ b/plugins/plugin-creator/skills/agentskills/references/integration.md
@@ -59,7 +59,7 @@ Filesystem-based discovery assumes the agent has access to the local filesystem.
 - **User-level skills need external provision** — Skills stored at the user level (e.g., `~/.claude/skills/`) are not present in a fresh sandbox. Provision them by cloning a config repository into the sandbox before agent startup, providing skill URLs the agent can fetch, or offering a web UI where users upload skills before starting a session.
 - **Built-in skills as static deployment artifacts** — Skills that the product ships as part of its deployment image are always available in any sandbox. Package commonly needed skills as static assets in the deployment.
 
-SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-04-23)
+SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-08-24)
 
 ---
 
@@ -118,7 +118,8 @@ When using a dedicated tool (rather than filesystem commands) to activate a skil
 
 ```xml
 <skill_content name="pdf-processing">
-  /path/to/skills/pdf-processing/
+  Skill directory: /path/to/skills/pdf-processing/
+  Relative paths in this skill are relative to the skill directory.
 
   <skill_resources>
     references/forms.md
@@ -129,7 +130,7 @@ When using a dedicated tool (rather than filesystem commands) to activate a skil
 </skill_content>
 ```
 
-SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-04-23)
+SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-08-24)
 
 ---
 
@@ -150,7 +151,7 @@ Project-level skills (committed to a repository) can come from untrusted sources
 
 **Recommended approach:** Gate project-level skill loading on an explicit trust signal — for example, requiring the user to mark a directory as trusted before its skills are loaded into context. This prevents untrusted repositories from injecting instructions automatically.
 
-SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-04-23)
+SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-08-24)
 
 ---
 
@@ -160,7 +161,7 @@ When an agent uses a permission system that prompts the user before file reads, 
 
 **Recommended approach:** When a skill is loaded, add its directory to the agent's read-permission allowlist so the model can access bundled resources without interrupting the user for each file. Without allowlisting, every reference file access produces a confirmation prompt that breaks the user experience.
 
-SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-04-23)
+SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-08-24)
 
 ---
 
@@ -174,7 +175,7 @@ Some agent implementations support running a skill in a separate subagent sessio
 
 This is useful for complex skill workflows that benefit from an isolated context window. Support for subagent delegation is optional and varies between agent implementations.
 
-SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-04-23)
+SOURCE: [agentskills.io integration guide](https://agentskills.io/integrate-skills.md) (accessed 2026-08-24)
 
 ---
 
@@ -200,6 +201,4 @@ Use the library source code as a reference implementation for building your own 
 
 ## Adoption
 
-Agent Skills are supported by 25+ products including:
-
-Claude Code, Cursor, VS Code, Gemini CLI, OpenAI Codex, GitHub, Roo Code, Amp, Goose, Factory, Databricks, Spring AI, Letta, Firebender, OpenCode, Autohand, Mux, Piebald, TRAE, Qodo, Agentman, Mistral Vibe, Command Code, Ona, VT Code.
+Agent Skills has been adopted by a growing number of agent products, including Claude Code, Cursor, VS Code, Gemini CLI, OpenAI Codex & Copilot, Roo Code, Amp, Goose, Factory, and Databricks. See the live client showcase at <https://agentskills.io> for the current full list.

--- a/plugins/plugin-creator/skills/agentskills/references/specification.md
+++ b/plugins/plugin-creator/skills/agentskills/references/specification.md
@@ -278,7 +278,7 @@ skills-ref validate ./my-skill
 
 **Why validate:** Validation catches frontmatter and naming errors before distribution and prevents agents from loading malformed skills. Run it before publishing or sharing skills.
 
-> **Note:** The live agentskills.io/specification page now documents only this single `skills-ref validate` command. The additional CLI subcommands, Python API, and XML output format below are confirmed directly against the [skills-ref repository](https://github.com/agentskills/agentskills/tree/main/skills-ref) — not the specification page. The skills-ref README also states it is **intended for demonstration purposes only** and is not meant to be used in production; treat it as a reference implementation, not a hardened validation gate.
+> **Note:** `skills-ref` is intended for demonstration purposes only and is not meant to be used in production — treat it as a reference implementation, not a hardened validation gate.
 
 **CLI commands:**
 

--- a/plugins/plugin-creator/skills/agentskills/references/specification.md
+++ b/plugins/plugin-creator/skills/agentskills/references/specification.md
@@ -161,6 +161,7 @@ The optional `compatibility` field:
 ```yaml
 compatibility: Designed for Claude Code (or similar products)
 compatibility: Requires git, docker, jq, and access to the internet
+compatibility: Requires Python 3.14+ and uv
 ```
 
 Most skills do not need this field.
@@ -245,7 +246,7 @@ Contains static resources:
 Skills should be structured for efficient use of context:
 
 1. **Metadata** (~100 tokens): The `name` and `description` fields are loaded at startup for all skills
-2. **Instructions** (<5000 tokens recommended): The full SKILL.md body is loaded when the skill is activated
+2. **Instructions** (<5000 tokens recommended, and ideally under 500 lines): The full SKILL.md body is loaded when the skill is activated
 3. **Resources** (as needed): Files in `scripts/`, `references/`, `assets/` are loaded only when required
 
 **Keep your main SKILL.md lean.** Move detailed reference material to separate files. Run `uvx skilllint@latest check <skill-path>` after writing and follow its guidance on token-based sizing.
@@ -276,6 +277,8 @@ skills-ref validate ./my-skill
 ```
 
 **Why validate:** Validation catches frontmatter and naming errors before distribution and prevents agents from loading malformed skills. Run it before publishing or sharing skills.
+
+> **Note:** The live agentskills.io/specification page now documents only this single `skills-ref validate` command. The additional CLI subcommands, Python API, and XML output format below are confirmed directly against the [skills-ref repository](https://github.com/agentskills/agentskills/tree/main/skills-ref) — not the specification page. The skills-ref README also states it is **intended for demonstration purposes only** and is not meant to be used in production; treat it as a reference implementation, not a hardened validation gate.
 
 **CLI commands:**
 


### PR DESCRIPTION
## Summary

Runs `/plugin-creator:skill-sync` against `plugins/plugin-creator/skills/agentskills/` (SKILL.md + all three reference files), driven by three parallel Stage 2 read agents (completeness audit, upstream-drift scan, structure validation) synthesized into a change plan, pre-fetch/URL-validated by `skill-sync-source-validator`, and applied by `skill-content-updater`.

- Replaces two STALE adoption-count claims (`SKILL.md`, `references/integration.md`) — upstream's own client showcase moved from a fixed "25+" figure to non-numeric phrasing; live count is 46 as of 2026-08-24, so this PR matches upstream's phrasing rather than hardcoding a fresh number that would just drift again
- Adds 6 NEW upstream claims, each with a `SOURCE:`-cited access date: the 500-line SKILL.md sizing heuristic (3 locations), a Claude Code-specific `name`/`description` validation note (no XML tags, no `anthropic`/`claude` reserved words), a `skills-ref` "demonstration purposes only, not for production" caveat plus reconciliation with this repo's actual standard validator (`uvx skilllint@latest check`), a third `compatibility` field example, and a path-resolution line in the structured-wrapping XML example
- Fixes 6 markdown-file-reference / skill-activation format violations flagged by structure review (backtick-only citations → markdown links; raw relative skill paths → skill-activation prose)
- Bumps 6 stale citation access dates on re-verified claims

**Deferred** (logged in the change plan, not this pass — out of scope for `skill-content-updater`, which syncs against upstream but does not rewrite/optimize content):
1. `references/integration.md`'s much larger upstream lifecycle rewrite (5-step Discover→Parse→Disclose→Activate→Manage-context model, `.agents/skills/` cross-client convention, name-collision precedence, lenient-validation rules, etc.)
2. `SKILL.md`'s description-vs-body Claude Code scope conflict (activation-boundary ambiguity)
3. Progressive Disclosure content triplicated near-verbatim across three files

## Test plan

- [x] `uvx skilllint@latest check` on all 4 modified skill files — exit 0, no findings
- [x] `uv run prek run --files ...` — all hooks pass (markdownlint, plugin/skill validator, manifest auto-sync)
- [x] Diff reviewed against the change plan entry-by-entry before commit
- [x] Stage 4.5 source-validator independently re-verified every cited URL (0 UNVERIFIABLE) and caught/corrected an inaccurate "50+" draft figure before the write pass ran

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyzq7JoLCZzzeudSoSrB9Z