### PR TITLE
fix(development-harness): repair layer 1 template link

### DIFF
--- a/plugins/development-harness/docs/sdlc-layers/layer-1/language-manifest-template.md
+++ b/plugins/development-harness/docs/sdlc-layers/layer-1/language-manifest-template.md
@@ -49,5 +49,5 @@ Canonical starting point for language manifests. All Layer 1 plugins produce a m
 
 ## Quick Reference
 
-- **Template file**: [plugins/development-harness/templates/language-manifest-template.md](../../../../plugins/development-harness/templates/language-manifest-template.md)
+- **Template file**: [plugins/development-harness/templates/language-manifest-template.md](../../../templates/language-manifest-template.md)
 - **Schema**: [language-manifest-schema.md](../../../skills/dh-meta-docs/references/language-manifest-schema.md)


### PR DESCRIPTION
Follow-up to #3235. Repairs the pre-existing Layer 1 template-file link so it resolves from the documentation source to the development-harness template.\n\nValidation: independent relative-path resolution for the repaired link and adjacent schema link; `prek` hygiene passed.