### PR TITLE
Cap pytest xdist workers at two

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,7 +431,7 @@ this file) was removed to avoid two files drifting out of sync.
 2. **Symlink issues on Windows**: Git symlinks (mode 120000) become plain files on Windows. The `repair-symlinks` pre-commit hook fixes this. Both `ruff` and `ty` have `extend-exclude` entries for symlinked directories.
 3. **Skip magic trailing comma**: Ruff config has `skip-magic-trailing-comma = true` — formatting differences around trailing commas are expected.
 4. **EXE003 ignored**: Scripts with `uv run --script` shebang pattern trigger EXE003 (intentionally suppressed).
-5. **pytest parallelism**: Tests run with `-n auto --dist loadgroup` (xdist). Tests marked with `@pytest.mark.xdist_group` run in same worker.
+5. **pytest parallelism**: Tests run with `-n 2 --dist loadgroup` (xdist): one controller plus two workers. Tests marked with `@pytest.mark.xdist_group` run in same worker.
 6. **No uv workspace**: plugin MCP servers are PEP 723 self-resolving scripts (inline `# /// script` deps are the runtime source of truth); root `pyproject.toml` dev-deps only mirror them for `ty`/`ruff`/IDE. No `[tool.uv.workspace]`, no per-plugin `uv.lock`.
 7. **Ignored planning context**: `plan/` and `.claude/backlog/` are ignored working context and excluded from markdownlint. Do not force-add either directory.
 8. **Skilllint hook**: The pre-commit hook runs `uvx skilllint@latest check --fix` on SKILL.md, plugin.json, agent, and command files.

--- a/plugins/fastmcp-creator/skills/fastmcp-creator/references/testing.md
+++ b/plugins/fastmcp-creator/skills/fastmcp-creator/references/testing.md
@@ -205,9 +205,9 @@ async def test_tool_schema():
 Commands:
 
 ```bash
-pytest --inline-snapshot=create        # populate empty snapshots
-pytest --inline-snapshot=fix           # update after intentional changes
-pytest --inline-snapshot=fix,create    # combined: create new and fix existing
+pytest -n 2 --inline-snapshot=create        # populate empty snapshots
+pytest -n 2 --inline-snapshot=fix           # update after intentional changes
+pytest -n 2 --inline-snapshot=fix,create    # combined: create new and fix existing
 ```
 
 For values that change between runs (timestamps, IDs, random data), use `dirty-equals` for flexible equality assertions:
@@ -375,12 +375,12 @@ async def test_tool(): ...
 ## Running Tests [18]
 
 ```bash
-uv run pytest                       # run all tests with the configured two workers
-uv run pytest -x                    # stop on first failure
-uv run pytest path/to/test.py       # run specific file
-uv run pytest -k "test_name"        # run tests matching pattern
-uv run pytest -m "not integration"  # exclude integration tests
-uv run pytest --cov=fastmcp         # run with coverage
+uv run pytest -n 2                       # run all tests in parallel
+uv run pytest -n 2 -x                    # stop on first failure
+uv run pytest -n 2 path/to/test.py       # run specific file
+uv run pytest -n 2 -k "test_name"        # run tests matching pattern
+uv run pytest -n 2 -m "not integration"  # exclude integration tests
+uv run pytest -n 2 --cov=fastmcp         # run with coverage
 ```
 
 ---

--- a/plugins/fastmcp-creator/skills/fastmcp-creator/references/testing.md
+++ b/plugins/fastmcp-creator/skills/fastmcp-creator/references/testing.md
@@ -375,8 +375,8 @@ async def test_tool(): ...
 ## Running Tests [18]
 
 ```bash
-uv run pytest -n auto               # run all tests in parallel
-uv run pytest -n auto -x            # stop on first failure
+uv run pytest                       # run all tests with the configured two workers
+uv run pytest -x                    # stop on first failure
 uv run pytest path/to/test.py       # run specific file
 uv run pytest -k "test_name"        # run tests matching pattern
 uv run pytest -m "not integration"  # exclude integration tests

--- a/plugins/fastmcp-creator/skills/fastmcp-python-tests/SKILL.md
+++ b/plugins/fastmcp-creator/skills/fastmcp-python-tests/SKILL.md
@@ -210,8 +210,8 @@ async def test_async_raises():
 ## Running Tests
 
 ```bash
-uv run pytest -n auto              # Run all tests in parallel
-uv run pytest -n auto -x           # Stop on first failure
+uv run pytest                      # Run all tests with the configured two workers
+uv run pytest -x                   # Stop on first failure
 uv run pytest path/to/test.py      # Run specific file
 uv run pytest -k "test_name"       # Run tests matching pattern
 uv run pytest -m "not integration" # Exclude integration tests

--- a/plugins/fastmcp-creator/skills/fastmcp-python-tests/SKILL.md
+++ b/plugins/fastmcp-creator/skills/fastmcp-python-tests/SKILL.md
@@ -129,8 +129,8 @@ def test_schema_generation():
 ```
 
 Commands:
-- `pytest --inline-snapshot=create` - populate empty snapshots
-- `pytest --inline-snapshot=fix` - update after intentional changes
+- `pytest -n 2 --inline-snapshot=create` - populate empty snapshots
+- `pytest -n 2 --inline-snapshot=fix` - update after intentional changes
 
 ## Fixtures
 
@@ -210,11 +210,11 @@ async def test_async_raises():
 ## Running Tests
 
 ```bash
-uv run pytest                      # Run all tests with the configured two workers
-uv run pytest -x                   # Stop on first failure
-uv run pytest path/to/test.py      # Run specific file
-uv run pytest -k "test_name"       # Run tests matching pattern
-uv run pytest -m "not integration" # Exclude integration tests
+uv run pytest -n 2                      # Run all tests in parallel
+uv run pytest -n 2 -x                   # Stop on first failure
+uv run pytest -n 2 path/to/test.py      # Run specific file
+uv run pytest -n 2 -k "test_name"       # Run tests matching pattern
+uv run pytest -n 2 -m "not integration" # Exclude integration tests
 ```
 
 ## Checklist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ addopts = [
     "--tb=short",
     "--import-mode=importlib",
     "-n",
-    "auto",
+    "2",
     "--dist",
     "loadgroup",
     "-m",


### PR DESCRIPTION
Caps the default pytest-xdist fan-out at two workers (one controller plus two workers per invocation), aligns repository and FastMCP guidance, and preserves loadgroup scheduling. Verification: focused pytest passed with two direct worker children observed.