### PR TITLE
fix(development-harness): correct artifact registration statuses

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.2.4",
+  "version": "9.2.5",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/code-review-architecture/SKILL.md
+++ b/plugins/development-harness/skills/code-review-architecture/SKILL.md
@@ -464,7 +464,7 @@ uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" artifact register \
   --artifact-type "codebase-analysis" \
   --artifact-id "architecture-graph-{slug}" \
   --content "{report_markdown}" \
-  --status "complete" \
+  --status "current" \
   --agent "code-review-architecture"
 ```
 
@@ -479,7 +479,7 @@ uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" artifact register \
   --artifact-type "codebase-analysis" \
   --artifact-id "architecture-graph-{slug}" \
   --content "{parent_report_markdown}" \
-  --status "complete" \
+  --status "current" \
   --agent "code-review-architecture"
 
 # Each child cluster
@@ -488,7 +488,7 @@ uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" artifact register \
   --artifact-type "codebase-analysis" \
   --artifact-id "architecture-graph-{slug}-{cluster-name}" \
   --content "{child_report_markdown}" \
-  --status "complete" \
+  --status "current" \
   --agent "code-review-architecture"
 ```
 

--- a/plugins/development-harness/tests/fixtures/mcp_call_shape_known_defects.json
+++ b/plugins/development-harness/tests/fixtures/mcp_call_shape_known_defects.json
@@ -51,6 +51,62 @@
       "expect_contains": "status=\"complete\""
     },
     {
+      "id": "enum-invalid-artifact-status-cli-one-line",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "Run `uv run sam_schema/cli.py artifact register --item-id 1 --artifact-type \"codebase-analysis\" --artifact-id \"audit\" --content \"report\" --status \"complete\" --agent \"code-review-architecture\"`.\n",
+      "expect_contains": "--status \"complete\""
+    },
+    {
+      "id": "enum-invalid-artifact-status-cli-multiline",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "```bash\nuv run sam_schema/cli.py artifact register \\\n  --item-id 1 \\\n  --artifact-type \"codebase-analysis\" \\\n  --artifact-id \"audit\" \\\n  --content \"report\" \\\n  --status \"complete\" \\\n  --agent \"code-review-architecture\"\n```\n",
+      "expect_contains": "--status \"complete\""
+    },
+    {
+      "id": "enum-invalid-artifact-status-cli-indented",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/docs/beads-and-workflow-usage.md",
+      "markdown": " artifact register --item-id 1 --artifact-type research --artifact-id findings --agent ecosystem-researcher --content report --status complete\n",
+      "expect_contains": "--status complete"
+    },
+    {
+      "id": "enum-invalid-artifact-status-cli-quoted-separator",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --content \"Compare A; B\" --status complete\n",
+      "expect_contains": "--status complete"
+    },
+    {
+      "id": "enum-invalid-artifact-status-cli-after-shell-separator",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --status current; artifact register --status complete\n",
+      "expect_contains": "--status complete"
+    },
+    {
+      "id": "enum-invalid-artifact-status-cli-hash-inside-content-token",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --content ref#part --status complete\n",
+      "expect_contains": "--status complete"
+    },
+    {
+      "id": "enum-invalid-artifact-status-cli-after-non-artifact-shell-command",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "cd docs && artifact register --status complete\n",
+      "expect_contains": "--status complete"
+    },
+    {
+      "id": "enum-malformed-artifact-register-cli-tokenization",
+      "guard": "artifact_enum",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --content \"Compare A; B --status complete\n",
+      "expect_contains": "malformed artifact register CLI tokenization"
+    },
+    {
       "id": "enum-invalid-artifact-type",
       "guard": "artifact_enum",
       "frozen_from": "plugins/development-harness/agents/tn-verification-gate.md",
@@ -88,6 +144,56 @@
       "id": "live-tool-names-and-enum-values-are-accepted",
       "frozen_from": "plugins/development-harness/agents/contract-verification.md",
       "markdown": "Call `mcp__plugin_dh_backlog__artifact_register(item_id=1, artifact_type=\"T0-baseline\", artifact_id='t0-x', content='y', status=\"current\")` then `sam_plan(config={\"action\":\"list\"})`.\n"
+    },
+    {
+      "id": "current-artifact-status-cli-one-line-is-accepted",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "Run `uv run sam_schema/cli.py artifact register --item-id 1 --artifact-type \"codebase-analysis\" --artifact-id \"audit\" --content \"report\" --status \"current\" --agent \"code-review-architecture\"`.\n"
+    },
+    {
+      "id": "placeholder-artifact-status-cli-multiline-is-exempt",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "```bash\nuv run sam_schema/cli.py artifact register \\\n  --item-id {issue_number} \\\n  --artifact-type \"codebase-analysis\" \\\n  --artifact-id \"architecture-graph-{slug}\" \\\n  --content \"{report_markdown}\" \\\n  --status \"{status}\" \\\n  --agent \"code-review-architecture\"\n```\n"
+    },
+    {
+      "id": "non-artifact-cli-status-is-not-an-artifact-status",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "Run `sam task --plan P1 --task T1 --status \"complete\"`.\n"
+    },
+    {
+      "id": "prose-artifact-register-status-is-not-a-cli-command",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "Use artifact register, then set --status complete.\n"
+    },
+    {
+      "id": "status-after-shell-separator-belongs-to-next-command",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --item-id 1; sam task --status complete\n"
+    },
+    {
+      "id": "status-after-shell-comment-is-not-an-artifact-status",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --status current # --status complete\n"
+    },
+    {
+      "id": "quoted-cli-content-status-is-not-a-flag",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --content \"Explain --status complete\" --status current\n"
+    },
+    {
+      "id": "quoted-cli-content-nested-artifact-after-separator-is-not-a-command",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --content \"example; artifact register --status complete\" --status current\n"
+    },
+    {
+      "id": "quoted-cli-content-nested-artifact-after-hash-is-not-a-command",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "artifact register --content \"example # artifact register --status complete\" --status current\n"
+    },
+    {
+      "id": "inline-current-artifact-status-cli-is-accepted",
+      "frozen_from": "plugins/development-harness/skills/code-review-architecture/SKILL.md",
+      "markdown": "Run `artifact register --status current`.\n"
     }
   ]
 }

--- a/plugins/development-harness/tests/mcp_call_shape_guards.py
+++ b/plugins/development-harness/tests/mcp_call_shape_guards.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import shlex
 from typing import TYPE_CHECKING, Final, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -66,7 +67,6 @@ _ARTIFACT_CALL_RE: Final = re.compile(
 
 _ARTIFACT_TYPE_KWARG_RE: Final = re.compile(r"""artifact_type\s*=\s*["']([^"']*)["']""")
 _STATUS_KWARG_RE: Final = re.compile(r"""status\s*=\s*["']([^"']*)["']""")
-
 # Characters that mark a literal as an authoring placeholder rather than a real value.
 _PLACEHOLDER_CHARS: Final = frozenset("{}<>$|")
 
@@ -225,15 +225,202 @@ def _artifact_call_spans(text: str) -> Iterator[str]:
         yield _call_span(text, match.end() - 1)
 
 
+def _is_shell_comment_start(text: str, index: int) -> bool:
+    return index == 0 or text[index - 1].isspace()
+
+
+def _skip_whitespace(text: str, start: int) -> int:
+    while start < len(text) and text[start].isspace():
+        start += 1
+    return start
+
+
+def _matches_artifact_register(text: str, start: int) -> bool:
+    if not text.startswith("artifact", start):
+        return False
+    cursor = start + len("artifact")
+    if cursor == len(text) or not text[cursor].isspace():
+        return False
+    cursor = _skip_whitespace(text, cursor)
+    if not text.startswith("register", cursor):
+        return False
+    cursor += len("register")
+    if cursor == len(text) or not text[cursor].isspace():
+        return False
+    cursor = _skip_whitespace(text, cursor)
+    return text.startswith("--", cursor) or (cursor < len(text) and text[cursor] == "\\")
+
+
+def _uv_run_arguments_start(text: str, start: int) -> int | None:
+    if not text.startswith("uv", start):
+        return None
+    cursor = start + len("uv")
+    if cursor == len(text) or not text[cursor].isspace():
+        return None
+    cursor = _skip_whitespace(text, cursor)
+    if not text.startswith("run", cursor):
+        return None
+    cursor += len("run")
+    if cursor == len(text) or not text[cursor].isspace():
+        return None
+    return cursor
+
+
+def _matches_uv_artifact_register(text: str, start: int) -> bool:
+    cursor = _uv_run_arguments_start(text, start)
+    if cursor is None:
+        return False
+
+    quote = ""
+    escaped = False
+    while cursor < len(text):
+        char = text[cursor]
+        if escaped:
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif quote:
+            if char == quote:
+                quote = ""
+        elif char in "\"'":
+            quote = char
+        elif char in ";&|#\n`":
+            return False
+        elif (cursor == start or text[cursor - 1].isspace()) and _matches_artifact_register(text, cursor):
+            return True
+        cursor += 1
+    return False
+
+
+def _cli_scan_character(char: str, quote: str, escaped: bool, artifact_command: bool) -> tuple[str, str, bool]:
+    if not artifact_command:
+        return char, quote, escaped
+    if escaped:
+        return " ", quote, False
+    if char == "\\":
+        return " ", quote, True
+    if quote:
+        return " ", "" if char == quote else quote, False
+    if char in "\"'":
+        return " ", char, False
+    return char, quote, escaped
+
+
+def _artifact_register_cli_starts(text: str) -> Iterator[tuple[int, bool]]:
+    index = 0
+    command_start = True
+    quote = ""
+    escaped = False
+    artifact_command = False
+    while index < len(text):
+        char, quote, escaped = _cli_scan_character(text[index], quote, escaped, artifact_command)
+        if command_start:
+            index = _skip_whitespace(text, index)
+            if index == len(text):
+                return
+            char = text[index]
+            if text[index] == "`":
+                index += 1
+                continue
+            if text[index] == "#":
+                index = text.find("\n", index)
+                if index == -1:
+                    return
+                command_start = True
+                index += 1
+                continue
+            if _matches_artifact_register(text, index) or _matches_uv_artifact_register(text, index):
+                inline = index > 0 and text[index - 1] == "`"
+                yield index, inline
+                artifact_command = True
+            command_start = False
+
+        if char == "`":
+            command_start = True
+            artifact_command = False
+        elif char == "#" and _is_shell_comment_start(text, index):
+            newline = text.find("\n", index)
+            if newline == -1:
+                return
+            command_start = True
+            artifact_command = False
+            index = newline
+        elif char in ";&|" or (char == "\n" and not text[:index].rstrip().endswith("\\")):
+            command_start = True
+            artifact_command = False
+        index += 1
+
+
+def _cli_command_span(text: str, start: int, inline: bool) -> tuple[str, str]:
+    quote = ""
+    escaped = False
+    end = start
+    while end < len(text):
+        char = text[end]
+        if escaped:
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == "\n":
+            if not text[start:end].rstrip().endswith("\\"):
+                break
+        elif quote:
+            if char == quote:
+                quote = ""
+        elif char in "\"'":
+            quote = char
+        elif char in ";&|" or (char == "#" and _is_shell_comment_start(text, end)) or (inline and char == "`"):
+            break
+        end += 1
+    return text[start:end], quote
+
+
+def _artifact_register_cli_defects(text: str, artifact_statuses: frozenset[str]) -> Iterator[Defect]:
+    for start, inline in _artifact_register_cli_starts(text):
+        span, quote = _cli_command_span(text, start, inline)
+        if quote:
+            yield Defect(
+                kind="artifact_enum",
+                found="artifact register",
+                detail=f"has malformed artifact register CLI tokenization: unterminated {quote!r} quote",
+            )
+            continue
+
+        try:
+            tokens = shlex.split(span, posix=False)
+        except ValueError as exc:
+            yield Defect(
+                kind="artifact_enum",
+                found="artifact register",
+                detail=f"has malformed artifact register CLI tokenization: {exc}",
+            )
+            continue
+
+        for index, token in enumerate(tokens):
+            if token == "--status" and index + 1 < len(tokens) and not tokens[index + 1].startswith("--"):
+                raw_value = tokens[index + 1]
+                found, value = f"--status {raw_value}", raw_value.strip("\"'")
+            elif token.startswith("--status="):
+                found, value = token, token.partition("=")[2].strip("\"'")
+            else:
+                continue
+            if not _is_placeholder(value) and value not in artifact_statuses:
+                yield Defect(
+                    kind="artifact_enum",
+                    found=found,
+                    detail=f"is not an ArtifactStatus; valid values are {sorted(artifact_statuses)}",
+                )
+
+
 def find_artifact_enum_defects(
     text: str, artifact_types: frozenset[str], artifact_statuses: frozenset[str]
 ) -> list[Defect]:
     """Flag ``artifact_type=`` and ``status=`` literals that are not enum members.
 
     ``artifact_type=`` is checked wherever it appears — that keyword is unique to the
-    artifact tools. ``status=`` is checked only inside an ``artifact_*`` call span,
-    because the same keyword carries an unrelated value domain on the backlog and task
-    tools.
+    artifact tools. ``status=`` is checked only inside an ``artifact_*`` call span, and
+    ``--status`` only inside an ``artifact register`` CLI command, because the same
+    values carry unrelated domains on the backlog and task tools.
 
     Args:
         text: Full markdown text of one shipped file.
@@ -262,4 +449,5 @@ def find_artifact_enum_defects(
         for value in _STATUS_KWARG_RE.findall(span)
         if not _is_placeholder(value) and value not in artifact_statuses
     )
+    defects.extend(_artifact_register_cli_defects(text, artifact_statuses))
     return defects


### PR DESCRIPTION
## Summary
- correct the three architecture-review CLI examples to use the valid `current` artifact lifecycle status
- extend the existing artifact enum drift guard to cover actual CLI `artifact register` commands
- cover multiline, inline, placeholder, prose, and shell-separator boundaries

Closes #3192.

## Validation
- `uv run pytest plugins/development-harness/tests/test_mcp_call_shape_drift.py plugins/development-harness/tests/test_artifact_type_ownership_drift.py`
- runtime ArtifactStatus input-contract tests: `current` accepted; `complete`, `done`, and `COMPLETE` rejected
- independent final gate: 55 focused checks passed