### PR TITLE
docs(development-harness): define Resolve, Close, and Evidence trail

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -102,35 +102,22 @@ is the plugin implementing it); "stateless agent" alone as a synonym for SAM its
 between the methodology and one literal stateless agent instance).
 
 **Resolve**:
-Mark a work item DONE with an evidence trail — `resolve_item()` (ADR-9). The evidence trail
-(summary, method, notes, follow-ups, findings) is meant as a contractual part of resolution, not a
-GitHub-only artifact — that is the design intent (see [#3220](https://github.com/Jamie-BitFlight/claude_skills/issues/3220)), not yet the implementation. As of this
-writing `resolve_item()` (`operations.py:3180`) persists only `status`/`priority`/`plan` to item
-metadata on every backend; the five evidence fields are forwarded exclusively to
-`resolve_github_issue()`, so SQLite and Memory backends discard them entirely and Beads keeps only
-`summary` as its native close reason. `#3220` tracks adding a `resolution` record to
-`BacklogItemMetadata` so the GitHub `## Resolved` comment becomes a rendering of a persisted
-record instead of the only copy. The backend's own status field is the sole authority for whether
-an item is resolved — native state (GitHub `CLOSED`, a Beads closed status) is a projection of it,
-not a second source of truth.
-_Avoid_: "close" for completed work — that is Resolve below with a different, incompatible
-contract (ADR-9). Avoid treating a provider's native closure as authoritative in its own right;
-verify the backend's status field before trusting a GitHub or Beads state directly.
+Mark a work item DONE with an evidence trail (summary, method, notes, follow-ups, findings) —
+`resolve_item()` ([ADR-9](./docs/adr-9-close-resolve-semantics.md)). The evidence trail is meant
+as contractual, not a GitHub-only artifact — persisting it on every backend, not only rendering it
+into a GitHub comment, is tracked by [#3220](https://github.com/Jamie-BitFlight/claude_skills/issues/3220).
+_Avoid_: "close" for completed work — that is Close below, a different, incompatible contract.
 
 **Close**:
-Dismiss a work item without completion — `close_item()` (ADR-9), requires a categorized `reason`
-(duplicate, out_of_scope, superseded, wontfix, blocked). Distinct from Resolve above: Close never
-carries an evidence trail because no work was done to document.
-_Avoid_: "resolve" for a dismissal, or "close" for completed work — ADR-9 exists because these
-were once conflated and callers used the wrong one for already-completed work.
+Dismiss a work item without completion — `close_item()` ([ADR-9](./docs/adr-9-close-resolve-semantics.md)),
+requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, blocked). Close
+records only that reason — no evidence trail.
+_Avoid_: "resolve" for a dismissal — [ADR-9](./docs/adr-9-close-resolve-semantics.md) exists
+because these were once conflated and callers used the wrong one for already-completed work.
 
 **Evidence trail**:
-The structured resolution record (summary, method, notes, follow-ups, findings) `resolve_item()`
-requires as arguments. Contractual by design — it is meant as part of what the resolution workflow
-itself must ensure happened, independent of which backend renders it natively — but as of this
-writing the requirement is enforced only for the `summary` argument, and persistence beyond the
-GitHub-rendered comment does not yet exist on any backend; see Resolve above and
-[#3220](https://github.com/Jamie-BitFlight/claude_skills/issues/3220).
+The structured resolution record Resolve above requires. Only `summary` is enforced today;
+persisting the rest beyond the GitHub-rendered comment is [#3220](https://github.com/Jamie-BitFlight/claude_skills/issues/3220).
 
 **Backend**:
 The data provider Collection reaches. Confirmed by the repo owner: "backend" always means the

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -110,8 +110,9 @@ _Avoid_: "close" for completed work — that is Close below, a different, incomp
 
 **Close**:
 Dismiss a work item without completion — `close_item()` ([ADR-9](./docs/adr-9-close-resolve-semantics.md)),
-requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, blocked). Close
-records only that reason — no evidence trail.
+requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, blocked), with
+optional `reference` and `comment` for dismissal context. No resolution evidence trail — that is
+Resolve's contract above, not Close's.
 _Avoid_: "resolve" for a dismissal — [ADR-9](./docs/adr-9-close-resolve-semantics.md) exists
 because these were once conflated and callers used the wrong one for already-completed work.
 

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -110,7 +110,8 @@ _Avoid_: "close" for completed work — that is Close below, a different, incomp
 
 **Close**:
 Dismiss a work item without completion — `close_item()` ([ADR-9](./docs/adr-9-close-resolve-semantics.md)),
-requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, blocked). No
+requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, permanently
+blocked — not a temporary wait on a dependency or input). No
 resolution evidence trail — that is Resolve's contract above, not Close's. `close_item()` also
 takes `reference`/`comment` parameters, forwarded on a GitHub-backed item to its closing comment
 — but as of this writing `reference` is overwritten with the item's own backend reference before

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -103,12 +103,16 @@ between the methodology and one literal stateless agent instance).
 
 **Resolve**:
 Mark a work item DONE with an evidence trail — `resolve_item()` (ADR-9). The evidence trail
-(summary, method, notes, follow-ups, findings) is a contractual part of resolution, persisted to
-the item's own metadata on every backend, not a GitHub-only artifact. A native rendering (a
-GitHub `## Resolved` comment plus `state: CLOSED`) is generated from that persisted record for
-backends where one exists; it is never the record's only copy. The backend's own status field is
-the sole authority for whether an item is resolved — native state (GitHub `CLOSED`, a Beads
-closed status) is a projection of it, not a second source of truth.
+(summary, method, notes, follow-ups, findings) is meant as a contractual part of resolution, not a
+GitHub-only artifact — that is the design intent (see [#3220](https://github.com/Jamie-BitFlight/claude_skills/issues/3220)), not yet the implementation. As of this
+writing `resolve_item()` (`operations.py:3180`) persists only `status`/`priority`/`plan` to item
+metadata on every backend; the five evidence fields are forwarded exclusively to
+`resolve_github_issue()`, so SQLite and Memory backends discard them entirely and Beads keeps only
+`summary` as its native close reason. `#3220` tracks adding a `resolution` record to
+`BacklogItemMetadata` so the GitHub `## Resolved` comment becomes a rendering of a persisted
+record instead of the only copy. The backend's own status field is the sole authority for whether
+an item is resolved — native state (GitHub `CLOSED`, a Beads closed status) is a projection of it,
+not a second source of truth.
 _Avoid_: "close" for completed work — that is Resolve below with a different, incompatible
 contract (ADR-9). Avoid treating a provider's native closure as authoritative in its own right;
 verify the backend's status field before trusting a GitHub or Beads state directly.
@@ -122,8 +126,11 @@ were once conflated and callers used the wrong one for already-completed work.
 
 **Evidence trail**:
 The structured resolution record (summary, method, notes, follow-ups, findings) `resolve_item()`
-requires and persists. Contractual, not a display feature: it is part of what the resolution
-workflow itself must ensure happened, independent of which backend renders it natively.
+requires as arguments. Contractual by design — it is meant as part of what the resolution workflow
+itself must ensure happened, independent of which backend renders it natively — but as of this
+writing the requirement is enforced only for the `summary` argument, and persistence beyond the
+GitHub-rendered comment does not yet exist on any backend; see Resolve above and
+[#3220](https://github.com/Jamie-BitFlight/claude_skills/issues/3220).
 
 **Backend**:
 The data provider Collection reaches. Confirmed by the repo owner: "backend" always means the

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -112,9 +112,11 @@ _Avoid_: "close" for completed work — that is Close below, a different, incomp
 Dismiss a work item without completion — `close_item()` ([ADR-9](./docs/adr-9-close-resolve-semantics.md)),
 requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, blocked). No
 resolution evidence trail — that is Resolve's contract above, not Close's. `close_item()` also
-takes `reference`/`comment` parameters, but as of this writing neither reaches the caller's
-intent: `reference` is overwritten with the item's own backend reference before use, and both are
-persisted to no backend's local metadata — see [#3230](https://github.com/Jamie-BitFlight/claude_skills/issues/3230).
+takes `reference`/`comment` parameters, forwarded on a GitHub-backed item to its closing comment
+— but as of this writing `reference` is overwritten with the item's own backend reference before
+that forwarding, so it never carries the caller's intended cross-reference, and neither parameter
+is persisted to any backend's local metadata (so a Beads, SQLite, or Memory item retains neither) —
+see [#3230](https://github.com/Jamie-BitFlight/claude_skills/issues/3230).
 _Avoid_: "resolve" for a dismissal — [ADR-9](./docs/adr-9-close-resolve-semantics.md) exists
 because these were once conflated and callers used the wrong one for already-completed work.
 

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -101,6 +101,30 @@ _Avoid_: "the SAM plugin" (there is no such thing — SAM is the methodology; `d
 is the plugin implementing it); "stateless agent" alone as a synonym for SAM itself (ambiguous
 between the methodology and one literal stateless agent instance).
 
+**Resolve**:
+Mark a work item DONE with an evidence trail — `resolve_item()` (ADR-9). The evidence trail
+(summary, method, notes, follow-ups, findings) is a contractual part of resolution, persisted to
+the item's own metadata on every backend, not a GitHub-only artifact. A native rendering (a
+GitHub `## Resolved` comment plus `state: CLOSED`) is generated from that persisted record for
+backends where one exists; it is never the record's only copy. The backend's own status field is
+the sole authority for whether an item is resolved — native state (GitHub `CLOSED`, a Beads
+closed status) is a projection of it, not a second source of truth.
+_Avoid_: "close" for completed work — that is Resolve below with a different, incompatible
+contract (ADR-9). Avoid treating a provider's native closure as authoritative in its own right;
+verify the backend's status field before trusting a GitHub or Beads state directly.
+
+**Close**:
+Dismiss a work item without completion — `close_item()` (ADR-9), requires a categorized `reason`
+(duplicate, out_of_scope, superseded, wontfix, blocked). Distinct from Resolve above: Close never
+carries an evidence trail because no work was done to document.
+_Avoid_: "resolve" for a dismissal, or "close" for completed work — ADR-9 exists because these
+were once conflated and callers used the wrong one for already-completed work.
+
+**Evidence trail**:
+The structured resolution record (summary, method, notes, follow-ups, findings) `resolve_item()`
+requires and persists. Contractual, not a display feature: it is part of what the resolution
+workflow itself must ensure happened, independent of which backend renders it natively.
+
 **Backend**:
 The data provider Collection reaches. Confirmed by the repo owner: "backend" always means the
 data-providing system, never a call to the MCP tool or CLI — those are Frontend below. Not one

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -110,9 +110,11 @@ _Avoid_: "close" for completed work — that is Close below, a different, incomp
 
 **Close**:
 Dismiss a work item without completion — `close_item()` ([ADR-9](./docs/adr-9-close-resolve-semantics.md)),
-requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, blocked), with
-optional `reference` and `comment` for dismissal context. No resolution evidence trail — that is
-Resolve's contract above, not Close's.
+requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, blocked). No
+resolution evidence trail — that is Resolve's contract above, not Close's. `close_item()` also
+takes `reference`/`comment` parameters, but as of this writing neither reaches the caller's
+intent: `reference` is overwritten with the item's own backend reference before use, and both are
+persisted to no backend's local metadata — see [#3230](https://github.com/Jamie-BitFlight/claude_skills/issues/3230).
 _Avoid_: "resolve" for a dismissal — [ADR-9](./docs/adr-9-close-resolve-semantics.md) exists
 because these were once conflated and callers used the wrong one for already-completed work.
 


### PR DESCRIPTION
## Summary
- Adds Resolve, Close, and Evidence trail to `CONTEXT.md`'s Language section — ADR-9 split the two operations but neither term was ever defined in the glossary
- States backend authority explicitly: the item's status field is the sole source of truth, native closure (GitHub CLOSED, a Beads status) is a projection of it
- Names the evidence trail as contractual: persisted to the item's own metadata on every backend, not a GitHub-only comment

## Context
Produced during a design session settling the scope of #3219 and #3220 (issue-linking policy for the dh workflow's PR/commit closure convention). Full design record is in those two issues.

## Test plan
- [x] `prek` hooks passed on commit (markdownlint, manifest sync, symlink checks)
- [x] No code paths touched — glossary-only change

Related to #3219, #3220