### PR TITLE
docs(agents-md): add Evidence Proportionality rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 This document covers everything an AI agent needs to work effectively in this repository.
 
+## Evidence Proportionality
+
+Before using tools, running tests, searching history, or gathering evidence, ask: Could the result
+materially change the decision, recommendation, or action? If not, skip that work; if uncertain,
+prefer the cheapest evidence that can resolve the uncertainty rather than maximizing information.
+
 ## Repository Overview
 
 **Project**: Claude Code Marketplace Plugin Collection (see `plugins/` for the full roster)


### PR DESCRIPTION
## Summary

- Adds a new "Evidence Proportionality" section near the top of `AGENTS.md`, right after the intro paragraph and before "Repository Overview" — placed early so it governs every action that follows it in the file
- Verbatim rule as specified: before using tools, running tests, searching history, or gathering evidence, ask whether the result could materially change the decision, recommendation, or action; skip if not, and prefer the cheapest resolving evidence over maximizing information when uncertain

## Test plan

- [x] `uv run prek run --files AGENTS.md` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyzq7JoLCZzzeudSoSrB9Z