### PR TITLE
fix(development-harness): persist close dismissal context

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.4.4",
+  "version": "10.4.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.4.4",
+  "version": "9.4.5",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.4.4",
+  "version": "6.4.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/CONTEXT.md
+++ b/plugins/development-harness/CONTEXT.md
@@ -113,11 +113,11 @@ Dismiss a work item without completion — `close_item()` ([ADR-9](./docs/adr-9-
 requires a categorized `reason` (duplicate, out_of_scope, superseded, wontfix, permanently
 blocked — not a temporary wait on a dependency or input). No
 resolution evidence trail — that is Resolve's contract above, not Close's. `close_item()` also
-takes `reference`/`comment` parameters, forwarded on a GitHub-backed item to its closing comment
-— but as of this writing `reference` is overwritten with the item's own backend reference before
-that forwarding, so it never carries the caller's intended cross-reference, and neither parameter
-is persisted to any backend's local metadata (so a Beads, SQLite, or Memory item retains neither) —
-see [#3230](https://github.com/Jamie-BitFlight/claude_skills/issues/3230).
+takes `reference`/`comment` parameters. The caller-provided `reference` is the related item and
+remains distinct from `BacklogItem.reference`, the storage identity. Close persists `close_reason`,
+`close_reference`, and `close_comment` in neutral metadata on every backend, and GitHub's closing
+comment uses those same caller-provided values — see
+[#3230](https://github.com/Jamie-BitFlight/claude_skills/issues/3230).
 _Avoid_: "resolve" for a dismissal — [ADR-9](./docs/adr-9-close-resolve-semantics.md) exists
 because these were once conflated and callers used the wrong one for already-completed work.
 

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -779,6 +779,8 @@ class BacklogItemMetadata(BaseModel):
     files: str = ""
     suggested_location: str = ""
     close_reason: str = ""
+    close_reference: str = ""
+    close_comment: str = ""
     assignees: list[str] = Field(default_factory=list)
     labels: list[str] = Field(default_factory=list)
     milestone: str = ""

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -3151,9 +3151,9 @@ def close_item(
 
     today()
 
-    reference = item.reference
+    storage_reference = item.reference
     # Unreachable — see BacklogItem class docstring (models.py).
-    if not reference:
+    if not storage_reference:
         msg = "Item has no backend reference"
         raise BacklogError(msg)
     already_closed = item.status.lower() in {"closed", "done"}
@@ -3161,7 +3161,18 @@ def close_item(
         out.info("Item already closed.")
         return {"title": item.title, "already_closed": True, **out.to_dict()}
 
-    update_item_metadata(reference, {"metadata": {"status": "closed", "close_reason": reason}}, output=out)
+    update_item_metadata(
+        storage_reference,
+        {
+            "metadata": {
+                "status": "closed",
+                "close_reason": reason,
+                "close_reference": reference,
+                "close_comment": comment,
+            }
+        },
+        output=out,
+    )
 
     out.info(f'Backlog item "{item.title}" closed ({reason}).')
     if issue_ref:

--- a/plugins/development-harness/docs/adr-9-close-resolve-semantics.md
+++ b/plugins/development-harness/docs/adr-9-close-resolve-semantics.md
@@ -47,8 +47,9 @@ Terminal state for items that will NOT be worked. Requires a categorized reason.
 | `wontfix` | Deliberate decision not to do this |
 | `blocked` | Permanently blocked, cannot proceed |
 
-**Metadata**: `{"status": "closed", "close_reason": "{reason}"}`
-**GitHub comment**: `Closed ({reason}). Reference: {reference}. {comment}`
+**Metadata**: `{"status": "closed", "close_reason": "{reason}", "close_reference": "{reference}", "close_comment": "{comment}"}` on every backend.
+The caller-provided `reference` is the related item and remains distinct from `BacklogItem.reference`, the storage identity.
+**GitHub comment**: `Closed ({reason}). Reference: {reference}. {comment}` using the same caller-provided `reference` and `comment`.
 **GitHub issue state**: `closed`
 
 ### `resolve` — Completed with evidence

--- a/plugins/development-harness/docs/backlog-item-lifecycle.md
+++ b/plugins/development-harness/docs/backlog-item-lifecycle.md
@@ -772,7 +772,7 @@ flowchart TD
 | P7_CLOSE_REF | orchestrator | reason value | reference-needed check | duplicate/superseded → P7_CLOSE_ASK_REF, other → P7_CLOSE_COMMENT |
 | P7_CLOSE_ASK_REF | user | — | reference item (title or `#N`) | always → P7_CLOSE_COMMENT |
 | P7_CLOSE_COMMENT | user | — | optional comment text | always → P7_CLOSE_CALL |
-| P7_CLOSE_CALL | `backlog_close` MCP | selector, reason, reference, comment | work item closed, `{"status": "closed", "close_reason": "{reason}"}` metadata | terminal |
+| P7_CLOSE_CALL | `backlog_close` MCP | selector, reason, reference, comment | work item closed, `{"status": "closed", "close_reason": "{reason}", "close_reference": "{reference}", "close_comment": "{comment}"}` metadata | terminal |
 | P7_VERIFIED_GATE | orchestrator | verified status, `--force` flag, plan presence | verified gate result | verified → P7_CHECKLIST_GATE, absent + `--force` → P7_CHECKLIST_GATE, absent without force → P7_STOP_UNVERIFIED |
 | P7_STOP_UNVERIFIED | orchestrator | — | 3-option report (run QG, force, or close) | terminal |
 | P7_CHECKLIST_GATE | orchestrator | logical plan, task completion counts | checklist completeness check | incomplete → P7_STOP_UNCHECKED, 100% or no plan → P7_AC_GATE |
@@ -783,7 +783,7 @@ flowchart TD
 | P7_STOP_PR_WAIT | orchestrator | open PR reference | local status update only, wait for PR merge | terminal |
 | P7_RESOLVE_CALL | `backlog_resolve` MCP | selector, summary (required), plan, method, notes, follow_ups, findings | work item closed, `{"status": "done", "priority": "completed", "plan": "{plan}"}` metadata | terminal |
 
-**close metadata** (ADR-9): `{"status": "closed", "close_reason": "{reason}"}`. The configured backend records the close reason, reference, and comment and transitions the work item to closed.
+**close metadata** (ADR-9): `{"status": "closed", "close_reason": "{reason}", "close_reference": "{reference}", "close_comment": "{comment}"}`. The configured backend records the close reason, related reference, and comment and transitions the work item to closed.
 
 **resolve metadata** (ADR-9): `{"status": "done", "priority": "completed", "plan": "{plan}"}`. The configured backend records the evidence and transitions the work item to resolved.
 

--- a/plugins/development-harness/skills/backlog/README.md
+++ b/plugins/development-harness/skills/backlog/README.md
@@ -354,6 +354,10 @@ backlog sync
 ### `backlog_close` — Dismiss an item
 
 Use for duplicates, out-of-scope items, superseded items, wontfix, or permanently blocked items. For completed work, use `backlog_resolve`.
+Close persists `close_reason`, `close_reference`, and `close_comment` in neutral metadata on every
+backend. The caller-provided `reference` is the related item, distinct from `BacklogItem.reference`,
+the storage identity; GitHub's closing comment uses the same caller-provided `reference` and
+`comment`.
 
 ```python
 mcp__plugin_dh_backlog__backlog_close(

--- a/plugins/development-harness/skills/backlog/README.md
+++ b/plugins/development-harness/skills/backlog/README.md
@@ -354,10 +354,9 @@ backlog sync
 ### `backlog_close` — Dismiss an item
 
 Use for duplicates, out-of-scope items, superseded items, wontfix, or permanently blocked items. For completed work, use `backlog_resolve`.
-Close persists `close_reason`, `close_reference`, and `close_comment` in neutral metadata on every
-backend. The caller-provided `reference` is the related item, distinct from `BacklogItem.reference`,
-the storage identity; GitHub's closing comment uses the same caller-provided `reference` and
-`comment`.
+Pass `reference` and `comment` when closing — `reference` names the related item, not
+`BacklogItem.reference` (the storage identity). Both persist verbatim as `close_reference` and
+`close_comment` in metadata on every backend, and are reused as GitHub's closing comment.
 
 ```python
 mcp__plugin_dh_backlog__backlog_close(

--- a/plugins/development-harness/skills/backlog/SKILL.md
+++ b/plugins/development-harness/skills/backlog/SKILL.md
@@ -130,6 +130,10 @@ Dismiss a backlog item without completing it and close its GitHub issue.
 
 Use for duplicates, out-of-scope items, superseded items, wontfix, or permanently blocked.
 For completed work, use `backlog_resolve` instead.
+Close persists `close_reason`, `close_reference`, and `close_comment` in neutral metadata on every
+backend. The caller-provided `reference` is the related item, distinct from `BacklogItem.reference`,
+the storage identity; GitHub's closing comment uses the same caller-provided `reference` and
+`comment`.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/plugins/development-harness/skills/backlog/SKILL.md
+++ b/plugins/development-harness/skills/backlog/SKILL.md
@@ -130,10 +130,9 @@ Dismiss a backlog item without completing it and close its GitHub issue.
 
 Use for duplicates, out-of-scope items, superseded items, wontfix, or permanently blocked.
 For completed work, use `backlog_resolve` instead.
-Close persists `close_reason`, `close_reference`, and `close_comment` in neutral metadata on every
-backend. The caller-provided `reference` is the related item, distinct from `BacklogItem.reference`,
-the storage identity; GitHub's closing comment uses the same caller-provided `reference` and
-`comment`.
+Pass `reference` and `comment` when closing — `reference` names the related item, not
+`BacklogItem.reference` (the storage identity). Both persist verbatim as `close_reference` and
+`close_comment` in metadata on every backend, and are reused as GitHub's closing comment.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import backlog_core.models as _bc_models
 import backlog_core.operations as ops
@@ -1451,6 +1451,41 @@ class TestCloseItem:
         result = close_item(selector="Closeable Item", reason="superseded")
 
         assert result["closed"] is True
+
+    @pytest.mark.parametrize(
+        ("related_reference", "close_comment"),
+        [("#related-item", "Superseded by the tracked item."), ("", "")],
+        ids=["context", "empty-optional-context"],
+    )
+    def test_close_item_persists_caller_context_and_forwards_it_to_github(
+        self, mocker: MockerFixture, related_reference: str, close_comment: str
+    ) -> None:
+        from backlog_core.backend_protocol import get_config
+
+        storage_reference = "storage://opaque-close-record"
+        item = BacklogItem(
+            title="Close Context Item",
+            description="A close-context regression fixture.",
+            reference=storage_reference,
+            metadata=BacklogItemMetadata(
+                source="test", added="2026-01-01", priority="P1", status="open", issue="#3230"
+            ),
+        )
+        get_config().backend.put_work_item(item)
+        mock_close_github_issue = mocker.patch("backlog_core.operations.close_github_issue")
+        mocker.patch("backlog_core.operations.check_open_prs_for_issue", return_value=[])
+
+        close_item(
+            selector="Close Context Item", reason="superseded", reference=related_reference, comment=close_comment
+        )
+
+        stored = get_config().backend.get_work_item(storage_reference)
+        assert stored.metadata.close_reason == "superseded"
+        assert stored.metadata.close_reference == related_reference
+        assert stored.metadata.close_comment == close_comment
+        mock_close_github_issue.assert_called_once_with(
+            "#3230", "superseded", reference=related_reference, comment=close_comment, repo="", output=ANY
+        )
 
     def test_close_item_with_open_pr_raises_backlog_error(self, mocker: MockerFixture) -> None:
         """Verify close_item raises BacklogError when open PRs reference the issue.

--- a/plugins/development-harness/tests/test_cross_backend.py
+++ b/plugins/development-harness/tests/test_cross_backend.py
@@ -427,6 +427,31 @@ class TestCloseItem:
         # Assert
         assert result.state == "closed"
 
+    def test_close_context_metadata_round_trips(self, backend: WorkItemBackend) -> None:
+        item = BacklogItem(
+            title="Close Context",
+            description="A close-context round-trip fixture.",
+            reference="storage://close-context",
+            metadata=BacklogItemMetadata(
+                source="test",
+                added="2026-01-01",
+                priority="P1",
+                status="closed",
+                close_reason="superseded",
+                close_reference="#related-item",
+                close_comment="Superseded by the tracked item.",
+            ),
+        )
+
+        backend.put_work_item(item)
+
+        stored = backend.get_work_item("storage://close-context")
+        assert (stored.metadata.close_reason, stored.metadata.close_reference, stored.metadata.close_comment) == (
+            "superseded",
+            "#related-item",
+            "Superseded by the tracked item.",
+        )
+
 
 # ---------------------------------------------------------------------------
 # TestResolveItem
@@ -745,6 +770,33 @@ class TestBeadsBackendConformance:
         beads_backend.close_github_issue("bd-a3f8", "done")
 
         bd_runner.run_text.assert_called_once_with(["close", "bd-a3f8", "--reason", "done"])
+
+    def test_put_work_item_serializes_close_context(self, beads_backend, bd_runner) -> None:
+        item = BacklogItem(
+            title="Close Context",
+            description="A close-context round-trip fixture.",
+            reference="bd-close-context",
+            metadata=BacklogItemMetadata(
+                source="test",
+                added="2026-01-01",
+                priority="P1",
+                status="closed",
+                issue="bd-close-context",
+                close_reason="superseded",
+                close_reference="#related-item",
+                close_comment="Superseded by the tracked item.",
+            ),
+        )
+
+        beads_backend.put_work_item(item)
+
+        command = bd_runner.run_text.call_args.args[0]
+        notes = BacklogItem.model_validate_json(command[command.index("--notes") + 1])
+        assert (notes.metadata.close_reason, notes.metadata.close_reference, notes.metadata.close_comment) == (
+            "superseded",
+            "#related-item",
+            "Superseded by the tracked item.",
+        )
 
     def test_apply_status_in_progress_calls_bd_update_claim(self, beads_backend, bd_runner) -> None:
         """apply_status_in_progress calls bd update --claim with the beads ID."""

--- a/plugins/development-harness/tests/test_models.py
+++ b/plugins/development-harness/tests/test_models.py
@@ -258,6 +258,20 @@ class TestBacklogItemMetadataCloseReason:
         m = BacklogItemMetadata(close_reason="superseded")
         assert m.close_reason == "superseded"
 
+    def test_close_context_defaults_empty(self) -> None:
+        m = BacklogItemMetadata()
+        assert (m.close_reason, m.close_reference, m.close_comment) == ("", "", "")
+
+    def test_close_context_accepted(self) -> None:
+        m = BacklogItemMetadata(
+            close_reason="superseded", close_reference="#related-item", close_comment="Superseded by the tracked item."
+        )
+        assert (m.close_reason, m.close_reference, m.close_comment) == (
+            "superseded",
+            "#related-item",
+            "Superseded by the tracked item.",
+        )
+
     def test_unknown_metadata_key_ignored(self) -> None:
         """Extra keys in frontmatter must be silently discarded, not raise ValidationError."""
         m = BacklogItemMetadata.model_validate({"status": "closed", "unknown_future_key": "value"})


### PR DESCRIPTION
Fixes #3230

Preserves Close caller context separately from backend storage identity, persists it as neutral metadata for every backend, and forwards the same values to the GitHub close renderer.

Validation:
- Focused regression suite: 7 passed
- Scoped ty: passed
- Changed-file prek: passed
- Mocked close scenario verified distinct storage and caller references