### PR TITLE
fix(development-harness): fix duplicate-write ordering and add slug entropy

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.0.15",
+  "version": "9.1.1",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.1.0",
+  "version": "9.0.15",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -66,16 +66,22 @@ Then stamp the run so this invocation gets its own address. Capture this command
 `run_stamp`:
 
 ```bash
-date -u +%Y%m%dT%H%M%SZ
+echo "$(date -u +%Y%m%dT%H%M%SZ)-${RANDOM}"
 ```
 
-`review_slug` is `{review_base}-{run_stamp}`, for example `review-2181-20260824T014233Z`.
+The UTC timestamp alone only has whole-second resolution: two invocations for the same
+`review_base` starting within the same second would derive the same `run_stamp`, and therefore the
+same `review_slug` and `multi-{review_slug}` team name, colliding at `TeamCreate` or sharing one
+team's namespace. `${RANDOM}` is bash's builtin pseudo-random 0-32767 integer — no new dependency —
+appended for the entropy the timestamp alone lacks.
+
+`review_slug` is `{review_base}-{run_stamp}`, for example `review-2181-20260824T014233Z-14822`.
 
 The stamp is what makes the plan ephemeral in fact and not just in name. `review_base` identifies
 the review subject and repeats across runs; `review_slug` identifies one run of it and never
-repeats. A verdict, and the changed-file set it was produced against, belong to a single run —
-addressing them by a slug that a later run resolves to as well is what lets one run read another
-run's results.
+repeats, including two runs launched concurrently for the same subject. A verdict, and the
+changed-file set it was produced against, belong to a single run — addressing them by a slug that
+a later run resolves to as well is what lets one run read another run's results.
 
 Use `review_slug` unchanged in plan operations. Use `multi-{review_slug}` as the team name.
 
@@ -200,14 +206,19 @@ dispatches it the same way.
 
 Every prompt names the same output destination: the `Review Results` section of the worker's own
 task. That section is the only channel the synthesizer reads in Step 6 — a reviewer that does not
-write it is a missing verdict, and the punch list records it as one.
+write it is a missing verdict, and the punch list records it as one. The loaded profile — not the
+dispatch prompt — performs that write: each reviewer agent's own SOP ends with a mandatory write
+to `Review Results` as part of what `dh:start-task` executes. Do not instruct the worker to write
+the section itself before running `dh:start-task`; a prompt that does both produces two
+`append_section` calls against the same heading, and the second leaves the section holding two
+concatenated JSON documents that no longer parse.
 
 ```text
 Agent(
   team_name="multi-{review_slug}",
   name="{worker}",
   subagent_type="dh:task-worker",
-  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are working on {lens} review. Your task: {PA}/{task}.\n\nWrite your structured verdict block as the content of the Review Results section on that task, via mcp__plugin_dh_sam__sam_task(plan=\"{PA}\", task=\"{task}\", config={\"action\": \"update\", \"append_section\": \"Review Results\", \"section_content\": <raw JSON verdict block>}). That section is where the punch list reads your verdict.\n\nThen run the dh:start-task skill against {PA} --task {task}."
+  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are working on {lens} review. Your task: {PA}/{task}.\n\nRun the dh:start-task skill against {PA} --task {task}. The loaded profile writes your structured verdict block into the task's Review Results section — that is where the punch list reads your verdict. Do not write that section yourself first; the profile's own SOP performs the single write."
 )
 ```
 
@@ -240,14 +251,17 @@ A task is terminal at `complete`, `blocked`, `failed`, `skipped`, or `deferred`.
 
 Dispatch one more worker against `T5`. It reads the four `Review Results` sections, merges
 findings that name the same defect across perspectives into single entries, and writes the
-punch-list block into `T5`'s own `Punch List` section.
+punch-list block into `T5`'s own `Punch List` section. As with the four reviewer workers, the
+`dh:review-synthesizer` profile — loaded by `dh:start-task` — performs that write as its own Step
+5; the dispatch prompt only tells the worker where to look and where its output is read, not to
+write the section itself.
 
 ```text
 Agent(
   team_name="multi-{review_slug}",
   name="synthesis-worker",
   subagent_type="dh:task-worker",
-  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are synthesizing the four perspective verdicts on plan {PA} into one punch list. Your task: {PA}/T5.\n\nWrite your punch-list block as the content of the Punch List section on that task, via mcp__plugin_dh_sam__sam_task(plan=\"{PA}\", task=\"T5\", config={\"action\": \"update\", \"append_section\": \"Punch List\", \"section_content\": <raw JSON punch-list block>}). That section is where the gate reads your output.\n\nThen run the dh:start-task skill against {PA} --task T5."
+  prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are synthesizing the four perspective verdicts on plan {PA} into one punch list. Your task: {PA}/T5.\n\nRun the dh:start-task skill against {PA} --task T5. The loaded profile writes your punch-list block into the task's Punch List section — that is where the gate reads your output. Do not write that section yourself first; the profile's own SOP performs the single write."
 )
 ```
 

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -66,16 +66,21 @@ Then stamp the run so this invocation gets its own address. Capture this command
 `run_stamp`:
 
 ```bash
-echo "$(date -u +%Y%m%dT%H%M%SZ)-${RANDOM}"
+echo "$(date -u +%Y%m%dT%H%M%SZ)-$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
 ```
 
 The UTC timestamp alone only has whole-second resolution: two invocations for the same
 `review_base` starting within the same second would derive the same `run_stamp`, and therefore the
 same `review_slug` and `multi-{review_slug}` team name, colliding at `TeamCreate` or sharing one
-team's namespace. `${RANDOM}` is bash's builtin pseudo-random 0-32767 integer — no new dependency —
-appended for the entropy the timestamp alone lacks.
+team's namespace. Bash's builtin `${RANDOM}` cannot fix this reliably: it is a weak generator
+seeded from the shell's own PID and start time, so sibling processes launched together (the exact
+case of many reviews dispatched at once) can draw correlated or identical values instead of the
+independent 1-in-32768 samples the odds assume. `/dev/urandom` is a kernel-backed CSPRNG with no
+such correlation — 8 bytes (64 bits) of it, hex-encoded via `od` (already present, no new
+dependency), makes an accidental suffix collision across concurrent runs practically impossible.
 
-`review_slug` is `{review_base}-{run_stamp}`, for example `review-2181-20260824T014233Z-14822`.
+`review_slug` is `{review_base}-{run_stamp}`, for example
+`review-2181-20260824T014233Z-3f9a2c7e1b804d56`.
 
 The stamp is what makes the plan ephemeral in fact and not just in name. `review_base` identifies
 the review subject and repeats across runs; `review_slug` identifies one run of it and never


### PR DESCRIPTION
## Summary

Follow-up to #3207, which merged before this Codex re-review pass landed. This carries the last commit (`725b22b9e`) that was stranded when the source branch was deleted on merge.

- **P1**: The T1-T4 reviewer and T5 synthesizer worker dispatch prompts in `multi-perspective-review/SKILL.md` told the worker to write its verdict/punch-list section manually via a raw `sam_task` call, then run `dh:start-task`. But `dh:start-task` loads the reviewer/synthesizer profile, whose own SOP performs the same write as a mandatory final step. Following the prompt literally produces two `append_section` calls against the same heading, leaving a section with two concatenated JSON documents that fails `json.loads()` on every otherwise-successful run. Fixed all five dispatch prompts (T1-T4 and T5) to only run `dh:start-task` and let the loaded profile perform the single write.
- **P2**: `review_slug`'s `run_stamp` used only whole-second UTC precision, so two invocations for the same `review_base` starting in the same second collide at `TeamCreate`. Appended bash's builtin `$RANDOM` for entropy.

Both findings came from Codex's review of #3207 after the branch was deleted by the merge — see PR #3207 thread `PRRT_kwDOQGimCs6bqEa9` (P1) and the review body on commit `5a1a86e53` (P2).

## Test plan

- [x] `uv run prek run --files plugins/development-harness/skills/multi-perspective-review/SKILL.md plugins/development-harness/.codex-plugin/plugin.json plugins/development-harness/.cursor-plugin/plugin.json` — all hooks passed