### PR TITLE
docs(development-harness): optimize multi-perspective-review skill prose

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.2.5",
+  "version": "10.2.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.2.5",
+  "version": "9.2.6",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL-GOALS.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL-GOALS.md
@@ -1,0 +1,15 @@
+The purpose and explicit goals of the skill multi-perspective-review:
+
+1. Orchestrate four independent, parallel perspective reviews (Security, Performance, Quality,
+   Accessibility) of a diff by creating an ephemeral SAM plan and dispatching four
+   `dh:task-worker` teammates via `TeamCreate`, without serializing them.
+2. Synthesize the four verdicts into one deduplicated, cross-referenced punch list via a fifth
+   synthesis worker, reconciling the synthesized output against each perspective's raw
+   `Review Results` section to catch a silently altered or dropped verdict or finding.
+3. Apply a gate (a missing verdict or any REJECT fails; SKIP is a passing outcome; all four
+   SKIP passes with a warning) and print one canonical summary line per perspective, exiting
+   non-zero when the gate fails.
+4. Guarantee run isolation — every invocation creates a fresh ephemeral plan and team, keyed by a
+   collision-resistant run stamp, so no run reads or is polluted by another run's state.
+5. Keep the verdict/punch-list schema and dispatch mechanics owned by companion skills
+   (`dh:review-verdict-contract`, `dh:dispatch-contract`) rather than duplicated in this file.

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -57,12 +57,16 @@ Do not create a team or a plan when `changed_files` is empty.
 
 ## Step 2: Derive Review Slug
 
-Derive `review_base` exactly once using the first matching rule:
+Derive `review_base` exactly once using this flowchart:
 
-1. `--slug` argument is provided → use its value directly
-2. `--issue <N>` argument is provided → `review-{N}` (e.g., `review-2181`)
-3. Neither provided → read current git branch name via `git rev-parse --abbrev-ref HEAD` and
-   use `review-{branch-name}` (sanitize branch name: replace `/` with `-`)
+```mermaid
+flowchart TD
+    Start([Derive review_base]) --> Q1{--slug argument provided?}
+    Q1 -->|Yes| A["review_base = --slug value"]
+    Q1 -->|No| Q2{--issue N argument provided?}
+    Q2 -->|Yes| B["review_base = review-{N}<br>e.g. review-2181"]
+    Q2 -->|No| C["git rev-parse --abbrev-ref HEAD<br>review_base = review-{branch-name}<br>sanitize: replace / with -"]
+```
 
 Run this command and capture its stdout as `run_stamp`:
 
@@ -426,3 +430,12 @@ orchestrator passes only the task reference `{PA}/T{N}` to the worker prompt.
 - **The punch list is the gate's input.** One defect two perspectives raised is one entry naming
   both, so a REJECT summary counts distinct defects rather than repeating one across lenses.
 - **All-SKIP warning is mandatory** when all four perspectives return SKIP.
+
+---
+
+## Manual Acceptance Testing
+
+Security REJECT, Accessibility SKIP, and summary-line-format behavior require live skill execution
+against real diff inputs and are not covered by automated structural checks. See
+[Acceptance Test Guide](./references/acceptance-test-guide.md) for fixture-based verification
+procedures.

--- a/plugins/development-harness/skills/multi-perspective-review/references/acceptance-test-guide.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/acceptance-test-guide.md
@@ -10,6 +10,14 @@ execution against real diff inputs. They are NOT covered by the plan's T0/TN boo
 deliberate scope decision — the bookend system verifies static artifacts; behavioral runtime
 verification is manual-only.
 
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [AC4 — Security REJECT on Hardcoded Secret](#ac4--security-reject-on-hardcoded-secret)
+- [AC5 — Accessibility SKIP When No UI Changes](#ac5--accessibility-skip-when-no-ui-changes)
+- [AC6 — Canonical Summary Line Format](#ac6--canonical-summary-line-format)
+- [Cleanup](#cleanup)
+
 ---
 
 ## Prerequisites
@@ -79,9 +87,9 @@ Security: REJECT (1 finding) | Performance: APPROVE (...) | Quality: APPROVE (..
 **Fixture**: `.tmp/test-fixtures/no-ui-changes.diff`
 
 The fixture modifies only `.py` files (`backlog_core/models.py`,
-`backlog_core/backend_protocol.py`). None of these match the UI file pattern list defined in
-`references/verdict-schema.md §2.3`. The accessibility reviewer must emit `verdict: SKIP`
-without scanning file contents.
+`backlog_core/backend_protocol.py`). None of these match the UI file pattern list. Activate the
+`/dh:review-verdict-contract` skill for the UI file pattern list definition (`review-verdict-contract`
+§2.3). The accessibility reviewer must emit `verdict: SKIP` without scanning file contents.
 
 **Invocation** (from repository root, after applying the fixture):
 ```bash
@@ -110,7 +118,8 @@ git apply .tmp/test-fixtures/no-ui-changes.diff
 ## AC6 — Canonical Summary Line Format
 
 **Context**: AC6 requires the orchestrating skill to emit one summary line per perspective in
-the canonical format defined in `references/verdict-schema.md §2.2`.
+the canonical format. Activate the `/dh:review-verdict-contract` skill for the canonical format
+definition (`review-verdict-contract` §2.2).
 
 **Canonical format**:
 ```text


### PR DESCRIPTION
## Summary
- Fresh skill-goal-extractor characterization of `multi-perspective-review`, recorded in `SKILL-GOALS.md` for the follow-up `evaluate-and-tighten-skills` pass.
- Converted the review-slug precedence rule in Step 2 to a Mermaid decision flowchart, matching this file's existing decision-logic convention (the mandate: tables/lists are prohibited for `if/else` branching logic, Mermaid is required).
- Fixed two broken cross-skill file references in `references/acceptance-test-guide.md` — both pointed at `references/verdict-schema.md`, a file that only exists inside the `review-verdict-contract` skill, not this one. Replaced with the skill-activation form already used consistently elsewhere in `SKILL.md` itself (`` `review-verdict-contract` §2.x ``).
- Added a Table of Contents to `acceptance-test-guide.md` (170 lines, over the 100-line reference-file threshold).
- Linked `acceptance-test-guide.md` from `SKILL.md` — it previously had no inbound reference from the skill it documents, so it was undiscoverable from the runtime file.

No behavioral changes to the orchestration logic itself. This was a manual re-read of the whole directory (`SKILL.md` + `references/` + `scripts/`), not a reuse of any prior partial edit — the file was already largely well-optimized (imperative language, positively-framed prohibitions paired with reasoning, no hedging) from an earlier ad-hoc pass on Step 2 only; the changes here are the remaining gaps a full pass over the whole directory surfaced.

**Flagged, not changed** (belongs to a `evaluate-and-tighten-skills` pass, not this optimization pass — see `SKILL-GOALS.md`):
- Two provenance/historical notes in `SKILL.md` ("#1430 replaces the stub gate logic...", "The gate logic is the pre-#1430 stub") that read as maintainer narrative rather than runtime instruction.
- The "T6 (skill implementation)" / "plan's T0/TN bookend checks" provenance sentence in `acceptance-test-guide.md`'s scope note, which references the feature-development plan that built this skill rather than this skill's own runtime behavior.
- `skilllint` reports `SK006`/`AS005` (SKILL.md body over the 4400-token threshold) as a **pre-existing** warning — confirmed via `git stash` comparison (4817 tokens before this PR, 4914 after; this PR's net addition is ~97 tokens). Worth a future `refactor-skill` pass to move detail into `references/`, but out of scope here.

## Test plan
- [x] `uvx skilllint@latest check` — only the pre-existing SK006/AS005 size warnings, confirmed present before this PR via `git stash` comparison
- [x] `uv run prek run --files <changed>` — all hooks pass (markdownlint-cli2 validates the new ToC's anchor links)
- [x] Manually diffed both files before commit to confirm no behavioral content was altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HM2E9C16VaPwEbHFE7FmFL