### PR TITLE
docs(development-harness): drop the docstring-pointer clause from the run-stamp note

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -75,8 +75,7 @@ as `C:\Users\Jane Doe\...`) truncates the argument and `uv` executes only the pr
 A UTC timestamp alone has only whole-second resolution, so two invocations for the same
 `review_base` starting within the same second would derive the same `run_stamp` and collide on
 `review_slug` and `multi-{review_slug}` team name. `${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py`
-appends a `secrets.token_hex` suffix to rule this out — see its docstring for why the timestamp
-alone, and bash's `${RANDOM}`, aren't sufficient.
+appends a `secrets.token_hex` suffix to rule this out.
 
 `review_slug` is `{review_base}-{run_stamp}`, for example
 `review-2181-20260824T014233Z-3f9a2c7e1b804d56`.


### PR DESCRIPTION
## What

Follow-up to #3231. That PR removed no-op prose from the run-stamp step, but kept one clause that fails the same test on closer inspection: "— see its docstring for why the timestamp alone, and bash's \`\${RANDOM}\`, aren't sufficient."

## Why it's a no-op

- The agent executing Step 2 doesn't need it — running the script doesn't depend on understanding why an earlier implementation was rejected.
- Its only real justification is anti-reversion insurance (stop a future edit from swapping the script call back for something weaker) — but that insurance is redundant here: anyone editing \`gen_run_stamp.py\` already has its docstring open, no pointer from SKILL.md required.

## What stays

The collision-explanation sentence it was attached to is kept, deliberately — that one *does* earn its place: this exact mechanism has been weakened three times in this file's own history this session (\`\${RANDOM}\` → \`/dev/urandom\`+\`od\` → \`secrets.token_hex\`), and the only place that protection works is inline in SKILL.md itself, since an editor simplifying this file may never open the script it calls.

## Gates

- \`uv run prek run --files plugins/development-harness/skills/multi-perspective-review/SKILL.md\` — all Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)