### PR TITLE
fix(development-harness): replace bash+/dev/urandom slug stamp with a portable script

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.1.2",
+  "version": "10.2.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.1.2",
+  "version": "9.2.0",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -62,11 +62,13 @@ Derive `review_base` exactly once using the first matching rule:
 3. Neither provided → read current git branch name via `git rev-parse --abbrev-ref HEAD` and
    use `review-{branch-name}` (sanitize branch name: replace `/` with `-`)
 
-Then stamp the run so this invocation gets its own address. Capture this command's stdout as
-`run_stamp`:
+Then stamp the run so this invocation gets its own address. Run this command and capture its
+stdout as `run_stamp`. It is a single `uv` invocation, not a shell pipeline — no `$(...)`
+substitution, pipes, or POSIX-only device file — so it runs unchanged whether the executing shell
+is bash, PowerShell, or cmd.exe:
 
-```bash
-echo "$(date -u +%Y%m%dT%H%M%SZ)-$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
+```text
+uv run --quiet --script ${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py
 ```
 
 The UTC timestamp alone only has whole-second resolution: two invocations for the same
@@ -75,9 +77,11 @@ same `review_slug` and `multi-{review_slug}` team name, colliding at `TeamCreate
 team's namespace. Bash's builtin `${RANDOM}` cannot fix this reliably: it is a weak generator
 seeded from the shell's own PID and start time, so sibling processes launched together (the exact
 case of many reviews dispatched at once) can draw correlated or identical values instead of the
-independent 1-in-32768 samples the odds assume. `/dev/urandom` is a kernel-backed CSPRNG with no
-such correlation — 8 bytes (64 bits) of it, hex-encoded via `od` (already present, no new
-dependency), makes an accidental suffix collision across concurrent runs practically impossible.
+independent 1-in-32768 samples the odds assume. `gen_run_stamp.py` draws 8 bytes (64 bits) from
+`secrets.token_hex`, Python's cross-platform CSPRNG binding (`os.urandom` under the hood — the
+Windows CryptoAPI on Windows, `/dev/urandom` on Linux/macOS), making an accidental suffix collision
+across concurrent runs practically impossible on every platform this skill runs on, not just POSIX
+shells with a `/dev/urandom` device node.
 
 `review_slug` is `{review_base}-{run_stamp}`, for example
 `review-2181-20260824T014233Z-3f9a2c7e1b804d56`.

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -68,8 +68,11 @@ substitution, pipes, or POSIX-only device file — so it runs unchanged whether 
 is bash, PowerShell, or cmd.exe:
 
 ```text
-uv run --quiet --script ${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py
+uv run --quiet --script "${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py"
 ```
+
+Quote the path exactly as shown. An install location with a space in it (a Windows profile such as
+`C:\Users\Jane Doe\...`) splits an unquoted argument, so `uv` would try to execute only the prefix.
 
 The UTC timestamp alone only has whole-second resolution: two invocations for the same
 `review_base` starting within the same second would derive the same `run_stamp`, and therefore the

--- a/plugins/development-harness/skills/multi-perspective-review/scripts/gen_run_stamp.py
+++ b/plugins/development-harness/skills/multi-perspective-review/scripts/gen_run_stamp.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Print a collision-resistant run stamp for multi-perspective-review slugs.
+
+A UTC timestamp alone only has whole-second resolution, so two review runs for
+the same review_base starting within the same second would derive the same
+review_slug and collide on TeamCreate / plan address. secrets.token_hex draws
+from the OS CSPRNG (os.urandom) on every platform Python runs on, unlike bash's
+${RANDOM} builtin (weak, seeded from the shell's PID and start time, so sibling
+processes launched together can draw correlated values) or piping /dev/urandom
+through od (POSIX-only device file, needs MSYS2/WSL emulation on Windows).
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime
+
+
+def main() -> None:
+    """Print "{UTC timestamp}-{16 hex chars}" to stdout."""
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    print(f"{timestamp}-{secrets.token_hex(8)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

`multi-perspective-review`'s Step 2 run-stamp generation piped `/dev/urandom` through `od`/`tr`:

```bash
echo "$(date -u +%Y%m%dT%H%M%SZ)-$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
```

This is POSIX shell syntax (`$(...)` substitution, pipes) reading a POSIX device file. It needs MSYS2/WSL emulation to work on Windows at all, and requires a shell that supports command substitution and pipes in the first place — this repo's SKILL.md content is meant to run under whichever shell executes it, not just POSIX ones (see the repo's Python-script-first policy for cross-platform script invocation).

## Fix

Replaced it with `scripts/gen_run_stamp.py` — a stdlib-only PEP 723 script invoked as a single command with no shell-specific syntax:

```text
uv run --quiet --script ${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py
```

It uses `secrets.token_hex(8)`, Python's cross-platform CSPRNG binding (`os.urandom` under the hood — Windows CryptoAPI on Windows, `/dev/urandom` on Linux/macOS), for the same collision resistance the original line was after, and prints `{UTC timestamp}-{16 hex chars}` to stdout — same output shape as before.

Checked for the same anti-pattern elsewhere in skill files: the only other `/dev/urandom`/`${RANDOM}` hit in the repo is `bash-development`'s own reference doc documenting bash's `$RANDOM` builtin, which is correctly bash-specific there (a doc about bash, not an execution instruction) — no other fix needed.

## Gates

- `uv run --quiet --script plugins/development-harness/skills/multi-perspective-review/scripts/gen_run_stamp.py` — runs, produces distinct values across invocations
- `uv run prek run --files <changed>` — all Passed
- `uvx skilllint@latest check plugins/development-harness/skills/multi-perspective-review/` — no new findings (pre-existing SK006/AS005 size warnings on this skill predate this change by a wide margin; unrelated, not addressed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)