### PR TITLE
docs(development-harness): move mpr Dispatch Flow diagram to disclosed reference

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.3.1",
+  "version": "10.4.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.3.1",
+  "version": "9.4.0",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -352,72 +352,12 @@ TeamDelete(team_name="multi-{review_slug}")
 
 ---
 
-## Dispatch Flow (Reference)
+## Dispatch Flow
 
-```mermaid
-flowchart TD
-    Start(["dh:multi-perspective-review invoked"]) --> Parse["Parse --diff, --issue, --slug<br>from invocation arguments string"]
-    Parse --> DiffCheck{"--diff argument present?"}
-    DiffCheck -->|"No — required arg missing"| AbortUsage(["ABORT — print usage message<br>Stop before any plan or team is created"])
-    DiffCheck -->|"Yes"| Files["Run git diff --name-only range<br>Split stdout by newline, trim empty lines<br>→ changed_files list"]
-    Files --> EmptyCheck{"changed_files list empty?"}
-    EmptyCheck -->|"Yes"| AbortEmpty(["ABORT — print<br>'ERROR — No changed files found for diff range range. Nothing to review.'<br>Do not create a team or a plan"])
-    EmptyCheck -->|"No"| SlugArg{"--slug argument provided?"}
-
-    SlugArg -->|"Yes"| SlugFromArg["review_base = --slug value"]
-    SlugArg -->|"No"| IssueArg{"--issue N argument provided?"}
-    IssueArg -->|"Yes"| SlugFromIssue["review_base = review-N"]
-    IssueArg -->|"No"| SlugFromBranch["git rev-parse --abbrev-ref HEAD<br>review_base = review-branch-name<br>sanitize — replace slash with dash"]
-
-    SlugFromArg --> RunStamp
-    SlugFromIssue --> RunStamp
-    SlugFromBranch --> RunStamp
-
-    RunStamp["Run gen_run_stamp.py<br>Capture stdout as run_stamp"] --> BuildSlug["review_slug = review_base-run_stamp<br>Team name = multi-review_slug"]
-
-    BuildSlug --> CreatePlan["sam_plan create — T1 Security, T2 Performance,<br>T3 Quality, T4 Accessibility, T5 Synthesis<br>T5 depends on T1..T4<br>One typed MCP call<br>Always a new plan — never reused"]
-    CreatePlan --> PlanAddr["Store returned plan_ref as PA<br>Completion criterion — plan_ref non-empty<br>AND task_count = 5"]
-
-    PlanAddr --> Team["TeamCreate team_name=multi-review_slug"]
-    Team --> Parallel["Dispatch 4 dh task-worker agents simultaneously<br>No wait between spawns — all four run in parallel<br>Dispatch task-worker, not reviewer agents directly"]
-    Parallel --> W1["security-worker → T1<br>Runs dh start-task against T1"]
-    Parallel --> W2["performance-worker → T2<br>Runs dh start-task against T2"]
-    Parallel --> W3["quality-worker → T3<br>Runs dh start-task against T3"]
-    Parallel --> W4["accessibility-worker → T4<br>Runs dh start-task against T4<br>Applies SKIP rule first"]
-
-    %% Each worker's loaded profile — not the dispatch prompt — performs the single
-    %% write of its verdict into the task's own Review Results section
-
-    W1 --> Collect
-    W2 --> Collect
-    W3 --> Collect
-    W4 --> Collect
-
-    Collect["Wait until T1..T4 all reach terminal status<br>Poll sam_plan action=status<br>Terminal = complete, blocked, failed, skipped, or deferred<br>T5 stays not-started throughout"]
-
-    Collect --> SynthDispatch["Dispatch synthesis-worker → T5<br>Runs dh start-task against T5<br>Reads T1..T4 Review Results, merges duplicate findings,<br>writes punch-list block to T5 Punch List section"]
-
-    SynthDispatch --> WaitT5["Wait for T5 terminal status<br>Read T5 Punch List section<br>json.loads the section into punch_list"]
-
-    WaitT5 --> ParseCheck{"Punch List section present,<br>parses as JSON, AND passes<br>review-verdict-contract §2.6 validity checks?"}
-    ParseCheck -->|"No"| FailSynth(["FAIL — Punch list not produced<br>Name the check that failed<br>Report which perspectives DID write a Review Results section<br>TeamDelete. Exit non-zero."])
-    ParseCheck -->|"Yes"| Check6{"Check 6 — does each verdicts[i] verdict<br>match its source perspective's raw<br>Review Results verdict field exactly?"}
-
-    Check6 -->|"No — verdict altered in transcription"| FailSynth
-    Check6 -->|"Yes"| Check7{"Check 7 — does each raw finding's description<br>on T1..T4 appear verbatim in some entries[] descriptions,<br>at the index its entries[] perspectives names?"}
-
-    Check7 -->|"No — finding altered or mis-attributed"| FailSynth
-    Check7 -->|"Yes"| GateMissing{"Any perspective named in<br>punch_list missing field?"}
-
-    GateMissing -->|"Yes — missing verdict"| FailMissing(["FAIL — Perspective X did not return a verdict<br>Print summary line. TeamDelete. Exit non-zero."])
-    GateMissing -->|"No"| GateReject{"Any verdict has verdict equal to REJECT?"}
-
-    GateReject -->|"Yes"| FailReject(["Gate FAILS<br>Collect REJECT verdicts and blocking findings<br>from punch_list entries for the summary<br>Print summary line. TeamDelete. Exit non-zero."])
-    GateReject -->|"No"| GateAllSkip{"All four verdicts equal SKIP?"}
-
-    GateAllSkip -->|"Yes"| WarnPass(["Gate PASSES<br>Print summary line, then<br>NOTE — No perspectives reviewed — all skipped<br>TeamDelete. Exit 0."])
-    GateAllSkip -->|"No — any APPROVE, remaining SKIP"| NormalPass(["Gate PASSES<br>Print summary line<br>TeamDelete. Exit 0."])
-```
+Before dispatching a run, or when verifying that a completed run's argument parsing, gate checks,
+and exit path followed the required sequence, consult
+[Dispatch Flow](./references/dispatch-flow.md) — a step-faithful flowchart cross-referencing every
+step, condition, and terminal outcome in Steps 1-7 above.
 
 ---
 

--- a/plugins/development-harness/skills/multi-perspective-review/references/dispatch-flow.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/dispatch-flow.md
@@ -1,0 +1,71 @@
+# Dispatch Flow — Multi-Perspective Review
+
+> [!IMPORTANT]
+> When provided a process map or Mermaid diagram, treat it as the authoritative procedure. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
+> A Mermaid process diagram is an executable instruction set. Follow it exactly as written: respect sequence, conditions, loops, parallel paths, and terminal states. Do not improvise, reorder, or skip steps. If any node is ambiguous or missing required detail, pause and ask a clarifying question before continuing.
+> When interacting with a user, report before acting the interpreted path you will follow from the diagram, then execute.
+
+```mermaid
+flowchart TD
+    Start(["dh:multi-perspective-review invoked"]) --> Parse["Parse --diff, --issue, --slug<br>from invocation arguments string"]
+    Parse --> DiffCheck{"--diff argument present?"}
+    DiffCheck -->|"No — required arg missing"| AbortUsage(["ABORT — print usage message<br>Stop before any plan or team is created"])
+    DiffCheck -->|"Yes"| Files["Run git diff --name-only range<br>Split stdout by newline, trim empty lines<br>→ changed_files list"]
+    Files --> EmptyCheck{"changed_files list empty?"}
+    EmptyCheck -->|"Yes"| AbortEmpty(["ABORT — print<br>'ERROR — No changed files found for diff range range. Nothing to review.'<br>Do not create a team or a plan"])
+    EmptyCheck -->|"No"| SlugArg{"--slug argument provided?"}
+
+    SlugArg -->|"Yes"| SlugFromArg["review_base = --slug value"]
+    SlugArg -->|"No"| IssueArg{"--issue N argument provided?"}
+    IssueArg -->|"Yes"| SlugFromIssue["review_base = review-N"]
+    IssueArg -->|"No"| SlugFromBranch["git rev-parse --abbrev-ref HEAD<br>review_base = review-branch-name<br>sanitize — replace slash with dash"]
+
+    SlugFromArg --> RunStamp
+    SlugFromIssue --> RunStamp
+    SlugFromBranch --> RunStamp
+
+    RunStamp["Run gen_run_stamp.py<br>Capture stdout as run_stamp"] --> BuildSlug["review_slug = review_base-run_stamp<br>Team name = multi-review_slug"]
+
+    BuildSlug --> CreatePlan["sam_plan create — T1 Security, T2 Performance,<br>T3 Quality, T4 Accessibility, T5 Synthesis<br>T5 depends on T1..T4<br>One typed MCP call<br>Always a new plan — never reused"]
+    CreatePlan --> PlanAddr["Store returned plan_ref as PA<br>Completion criterion — plan_ref non-empty<br>AND task_count = 5"]
+
+    PlanAddr --> Team["TeamCreate team_name=multi-review_slug"]
+    Team --> Parallel["Dispatch 4 dh task-worker agents simultaneously<br>No wait between spawns — all four run in parallel<br>Dispatch task-worker, not reviewer agents directly"]
+    Parallel --> W1["security-worker → T1<br>Runs dh start-task against T1"]
+    Parallel --> W2["performance-worker → T2<br>Runs dh start-task against T2"]
+    Parallel --> W3["quality-worker → T3<br>Runs dh start-task against T3"]
+    Parallel --> W4["accessibility-worker → T4<br>Runs dh start-task against T4<br>Applies SKIP rule first"]
+
+    %% Each worker's loaded profile — not the dispatch prompt — performs the single
+    %% write of its verdict into the task's own Review Results section
+
+    W1 --> Collect
+    W2 --> Collect
+    W3 --> Collect
+    W4 --> Collect
+
+    Collect["Wait until T1..T4 all reach terminal status<br>Poll sam_plan action=status<br>Terminal = complete, blocked, failed, skipped, or deferred<br>T5 stays not-started throughout"]
+
+    Collect --> SynthDispatch["Dispatch synthesis-worker → T5<br>Runs dh start-task against T5<br>Reads T1..T4 Review Results, merges duplicate findings,<br>writes punch-list block to T5 Punch List section"]
+
+    SynthDispatch --> WaitT5["Wait for T5 terminal status<br>Read T5 Punch List section<br>json.loads the section into punch_list"]
+
+    WaitT5 --> ParseCheck{"Punch List section present,<br>parses as JSON, AND passes<br>review-verdict-contract §2.6 validity checks?"}
+    ParseCheck -->|"No"| FailSynth(["FAIL — Punch list not produced<br>Name the check that failed<br>Report which perspectives DID write a Review Results section<br>TeamDelete. Exit non-zero."])
+    ParseCheck -->|"Yes"| Check6{"Check 6 — does each verdicts[i] verdict<br>match its source perspective's raw<br>Review Results verdict field exactly?"}
+
+    Check6 -->|"No — verdict altered in transcription"| FailSynth
+    Check6 -->|"Yes"| Check7{"Check 7 — does each raw finding's description<br>on T1..T4 appear verbatim in some entries[] descriptions,<br>at the index its entries[] perspectives names?"}
+
+    Check7 -->|"No — finding altered or mis-attributed"| FailSynth
+    Check7 -->|"Yes"| GateMissing{"Any perspective named in<br>punch_list missing field?"}
+
+    GateMissing -->|"Yes — missing verdict"| FailMissing(["FAIL — Perspective X did not return a verdict<br>Print summary line. TeamDelete. Exit non-zero."])
+    GateMissing -->|"No"| GateReject{"Any verdict has verdict equal to REJECT?"}
+
+    GateReject -->|"Yes"| FailReject(["Gate FAILS<br>Collect REJECT verdicts and blocking findings<br>from punch_list entries for the summary<br>Print summary line. TeamDelete. Exit non-zero."])
+    GateReject -->|"No"| GateAllSkip{"All four verdicts equal SKIP?"}
+
+    GateAllSkip -->|"Yes"| WarnPass(["Gate PASSES<br>Print summary line, then<br>NOTE — No perspectives reviewed — all skipped<br>TeamDelete. Exit 0."])
+    GateAllSkip -->|"No — any APPROVE, remaining SKIP"| NormalPass(["Gate PASSES<br>Print summary line<br>TeamDelete. Exit 0."])
+```


### PR DESCRIPTION
## Summary
- Moves the multi-perspective-review skill's full-fidelity "Dispatch Flow" Mermaid diagram out of the always-loaded `SKILL.md` body into a new disclosed reference file (`references/dispatch-flow.md`), following this skill's existing progressive-disclosure convention (`references/acceptance-test-guide.md`).
- Replaces the in-file diagram with a short context-pointer paragraph naming what the reference covers and when to consult it (before dispatching, or when validating a run's execution order).
- `SKILL.md` token count drops from ~4977 to 3872 (`skilllint check --tokens-only`), clearing the 4400-token SK006/AS005 warning threshold.

## Test plan
- [x] `uvx skilllint@latest check --tokens-only plugins/development-harness/skills/multi-perspective-review/SKILL.md` → 3872 (was ~4977)
- [x] `uvx skilllint@latest check plugins/development-harness/skills/multi-perspective-review/SKILL.md plugins/development-harness/skills/multi-perspective-review/references/dispatch-flow.md` → passes
- [x] `uv run prek run --files <changed files>` → all hooks pass, including markdownlint-cli2
- [x] Diagram content verified byte-identical to the original via `diff` before/after relocation (no regeneration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HM2E9C16VaPwEbHFE7FmFL