### PR TITLE
docs(development-harness): tighten multi-perspective-review skill prose

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.2.6",
+  "version": "10.3.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.2.6",
+  "version": "9.3.0",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.2.6",
+  "version": "6.3.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/MAINTENANCE.md
+++ b/plugins/development-harness/skills/multi-perspective-review/MAINTENANCE.md
@@ -1,0 +1,17 @@
+# Skill maintenance
+
+## Regression provenance
+
+- Plan reuse cannot be made safe by resetting task status alone.
+  - Observed in: SKILL.md Step 3 authoring history (plan-reuse rationale, removed from runtime
+    prose during a tightening pass — the bounded instruction "always create a new plan" survives
+    in SKILL.md, this is why).
+  - Required behavior: every run must create a brand-new ephemeral plan, never reuse an existing
+    one by resetting task status.
+  - Why: resetting a task's status makes it claimable again, but the task body still names the
+    previous run's `changed_files` (workers would review the wrong file set), and the task's
+    `Review Results` section already exists — the next `append_section` call lands inside that
+    heading instead of creating a new one, leaving the section holding two concatenated JSON
+    documents that no longer parse.
+  - Protected by: none (no automated eval covers this; a regression would surface as a corrupted
+    `Review Results` section on a reused plan).

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -16,10 +16,6 @@ dispatches a fifth worker that reads the four verdict blocks back and synthesize
 deduplicated punch list, applies the gate logic to that punch list, and prints one canonical
 summary line per perspective.
 
-This skill does NOT replace language-scoped code review (`dh:forensic-review`). It runs
-alongside it as an orthogonal quality signal. #1430 replaces the stub gate logic in Step 7 without
-changing the caller interface.
-
 Activate `dh:review-verdict-contract` before the first verdict-schema operation.
 
 ## Argument Parsing
@@ -84,14 +80,8 @@ Use `review_slug` unchanged in plan operations. Use `multi-{review_slug}` as the
 ## Step 3: Create the Ephemeral Review Plan
 
 **Create a new plan on every run.** Never search for and reuse an existing plan. `review_slug`
-carries this run's stamp, so no earlier plan can match it and every run starts with tasks that are
-`not-started`, bodies that describe this run's `changed_files`, and no `Review Results` section.
-
-Reuse cannot be made safe by resetting task status alone. Resetting status makes a task claimable
-again, but the task body still names the previous run's changed files, so workers would review the
-wrong file set; and `Review Results` already exists on the task, so the next append lands inside
-that heading rather than creating a second one, leaving a section that holds two concatenated
-JSON documents and no longer parses.
+carries this run's stamp, so no earlier plan can match it and every run starts with `not-started`
+tasks, bodies naming this run's `changed_files`, and no `Review Results` section.
 
 ### Create the Ephemeral Plan
 
@@ -186,17 +176,15 @@ TeamCreate(team_name="multi-{review_slug}")
 
 Dispatch all four workers simultaneously. Do NOT wait between spawns — all four are independent
 and must run in parallel. Each worker receives a minimal prompt that tells it to run the
-`dh:start-task` skill against its own task reference. `dh:start-task` owns claim, active-task
-registration, and execution. Name the skill in prose — a harness-specific invocation form
-reaches only the harness that defines it, and a worker that never runs `dh:start-task` never
-claims its task and writes nothing. The `agent:` field in each
-SAM task tells `dh:task-worker` which specialist profile to load via `profile_load` internally.
+`dh:start-task` skill (name it in prose — a harness-specific invocation form reaches only the
+harness that defines it) against its own task reference. `dh:start-task` owns claim, active-task
+registration, and execution; a worker that never runs it claims nothing and writes nothing, which
+Step 6 records as a missing verdict. The `agent:` field in each SAM task tells `dh:task-worker`
+which specialist profile to load via `profile_load` internally.
 
-Dispatch `dh:task-worker` for all four tasks: the four perspective reviewer agents declare
-`sam_task` to write their verdict but not the rest of the SAM task lifecycle, so under
-`dh:dispatch-contract` they cannot be the dispatch target and their behavior reaches the work as a
-loaded profile instead. `dh:review-synthesizer` reaches the same one operation, so Step 6
-dispatches it the same way.
+Dispatch `dh:task-worker` for all four tasks, not the reviewer agents directly — see Behavioral
+Rules for why. `dh:review-synthesizer` reaches the plan the same way, so Step 6 dispatches it
+identically.
 
 Every prompt names the same output destination: the `Review Results` section of the worker's own
 task. That section is the only channel the synthesizer reads in Step 6 — a reviewer that does not
@@ -314,9 +302,8 @@ only ones that will run for it.
 
 ### Gate Logic
 
-The gate logic is the pre-#1430 stub. The full gate logic including the all-SKIP edge case is
-defined in `review-verdict-contract` §2.4. Both inputs come
-from the punch list read in Step 6: `punch_list["verdicts"]` and `punch_list["missing"]`.
+Both inputs come from the punch list read in Step 6: `punch_list["verdicts"]` and
+`punch_list["missing"]`.
 
 Apply gate in this order:
 
@@ -336,10 +323,6 @@ Apply gate in this order:
    ```
 
 4. **All other combinations** (any APPROVE, remaining SKIP) → gate PASSES.
-
-**Gate interface:** The gate interface is stable:
-`gate(verdicts: list[VerdictBlock]) -> GateResult` where `GateResult = {passed: bool,
-summary_line: str, blocking_findings: list[Finding]}`.
 
 ### Summary Line Format
 
@@ -402,34 +385,12 @@ flowchart TD
 
 ---
 
-## Ephemeral Plan Task Structure
-
-The ephemeral plan always has exactly the five tasks the Step 3 create call defines — `T1`
-security, `T2` performance, `T3` quality, `T4` accessibility, `T5` synthesis.
-
-The four review tasks have `dependencies: []` — they are independent and run in parallel. T5
-depends on all four, so `sam_plan(action="ready")` offers it only once every perspective has
-finished. `dh:task-worker` reads the `agent:` field itself and passes it to `profile_load`; the
-orchestrator passes only the task reference `{PA}/T{N}` to the worker prompt.
-
----
-
 ## Behavioral Rules
 
-- **SKIP is a passing outcome.** A perspective that SKIPs is not a blocker. The punch list records
-  it as coverage that was declined, with the reviewer's `skip_reason`.
-- **All four verdicts must arrive before the gate runs.** Do not apply the gate on partial results.
-- **Every run creates its own plan.** `review_slug` carries this run's stamp, so no earlier
-  plan can match it and no run reads another run's results.
 - Dispatch uses `dh:task-worker` because the perspective reviewer agents cannot claim or close a SAM task. Specialist behavior is selected through the task profile. See `dh:dispatch-contract`.
-- **Do not embed the verdict or punch-list schema, or the UI pattern list.** Activate
-  `dh:review-verdict-contract` for all schema definitions.
 - **Each reviewer task body must embed the newline-separated changed-files list.** Reviewers read
   their task body to obtain the scan target; they do not receive it via the prompt. T5 reads the
   four verdict sections instead, so its body names those and carries no file list.
-- **The punch list is the gate's input.** One defect two perspectives raised is one entry naming
-  both, so a REJECT summary counts distinct defects rather than repeating one across lenses.
-- **All-SKIP warning is mandatory** when all four perspectives return SKIP.
 
 ---
 

--- a/plugins/development-harness/skills/multi-perspective-review/references/acceptance-test-guide.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/acceptance-test-guide.md
@@ -5,9 +5,8 @@ AC6 (summary format). These tests require the full `dh:multi-perspective-review`
 operational and must be run after T6 (skill implementation) completes.
 
 **Scope note**: AC4, AC5, and AC6 are behavioral acceptance criteria that require live skill
-execution against real diff inputs. They are NOT covered by the plan's T0/TN bookend checks
-(which verify only structural ACs 1–2–7: file existence and schema correctness). This is a
-deliberate scope decision — the bookend system verifies static artifacts; behavioral runtime
+execution against real diff inputs, so they are not covered by the plan's T0/TN bookend checks
+(structural ACs 1–2–7 only: file existence and schema correctness) — behavioral runtime
 verification is manual-only.
 
 ## Contents


### PR DESCRIPTION
## Summary

Applies the `plugin-creator:evaluate-and-tighten-skills` procedure to
`plugins/development-harness/skills/multi-perspective-review/` against the
goals already recorded in `SKILL-GOALS.md` (from the recent #3240
prose-optimization pass). Every removal was checked against the behavioral
contract derived from those five goals before being cut.

- Removed a bare `#1430` provenance reference and a "does not replace
  forensic-review" scope note from Role — neither is one of the skill's
  five goals nor changes any executing agent's behavior.
- Removed a stale "The gate logic is the pre-#1430 stub" self-description
  in Step 7, plus an orphaned `gate(verdicts) -> GateResult` interface
  block. Both predate #1430 actually inlining the real gate algorithm into
  Step 7, and both duplicate (and now contradict) `review-verdict-contract`
  §2.4, which is itself still labeled "Stub Consolidation — Pre-#1430" —
  flagging that companion-skill staleness separately below, out of this
  PR's scope.
- Deleted the "Ephemeral Plan Task Structure" section — every fact in it
  (T1-T5 mapping, T5's dependency gating, `agent:` field → `profile_load`)
  was already stated once in Steps 3-5.
- Trimmed "Behavioral Rules" from 8 bullets to 2 — six were verbatim or
  near-verbatim restatements of Step 3/4/7 content.
- Trimmed the Step 3 plan-reuse rationale and the Step 4 worker-dispatch
  rationale to their bounded instructions; moved the plan-reuse "why" (a
  genuine regression-prevention fact) to a new `MAINTENANCE.md` — it
  protects future maintainers from re-introducing a concatenated-JSON bug,
  not runtime execution, so it doesn't belong in the executing agent's
  context.
- Minor redundant-sentence trim in `references/acceptance-test-guide.md`'s
  scope note.

**Result:** `SKILL.md` 441 → 402 lines, 2768 → 2376 words. `skilllint`'s
pre-existing SK006/AS005 token-threshold warning is now clear (exit 0, no
findings). No behavioral content was removed — every one of the five goals
in `SKILL-GOALS.md` is still fully supported by the tightened prose.

**Pre-existing issue found (not fixed here, out of scope):**
`plugins/development-harness/skills/review-verdict-contract/references/verdict-schema.md`
§2.4 is still titled "Gate Logic (Stub Consolidation — Pre-#1430)" and
describes the pre-#1430 design, even though #1430 already shipped and
moved the real gate algorithm into `multi-perspective-review`'s Step 7.
Worth a follow-up backlog item to reconcile or retire that section.

## Test plan

- [x] `uvx skilllint@latest check plugins/development-harness/skills/multi-perspective-review` — exit 0, no findings (previously SK006/AS005 warning)
- [x] `uv run prek run --files <changed files>` — all hooks pass
- [x] Manual re-read of the tightened SKILL.md against the SKILL-GOALS.md behavioral contract — all 5 goals still supported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HM2E9C16VaPwEbHFE7FmFL