### PR TITLE
docs(development-harness): restore full step fidelity to mpr Dispatch Flow diagram

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -356,31 +356,67 @@ TeamDelete(team_name="multi-{review_slug}")
 
 ```mermaid
 flowchart TD
-    Start([dh:multi-perspective-review invoked]) --> Parse[Parse --diff and --issue args]
-    Parse --> Files["git diff --name-only range → changed_files list"]
-    Files --> Empty{changed_files empty?}
-    Empty -->|Yes| Abort[ABORT — no changed files to review]
-    Empty -->|No| Slug["Derive review_base, then<br>review_slug = review_base + run stamp"]
-    Slug --> CreatePlan["sam_plan(config: create + T1..T5)<br>always a new plan — never reused"]
-    CreatePlan --> PlanAddr["Store new plan address as {PA}"]
-    PlanAddr --> Team["TeamCreate(team_name='multi-{review_slug}')"]
-    Team --> Parallel[Dispatch 4 workers in parallel — no wait between spawns]
-    Parallel --> W1["Agent(name='security-worker', subagent_type='dh:task-worker')"]
-    Parallel --> W2["Agent(name='performance-worker', subagent_type='dh:task-worker')"]
-    Parallel --> W3["Agent(name='quality-worker', subagent_type='dh:task-worker')"]
-    Parallel --> W4["Agent(name='accessibility-worker', subagent_type='dh:task-worker')"]
-    W1 --> Collect["Wait for T1..T4 terminal via sam_plan status"]
+    Start(["dh:multi-perspective-review invoked"]) --> Parse["Parse --diff, --issue, --slug<br>from invocation arguments string"]
+    Parse --> DiffCheck{"--diff argument present?"}
+    DiffCheck -->|"No — required arg missing"| AbortUsage(["ABORT — print usage message<br>Stop before any plan or team is created"])
+    DiffCheck -->|"Yes"| Files["Run git diff --name-only range<br>Split stdout by newline, trim empty lines<br>→ changed_files list"]
+    Files --> EmptyCheck{"changed_files list empty?"}
+    EmptyCheck -->|"Yes"| AbortEmpty(["ABORT — print<br>'ERROR — No changed files found for diff range range. Nothing to review.'<br>Do not create a team or a plan"])
+    EmptyCheck -->|"No"| SlugArg{"--slug argument provided?"}
+
+    SlugArg -->|"Yes"| SlugFromArg["review_base = --slug value"]
+    SlugArg -->|"No"| IssueArg{"--issue N argument provided?"}
+    IssueArg -->|"Yes"| SlugFromIssue["review_base = review-N"]
+    IssueArg -->|"No"| SlugFromBranch["git rev-parse --abbrev-ref HEAD<br>review_base = review-branch-name<br>sanitize — replace slash with dash"]
+
+    SlugFromArg --> RunStamp
+    SlugFromIssue --> RunStamp
+    SlugFromBranch --> RunStamp
+
+    RunStamp["Run gen_run_stamp.py<br>Capture stdout as run_stamp"] --> BuildSlug["review_slug = review_base-run_stamp<br>Team name = multi-review_slug"]
+
+    BuildSlug --> CreatePlan["sam_plan create — T1 Security, T2 Performance,<br>T3 Quality, T4 Accessibility, T5 Synthesis<br>T5 depends on T1..T4<br>One typed MCP call<br>Always a new plan — never reused"]
+    CreatePlan --> PlanAddr["Store returned plan_ref as PA<br>Completion criterion — plan_ref non-empty<br>AND task_count = 5"]
+
+    PlanAddr --> Team["TeamCreate team_name=multi-review_slug"]
+    Team --> Parallel["Dispatch 4 dh task-worker agents simultaneously<br>No wait between spawns — all four run in parallel<br>Dispatch task-worker, not reviewer agents directly"]
+    Parallel --> W1["security-worker → T1<br>Runs dh start-task against T1"]
+    Parallel --> W2["performance-worker → T2<br>Runs dh start-task against T2"]
+    Parallel --> W3["quality-worker → T3<br>Runs dh start-task against T3"]
+    Parallel --> W4["accessibility-worker → T4<br>Runs dh start-task against T4<br>Applies SKIP rule first"]
+
+    %% Each worker's loaded profile — not the dispatch prompt — performs the single
+    %% write of its verdict into the task's own Review Results section
+
+    W1 --> Collect
     W2 --> Collect
     W3 --> Collect
     W4 --> Collect
-    Collect --> Synth["Dispatch synthesis worker on T5<br>Wait for T5 terminal<br>Read its Punch List section"]
-    Synth --> NoList{"Punch List parses AND<br>validates against §2.6?"}
-    NoList -->|No| FailSynth[FAIL — Punch list not produced.<br>TeamDelete. Exit non-zero.]
-    NoList -->|Yes| Gate{Any REJECT?}
-    Gate -->|Missing verdict| Fail[FAIL — Perspective X did not return a verdict.<br>Print summary. TeamDelete. Exit non-zero.]
-    Gate -->|Any REJECT| Fail2[Print summary. TeamDelete. Exit non-zero.]
-    Gate -->|All SKIP| Warn[Print summary. Print all-SKIP warning. TeamDelete. Exit 0.]
-    Gate -->|All APPROVE or APPROVE+SKIP| Pass[Print summary. TeamDelete. Exit 0.]
+
+    Collect["Wait until T1..T4 all reach terminal status<br>Poll sam_plan action=status<br>Terminal = complete, blocked, failed, skipped, or deferred<br>T5 stays not-started throughout"]
+
+    Collect --> SynthDispatch["Dispatch synthesis-worker → T5<br>Runs dh start-task against T5<br>Reads T1..T4 Review Results, merges duplicate findings,<br>writes punch-list block to T5 Punch List section"]
+
+    SynthDispatch --> WaitT5["Wait for T5 terminal status<br>Read T5 Punch List section<br>json.loads the section into punch_list"]
+
+    WaitT5 --> ParseCheck{"Punch List section present,<br>parses as JSON, AND passes<br>review-verdict-contract §2.6 validity checks?"}
+    ParseCheck -->|"No"| FailSynth(["FAIL — Punch list not produced<br>Name the check that failed<br>Report which perspectives DID write a Review Results section<br>TeamDelete. Exit non-zero."])
+    ParseCheck -->|"Yes"| Check6{"Check 6 — does each verdicts[i] verdict<br>match its source perspective's raw<br>Review Results verdict field exactly?"}
+
+    Check6 -->|"No — verdict altered in transcription"| FailSynth
+    Check6 -->|"Yes"| Check7{"Check 7 — does each raw finding's description<br>on T1..T4 appear verbatim in some entries[] descriptions,<br>at the index its entries[] perspectives names?"}
+
+    Check7 -->|"No — finding altered or mis-attributed"| FailSynth
+    Check7 -->|"Yes"| GateMissing{"Any perspective named in<br>punch_list missing field?"}
+
+    GateMissing -->|"Yes — missing verdict"| FailMissing(["FAIL — Perspective X did not return a verdict<br>Print summary line. TeamDelete. Exit non-zero."])
+    GateMissing -->|"No"| GateReject{"Any verdict has verdict equal to REJECT?"}
+
+    GateReject -->|"Yes"| FailReject(["Gate FAILS<br>Collect REJECT verdicts and blocking findings<br>from punch_list entries for the summary<br>Print summary line. TeamDelete. Exit non-zero."])
+    GateReject -->|"No"| GateAllSkip{"All four verdicts equal SKIP?"}
+
+    GateAllSkip -->|"Yes"| WarnPass(["Gate PASSES<br>Print summary line, then<br>NOTE — No perspectives reviewed — all skipped<br>TeamDelete. Exit 0."])
+    GateAllSkip -->|"No — any APPROVE, remaining SKIP"| NormalPass(["Gate PASSES<br>Print summary line<br>TeamDelete. Exit 0."])
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Rebuilds the "Dispatch Flow (Reference)" Mermaid diagram in `plugins/development-harness/skills/multi-perspective-review/SKILL.md` against the *current* Steps 1-7 prose (post-#3240/#3241), not the stale pre-tightening version a superseded attempt (#3242, closed) was built against.
- Restores four fidelity defects present in the previous diagram:
  1. The `--diff` usage-abort path (Step 1's "abort with usage message if `--diff` is absent") was missing entirely — added as an explicit diamond before the changed-files check.
  2. Step 2's 3-rule slug-derivation chain (`--slug` → `--issue` → git-branch fallback) was collapsed into one opaque node — expanded into its own decision chain.
  3. Step 6's Check 6 (verdict-tamper reconciliation) and Check 7 (finding-tamper reconciliation) were dropped entirely — added as their own diamonds, both routing failures to the shared "Punch list not produced" terminal.
  4. Step 7's ordered gate priority chain (missing verdict → REJECT → all-SKIP → pass) was rendered as parallel branches off one `Any REJECT?` diamond, letting a reading agent evaluate REJECT before checking for a missing verdict — reversed the mandated precedence. Rebuilt as a strict sequential chain of three diamonds matching the prose's explicit ordering ("Apply gate in this order").

## Token budget trade-off (flagged, not resolved)

- Baseline (post-#3241, before this change): **4306 tokens** (`skilllint check --tokens-only`), under the `SK006`/`AS005` 4400-token warning threshold.
- After this fidelity rebuild: **4977 tokens** — `skilllint check` now reports `AS005`/`SK006` warnings ("consider splitting into sub-skills" / "move content to references/"). These are **warnings, not errors** (exit code 0; error threshold is 8800 tokens) and `prek` passes clean.
- I did not move the diagram to a `references/` file — the task scope was a straight in-place rebuild, and that remains an acceptable outcome per the assignment. If the token-budget warning is a concern, disclosing this diagram to a `references/dispatch-flow.md` file (reached by a context pointer from the "Dispatch Flow (Reference)" section) is a viable follow-up per this repo's progressive-disclosure convention — flagging the option here rather than deciding it unilaterally.

## Test plan

- [x] Both Mermaid diagrams in the file (the unchanged Step 2 slug-derivation flowchart and the rebuilt Dispatch Flow diagram) parse successfully via `mermaid.parse()` (v11.17.2, flowchart-v2 grammar) — verified with a local jsdom-backed Node script.
- [x] `uv run prek run --files plugins/development-harness/skills/multi-perspective-review/SKILL.md` — all hooks pass (markdownlint, skilllint auto-fix/validate, manifest auto-sync, conventional-commit).
- [x] `uvx skilllint@latest check plugins/development-harness/skills/multi-perspective-review/SKILL.md` — exit 0 (AS005/SK006 warnings only, both under the 8800-token error threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HM2E9C16VaPwEbHFE7FmFL