### PR TITLE
fix(development-harness): match dispatch-flow diagram's abort text to Step 1

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.4.0",
+  "version": "10.4.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/skills/multi-perspective-review/references/dispatch-flow.md
+++ b/plugins/development-harness/skills/multi-perspective-review/references/dispatch-flow.md
@@ -12,7 +12,7 @@ flowchart TD
     DiffCheck -->|"No — required arg missing"| AbortUsage(["ABORT — print usage message<br>Stop before any plan or team is created"])
     DiffCheck -->|"Yes"| Files["Run git diff --name-only range<br>Split stdout by newline, trim empty lines<br>→ changed_files list"]
     Files --> EmptyCheck{"changed_files list empty?"}
-    EmptyCheck -->|"Yes"| AbortEmpty(["ABORT — print<br>'ERROR — No changed files found for diff range range. Nothing to review.'<br>Do not create a team or a plan"])
+    EmptyCheck -->|"Yes"| AbortEmpty(["ABORT — print<br>'ERROR: No changed files found for diff range &lt;git-range&gt;. Nothing to review.'<br>Do not create a team or a plan"])
     EmptyCheck -->|"No"| SlugArg{"--slug argument provided?"}
 
     SlugArg -->|"Yes"| SlugFromArg["review_base = --slug value"]


### PR DESCRIPTION
## Summary
Fixes a Codex finding on #3245 (thread PRRT_kwDOQGimCs6cqbbn, comment 3867903280): the relocated Dispatch Flow diagram's empty-diff abort message used `ERROR —` instead of `ERROR:` and a literal `range range` where the `<git-range>` placeholder belongs, diverging from Step 1's exact required output. Since the file's own admonition tells an agent to treat the diagram as authoritative, this could cause the wrong machine-facing error text to be emitted.

The bug predates #3245 — it was already present in the diagram body when it lived inline in `SKILL.md` (introduced in #3243's full-fidelity rebuild) and was carried over verbatim during the #3245 relocation, not introduced by it.

## Test plan
- [x] `uv run prek run --files <changed>` — passed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01HM2E9C16VaPwEbHFE7FmFL