### PR TITLE
docs(agents-md): make PR Review Protocol's addressing step explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,7 +482,14 @@ gh api repos/Jamie-BitFlight/claude_skills/pulls/<N>/comments --jq '[.[] | {path
 
 `reviewDecision` being empty and `state: COMMENTED` does NOT mean no findings. Codex and other bots post substantive per-line feedback as inline comments, not as blocking review verdicts. Checking only the top-level state misses these entirely.
 
-Address all inline comments before declaring the PR review complete.
+Address all inline comments before declaring the PR review complete: when a PR is ready for
+review, treat every unresolved review thread as actionable input. Read it, validate the claim
+locally, assess it against the change goal and repository instructions, implement and commit it
+only when it improves the product, then reply with the disposition and resolve the thread. After
+all current threads are resolved, check for additional reviews three times at 10-minute intervals
+using `/loop` or `/schedule`; if any new review arrives, cancel the remaining checks and restart
+this process. Treat a Codex thumbs-up reaction on the PR body, or an explicit "no reviews", "no
+changes", or "0 comments" response, as that reviewer's completion signal.
 
 ## GitHub CLI Conventions
 


### PR DESCRIPTION
## Summary

- Replaces the underspecified "address all inline comments before declaring the PR review complete" line in `AGENTS.md`'s PR Review Protocol with the full explicit procedure: validate each unresolved thread's claim locally, assess it against the change goal and repo instructions, fix and commit only when it improves the product, reply with the disposition, resolve the thread
- Adds a bounded re-check cadence for reviews landing after the first pass (3x at 10-minute intervals via `/loop` or `/schedule`, restart-on-new-review) with explicit completion signals for a Codex thumbs-up-only response or an explicit no-findings reply
- Direct fix for a gap surfaced this session: fixing the underlying issue happened correctly, but replying on the GitHub thread and resolving it were both skipped until asked for explicitly — twice — because the old rule's "address" never named those as required steps

Note: `/loop`/`/schedule` name Claude Code's own mechanism for the bounded re-check cadence — the underlying pattern (poll N times at a fixed interval, restart on new input) is a common practice any harness can implement with its own equivalent (a CLI's own scheduling, or shelling out to another agent CLI), so this isn't a portability blocker for `AGENTS.md`'s cross-harness readership.

## Test plan

- [x] `uv run prek run --files AGENTS.md` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyzq7JoLCZzzeudSoSrB9Z