### PR TITLE
fix(development-harness): drop the graphify merge-driver attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 # Force LF for JSON (pre-commit mixed-line-ending uses --fix=lf)
 *.json text eol=lf
-graphify-out/graph.json merge=graphify


### PR DESCRIPTION
Reverts the `.gitattributes` half of #3217. The graphify git hooks installed alongside it have been uninstalled locally.

## Why

The hooks assume the graph lives at `graphify-out/` in the **repository root**. This repository's graph is deliberately scoped to `plugins/development-harness/graphify-out/`, so that the other plugins stay out of it.

Installed against that assumption, `post-checkout` matched a root-level `graphify-out/` that `post-commit` had created incidentally, and began an AST rebuild of **all 3,227 code files in the repository**, writing a 75MB root-level `graphify-out/`. AST extraction uses no LLM, so this cost wall-clock rather than tokens — but the output was a whole-repo graph nobody asked for, sitting untracked where it could be committed by accident.

## Why the attribute goes too

`graphify-out/graph.json merge=graphify` names a driver that only exists in a developer's local git config after `graphify hook install`. Without the hooks, git warns about an undefined merge driver on every merge touching `graph.json` and falls back to the default merge regardless.

## What is kept

Everything else from #3217 stands: the rebuilt graph, path-qualified node IDs, the repo-relative `manifest.json` that repairs `--update`, and `graph.html`.

## Follow-up worth doing

A union merge driver for a 28MB `graph.json` is genuinely useful — two branches rebuilding in parallel will otherwise conflict irreconcilably. It needs scoping to the plugin path rather than the repository root before it can be reinstated, along with the rebuild hooks. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6yky1coe1DFi7f22Cjgtg