### PR TITLE
fix(development-harness): isolate Codex MCP root context

### DIFF
--- a/docs/codex-mcp-runtime.md
+++ b/docs/codex-mcp-runtime.md
@@ -52,23 +52,57 @@ workspace/IDE hints, Codex `PWD`, then process-cwd discovery.
 
 ## Runtime Validation
 
-Validate a Codex plugin through a fresh local marketplace and a real Codex MCP
-call. Starting a script or reading a `SKILL.md` is not integration evidence.
+Validate through a fresh local marketplace and an interactive Codex MCP call.
+Starting a script, reading a `SKILL.md`, or a passing `codex exec` command is
+not integration evidence. Do not report an interactive call as passed until
+its rendered tool result and the server artifact below are both retained.
+
+Use one disposable directory for `CODEX_HOME`, the local marketplace copy,
+fixture artifacts, and a fresh tmux server. Start that server under `env -i`
+so it cannot inherit the orchestrating session. Give it an explicit complete
+`PATH`: include the directories containing `codex`, `uv`, `npx`, and every
+other command the selected MCP entries launch, plus the required system paths.
+For example:
 
 ```bash
-CODEX_HOME=/tmp/codex-plugin-test codex plugin marketplace add /path/to/repository
-CODEX_HOME=/tmp/codex-plugin-test codex plugin add plugin-name@marketplace-name
-CODEX_HOME=/tmp/codex-plugin-test codex exec -C /path/to/project \
-  "Use the installed plugin MCP tool named tool_name."
+TEST_ROOT=$(mktemp -d)
+TEST_PATH="$(dirname "$(command -v codex)"):$(dirname "$(command -v uv)"):$(dirname "$(command -v npx)"):/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+TMUX_SOCKET="codex-mcp-$RANDOM"
+
+env -i HOME="$TEST_ROOT/home" PATH="$TEST_PATH" TERM=xterm-256color TMPDIR="$TEST_ROOT/tmp" \
+  tmux -L "$TMUX_SOCKET" -f /dev/null start-server
+tmux -L "$TMUX_SOCKET" set-option -g default-shell /bin/sh
+tmux -L "$TMUX_SOCKET" set-option -g update-environment ''
+tmux -L "$TMUX_SOCKET" new-session -d -s codex-mcp /bin/sh
 ```
 
-Use a fresh `CODEX_HOME` for each check. The positive control must invoke a
-named read-only DH MCP tool from a Git project with `CODEX_THREAD_ID` absent;
-the marker in the dedicated configuration and forwarded `PWD` must still let
-the tool resolve the project. The negative control must use a separate,
-disposable package copy whose `.mcp.codex.json` omits `DH_CODEX_MCP`, or launch
-against an invalid `PWD`; the same project-dependent tool must fail to resolve
-the project. Do not modify the source package for either control.
+Copy the marketplace and plugin under test into `TEST_ROOT`, set
+`CODEX_HOME="$TEST_ROOT/home"`, and add/install that marketplace from the
+interactive shell. Do not reuse an installed plugin or an existing
+`CODEX_HOME`.
+
+Before testing DH, install a disposable fixture plugin whose named MCP tool
+writes its child `cwd` and forwarded `PWD` to `TEST_ROOT/fixture-mcp.json`,
+then returns the same values. Invoke that named tool in the interactive Codex
+session and capture the rendered result. The rendered result must match
+`fixture-mcp.json`; this is the canary that proves plugin-cache `cwd` and
+agent-project `PWD` reached the MCP process before DH results are interpreted.
+
+Run the DH controls as separate fresh interactive sessions, each forwarding a
+repository `PWD` and with `CODEX_THREAD_ID` absent:
+
+1. Positive: install the unmodified disposable package, whose dedicated MCP
+   configuration contains `DH_CODEX_MCP: "1"`. Invoke a named read-only tool
+   such as `backlog_list`; retain its rendered result and server logs.
+2. Negative: install a second disposable package copy after removing only
+   `DH_CODEX_MCP` from its dedicated MCP entries. The same project-dependent
+   tool must fail project-root resolution; retain the rendered error and logs.
+
+These controls exercise the marker contract. They do not prove that an
+arbitrary resumed Codex thread has the same launch state. Treat a new
+interactive session as the controlled integration check. If a resumed session
+has a handshake error, preserve its stderr/log evidence and compare it with a
+new session launched from the same repository before changing DH source.
 
 For direct protocol checks, load the `fastmcp-creator:fastmcp-client-cli` skill
 first. On this macOS host the isolated CLI command is:

--- a/docs/codex-mcp-runtime.md
+++ b/docs/codex-mcp-runtime.md
@@ -34,15 +34,17 @@ reliable two-root pattern for local marketplace plugins:
   "command": "uv",
   "args": ["run", "--script", "scripts/run_server.py"],
   "cwd": ".",
-  "env_vars": ["PWD", "CODEX_THREAD_ID"]
+  "env": { "DH_CODEX_MCP": "1" },
+  "env_vars": ["PWD"]
 }
 ```
 
 `cwd: "."` starts the server in the installed plugin bundle. `PWD` is the
 Codex agent project working directory when forwarded through `env_vars`.
-`CODEX_THREAD_ID` is a Codex marker: use it to ensure the server interprets
-`PWD` as the project root only in Codex. Validate `PWD` with GitPython before
-using it; it can name a directory that is not a Git repository.
+`DH_CODEX_MCP: "1"` is a launch-mode hint supplied by the dedicated Codex
+configuration, not provenance or authentication. Use it only to select the
+Codex `PWD` fallback, then validate `PWD` with GitPython before using it; it
+can name a directory that is not a Git repository.
 
 Keep explicit project overrides and existing host-specific project hints ahead
 of the Codex fallback. Development Harness uses this order: explicit override,
@@ -59,6 +61,14 @@ CODEX_HOME=/tmp/codex-plugin-test codex plugin add plugin-name@marketplace-name
 CODEX_HOME=/tmp/codex-plugin-test codex exec -C /path/to/project \
   "Use the installed plugin MCP tool named tool_name."
 ```
+
+Use a fresh `CODEX_HOME` for each check. The positive control must invoke a
+named read-only DH MCP tool from a Git project with `CODEX_THREAD_ID` absent;
+the marker in the dedicated configuration and forwarded `PWD` must still let
+the tool resolve the project. The negative control must use a separate,
+disposable package copy whose `.mcp.codex.json` omits `DH_CODEX_MCP`, or launch
+against an invalid `PWD`; the same project-dependent tool must fail to resolve
+the project. Do not modify the source package for either control.
 
 For direct protocol checks, load the `fastmcp-creator:fastmcp-client-cli` skill
 first. On this macOS host the isolated CLI command is:

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.4.2",
+  "version": "10.4.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -22,5 +22,5 @@
       "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human"
     ]
   },
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.codex.json"
 }

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.4.2",
+  "version": "9.4.3",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.mcp.codex.json
+++ b/plugins/development-harness/.mcp.codex.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "backlog": {
+      "command": "uv",
+      "args": ["run", "--script", "scripts/run_backlog_server.py"],
+      "cwd": ".",
+      "env": { "DH_CODEX_MCP": "1" },
+      "env_vars": ["PWD"]
+    },
+    "sam": {
+      "command": "uv",
+      "args": ["run", "--script", "scripts/run_sam_server.py"],
+      "cwd": ".",
+      "env": { "DH_CODEX_MCP": "1" },
+      "env_vars": ["PWD"]
+    }
+  }
+}

--- a/plugins/development-harness/.mcp.codex.json
+++ b/plugins/development-harness/.mcp.codex.json
@@ -13,6 +13,10 @@
       "cwd": ".",
       "env": { "DH_CODEX_MCP": "1" },
       "env_vars": ["PWD"]
+    },
+    "sequential_thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
     }
   }
 }

--- a/plugins/development-harness/dh_paths.py
+++ b/plugins/development-harness/dh_paths.py
@@ -29,7 +29,6 @@ plugin cache cwd, IDEs). Checked in order by :func:`infer_project_root` when
 
     DH_PROJECT_ROOT=/path/to/repo          # explicit override (any host)
     WORKSPACE_FOLDER_PATHS=["/path"]       # VS Code / Cursor (JSON array)
-    PWD=/path/to/repo                        # Codex MCP, with CODEX_THREAD_ID
     CURSOR_PROJECT_ROOT=/path/to/repo      # when the Cursor host sets it
     CLAUDE_PROJECT_DIR=/path/to/repo       # when the Claude Code host sets it
 
@@ -228,7 +227,7 @@ def _infer_from_codex_pwd() -> Path | None:
     Returns:
         Resolved Git root from PWD, or ``None`` outside Codex or without a repo.
     """
-    if not os.environ.get("CODEX_THREAD_ID"):
+    if os.environ.get("DH_CODEX_MCP") != "1":
         return None
     raw = os.environ.get("PWD", "").strip()
     if not raw:
@@ -288,7 +287,8 @@ def infer_project_root(cwd: Path | None = None) -> Path:
        that resolves as a git worktree.
     #. ``CURSOR_PROJECT_ROOT``, then ``CLAUDE_PROJECT_DIR`` — only if the host
        sets them (Cursor before Claude when both are present).
-    #. ``PWD`` — Codex agent cwd, only when ``CODEX_THREAD_ID`` is present.
+    #. Codex's forwarded ``PWD`` — only when ``DH_CODEX_MCP=1`` and *cwd* is
+       not explicit.
     #. Walk upward from *cwd* (default ``Path.cwd()``) for a ``.git`` entry,
        then resolve its Git common directory (preserves worktree semantics).
     #. Discover a Git repository from *cwd* itself.

--- a/plugins/development-harness/tests/test_dh_paths.py
+++ b/plugins/development-harness/tests/test_dh_paths.py
@@ -470,10 +470,9 @@ class TestInferProjectRoot:
 
         assert git_project_root() == repo
 
-    def test_infer_uses_codex_pwd_when_plugin_cwd_is_not_a_repository(
+    def test_infer_uses_codex_pwd_when_marker_and_git_pwd_are_present(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Codex MCP uses its forwarded agent PWD instead of the plugin cache cwd."""
         project = tmp_path / "project"
         plugin_cache = tmp_path / "plugin-cache"
         _init_repo(project)
@@ -482,13 +481,52 @@ class TestInferProjectRoot:
         monkeypatch.delenv("WORKSPACE_FOLDER_PATHS", raising=False)
         monkeypatch.delenv("CURSOR_PROJECT_ROOT", raising=False)
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
-        monkeypatch.setenv("CODEX_THREAD_ID", "codex-test-thread")
+        monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+        monkeypatch.setenv("DH_CODEX_MCP", "1")
         monkeypatch.setenv("PWD", str(project))
         monkeypatch.chdir(plugin_cache)
 
         assert infer_project_root() == project
 
-    def test_infer_ignores_codex_pwd_when_cwd_is_explicit(
+    def test_infer_ignores_pwd_with_codex_thread_id_without_codex_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        project = tmp_path / "project"
+        plugin_cache = tmp_path / "plugin-cache"
+        _init_repo(project)
+        plugin_cache.mkdir()
+        monkeypatch.delenv("DH_PROJECT_ROOT", raising=False)
+        monkeypatch.delenv("WORKSPACE_FOLDER_PATHS", raising=False)
+        monkeypatch.delenv("CURSOR_PROJECT_ROOT", raising=False)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setenv("CODEX_THREAD_ID", "thread-present")
+        monkeypatch.delenv("DH_CODEX_MCP", raising=False)
+        monkeypatch.setenv("PWD", str(project))
+        monkeypatch.chdir(plugin_cache)
+
+        with pytest.raises(RuntimeError, match="Could not resolve the git project root"):
+            infer_project_root()
+
+    def test_infer_ignores_marker_when_pwd_is_not_a_git_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        plugin_cache = tmp_path / "plugin-cache"
+        invalid_pwd = tmp_path / "not-a-repository"
+        plugin_cache.mkdir()
+        invalid_pwd.mkdir()
+        monkeypatch.delenv("DH_PROJECT_ROOT", raising=False)
+        monkeypatch.delenv("WORKSPACE_FOLDER_PATHS", raising=False)
+        monkeypatch.delenv("CURSOR_PROJECT_ROOT", raising=False)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+        monkeypatch.setenv("DH_CODEX_MCP", "1")
+        monkeypatch.setenv("PWD", str(invalid_pwd))
+        monkeypatch.chdir(plugin_cache)
+
+        with pytest.raises(RuntimeError, match="Could not resolve the git project root"):
+            infer_project_root()
+
+    def test_infer_ignores_marker_gated_pwd_when_cwd_is_explicit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The Codex PWD hint only applies to the no-arg (MCP) resolution path."""
@@ -500,7 +538,7 @@ class TestInferProjectRoot:
         monkeypatch.delenv("WORKSPACE_FOLDER_PATHS", raising=False)
         monkeypatch.delenv("CURSOR_PROJECT_ROOT", raising=False)
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
-        monkeypatch.setenv("CODEX_THREAD_ID", "codex-test-thread")
+        monkeypatch.setenv("DH_CODEX_MCP", "1")
         monkeypatch.setenv("PWD", str(pwd_repo))
 
         assert infer_project_root(cwd=explicit_repo) == explicit_repo

--- a/tests/test_sync_codex_plugin_manifests.py
+++ b/tests/test_sync_codex_plugin_manifests.py
@@ -175,6 +175,15 @@ def test_sync_preserves_explicit_codex_mcp_target_without_rewriting_it(tmp_path:
     assert dedicated_config.read_bytes() == before
 
 
+def test_development_harness_codex_mcp_config_includes_all_servers() -> None:
+    plugin_dir = Path(__file__).parents[1] / "plugins" / "development-harness"
+    claude_config = json.loads((plugin_dir / ".mcp.json").read_text(encoding="utf-8"))
+    codex_config = json.loads((plugin_dir / ".mcp.codex.json").read_text(encoding="utf-8"))
+
+    assert set(codex_config["mcpServers"]) == {"backlog", "sam", "sequential_thinking"}
+    assert codex_config["mcpServers"]["sequential_thinking"] == claude_config["mcpServers"]["sequential_thinking"]
+
+
 def test_sync_manifest_always_resyncs_derived_description_and_developer_fields(tmp_path: Path) -> None:
     """shortDescription/longDescription/developerName are pure derivations, never preserved stale.
 

--- a/tests/test_sync_codex_plugin_manifests.py
+++ b/tests/test_sync_codex_plugin_manifests.py
@@ -152,6 +152,29 @@ def test_sync_manifest_preserves_hand_curated_interface_fields_on_rerun(tmp_path
     assert changed is False
 
 
+def test_sync_preserves_explicit_codex_mcp_target_without_rewriting_it(tmp_path: Path) -> None:
+    plugin_dir = _build_plugin_dir(
+        tmp_path,
+        "widget-tools",
+        description="Widgets.",
+        mcp_servers={"widget-server": {"command": "uv", "args": ["run", "server.py"]}},
+    )
+    manifest_path = plugin_dir / ".codex-plugin" / "plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["mcpServers"] = "./.mcp.codex.json"
+    _write_json(manifest_path, manifest)
+    dedicated_config = plugin_dir / ".mcp.codex.json"
+    dedicated_config.write_text('{"mcpServers":{"dedicated":{"command":"uv"}}}\n', encoding="utf-8")
+    before = dedicated_config.read_bytes()
+
+    sync_module.sync_mcp_file(plugin_dir)
+    sync_module.sync_manifest(plugin_dir)
+
+    reread_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert reread_manifest["mcpServers"] == "./.mcp.codex.json"
+    assert dedicated_config.read_bytes() == before
+
+
 def test_sync_manifest_always_resyncs_derived_description_and_developer_fields(tmp_path: Path) -> None:
     """shortDescription/longDescription/developerName are pure derivations, never preserved stale.
 


### PR DESCRIPTION
Relates to #3252

## Summary
- Use a Codex-only MCP configuration that forwards project PWD and supplies a DH-owned launch marker.
- Resolve forwarded PWD only when that marker is present; remove the CODEX_THREAD_ID dependency.
- Preserve shared MCP behavior; plugin manifests receive the hook-required patch metadata bump.

## Validation
- Focused resolver and manifest-sync tests: 65 passed.
- Changed-file prek: passed.
- Independent diff review: passed.

## Runtime note
An isolated interactive Codex plugin-manager invocation was attempted, but the evaluator did not prove it loaded the task worktree package; its MCP startup result is therefore inconclusive and is not counted as validation.