### PR TITLE
docs(development-harness): strip Step 2 to operational content only

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.2.2",
+  "version": "10.2.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -62,29 +62,14 @@ Derive `review_base` exactly once using the first matching rule:
 3. Neither provided → read current git branch name via `git rev-parse --abbrev-ref HEAD` and
    use `review-{branch-name}` (sanitize branch name: replace `/` with `-`)
 
-Then stamp the run so this invocation gets its own address. Run this command and capture its
-stdout as `run_stamp`:
+Run this command and capture its stdout as `run_stamp`:
 
 ```text
 uv run --quiet --script "${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py"
 ```
 
-Keep the path quoted exactly as shown — an unquoted path with a space (e.g. a Windows profile such
-as `C:\Users\Jane Doe\...`) truncates the argument and `uv` executes only the prefix.
-
-A UTC timestamp alone has only whole-second resolution, so two invocations for the same
-`review_base` starting within the same second would derive the same `run_stamp` and collide on
-`review_slug` and `multi-{review_slug}` team name. `${CLAUDE_SKILL_DIR}/scripts/gen_run_stamp.py`
-appends a `secrets.token_hex` suffix to rule this out.
-
 `review_slug` is `{review_base}-{run_stamp}`, for example
 `review-2181-20260824T014233Z-3f9a2c7e1b804d56`.
-
-The stamp is what makes the plan ephemeral in fact and not just in name. `review_base` identifies
-the review subject and repeats across runs; `review_slug` identifies one run of it and never
-repeats, including two runs launched concurrently for the same subject. A verdict, and the
-changed-file set it was produced against, belong to a single run — addressing them by a slug that
-a later run resolves to as well is what lets one run read another run's results.
 
 Use `review_slug` unchanged in plan operations. Use `multi-{review_slug}` as the team name.
 


### PR DESCRIPTION
## What

Follow-up to #3231/#3232. Those removed two no-op sentences from Step 2 but left three more that fail the same test — none of them change what the agent does:

- The quoting reminder — hedging against a bug in the code block itself (already fixed), not any observed agent behavior. No other command block in this file carries a "copy this exactly" note.
- The collision-resistance paragraph — explains *why* run_stamp needs entropy; the agent only needs its value.
- The "ephemeral in fact and not just in name" paragraph — duplicates Step 3, which already states the same rule with its own rationale, co-located with the instruction it justifies.

Step 2 is now: derive `review_base`, run the script, capture stdout, compose `review_slug`, use it. Nothing else changes the output.

## Where did the rationale go?

Nowhere new — it's already in the commit messages and PR descriptions for #3226, #3229, #3231, and #3232. This repo's own convention (`docs/adrs/`, referenced from AGENTS.md) reserves standalone rationale records for actual architectural decisions (78-275 lines each, covering things like backend design and caching strategy) — a run-stamp entropy mechanism doesn't rise to that. Git history is the right-sized lookup for this, and it already has it.

## Gates

- `uv run prek run --files plugins/development-harness/skills/multi-perspective-review/SKILL.md` — all Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)