### PR TITLE
fix(development-harness): fix stale code-reviewer artifact type in system model diagram

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/docs/dh-system-model.html
+++ b/plugins/development-harness/docs/dh-system-model.html
@@ -1357,7 +1357,7 @@ flowchart TD
     CLAIM["task-worker claims task\nsam_task(action='claim')"]
     READ["Reads fresh per task:\n• sam_task read → plan.context\n• architect artifact by owner + type\n• feature-context artifact by owner + type\n• Context Manifest from task record"]
     IMPL["Specialist agent implements\n(loaded via profile_load)"]
-    REVIEW["dh:code-reviewer\n→ registers codebase-analysis content\nwith a stable logical artifact ID"]
+    REVIEW["dh:code-reviewer\n→ registers code-review content\nwith a stable logical artifact ID"]
     CONTRACT["dh:contract-verification\n→ appends CONTRACT: items\nto Concerns section on issue"]
     COMPLETE["sam_task(action='state', state='complete')"]
     MORE{"More ready tasks?"}


### PR DESCRIPTION
## What

`dh-system-model.html`'s Phase 5 implement-feature mermaid diagram labeled the REVIEW node as `dh:code-reviewer → registers codebase-analysis content`. PR #3147 repointed `code-reviewer`'s registration to the `code-review` artifact type everywhere else in the plugin (AGENTS.md owner map, `agents/code-reviewer.md`, `forensic-review/SKILL.md`, `complete-implementation/SKILL.md`), but this file wasn't in that PR's changed-file list and was missed.

## Why now

Flagged by `chatgpt-codex-connector` as an unresolved review thread (`PRRT_kwDOQGimCs6bqgwm`) on #3147. The agent addressing #3147's review threads had its worktree torn down (post-merge cleanup) before it could act on this one, so it went unaddressed when #3147 merged. Confirmed still stale by reading the current file on `main`.

Checked for the same pattern elsewhere in the file: line 1342's table row also mentions `code-reviewer` alongside `codebase-analysis`, but there it's listed as a *consumer* (reads codebase-analysis as optional context), which is unaffected by #3147's change to the *producer* side — no further edit needed there.

Part of #3227.

## Gates

- `uv run prek run --files plugins/development-harness/docs/dh-system-model.html` — all Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)