### PR TITLE
fix(python3-development): point design stage_skills at python-cli-design-spec

### DIFF
--- a/plugins/python3-development/.claude-plugin/plugin.json
+++ b/plugins/python3-development/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "python3-development",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/python3-development/.codex-plugin/plugin.json
+++ b/plugins/python3-development/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python3-development",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "Python 3.11+ development workflows including CLI apps with Typer/Rich, script writing, test development, code review, linting troubleshooting, and pyproject.toml configuration. Provides TDD patterns, modern type hints, PEP 723 metadata, and solutions for common Python errors.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/python3-development/manifests/python3-cli/language-manifest.yaml
+++ b/plugins/python3-development/manifests/python3-cli/language-manifest.yaml
@@ -9,7 +9,7 @@ project_detection:
   required_dependencies: [typer]
 
 stage_skills:
-  design: [python3-design-cli]
+  design: [python3-development:python-cli-design-spec]
   implementation: [python3-implementation-cli]
 
 quality_gates:

--- a/plugins/python3-development/manifests/python3/language-manifest.yaml
+++ b/plugins/python3-development/manifests/python3/language-manifest.yaml
@@ -9,7 +9,7 @@ project_detection:
 
 stage_skills:
   discovery: [python3-discovery]
-  design: [python3-design]
+  design: [python3-development:python-cli-design-spec]
   planning-context-integration: [python3-implementation]
   planning-task-decomposition: [python3-planning-task-decomposition]
   implementation: [python3-implementation]


### PR DESCRIPTION
## Summary

- `stage_skills.design` in `plugins/python3-development/manifests/python3/language-manifest.yaml` and the sibling `manifests/python3-cli/language-manifest.yaml` named `python3-design` / `python3-design-cli` — neither exists as an agent or skill in any plugin. `profile_load(agent_name='python3-design')` fails with "not found in any plugin".
- Repointed both to `python3-development:python-cli-design-spec`, the plugin's actual CLI architecture-spec agent. Its description matches the design-stage role, and it's the same role `add-new-feature/SKILL.md` Phase 3 resolves via `profile_load` for design-spec dispatch. Verified `profile_load(agent_name='python3-development:python-cli-design-spec')` resolves successfully (a bare, unqualified `python-cli-design-spec` is ambiguous — it also exists in the `python-engineering` plugin).
- Filed #3255 for the remaining `stage_skills` entries in both manifests (`discovery`, `implementation`, `planning-task-decomposition`, `testing-forensic-review`, `testing-final-verification`) that also point at skill names with no matching skill under `plugins/python3-development/` — out of scope here since fixing those needs a design decision on which skill should own each stage, not a mechanical rename.

Fixes #3254

## Test plan

- [x] `mcp__plugin_dh_backlog__profile_load(agent_name='python3-development:python-cli-design-spec')` resolves successfully
- [x] Confirmed no test fixture reads these manifest files directly (tests use inline YAML fixtures with placeholder names, unaffected by this change)
- [x] `uv run prek run --files <changed>` passes (auto-sync bumped `plugins/python3-development/.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` versions, included in the commit)

Claude-Session: https://claude.ai/code/session_01HM2E9C16VaPwEbHFE7FmFL