### PR TITLE
fix(development-harness): add SendMessage completion report to impact-analyst

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.4.1",
+  "version": "10.4.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/agents/impact-analyst.md
+++ b/plugins/development-harness/agents/impact-analyst.md
@@ -385,6 +385,19 @@ SCOPE_EXPANSION: Found {N} systems not in original description — {brief summar
 IMPACT_RADIUS_COMPLETE: Written to item {selector}. Overall risk: {LOW|MEDIUM|HIGH}. Highest-risk: {top 2-3 systems}.
 ```
 
+## Reporting Completion to the Dispatcher
+
+The Impact Radius section above is for peer teammates (fact-checker, rtica-assessor) reading the
+backlog item — it does not reach whoever dispatched you. Separately, always send an explicit
+completion message to the dispatcher using `SendMessage`:
+
+```text
+SendMessage(to="team-lead", summary="Impact Radius written for {selector}", message="STATUS: DONE — Impact Radius section written to {selector}\nOverall risk: {LOW|MEDIUM|HIGH}\nHighest-risk: {top 2-3 systems}")
+```
+
+When not operating as a teammate (no team-lead present), end your response with the same
+`STATUS: DONE` block as your final output instead.
+
 **Update your agent memory** as you discover codebase structure, module dependency patterns, common consumer chains, frequently-affected configuration files, and recurring risk patterns. This builds up institutional knowledge across conversations. Write concise notes about what you found and where.
 
 Examples of what to record:


### PR DESCRIPTION
## Summary
- `impact-analyst.md` grants the `SendMessage` tool but never instructed the agent to notify its dispatcher on completion, unlike sibling agents `technical-researcher.md` and `fact-checker.md`, which both end with an explicit `STATUS: DONE` report.
- Observed failure: in a real grooming-swarm run, impact-analyst finished writing the Impact Radius section but the dispatching session received no completion notification for over three hours — only idle notifications — until the orchestrator manually re-read the backlog item.
- Adds a new "Reporting Completion to the Dispatcher" instruction directly after the existing `IMPACT_RADIUS_COMPLETE:` line in the "Publishing Findings to the Swarm" section. Keeps the existing `IMPACT_RADIUS_COMPLETE:` line (written into the backlog item for peer teammates fact-checker/rtica-assessor) and additionally instructs the agent to call `SendMessage(to="team-lead", ...)` with a `STATUS: DONE` message, matching the canonical pattern in `.claude/rules/agent-output-contracts.md`.
- Scope: this change touches only `plugins/development-harness/agents/impact-analyst.md` (plus the plugin manifest version auto-bump from the pre-commit hook).

Addresses backlog item #3248.

## Test plan
- [x] `uvx skilllint@latest check --fix plugins/development-harness/agents/impact-analyst.md` — exit 0 (pre-existing unrelated warnings only: description length SK004, token threshold AS005, external MCP server references AS008)
- [x] `uv run prek run --files plugins/development-harness/agents/impact-analyst.md` — all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HM2E9C16VaPwEbHFE7FmFL