### PR TITLE
docs(development-harness): prune no-op rationale from multi-perspective-review run-stamp step

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -74,9 +74,9 @@ as `C:\Users\Jane Doe\...`) truncates the argument and `uv` executes only the pr
 
 A UTC timestamp alone has only whole-second resolution, so two invocations for the same
 `review_base` starting within the same second would derive the same `run_stamp` and collide on
-`review_slug` and `multi-{review_slug}` team name. `gen_run_stamp.py` appends a `secrets.token_hex`
-suffix to rule this out — see its docstring for why the timestamp alone, and bash's `${RANDOM}`,
-aren't sufficient.
+`review_slug` and `multi-{review_slug}` team name. `${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py`
+appends a `secrets.token_hex` suffix to rule this out — see its docstring for why the timestamp
+alone, and bash's `${RANDOM}`, aren't sufficient.
 
 `review_slug` is `{review_base}-{run_stamp}`, for example
 `review-2181-20260824T014233Z-3f9a2c7e1b804d56`.

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -63,28 +63,20 @@ Derive `review_base` exactly once using the first matching rule:
    use `review-{branch-name}` (sanitize branch name: replace `/` with `-`)
 
 Then stamp the run so this invocation gets its own address. Run this command and capture its
-stdout as `run_stamp`. It is a single `uv` invocation, not a shell pipeline — no `$(...)`
-substitution, pipes, or POSIX-only device file — so it runs unchanged whether the executing shell
-is bash, PowerShell, or cmd.exe:
+stdout as `run_stamp`:
 
 ```text
 uv run --quiet --script "${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py"
 ```
 
-Quote the path exactly as shown. An install location with a space in it (a Windows profile such as
-`C:\Users\Jane Doe\...`) splits an unquoted argument, so `uv` would try to execute only the prefix.
+Keep the path quoted exactly as shown — an unquoted path with a space (e.g. a Windows profile such
+as `C:\Users\Jane Doe\...`) truncates the argument and `uv` executes only the prefix.
 
-The UTC timestamp alone only has whole-second resolution: two invocations for the same
-`review_base` starting within the same second would derive the same `run_stamp`, and therefore the
-same `review_slug` and `multi-{review_slug}` team name, colliding at `TeamCreate` or sharing one
-team's namespace. Bash's builtin `${RANDOM}` cannot fix this reliably: it is a weak generator
-seeded from the shell's own PID and start time, so sibling processes launched together (the exact
-case of many reviews dispatched at once) can draw correlated or identical values instead of the
-independent 1-in-32768 samples the odds assume. `gen_run_stamp.py` draws 8 bytes (64 bits) from
-`secrets.token_hex`, Python's cross-platform CSPRNG binding (`os.urandom` under the hood — the
-Windows CryptoAPI on Windows, `/dev/urandom` on Linux/macOS), making an accidental suffix collision
-across concurrent runs practically impossible on every platform this skill runs on, not just POSIX
-shells with a `/dev/urandom` device node.
+A UTC timestamp alone has only whole-second resolution, so two invocations for the same
+`review_base` starting within the same second would derive the same `run_stamp` and collide on
+`review_slug` and `multi-{review_slug}` team name. `gen_run_stamp.py` appends a `secrets.token_hex`
+suffix to rule this out — see its docstring for why the timestamp alone, and bash's `${RANDOM}`,
+aren't sufficient.
 
 `review_slug` is `{review_base}-{run_stamp}`, for example
 `review-2181-20260824T014233Z-3f9a2c7e1b804d56`.


### PR DESCRIPTION
## Summary

- Applies `/mattpocock-skills:writing-for-agents`'s no-op test to Step 2 of `plugins/development-harness/skills/multi-perspective-review/SKILL.md`, which was touched in the immediately preceding session (commits 757e024, 35ca82b, bca1b4489, 63d0da4) replacing a bash `/dev/urandom` pipeline with `gen_run_stamp.py`.
- Removes the sentence claiming the invocation "runs unchanged whether the executing shell is bash, PowerShell, or cmd.exe" — an executing agent runs the given command line regardless of shell brand, so the sentence doesn't change what it does. Same test applied to the "single `uv` invocation, not a shell pipeline" clause introduced alongside it.
- De-duplicates the CSPRNG/`${RANDOM}`-weakness rationale that this session's edit had grown into a near-verbatim restatement of `gen_run_stamp.py`'s own docstring. The script's docstring is now the single source of truth for that "why"; SKILL.md points to it instead of repeating it.
- Kept "Quote the path exactly as shown" (added after a prior Codex review caught a real unquoted-path bug) — this one is not a no-op, since an agent already stripped the quotes once. Compressed its rationale into the same sentence rather than a separate one.

## Test plan

- [x] `uv run prek run --files plugins/development-harness/skills/multi-perspective-review/SKILL.md plugins/development-harness/scripts/gen_run_stamp.py` — all hooks pass (ruff, markdownlint, skilllint/manifest-sync, ty, conventional-commit)
- [x] Manual re-read of Step 2 confirms every fact the executing agent needs (what to run, how to quote it, why the stamp exists) survives; only restated/no-op prose was cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HM2E9C16VaPwEbHFE7FmFL