### PR TITLE
fix(development-harness): fix dh-context-gathering's description/body contradiction

### DIFF
--- a/plugins/development-harness/agents/dh-context-gathering.md
+++ b/plugins/development-harness/agents/dh-context-gathering.md
@@ -1,6 +1,6 @@
 ---
 name: dh-context-gathering
-description: Use when creating a new task OR when starting/switching to a task that lacks a context manifest. ALWAYS provide the task file path so the agent can read it and update it directly with the context manifest. Skip if task file already contains "Context Manifest" section.
+description: Use when creating a new task OR when starting/switching to a task that lacks a context manifest. Provide the plan address (e.g. P{N}) so the agent can read it via sam_plan and write the context manifest back through the SAM update operation — never a task file path, and never a direct file edit. Skip if the plan's context field already contains a "Context Manifest" section.
 tools: Read, Grep, Glob, Bash, Write, Skill, SendMessage, mcp__plugin_dh_sam
 model: haiku
 color: cyan

--- a/plugins/development-harness/agents/dh-context-gathering.md
+++ b/plugins/development-harness/agents/dh-context-gathering.md
@@ -13,7 +13,7 @@ skills:
 
 ## CRITICAL CONTEXT: Why You've Been Invoked
 
-You are part of the feature development workflow. A task file has just been created and you've been given its path. Your job is to ensure the implementation has EVERYTHING needed to complete this task without errors.
+You are part of the feature development workflow. A plan has just been created and you've been given its address. Your job is to ensure the implementation has EVERYTHING needed to complete this task without errors.
 
 **The Stakes**: If you miss relevant context, the implementation WILL have problems. Bugs will occur. Features will break. Your context manifest must be so complete that someone could implement this task perfectly just by reading it.
 
@@ -213,9 +213,9 @@ After completing your work, return status using the subagent-contract format:
 
 ```text
 STATUS: DONE
-SUMMARY: Context manifest added to task file with comprehensive coverage of [feature/system area].
+SUMMARY: Context manifest added to plan with comprehensive coverage of [feature/system area].
 ARTIFACTS:
-  - Updated task file: [path to task file]
+  - Updated plan: [plan address]
   - Context sections added: [list of sections]
 RISKS:
   - [Any areas where context may be incomplete]
@@ -230,7 +230,7 @@ NOTES:
 STATUS: BLOCKED
 SUMMARY: Cannot generate context manifest because [reason].
 NEEDED:
-  - [Missing input - e.g., task file path not provided]
+  - [Missing input - e.g., plan address not provided]
   - [Missing information - e.g., architecture spec not found]
 SUGGESTED NEXT STEP:
   - [What the orchestrator should provide or do]


### PR DESCRIPTION
## Summary
- `dh-context-gathering`'s frontmatter `description` told a dispatching agent to hand over a task file path for direct file editing; its body explicitly forbids that (`FORBIDDEN from using the Edit or Write tool on any task file`) and reads/writes everything through `sam_plan`.
- `context-refinement.md` had the identical contradiction per #3141, but it was already fixed incidentally by #3166 (unrelated routing refactor) — this closes the other half of the issue.
- Scope limited to the two agents #3141 names; the issue notes other agents sharing this template may carry the same defect — not swept here.

Stacked on `docs/create-hypothesis-labeling` (#3259) since this branch was checked out from it; will need rebasing onto `main` directly once #3259 merges.

Fixes #3141

## Test plan
- [ ] Confirm `dh-context-gathering`'s description now matches its body's actual invocation contract (plan address, not file path)
- [ ] Confirm no other repo content depends on the old file-path description wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mvhWqFKxRUn3BeVBFCDQt