### PR TITLE
fix(development-harness): stop the shared cache's pending-queue leaks and orphaned MCP processes

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.4.7",
+  "version": "10.4.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude/rules/hook-subprocess-invocation.md
+++ b/plugins/development-harness/.claude/rules/hook-subprocess-invocation.md
@@ -1,0 +1,47 @@
+---
+paths:
+- hooks/**
+- skills/implementation-manager/scripts/task_status_hook.py
+---
+
+# Hook Subprocess Invocation
+
+When writing or editing a hook script (anything registered in `hooks/hooks.json`) or any other
+high-frequency automated path that needs to call into the SAM/backlog backend:
+
+## Never call `fastmcp call` from here
+
+`fastmcp call` (documented in `AGENTS.md`'s FastMCP CLI section) is correct for manual
+verification and CI — a human or a CI job running it once does not care about a stranded
+process. It is **not** safe for a hook or any other path that runs frequently and
+unattended.
+
+Upstream `fastmcp`'s CLI `call` command builds its `StdioTransport` without
+`keep_alive=False`, so it inherits the library default `keep_alive=True`. That causes
+`connect_session()` to skip calling `disconnect()` when the call finishes — the only thing
+that triggers the MCP SDK's shutdown sequence (close stdin → wait → SIGTERM → SIGKILL on the
+process group). Cleanup is then left to asyncio's best-effort task-cancellation at
+interpreter exit, which loses the race whenever the server's stdin-reading thread is already
+blocked in an uninterruptible OS read — a non-daemon thread, so the process can never exit
+once that happens.
+
+This exact defect caused a real orphaned-process incident: `task_status_hook.py` used
+`fastmcp call` for its SAM state writes; each PostToolUse invocation made two sequential
+MCP round-trips measuring ~5.65s each (~11.3s total), exceeding Claude Code's own 10s
+PostToolUse hook timeout — so Claude Code SIGKILLed the hook before its own internal
+subprocess timeout could fire, and the hook's cleanup code never ran. Over time this
+accumulated 160+ zombie processes.
+
+## Use the plain CLI instead
+
+Call `sam_schema/cli.py` directly (via its PEP 723 sibling `scripts/run_sam_cli.py`, which
+resolves to the same cached uv environment as `run_sam_server.py`) instead of going through
+the MCP protocol. Both front-ends resolve through the same `get_config().backend` and
+delegate to the same `dh_core.operations` functions — the CLI is not a lesser-featured
+shortcut, it is the same backend-agnostic write path with a plain-subprocess front end
+instead of an MCP-over-stdio one. See `task_status_hook.py`'s `_call_sam_cli()` for the
+current pattern (measured ~1.29s per call, comfortably inside any hook timeout budget).
+
+Do not add a generic JSON-passthrough escape hatch to route around a missing CLI option —
+if an operation the CLI doesn't support yet is needed, add a typed option to the relevant
+`sam_schema/cli.py` subcommand instead.

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.4.7",
+  "version": "9.4.8",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.4.7",
+  "version": "6.4.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -85,9 +85,11 @@ MCP, CLI, skills, and agents use its logical protocols and do not select a secon
 
 Remote-capable providers privately compose `FileCache` for snapshots, stale reads, queued offline
 mutations, provider revisions, and artifact/plan continuity. Cache misses are unavailable data,
-not authoritative empty results; revision conflicts retain pending work. Beads, SQLite, and Memory
-use native storage directly: they never instantiate `FileCache`, read or write backlog YAML, or
-queue remote mutations.
+not authoritative empty results. A revision conflict stays pending and is retried until it either
+succeeds or a replay attempt determines it can never succeed, at which point it moves to a
+terminal, inspectable `rejected` state rather than being retried forever or silently dropped.
+Beads, SQLite, and Memory use native storage directly: they never instantiate `FileCache`, read or
+write backlog YAML, or queue remote mutations.
 
 Agents address plans and tasks logically (`P{id}/T{M}`) through `sam_plan`, `sam_task`, or the
 grouped DH CLI adapter. Physical paths, cache records, provider IDs, and wire formats are backend

--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -383,7 +383,9 @@ class _GitHubContentCache:
             cached = self.cached_content(mutation.write.reference)
             try:
                 record = self._provider._write_online_content(mutation.write, cached)
-            except (ContentConflictError, UnsupportedCapabilityError):
+            except (ContentConflictError, UnsupportedCapabilityError) as exc:
+                _log.warning("replay rejected %s: %s", mutation.write.reference.model_dump_json(), exc)
+                self._cache.reject_pending(mutation.write.reference, str(exc))
                 continue
             except (BacklogError, ContentUnavailableError, OSError):
                 break

--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -268,6 +268,16 @@ class _GitHubContentCache:
                         len(records),
                         len(records) - stored,
                     )
+                # Same reasoning as get_content(): replay_pending() above may have just
+                # rejected one of these exact references during this same call, and
+                # conflict_reason is only ever derived live from cache state.
+                state = self._cache._load_state()
+                records = [
+                    record.model_copy(
+                        update={"conflict_reason": self._cache._rejection_reason(state, record.reference)}
+                    )
+                    for record in records
+                ]
                 return records[query.offset : query.offset + query.limit]
         # A stored record's own `pending` field is never trusted (FileCache normalises it
         # to False on write) -- the durable mutation queue is the sole source of truth, so

--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -334,7 +334,15 @@ class _GitHubContentCache:
         except (BacklogError, ContentUnavailableError, OSError):
             return self._cache.get_content(reference, stale=True)
         self._cache.cache_content(record)
-        return record
+        # Route through FileCache.get_content() rather than returning `record`
+        # directly: replay_pending() above may have just rejected this exact
+        # reference's pending mutation during this same call, and conflict_reason
+        # is only ever derived live inside get_content() -- returning the raw
+        # provider record would silently drop that discovery. Look up by
+        # record.reference, not the queried reference -- a legacy-fallback read
+        # can return content under a different (normalized) reference than the
+        # one queried, and cache_content() stores it under record.reference.
+        return self._cache.get_content(record.reference)
 
     def put_content(self, request: ContentWrite) -> ContentRecord:
         """Write content, durably queueing it while GitHub is offline.

--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -385,7 +385,7 @@ class _GitHubContentCache:
                 record = self._provider._write_online_content(mutation.write, cached)
             except (ContentConflictError, UnsupportedCapabilityError) as exc:
                 _log.warning("replay rejected %s: %s", mutation.write.reference.model_dump_json(), exc)
-                self._cache.reject_pending(mutation.write.reference, str(exc))
+                self._cache.reject_pending(mutation.write.reference, mutation.idempotency_key, str(exc))
                 continue
             except (BacklogError, ContentUnavailableError, OSError):
                 break

--- a/plugins/development-harness/backlog_core/backends/github_content_migration.py
+++ b/plugins/development-harness/backlog_core/backends/github_content_migration.py
@@ -282,10 +282,21 @@ class _GitHubContentCache:
         # A stored record's own `pending` field is never trusted (FileCache normalises it
         # to False on write) -- the durable mutation queue is the sole source of truth, so
         # it is recomputed here the same way FileCache.get_content() derives it live.
+        # conflict_reason is likewise recomputed live rather than trusted from the stored
+        # record, for the same reason -- this fallback path builds records manually
+        # instead of routing through FileCache.get_content(), so it needs its own
+        # derivation to stay consistent with that method's live-derivation contract.
+        state = self._cache._load_state()
         pending_references = [mutation.write.reference for mutation in self._cache.pending_mutations()]
         records = [
-            record.model_copy(update={"stale": not online, "pending": record.reference in pending_references})
-            for record in self._cache._load_state().records
+            record.model_copy(
+                update={
+                    "stale": not online,
+                    "pending": record.reference in pending_references,
+                    "conflict_reason": self._cache._rejection_reason(state, record.reference),
+                }
+            )
+            for record in state.records
             if record.reference.kind == query.kind
             and not is_work_item_head_ref(record.reference)
             and (query.owner_reference is None or record.owner_reference == query.owner_reference)

--- a/plugins/development-harness/backlog_core/backends/github_work_items.py
+++ b/plugins/development-harness/backlog_core/backends/github_work_items.py
@@ -522,12 +522,14 @@ class _GitHubReconciliation:
                 mutation.idempotency_key
                 for mutation in pending_work_items
                 if mutation.item.metadata.issue in snapshot_by_reference
-                and mutation.item.title == snapshot_by_reference[mutation.item.metadata.issue].title
+                and mutation.item.metadata.issue not in set(plan.conflicted_references)
                 and mutation.item.metadata.issue not in failed_cache_references
                 and (patch_statuses.get(mutation.item.metadata.issue, "no_patch") in {"no_patch", "applied"})
             })
         pending_mutations = len(self._cache.pending_mutations()) + len(self._cache._pending_work_item_mutations())
-        return outcome.result.model_copy(update={"pending_mutations": pending_mutations})
+        return outcome.result.model_copy(
+            update={"pending_mutations": pending_mutations, "rejected_mutations": len(self._cache.rejected_mutations())}
+        )
 
     def load_records(
         self, pending_work_items: Sequence[_PendingWorkItemMutation] | None = None

--- a/plugins/development-harness/backlog_core/backends/github_work_items.py
+++ b/plugins/development-harness/backlog_core/backends/github_work_items.py
@@ -513,7 +513,7 @@ class _GitHubReconciliation:
             patch_statuses = {patch.reference: "pending" for patch in plan.provider_patches}
             patch_statuses.update({result.reference: result.status for result in patch_results})
             failed_cache_references = {
-                action.record.item.metadata.issue
+                action.reference
                 for action in plan.cache_actions
                 for result in cache_results
                 if (action.key, action.phase) == (result.key, result.phase) and result.status == "error"

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -22,6 +22,7 @@ from .file_cache_state import (
     _CacheStateStore,
     _PendingWorkItemMutation,
     _ProviderSnapshotCheckpoint,
+    _RejectedMutation,
 )
 from .models import BacklogItem, ContentRecord, ContentRef, ContentUnavailableError, ContentWrite, parse_issue_number
 from .yaml_io import load_item, load_item_text, save_item
@@ -175,25 +176,53 @@ class FileCache:
         """Return pending mutations in durable insertion order."""
         return list(self._load_state().pending)
 
+    def rejected_mutations(self) -> list[_RejectedMutation]:
+        """Return rejected mutations in durable insertion order."""
+        return list(self._load_state().rejected)
+
     def discard_pending(self, reference: ContentRef) -> None:
-        """Drop any queued mutation for a reference without touching cached content.
+        """Drop any queued or rejected mutation for a reference without touching cached content.
 
         Called after a direct online write for a reference lands successfully --
         that write already ran ahead of :meth:`pending_mutations` for the same
         reference (``put_content`` always calls ``replay_pending`` first), so a
         mutation still queued for it afterward is stale, superseded intent that
         must never be replayed against the fresher record it would land on top of.
-        No companion update to ``state.records`` is needed here: a stored record
-        never independently tracks pending status, so removing the queue entry
-        alone is sufficient -- the next :meth:`get_content` call derives
+        A rejected entry for the same reference is equally stale -- the newer
+        write supersedes whatever precondition previously failed. No companion
+        update to ``state.records`` is needed here: a stored record never
+        independently tracks pending status, so removing the queue entry alone
+        is sufficient -- the next :meth:`get_content` call derives
         ``pending=False`` from this queue's absence of an entry.
         """
 
         def discard(state: _CacheState) -> tuple[_CacheState, None]:
             remaining = [entry for entry in state.pending if entry.write.reference != reference]
-            return state.model_copy(update={"pending": remaining}), None
+            remaining_rejected = [entry for entry in state.rejected if entry.write.reference != reference]
+            return state.model_copy(update={"pending": remaining, "rejected": remaining_rejected}), None
 
         self._state.transaction(discard)
+
+    def reject_pending(self, reference: ContentRef, reason: str) -> None:
+        """Move the queued mutation for a reference out of ``pending`` into ``rejected``.
+
+        Called when a replay attempt fails with a precondition error that
+        retrying can never satisfy, so the mutation must stop occupying the
+        unbounded-retry pending queue while still being retained for inspection.
+        """
+
+        def reject(state: _CacheState) -> tuple[_CacheState, None]:
+            entry = next((item for item in state.pending if item.write.reference == reference), None)
+            if entry is None:
+                return state, None
+            remaining = [item for item in state.pending if item.write.reference != reference]
+            rejected = [
+                *(item for item in state.rejected if item.write.reference != reference),
+                _RejectedMutation(idempotency_key=entry.idempotency_key, write=entry.write, reason=reason),
+            ]
+            return state.model_copy(update={"pending": remaining, "rejected": rejected}), None
+
+        self._state.transaction(reject)
 
     def _queue_work_item(self, key: str, item: BacklogItem) -> _PendingWorkItemMutation:
         payload = json.dumps(item.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
@@ -218,6 +247,8 @@ class FileCache:
         return list(self._load_state().pending_work_items)
 
     def _acknowledge_work_items(self, idempotency_keys: set[str]) -> None:
+        if not idempotency_keys:
+            return
         self._state.transaction(
             lambda state: (
                 state.model_copy(
@@ -411,6 +442,10 @@ class FileCache:
         flag is ever independently trusted; every record written into
         ``state.records`` is normalised to ``pending=False`` on write
         (:meth:`cache_content`, :meth:`queue_write`, :meth:`acknowledge_replay`)
-        and this method recomputes the true value on every read.
+        and this method recomputes the true value on every read. A reference
+        moved to ``state.rejected`` by :meth:`reject_pending` is deliberately
+        *not* pending here -- once a mutation's precondition can never be
+        satisfied, a fresh online/legacy read is trusted again instead of
+        being shadowed by the stale queued content forever.
         """
         return any(entry.write.reference == reference for entry in state.pending)

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -165,8 +165,18 @@ class FileCache:
                     "stale": False,
                 }
             )
+            # A prior rejection for this reference is moot the moment new intent is
+            # queued for it -- mirrors discard_pending treating a rejected entry as
+            # stale once superseded, and stops it from outliving a later successful write.
+            rejected = [item for item in state.rejected if item.write.reference != write.reference]
             return (
-                state.model_copy(update={"records": self._replace_record(state.records, cached), "pending": pending}),
+                state.model_copy(
+                    update={
+                        "records": self._replace_record(state.records, cached),
+                        "pending": pending,
+                        "rejected": rejected,
+                    }
+                ),
                 mutation,
             )
 
@@ -203,19 +213,26 @@ class FileCache:
 
         self._state.transaction(discard)
 
-    def reject_pending(self, reference: ContentRef, reason: str) -> None:
-        """Move the queued mutation for a reference out of ``pending`` into ``rejected``.
+    def reject_pending(self, reference: ContentRef, idempotency_key: str, reason: str) -> None:
+        """Move the queued mutation matching ``idempotency_key`` out of ``pending`` into ``rejected``.
 
         Called when a replay attempt fails with a precondition error that
         retrying can never satisfy, so the mutation must stop occupying the
         unbounded-retry pending queue while still being retained for inspection.
+
+        Matches by ``idempotency_key`` rather than ``reference`` alone: a newer
+        ``queue_write`` call can replace the pending entry for a reference between
+        when a replay attempt started and when it failed, and rejecting by
+        reference alone would wrongly discard that newer, never-attempted
+        mutation. A no-op when no pending entry matches the key -- the mutation
+        that failed has already been superseded or otherwise handled.
         """
 
         def reject(state: _CacheState) -> tuple[_CacheState, None]:
-            entry = next((item for item in state.pending if item.write.reference == reference), None)
+            entry = next((item for item in state.pending if item.idempotency_key == idempotency_key), None)
             if entry is None:
                 return state, None
-            remaining = [item for item in state.pending if item.write.reference != reference]
+            remaining = [item for item in state.pending if item.idempotency_key != idempotency_key]
             rejected = [
                 *(item for item in state.rejected if item.write.reference != reference),
                 _RejectedMutation(idempotency_key=entry.idempotency_key, write=entry.write, reason=reason),

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -46,12 +46,22 @@ class FileCache:
         ``pending`` is derived live from the durable mutation queue
         (``state.pending``) rather than trusted from the stored record --
         that queue is the sole source of truth for whether a reference has
-        unreplayed intent. See :meth:`_is_pending`.
+        unreplayed intent. See :meth:`_is_pending`. ``conflict_reason`` is
+        likewise derived live from ``state.rejected`` -- this is the logical
+        API surface a caller (possibly a different call than the one whose
+        write was rejected) uses to discover a terminal replay conflict,
+        since :meth:`reject_pending` only logs a warning at replay time.
         """
         state = self._load_state()
         for record in state.records:
             if record.reference == reference:
-                return record.model_copy(update={"stale": stale, "pending": self._is_pending(state, reference)})
+                return record.model_copy(
+                    update={
+                        "stale": stale,
+                        "pending": self._is_pending(state, reference),
+                        "conflict_reason": self._rejection_reason(state, reference),
+                    }
+                )
         raise ContentUnavailableError(str(reference.model_dump(mode="json")))
 
     def cache_content(self, record: ContentRecord, *, acknowledge_pending: bool = False) -> None:
@@ -466,3 +476,15 @@ class FileCache:
         being shadowed by the stale queued content forever.
         """
         return any(entry.write.reference == reference for entry in state.pending)
+
+    @staticmethod
+    def _rejection_reason(state: _CacheState, reference: ContentRef) -> str:
+        """Return the reason a reference's mutation was terminally rejected, or "".
+
+        Mirrors :meth:`_is_pending`: ``state.rejected`` is the sole source of
+        truth, recomputed on every read rather than trusted from the stored
+        record, so a reference cleared of its rejection (:meth:`queue_write`)
+        stops surfacing a stale reason immediately.
+        """
+        entry = next((item for item in state.rejected if item.write.reference == reference), None)
+        return entry.reason if entry is not None else ""

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -61,6 +61,16 @@ class _PendingWorkItemMutation(BaseModel):
     item: BacklogItem
 
 
+class _RejectedMutation(BaseModel):
+    """Durable provider mutation whose precondition can never be satisfied by retrying."""
+
+    model_config = ConfigDict(frozen=True)
+
+    idempotency_key: str
+    write: ContentWrite
+    reason: str
+
+
 class ReplayAcknowledgement(BaseModel):
     """Applied provider mutation and its resulting checkpoint."""
 
@@ -77,6 +87,7 @@ class _CacheState(BaseModel):
     records: list[ContentRecord] = Field(default_factory=list)
     checkpoints: list[CacheCheckpoint] = Field(default_factory=list)
     pending: list[PendingMutation] = Field(default_factory=list)
+    rejected: list[_RejectedMutation] = Field(default_factory=list)
     pending_work_items: list[_PendingWorkItemMutation] = Field(default_factory=list)
     snapshot_checkpoint: _ProviderSnapshotCheckpoint | None = None
 

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -1313,6 +1313,7 @@ class ReconcileResult(BaseModel):
     stale: bool = False
     unavailable_references: list[str] = Field(default_factory=list)
     pending_mutations: int = 0
+    rejected_mutations: int = 0
 
 
 class Output(BaseModel):

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -1269,6 +1269,7 @@ class ContentRecord(BaseModel):
     revision: str = ""
     stale: bool = False
     pending: bool = False
+    conflict_reason: str = ""
 
 
 class ContentWrite(BaseModel):

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1174,7 +1174,8 @@ def _reconcile_groomed_item(item: BacklogItem, output: Output) -> None:
         return
     output.info(
         f"Reconciled {item.issue}: {result.provider_patches} provider patch(es), "
-        f"{result.pending_mutations} pending mutation(s), {result.failures} failure(s)."
+        f"{result.pending_mutations} pending mutation(s), {result.rejected_mutations} rejected mutation(s), "
+        f"{result.failures} failure(s)."
     )
 
 

--- a/plugins/development-harness/backlog_core/reconciliation.py
+++ b/plugins/development-harness/backlog_core/reconciliation.py
@@ -58,6 +58,7 @@ class ReconcilePlan(BaseModel):
     result: ReconcileResult = Field(default_factory=ReconcileResult)
     snapshot_checkpoint: str = ""
     dry_run: bool = False
+    conflicted_references: list[str] = Field(default_factory=list)
 
 
 class ActionResult(BaseModel):
@@ -144,6 +145,23 @@ def _checkpoint(item: BacklogItem, revision: str) -> BacklogItem:
     )
 
 
+def _merged_title(local: BacklogItem, remote: BacklogItem, baseline: str) -> str:
+    """Return the provider's title when local never edited it, else keep local's.
+
+    Substitutes ``local.title`` into the remote projection and checks whether
+    that hypothetical fingerprint reproduces ``baseline``. A match proves the
+    only thing distinguishing ``remote`` from ``baseline`` was its title, so
+    ``local`` never touched the title and the remote rename is safe to accept.
+    A remote-side change to any other field breaks the substitution even when
+    local's title is untouched -- that case falls back to ``local.title`` and
+    surfaces as a conflict instead of silently discarding the remote change.
+    """
+    if not baseline:
+        return local.title
+    probe = remote.model_copy(update={"title": local.title})
+    return remote.title if synchronized_fingerprint(probe) == baseline else local.title
+
+
 def _candidate(
     local: BacklogItem, provider: ProviderItem, request: ReconcileRequest
 ) -> tuple[BacklogItem, ProviderPatch | None]:
@@ -155,7 +173,8 @@ def _candidate(
     if request.force:
         candidate = remote
     elif local_changed and remote_changed:
-        candidate = _compose(local, provider, merge_item(local, remote_body), title=local.title)
+        merged_title = _merged_title(local, remote, baseline)
+        candidate = _compose(local, provider, merge_item(local, remote_body), title=merged_title)
     elif remote_changed:
         candidate = remote
     else:
@@ -214,6 +233,7 @@ def _plan_item(
             plan.provider_patches.append(patch)
         plan.result.conflicts += 1
         plan.result.changed_references.append(provider.reference)
+        plan.conflicted_references.append(provider.reference)
         if request.include_diff and patch is not None:
             plan.result.diffs[provider.reference] = (
                 f"{_normalized_body(provider.body)}\n---\n{_normalized_body(patch.body)}"

--- a/plugins/development-harness/backlog_core/reconciliation.py
+++ b/plugins/development-harness/backlog_core/reconciliation.py
@@ -48,6 +48,7 @@ class CacheAction(BaseModel):
     phase: Literal["before_provider", "checkpoint"] = "before_provider"
     record: LogicalCacheRecord
     requires_patch: str = ""
+    reference: str = ""
 
 
 class ReconcilePlan(BaseModel):
@@ -197,9 +198,15 @@ def _action(
     phase: Literal["before_provider", "checkpoint"] = "before_provider",
     requires_patch: str = "",
     kind: Literal["upsert", "unlink"] = "upsert",
+    reference: str = "",
 ) -> CacheAction:
     return CacheAction(
-        key=key, kind=kind, phase=phase, record=LogicalCacheRecord(key=key, item=item), requires_patch=requires_patch
+        key=key,
+        kind=kind,
+        phase=phase,
+        record=LogicalCacheRecord(key=key, item=item),
+        requires_patch=requires_patch,
+        reference=reference or item.metadata.issue,
     )
 
 
@@ -222,7 +229,7 @@ def _plan_item(
             sections=local.sections,
             metadata=metadata,
         )
-        plan.cache_actions.append(_action(record.key, unlinked, kind="unlink"))
+        plan.cache_actions.append(_action(record.key, unlinked, kind="unlink", reference=local.metadata.issue))
         plan.result.changed_references.append(provider.reference)
         return
     candidate, patch = _candidate(local, provider, request)

--- a/plugins/development-harness/docs/workflow-architecture-diagram.md
+++ b/plugins/development-harness/docs/workflow-architecture-diagram.md
@@ -310,7 +310,7 @@ Exit code 1 when: already claimed, task not found, or `status != not-started`.
 flowchart TD
     Created([Task created]) -->|"swarm-task-planner via `plan create`"| NS[not-started]
     NS -->|"start-task skill via sam_task claim<br>Guard: exit code 0 only<br>Fails if already claimed"| IP[in-progress]
-    IP -->|"task_status_hook.py SubagentStop<br>via sam_task(plan='{plan_address}', task='{task_address}', config={action:'state', status:'complete'})"| CO[complete]
+    IP -->|"task_status_hook.py SubagentStop<br>via sam plan state --address {plan_address}/{task_address} --new-status complete"| CO[complete]
     IP -->|"agent or human operator<br>via sam_task(plan='{plan_address}', task='{task_address}', config={action:'state', status:'blocked'})"| BL[blocked]
     IP -->|"agent or orchestrator<br>via sam_task(plan='{plan_address}', task='{task_address}', config={action:'state', status:'failed'})"| FA[failed]
     NS -->|"orchestrator<br>via sam_task(plan='{plan_address}', task='{task_address}', config={action:'state', status:'deferred'})"| DE[deferred]
@@ -402,11 +402,11 @@ Processing sequence:
 2. Parse prompt for `/start-task <path> --task <id>` or `Skill(skill="start-task", args="<path> --task <id>")` pattern.
 3. If no match, read the session-scoped active-task context.
 4. If still no match, exit 0 silently (not a `/start-task` sub-agent).
-5. Call `sam_task(plan="{plan_address}", task="{task_address}", config={"action":"state", "status":"complete"})` via the FastMCP CLI subprocess; on MCP failure, exit 0 (best-effort).
-6. Call `sam_task(plan="{plan_address}", task="{task_address}", config={"action":"update", "set_fields":{"completed": <ISO timestamp>}})` via the FastMCP CLI subprocess.
+5. Call `sam plan state --address {plan_address}/{task_address} --new-status complete` via the SAM CLI subprocess (`scripts/run_sam_cli.py`); on failure, exit 0 (best-effort).
+6. Call `sam plan update --plan-address {plan_address}/{task_address} --completed <ISO timestamp>` via the SAM CLI subprocess.
 7. Clear the session-scoped active-task context.
 
-Backend synchronization is the responsibility of the configured backend (see [Backend Providers](./backend-providers.md)) — not the hook. The hook is backend-agnostic and only routes status writes through the SAM MCP server.
+Backend synchronization is the responsibility of the configured backend (see [Backend Providers](./backend-providers.md)) — not the hook. The hook is backend-agnostic and only routes status writes through the provider-neutral SAM CLI.
 
 Fields written: `status: complete`, `completed: <ISO timestamp>`
 

--- a/plugins/development-harness/sam_schema/cli_inputs.py
+++ b/plugins/development-harness/sam_schema/cli_inputs.py
@@ -137,6 +137,12 @@ class TaskUpdateFields(_CliInput):
     is_bookend: bool | None = None
     bookend_type: BookendType | None = None
     github_issue: int | None = Field(default=None, ge=1)
+    completed: str | None = None
+    last_activity: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("last-activity", "last_activity"),
+        serialization_alias="last-activity",
+    )
 
     @model_validator(mode="after")
     def require_patch(self) -> TaskUpdateFields:

--- a/plugins/development-harness/sam_schema/cli_inputs.py
+++ b/plugins/development-harness/sam_schema/cli_inputs.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Annotated, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, StringConstraints, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, StringConstraints, field_validator, model_validator
 
 from sam_schema.core.action_models import AppendTaskConfig, CreatePlanConfig, TaskDefinition
 from sam_schema.core.models import (
@@ -143,6 +144,21 @@ class TaskUpdateFields(_CliInput):
         validation_alias=AliasChoices("last-activity", "last_activity"),
         serialization_alias="last-activity",
     )
+
+    @field_validator("completed", "last_activity")
+    @classmethod
+    def _validate_iso_datetime(cls, value: str | None) -> str | None:
+        """Reject non-ISO-8601 strings without converting the stored value.
+
+        Kept as ``str`` (not ``datetime``) because click's ``DateTime`` CLI
+        type rejects UTC-offset ISO-8601 strings; this only validates shape.
+
+        Returns:
+            The original string, unconverted.
+        """
+        if value is not None:
+            datetime.fromisoformat(value)
+        return value
 
     @model_validator(mode="after")
     def require_patch(self) -> TaskUpdateFields:

--- a/plugins/development-harness/sam_schema/core/task_backend_types.py
+++ b/plugins/development-harness/sam_schema/core/task_backend_types.py
@@ -191,7 +191,7 @@ class TaskFieldsUpdate(TypedDict, total=False):
     created: str | None
     started: str | None
     completed: str | None
-    last_activity: str | None
+    last_activity: Annotated[str | None, Field(validation_alias=AliasChoices("last-activity", "last_activity"))]
     body: str
     description: str
     objective: str

--- a/plugins/development-harness/sam_schema/sam_plan.py
+++ b/plugins/development-harness/sam_schema/sam_plan.py
@@ -321,6 +321,8 @@ def update(
     skill: Annotated[list[str] | None, typer.Option("--skill")] = None,
     append_section: Annotated[str | None, typer.Option("--append-section")] = None,
     section_content: Annotated[str | None, typer.Option("--section-content")] = None,
+    completed: Annotated[str | None, typer.Option("--completed")] = None,
+    last_activity: Annotated[str | None, typer.Option("--last-activity")] = None,
     plan_dir: Annotated[Path | None, typer.Option("--plan-dir")] = None,
 ) -> None:
     """Update declared plan/task fields or append a task section."""
@@ -344,7 +346,18 @@ def update(
             )
         try:
             has_task_fields = any(
-                value is not None for value in (title, task_status, agent, priority, complexity, dependency, skill)
+                value is not None
+                for value in (
+                    title,
+                    task_status,
+                    agent,
+                    priority,
+                    complexity,
+                    dependency,
+                    skill,
+                    completed,
+                    last_activity,
+                )
             )
             fields = (
                 TaskUpdateFields(
@@ -355,6 +368,8 @@ def update(
                     complexity=complexity,
                     dependencies=dependency,
                     skills=skill,
+                    completed=completed,
+                    last_activity=last_activity,
                 )
                 if has_task_fields
                 else None

--- a/plugins/development-harness/sam_schema/tests/test_backend_resolution_parity.py
+++ b/plugins/development-harness/sam_schema/tests/test_backend_resolution_parity.py
@@ -1,0 +1,66 @@
+"""Parity between the CLI and MCP backend-resolution seams.
+
+``sam_plan._backend()`` (CLI) and ``server._get_backend()`` (MCP) must resolve
+to the same underlying provider — a divergence here would mean the CLI and MCP
+server silently operate on different backlog state.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from backlog_core.backend_protocol import reset_config, set_config
+from backlog_core.backend_types import BacklogConfig
+from backlog_core.backends.bd_runner import BdRunner
+from backlog_core.backends.beads_backend import BeadsBackend
+from backlog_core.backends.memory_backend import InMemoryBackend
+
+import sam_schema.sam_plan as sam_plan
+import sam_schema.server as server
+from sam_schema.core.backends.content import ContentTaskProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend_config() -> Generator[None, None, None]:
+    # Reset before too: the beads test relies on get_config() being uninitialised
+    # so BACKLOG_BACKEND is actually consulted. Under the full suite, an earlier
+    # test elsewhere can leave the module-level _active_config singleton cached
+    # (e.g. to a real GitHubBackend), which would otherwise short-circuit env
+    # resolution here and trigger a real (sandbox-blocked) network call.
+    reset_config()
+    yield
+    reset_config()
+
+
+def test_cli_and_mcp_backend_resolution_match_default() -> None:
+    backend = InMemoryBackend()
+    set_config(BacklogConfig(backend=backend))
+
+    cli_provider = sam_plan._backend()
+    mcp_provider = server._get_backend("")
+
+    assert isinstance(cli_provider, ContentTaskProvider)
+    assert isinstance(mcp_provider, ContentTaskProvider)
+    assert cli_provider._provider is backend
+    assert mcp_provider._provider is backend
+
+
+def test_cli_and_mcp_backend_resolution_match_beads(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_runner = MagicMock(spec=BdRunner)
+    mock_runner.run_json.return_value = {}
+    monkeypatch.setattr("backlog_core.backends.beads_backend.BdRunner", lambda: mock_runner)
+    monkeypatch.setenv("BACKLOG_BACKEND", "beads")
+
+    cli_provider = sam_plan._backend()
+    mcp_provider = server._get_backend("")
+
+    assert isinstance(cli_provider, ContentTaskProvider)
+    assert isinstance(mcp_provider, ContentTaskProvider)
+    assert isinstance(cli_provider._provider, BeadsBackend)
+    # Same cached BacklogConfig singleton backs both seams.
+    assert cli_provider._provider is mcp_provider._provider

--- a/plugins/development-harness/sam_schema/tests/test_cli_inputs.py
+++ b/plugins/development-harness/sam_schema/tests/test_cli_inputs.py
@@ -57,3 +57,24 @@ def test_update_adapters_reject_incomplete_sections_and_empty_patches() -> None:
         )
     with pytest.raises(ValidationError, match="at least one plan update field"):
         PlanUpdateInput(plan_address="P1")
+
+
+def test_completed_and_last_activity_reject_non_iso_datetime_strings() -> None:
+    """`completed`/`last-activity` are deliberately `str` fields (click's DateTime type
+    rejects UTC-offset ISO-8601 strings), but that must not mean any string is accepted.
+    """
+    with pytest.raises(ValidationError):
+        TaskUpdateFields(completed="not-a-date")
+    with pytest.raises(ValidationError):
+        TaskUpdateFields(last_activity="not-a-date")
+
+
+def test_completed_and_last_activity_accept_iso_datetime_strings_and_stay_strings() -> None:
+    """Naive and UTC-offset ISO-8601 strings are both valid and round-trip as strings, not datetimes."""
+    naive = TaskUpdateFields(completed="2026-08-29T12:00:00")
+    offset = TaskUpdateFields(last_activity="2026-08-29T12:00:00+00:00")
+
+    assert naive.as_operation_fields() == {"completed": "2026-08-29T12:00:00"}
+    assert isinstance(naive.completed, str)
+    assert offset.as_operation_fields() == {"last-activity": "2026-08-29T12:00:00+00:00"}
+    assert isinstance(offset.last_activity, str)

--- a/plugins/development-harness/scripts/run_bounded.py
+++ b/plugins/development-harness/scripts/run_bounded.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Run one command with a timeout and terminate its process group on expiry.
+
+Vendored copy of ``scripts/run_bounded.py`` at the repository root. Plugin
+runtime code (hooks) cannot import from the repository root: a marketplace
+install ships only ``plugins/development-harness``, not sibling repo-root
+directories. Keep this in sync with the repository-root original by hand --
+there is no automated sync for this file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import shutil
+import signal
+import subprocess
+import sys
+from typing import Any
+
+TIMEOUT_EXIT_CODE = 124
+TERMINATION_GRACE_SECONDS = 0.5
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser.
+
+    Returns:
+        A configured parser accepting ``--timeout-seconds`` and the trailing command.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=5.0,
+        help="Maximum command duration before process-tree termination. Default: 5.",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def terminate_windows_process_tree(pid: int) -> None:
+    """Terminate a Windows process and all of its descendants.
+
+    Args:
+        pid: Process ID of the tree's root process.
+    """
+    taskkill = shutil.which("taskkill") or "taskkill"
+    subprocess.run([taskkill, "/PID", str(pid), "/T", "/F"], check=False)
+
+
+def process_group_is_alive(pgid: int) -> bool:
+    """Probe whether any process remains in the given process group.
+
+    Args:
+        pgid: Process group ID to probe, typically the group leader's PID.
+
+    Returns:
+        ``True`` if at least one process in the group is still alive.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def terminate_process_tree(process: subprocess.Popen[Any]) -> None:
+    """Terminate the isolated process group, escalating after a short grace period."""
+    if os.name != "posix":
+        terminate_windows_process_tree(process.pid)
+        return
+
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=TERMINATION_GRACE_SECONDS)
+
+    # The leader's wait() can return before its descendants exit — a descendant
+    # that ignores SIGTERM keeps the process group alive after the leader is
+    # reaped. Probe the group itself rather than trusting the leader's status.
+    if not process_group_is_alive(process.pid):
+        return
+
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    process.wait()
+
+
+def run_command(command: list[str], timeout_seconds: float) -> int:
+    """Run a command and return its exit status, or 124 after a timeout.
+
+    Args:
+        command: Argv of the command to run.
+        timeout_seconds: Maximum duration before the process tree is terminated.
+
+    Returns:
+        The command's exit status, or ``TIMEOUT_EXIT_CODE`` if it was terminated.
+
+    Raises:
+        ValueError: If ``timeout_seconds`` is not positive or ``command`` is empty.
+    """
+    if timeout_seconds <= 0:
+        raise ValueError("--timeout-seconds must be greater than zero")
+    if not command:
+        raise ValueError("A command is required after --")
+
+    process = subprocess.Popen(command, start_new_session=os.name == "posix")
+    try:
+        return process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        terminate_process_tree(process)
+        print(f"timed out after {timeout_seconds:g} seconds", file=sys.stderr)
+        return TIMEOUT_EXIT_CODE
+
+
+def main() -> int:
+    """Run the parsed command within the selected timeout.
+
+    Returns:
+        The wrapped command's exit status, ``TIMEOUT_EXIT_CODE`` on timeout, or ``2``
+        on an invalid invocation.
+    """
+    args = create_parser().parse_args()
+    try:
+        command = args.command[1:] if args.command[:1] == ["--"] else args.command
+        return run_command(command, args.timeout_seconds)
+    except (OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -298,7 +298,7 @@ Skip this gate when `autonomy_mode` is `"full_auto"` or `"per_task"`.
 Note: under `"per_task"`, per-task gates already fire for each task; no additional wave gate is needed.
 
 > **Hook behavior on SubagentStop**: When a sub-agent finishes, `task_status_hook.py` marks
-> the task complete via the SAM MCP server (backend-agnostic). After updating the SAM state,
+> the task complete via the SAM CLI (backend-agnostic). After updating the SAM state,
 > the hook syncs completion to the external tracker (if `parent_issue_number` is set in the
 > active-task context). External tracker sync failure does not affect the hook exit code.
 > `parent_issue_number` accepts `str | int` — GitHub integer IDs and beads string IDs are

--- a/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
+++ b/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
@@ -13,8 +13,8 @@ This hook script handles multiple hook events:
 - SubagentStop: Parse prompt for task info, set status to COMPLETE, add Completed timestamp
 - PostToolUse (Write|Edit|Bash): Update LastActivity timestamp using context file
 
-All task state WRITES route through the SAM MCP server via fastmcp CLI subprocess,
-making the hook backend-agnostic (hooks must not write directly to YAML).
+All task state WRITES route through the SAM CLI (scripts/run_sam_cli.py) as a single
+subprocess, making the hook backend-agnostic (hooks must not write directly to YAML).
 
 Context File Mechanism:
 - The /start-task command writes task context to ~/.dh/projects/{slug}/context/active-task-{session_id}.json
@@ -49,7 +49,7 @@ _DH_PLUGIN_DIR = Path(__file__).resolve().parents[3]
 if str(_DH_PLUGIN_DIR) not in sys.path:
     sys.path.insert(0, str(_DH_PLUGIN_DIR))
 
-_SAM_RUN_SERVER_PATH = _DH_PLUGIN_DIR / "scripts" / "run_sam_server.py"
+_SAM_CLI_PATH = _DH_PLUGIN_DIR / "scripts" / "run_sam_cli.py"
 
 import dh_paths as _dh_paths
 
@@ -153,7 +153,7 @@ def run_strict_pre_completion_checks(task: SamTask, task_id: str) -> list[str]:
     Warnings are observational — they do not prevent task completion.
 
     Args:
-        task: The already-loaded SamTask object (avoids a second MCP round-trip).
+        task: The already-loaded SamTask object (avoids a second SAM CLI subprocess call).
         task_id: Task ID being completed (used in warning messages).
 
     Returns:
@@ -336,7 +336,7 @@ def read_task_context(cwd: Path, session_id: str) -> tuple[str | None, str | Non
 
 
 def _call_sam_active_task_get(session_id: str, timeout: int = 10) -> tuple[str | None, str | None, str | int | None]:
-    """Retrieve active task context via fastmcp CLI call to sam_active_task(action='get').
+    """Retrieve active task context via the SAM CLI's ``active-task get`` subcommand.
 
     Primary retrieval path for SubagentStop. Returns parsed fields from the
     ``ActiveTaskContext`` on success, or ``(None, None, None)`` if the call fails
@@ -352,16 +352,12 @@ def _call_sam_active_task_get(session_id: str, timeout: int = 10) -> tuple[str |
         All ``None`` when the call fails or active task is not set.
     """
     resolved = session_id or "_default"
-    stdout = _call_sam_fastmcp(
-        {"config": {"action": "get"}, "session_id": resolved}, timeout=timeout, target="sam_active_task"
-    )
+    stdout = _call_sam_cli(["active-task", "get", "--session-id", resolved], timeout=timeout)
     if stdout is None:
         return None, None, None
 
     try:
-        outer = json.loads(stdout)
-        text = outer["content"][0]["text"]
-        data: dict[str, Any] = json.loads(text)
+        data: dict[str, Any] = json.loads(stdout)
         active = data.get("active_task")
         if not active:
             return None, None, None
@@ -385,7 +381,7 @@ def _call_sam_active_task_get(session_id: str, timeout: int = 10) -> tuple[str |
 
 
 def _call_sam_active_task_clear(session_id: str, timeout: int = 10) -> bool:
-    """Clear active task context via fastmcp CLI call to sam_active_task(action='clear').
+    """Clear active task context via the SAM CLI's ``active-task clear`` subcommand.
 
     Best-effort cleanup after SubagentStop completes. Never raises.
 
@@ -398,9 +394,7 @@ def _call_sam_active_task_clear(session_id: str, timeout: int = 10) -> bool:
         ``True`` if the active task was successfully cleared, ``False`` otherwise.
     """
     resolved = session_id or "_default"
-    stdout = _call_sam_fastmcp(
-        {"config": {"action": "clear"}, "session_id": resolved}, timeout=timeout, target="sam_active_task"
-    )
+    stdout = _call_sam_cli(["active-task", "clear", "--session-id", resolved], timeout=timeout)
     return stdout is not None
 
 
@@ -413,47 +407,32 @@ def _get_uv_executable() -> str | None:
     return shutil.which("uv")
 
 
-def _call_sam_fastmcp(input_data: dict[str, Any], timeout: int = 15, target: str = "sam_task") -> str | None:
-    """Execute a fastmcp call against the SAM server and return raw stdout.
+def _call_sam_cli(args: list[str], timeout: int = 15) -> str | None:
+    """Execute the SAM CLI as a subprocess and return raw stdout.
 
-    Handles uv resolution, environment setup, subprocess execution, and
-    common failure modes. Callers are responsible for JSON parsing and
-    context-specific error logging.
+    Handles uv resolution, subprocess execution, and common failure modes.
+    Callers are responsible for JSON parsing and context-specific error
+    logging.
 
     Args:
-        input_data: Dict to serialise as the ``--input-json`` argument.
+        args: Subcommand and options to pass to the SAM CLI (e.g.
+            ``["plan", "read", "--address", "P1/T1"]``).
         timeout: Subprocess timeout in seconds.
-        target: MCP tool name to invoke on the SAM server (e.g. ``"sam_task"``
-            or ``"sam_active_task"``). Defaults to ``"sam_task"``.
 
     Returns:
         Raw stdout string on success, None on any failure (uv missing,
-        server script missing, subprocess error, timeout, non-zero exit).
+        CLI script missing, subprocess error, timeout, non-zero exit).
     """
     uv = _get_uv_executable()
-    if uv is None or not _SAM_RUN_SERVER_PATH.exists():
+    if uv is None or not _SAM_CLI_PATH.exists():
         return None
 
-    env = {**os.environ, "FASTMCP_SHOW_SERVER_BANNER": "false", "FASTMCP_LOG_ENABLED": "false"}
     try:
         result = subprocess.run(
-            [
-                uv,
-                "run",
-                "fastmcp",
-                "call",
-                "--command",
-                f"uv run --script {_SAM_RUN_SERVER_PATH}",
-                "--target",
-                target,
-                "--input-json",
-                json.dumps(input_data),
-                "--json",
-            ],
+            [uv, "run", "--script", str(_SAM_CLI_PATH), *args],
             capture_output=True,
             text=True,
             timeout=timeout,
-            env=env,
             check=False,
         )
     except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError):
@@ -461,17 +440,17 @@ def _call_sam_fastmcp(input_data: dict[str, Any], timeout: int = 15, target: str
 
     if result.returncode != 0:
         if result.stderr:
-            print(f"[hook] fastmcp {target} failed: {result.stderr.strip()}", file=sys.stderr)
+            print(f"[hook] sam CLI {args[0] if args else ''} failed: {result.stderr.strip()}", file=sys.stderr)
         return None
 
     return result.stdout
 
 
 def _call_sam_task_state(plan_addr: str, task_id: str, status: SamTaskStatus, timeout: int = 15) -> bool:
-    """Update task status via fastmcp CLI call to sam_task(action='state').
+    """Update task status via the SAM CLI's ``plan state`` subcommand.
 
-    Routes state writes through the SAM MCP server, keeping the hook
-    backend-agnostic. The server handles downstream skip cascades when
+    Routes state writes through the SAM CLI, keeping the hook
+    backend-agnostic. The CLI handles downstream skip cascades when
     ``status="failed"``.
 
     Args:
@@ -481,52 +460,61 @@ def _call_sam_task_state(plan_addr: str, task_id: str, status: SamTaskStatus, ti
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        ``True`` if the MCP call succeeded, ``False`` on any failure.
+        ``True`` if the CLI call succeeded, ``False`` on any failure.
     """
-    stdout = _call_sam_fastmcp(
-        {"plan": plan_addr, "task": task_id, "config": {"action": "state", "status": status}}, timeout=timeout
+    stdout = _call_sam_cli(
+        ["plan", "state", "--address", f"{plan_addr}/{task_id}", "--new-status", str(status)], timeout=timeout
     )
     if stdout is None:
         print(f"[hook] sam_task state={status} failed for {plan_addr}/{task_id}", file=sys.stderr)
         return False
 
     try:
-        outer = json.loads(stdout)
-        json.loads(outer["content"][0]["text"])
-    except (json.JSONDecodeError, KeyError, IndexError):
+        json.loads(stdout)
+    except json.JSONDecodeError:
         print(f"[hook] sam_task state: unexpected response for {plan_addr}/{task_id}", file=sys.stderr)
         return False
 
     return True
 
 
-def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, Any], timeout: int = 15) -> bool:
-    """Update task fields via fastmcp CLI call to sam_task(action='update').
+_UPDATE_FIELD_OPTIONS: dict[str, str] = {"completed": "--completed", "last-activity": "--last-activity"}
 
-    Routes field writes through the SAM MCP server, keeping the hook
-    backend-agnostic.
+
+def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, Any], timeout: int = 15) -> bool:
+    """Update task fields via the SAM CLI's ``plan update`` subcommand.
+
+    Only fields with a mapped CLI option are supported (a typed allowlist,
+    not a generic JSON passthrough). An unmapped field fails closed without
+    invoking the CLI at all.
 
     Args:
         plan_addr: Plan address (e.g. ``"Pf4281187"``).
         task_id: Task ID within the plan (e.g. ``"T1"``).
-        set_fields: Field name/value pairs to patch on the task.
+        set_fields: Field name/value pairs to patch on the task. Keys must
+            be one of ``_UPDATE_FIELD_OPTIONS``.
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        ``True`` if the MCP call succeeded, ``False`` on any failure.
+        ``True`` if the CLI call succeeded, ``False`` on any failure or
+        unmapped field.
     """
-    stdout = _call_sam_fastmcp(
-        {"plan": plan_addr, "task": task_id, "config": {"action": "update", "set_fields_json": set_fields}},
-        timeout=timeout,
-    )
+    options: list[str] = []
+    for key, value in set_fields.items():
+        option = _UPDATE_FIELD_OPTIONS.get(key)
+        if option is None:
+            print(f"[hook] sam_task update: unsupported field {key!r} for {plan_addr}/{task_id}", file=sys.stderr)
+            return False
+        options.extend([option, str(value)])
+
+    stdout = _call_sam_cli(["plan", "update", "--plan-address", f"{plan_addr}/{task_id}", *options], timeout=timeout)
     if stdout is None:
         print(f"[hook] sam_task update failed for {plan_addr}/{task_id}", file=sys.stderr)
         return False
 
     try:
-        outer = json.loads(stdout)
-        json.loads(outer["content"][0]["text"])
-    except (json.JSONDecodeError, KeyError, IndexError):
+        json.loads(stdout)
+    except json.JSONDecodeError:
         print(f"[hook] sam_task update: unexpected response for {plan_addr}/{task_id}", file=sys.stderr)
         return False
 
@@ -534,9 +522,9 @@ def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, An
 
 
 def _call_sam_task_read(plan_id: str, task_id: str, timeout: int = 15) -> SamTask | None:
-    """Read a task via fastmcp CLI call to sam_task(action='read').
+    """Read a task via the SAM CLI's ``plan read`` subcommand.
 
-    Routes task reads through the SAM MCP server, keeping the hook backend-agnostic.
+    Routes task reads through the SAM CLI, keeping the hook backend-agnostic.
     Returns the parsed Task object on success, None on any failure.
 
     Args:
@@ -547,39 +535,35 @@ def _call_sam_task_read(plan_id: str, task_id: str, timeout: int = 15) -> SamTas
     Returns:
         The parsed ``SamTask`` on success, ``None`` on any failure.
     """
-    stdout = _call_sam_fastmcp({"plan": plan_id, "task": task_id, "config": {"action": "read"}}, timeout=timeout)
+    stdout = _call_sam_cli(["plan", "read", "--address", f"{plan_id}/{task_id}"], timeout=timeout)
     if stdout is None:
         return None
 
     try:
-        outer = json.loads(stdout)
-        text = outer["content"][0]["text"]
-        data: dict[str, Any] = json.loads(text)
+        data: dict[str, Any] = json.loads(stdout)
         task_data = data.get("task")
-        if not task_data:
-            return None
-        return SamTask.model_validate(task_data)
-    except (json.JSONDecodeError, KeyError, IndexError, ValueError):
+        return SamTask.model_validate(task_data) if task_data else None
+    except (json.JSONDecodeError, ValueError):
         return None
 
 
 def _cleanup_active_task_context(session_id: str | None, fallback_context_file: Path | None) -> None:
     """Clean up active task context after SubagentStop completes.
 
-    Primary path: call sam_active_task(action='clear') via fastmcp CLI.
-    Fallback: delete the filesystem context file if MCP clear fails or is unavailable.
+    Primary path: call the SAM CLI's ``active-task clear`` subcommand.
+    Fallback: delete the filesystem context file if the CLI clear fails or is unavailable.
 
     Args:
-        session_id: Sub-agent session identifier for MCP clear. ``None`` skips
-            the MCP path entirely.
-        fallback_context_file: Filesystem context file to delete if MCP clear
-            fails or session_id is ``None``.
+        session_id: Sub-agent session identifier for the CLI clear call. ``None``
+            skips that path entirely.
+        fallback_context_file: Filesystem context file to delete if the CLI
+            clear fails or session_id is ``None``.
     """
-    mcp_cleared = False
+    cli_cleared = False
     if session_id:
-        mcp_cleared = _call_sam_active_task_clear(session_id)
+        cli_cleared = _call_sam_active_task_clear(session_id)
 
-    if not mcp_cleared and fallback_context_file is not None:
+    if not cli_cleared and fallback_context_file is not None:
         with contextlib.suppress(FileNotFoundError):
             fallback_context_file.unlink()
 
@@ -792,10 +776,10 @@ def _resolve_active_task_context(
     """Resolve the active task context for the agent that just stopped.
 
     Three-step resolution chain:
-    1. sam_active_task(action='get') via fastmcp CLI using the sub-agent's
+    1. The SAM CLI's ``active-task get`` subcommand, using the sub-agent's
        session_id extracted from the transcript (primary path).
     2. Filesystem context file via ``_resolve_context_file_from_transcript``
-       (fallback when agent did not call sam_active_task(set)).
+       (fallback when the agent did not call ``active-task set``).
     3. Prompt extraction from the JSONL transcript via
        ``_extract_prompt_from_transcript`` + ``extract_task_info_from_prompt``
        (final fallback for agents dispatched without context registration).
@@ -818,7 +802,7 @@ def _resolve_active_task_context(
     parent_issue_number: str | int | None = None
     context_file: Path | None = None
 
-    # Step 1: MCP lookup via sam_active_task(get)
+    # Step 1: SAM CLI lookup via active-task get
     if sub_agent_session_id:
         plan_id, task_id, parent_issue_number = _call_sam_active_task_get(sub_agent_session_id)
 
@@ -858,10 +842,10 @@ def _cascade_failed_task(
 ) -> None:
     """Best-effort downstream skip cascade when a task is already in FAILED status.
 
-    Routes the cascade through the SAM MCP server via sam_task(action='state',
-    status='failed'). The server handles DependencyGraph construction and
+    Routes the cascade through the SAM CLI's ``plan state`` subcommand
+    (``--new-status failed``). The CLI handles DependencyGraph construction and
     downstream SKIPPED writes atomically. Absorbs all failures — SubagentStop
-    critical path must not be blocked by network or write errors.
+    critical path must not be blocked by subprocess or write errors.
 
     Args:
         plan_id: Plan address string (e.g. ``"Pf4281187"``).
@@ -879,19 +863,20 @@ def _cascade_failed_task(
 def handle_subagent_stop(hook_input: dict[str, Any], profile: HookProfile = HookProfile.STANDARD) -> None:
     """Handle SubagentStop event - mark task COMPLETE with timestamp.
 
-    Discovers the active task via sam_active_task MCP tool (primary) or the
-    ``active-task-{session_id}.json`` context file (fallback). This ensures only
-    the task belonging to the finished agent is marked complete — not all
-    in-progress tasks — which is critical for correct behaviour with parallel agents.
+    Discovers the active task via the SAM CLI's ``active-task get`` subcommand
+    (primary) or the ``active-task-{session_id}.json`` context file (fallback).
+    This ensures only the task belonging to the finished agent is marked
+    complete — not all in-progress tasks — which is critical for correct
+    behaviour with parallel agents.
 
     Discovery steps:
     1. Extract sub-agent's session_id from ``agent_transcript_path``.
-    2. Call sam_active_task(action='get') via fastmcp CLI (primary path).
-    3. Fall back to ``active-task-{session_id}.json`` on disk if MCP call fails.
-    4. After status update, call sam_active_task(action='clear') or delete file.
+    2. Call the SAM CLI's ``active-task get`` subcommand (primary path).
+    3. Fall back to ``active-task-{session_id}.json`` on disk if that call fails.
+    4. After status update, call ``active-task clear`` or delete the file.
 
-    All status and field writes route through the SAM MCP server via fastmcp CLI,
-    making the hook backend-agnostic.
+    All status and field writes route through the SAM CLI as a single
+    subprocess, making the hook backend-agnostic.
 
     When profile is STRICT, runs pre-completion validation checks and prints
     any warnings to stderr before completing (warnings do not prevent completion).
@@ -917,7 +902,7 @@ def handle_subagent_stop(hook_input: dict[str, Any], profile: HookProfile = Hook
     current_task = _call_sam_task_read(plan_addr, task_id)
     if current_task is None:
         print(
-            f"[hook] SubagentStop: could not read task {task_id} from plan {plan_addr} via MCP — skipping",
+            f"[hook] SubagentStop: could not read task {task_id} from plan {plan_addr} via the SAM CLI — skipping",
             file=sys.stderr,
         )
         _cleanup_active_task_context(sub_agent_session_id, context_file)
@@ -929,7 +914,7 @@ def handle_subagent_stop(hook_input: dict[str, Any], profile: HookProfile = Hook
 
     if current_task.status == SamTaskStatus.FAILED:
         # Agent explicitly set task to FAILED before stopping.
-        # Cascade skip signals to all downstream dependents via MCP.
+        # Cascade skip signals to all downstream dependents via the SAM CLI.
         # _cascade_failed_task is terminal (calls sys.exit(0)); return guards mocked callers.
         _cascade_failed_task(plan_addr, task_id, sub_agent_session_id, context_file)
         return
@@ -941,7 +926,7 @@ def handle_subagent_stop(hook_input: dict[str, Any], profile: HookProfile = Hook
     timestamp = get_iso_timestamp()
     state_ok = _call_sam_task_state(plan_addr, task_id, SamTaskStatus.COMPLETE)
     if not state_ok:
-        print(f"[hook] SubagentStop: failed to mark {task_id} complete via MCP", file=sys.stderr)
+        print(f"[hook] SubagentStop: failed to mark {task_id} complete via the SAM CLI", file=sys.stderr)
         _cleanup_active_task_context(sub_agent_session_id, context_file)
         sys.exit(0)
     _call_sam_task_update(plan_addr, task_id, {"completed": timestamp})
@@ -952,7 +937,7 @@ def handle_activity_update(hook_input: dict[str, Any]) -> None:
     """Handle PostToolUse event - update LastActivity timestamp.
 
     Reads task info from context file and updates the last-activity field
-    via the SAM MCP server (backend-agnostic write path).
+    via the SAM CLI (backend-agnostic write path).
 
     Args:
         hook_input: Parsed hook input from stdin.
@@ -971,7 +956,7 @@ def handle_activity_update(hook_input: dict[str, Any]) -> None:
     current_task = _call_sam_task_read(plan_addr, task_id)
     if current_task is None:
         print(
-            f"[hook] PostToolUse: could not read task {task_id} from plan {plan_addr} via MCP — skipping",
+            f"[hook] PostToolUse: could not read task {task_id} from plan {plan_addr} via the SAM CLI — skipping",
             file=sys.stderr,
         )
     elif current_task.status == SamTaskStatus.COMPLETE:

--- a/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
+++ b/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
@@ -39,6 +39,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -335,7 +336,7 @@ def read_task_context(cwd: Path, session_id: str) -> tuple[str | None, str | Non
     return None, None
 
 
-def _call_sam_active_task_get(session_id: str, timeout: int = 10) -> tuple[str | None, str | None, str | int | None]:
+def _call_sam_active_task_get(session_id: str, timeout: int = 8) -> tuple[str | None, str | None, str | int | None]:
     """Retrieve active task context via the SAM CLI's ``active-task get`` subcommand.
 
     Primary retrieval path for SubagentStop. Returns parsed fields from the
@@ -380,7 +381,7 @@ def _call_sam_active_task_get(session_id: str, timeout: int = 10) -> tuple[str |
     return None, None, None
 
 
-def _call_sam_active_task_clear(session_id: str, timeout: int = 10) -> bool:
+def _call_sam_active_task_clear(session_id: str, timeout: int = 8) -> bool:
     """Clear active task context via the SAM CLI's ``active-task clear`` subcommand.
 
     Best-effort cleanup after SubagentStop completes. Never raises.
@@ -407,17 +408,29 @@ def _get_uv_executable() -> str | None:
     return shutil.which("uv")
 
 
-def _call_sam_cli(args: list[str], timeout: int = 15) -> str | None:
+def _call_sam_cli(args: list[str], timeout: int = 8) -> str | None:
     """Execute the SAM CLI as a subprocess and return raw stdout.
 
     Handles uv resolution, subprocess execution, and common failure modes.
     Callers are responsible for JSON parsing and context-specific error
     logging.
 
+    Launches the subprocess in its own session (``start_new_session=True``)
+    so a timeout can kill the whole process group, not just the immediate
+    ``uv`` child -- ``uv run --script`` may spawn its own child interpreter,
+    and killing only the ``uv`` pid would leave that interpreter orphaned.
+    The default timeout is kept comfortably below the 10-second PostToolUse
+    hook deadline in ``hooks/hooks.json`` -- a default at or above that
+    deadline lets Claude Code's own external SIGKILL win the race before
+    this method's internal timeout handling (and process-group cleanup) ever
+    runs, which is exactly the orphaned-process failure mode described in
+    ``.claude/rules/hook-subprocess-invocation.md``.
+
     Args:
         args: Subcommand and options to pass to the SAM CLI (e.g.
             ``["plan", "read", "--address", "P1/T1"]``).
-        timeout: Subprocess timeout in seconds.
+        timeout: Subprocess timeout in seconds. Must stay below the
+            PostToolUse hook's own timeout for the reason above.
 
     Returns:
         Raw stdout string on success, None on any failure (uv missing,
@@ -428,25 +441,33 @@ def _call_sam_cli(args: list[str], timeout: int = 15) -> str | None:
         return None
 
     try:
-        result = subprocess.run(
+        proc = subprocess.Popen(
             [uv, "run", "--script", str(_SAM_CLI_PATH), *args],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=timeout,
-            check=False,
+            start_new_session=True,
         )
-    except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError):
+    except (subprocess.SubprocessError, OSError):
         return None
 
-    if result.returncode != 0:
-        if result.stderr:
-            print(f"[hook] sam CLI {args[0] if args else ''} failed: {result.stderr.strip()}", file=sys.stderr)
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        proc.communicate()
         return None
 
-    return result.stdout
+    if proc.returncode != 0:
+        if stderr:
+            print(f"[hook] sam CLI {args[0] if args else ''} failed: {stderr.strip()}", file=sys.stderr)
+        return None
+
+    return stdout
 
 
-def _call_sam_task_state(plan_addr: str, task_id: str, status: SamTaskStatus, timeout: int = 15) -> bool:
+def _call_sam_task_state(plan_addr: str, task_id: str, status: SamTaskStatus, timeout: int = 8) -> bool:
     """Update task status via the SAM CLI's ``plan state`` subcommand.
 
     Routes state writes through the SAM CLI, keeping the hook
@@ -481,7 +502,7 @@ def _call_sam_task_state(plan_addr: str, task_id: str, status: SamTaskStatus, ti
 _UPDATE_FIELD_OPTIONS: dict[str, str] = {"completed": "--completed", "last-activity": "--last-activity"}
 
 
-def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, Any], timeout: int = 15) -> bool:
+def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, Any], timeout: int = 8) -> bool:
     """Update task fields via the SAM CLI's ``plan update`` subcommand.
 
     Only fields with a mapped CLI option are supported (a typed allowlist,
@@ -521,7 +542,7 @@ def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, An
     return True
 
 
-def _call_sam_task_read(plan_id: str, task_id: str, timeout: int = 15) -> SamTask | None:
+def _call_sam_task_read(plan_id: str, task_id: str, timeout: int = 8) -> SamTask | None:
     """Read a task via the SAM CLI's ``plan read`` subcommand.
 
     Routes task reads through the SAM CLI, keeping the hook backend-agnostic.

--- a/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
+++ b/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
@@ -39,9 +39,9 @@ import json
 import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -59,9 +59,15 @@ _HOOK_SAM_PACKAGES_DIR = str(_HOOK_REPO_ROOT / "packages")
 if _HOOK_SAM_PACKAGES_DIR not in sys.path:
     sys.path.insert(0, _HOOK_SAM_PACKAGES_DIR)
 
+_HOOK_REPO_SCRIPTS_DIR = str(_HOOK_REPO_ROOT / "scripts")
+if _HOOK_REPO_SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _HOOK_REPO_SCRIPTS_DIR)
+
 # Import directly from submodules for concrete types (avoids lazy __getattr__ object).
 from sam_schema.core.addressing import AddressingError, resolve_plan_address
 from sam_schema.core.models import Task as SamTask, TaskStatus as SamTaskStatus
+
+from run_bounded import terminate_process_tree
 
 # Alphanumeric task ID pattern: "1", "1.1", "T1", "P0-T01", etc.
 _TASK_ID_RE = r"[A-Za-z0-9]+(?:[-.][\dA-Za-z]+)*"
@@ -336,7 +342,7 @@ def read_task_context(cwd: Path, session_id: str) -> tuple[str | None, str | Non
     return None, None
 
 
-def _call_sam_active_task_get(session_id: str, timeout: int = 8) -> tuple[str | None, str | None, str | int | None]:
+def _call_sam_active_task_get(session_id: str, timeout: float = 8) -> tuple[str | None, str | None, str | int | None]:
     """Retrieve active task context via the SAM CLI's ``active-task get`` subcommand.
 
     Primary retrieval path for SubagentStop. Returns parsed fields from the
@@ -381,7 +387,7 @@ def _call_sam_active_task_get(session_id: str, timeout: int = 8) -> tuple[str | 
     return None, None, None
 
 
-def _call_sam_active_task_clear(session_id: str, timeout: int = 8) -> bool:
+def _call_sam_active_task_clear(session_id: str, timeout: float = 8) -> bool:
     """Clear active task context via the SAM CLI's ``active-task clear`` subcommand.
 
     Best-effort cleanup after SubagentStop completes. Never raises.
@@ -408,23 +414,23 @@ def _get_uv_executable() -> str | None:
     return shutil.which("uv")
 
 
-def _call_sam_cli(args: list[str], timeout: int = 8) -> str | None:
+def _call_sam_cli(args: list[str], timeout: float = 8) -> str | None:
     """Execute the SAM CLI as a subprocess and return raw stdout.
 
     Handles uv resolution, subprocess execution, and common failure modes.
     Callers are responsible for JSON parsing and context-specific error
     logging.
 
-    Launches the subprocess in its own session (``start_new_session=True``)
-    so a timeout can kill the whole process group, not just the immediate
-    ``uv`` child -- ``uv run --script`` may spawn its own child interpreter,
-    and killing only the ``uv`` pid would leave that interpreter orphaned.
-    The default timeout is kept comfortably below the 10-second PostToolUse
-    hook deadline in ``hooks/hooks.json`` -- a default at or above that
-    deadline lets Claude Code's own external SIGKILL win the race before
-    this method's internal timeout handling (and process-group cleanup) ever
-    runs, which is exactly the orphaned-process failure mode described in
-    ``.claude/rules/hook-subprocess-invocation.md``.
+    Launches the subprocess in its own session on POSIX so a timeout can
+    terminate the whole process tree via :func:`run_bounded.terminate_process_tree`,
+    not just the immediate ``uv`` child -- ``uv run --script`` may spawn its
+    own child interpreter, and killing only the ``uv`` pid would leave that
+    interpreter orphaned. The default timeout is kept comfortably below the
+    10-second PostToolUse hook deadline in ``hooks/hooks.json`` -- a default
+    at or above that deadline lets Claude Code's own external SIGKILL win the
+    race before this method's internal timeout handling (and process-tree
+    cleanup) ever runs, which is exactly the orphaned-process failure mode
+    described in ``.claude/rules/hook-subprocess-invocation.md``.
 
     Args:
         args: Subcommand and options to pass to the SAM CLI (e.g.
@@ -446,7 +452,7 @@ def _call_sam_cli(args: list[str], timeout: int = 8) -> str | None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            start_new_session=True,
+            start_new_session=os.name == "posix",
         )
     except (subprocess.SubprocessError, OSError):
         return None
@@ -454,8 +460,7 @@ def _call_sam_cli(args: list[str], timeout: int = 8) -> str | None:
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
-        with contextlib.suppress(ProcessLookupError):
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        terminate_process_tree(proc)
         proc.communicate()
         return None
 
@@ -467,7 +472,7 @@ def _call_sam_cli(args: list[str], timeout: int = 8) -> str | None:
     return stdout
 
 
-def _call_sam_task_state(plan_addr: str, task_id: str, status: SamTaskStatus, timeout: int = 8) -> bool:
+def _call_sam_task_state(plan_addr: str, task_id: str, status: SamTaskStatus, timeout: float = 8) -> bool:
     """Update task status via the SAM CLI's ``plan state`` subcommand.
 
     Routes state writes through the SAM CLI, keeping the hook
@@ -502,7 +507,7 @@ def _call_sam_task_state(plan_addr: str, task_id: str, status: SamTaskStatus, ti
 _UPDATE_FIELD_OPTIONS: dict[str, str] = {"completed": "--completed", "last-activity": "--last-activity"}
 
 
-def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, Any], timeout: int = 8) -> bool:
+def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, Any], timeout: float = 8) -> bool:
     """Update task fields via the SAM CLI's ``plan update`` subcommand.
 
     Only fields with a mapped CLI option are supported (a typed allowlist,
@@ -542,7 +547,7 @@ def _call_sam_task_update(plan_addr: str, task_id: str, set_fields: dict[str, An
     return True
 
 
-def _call_sam_task_read(plan_id: str, task_id: str, timeout: int = 8) -> SamTask | None:
+def _call_sam_task_read(plan_id: str, task_id: str, timeout: float = 8) -> SamTask | None:
     """Read a task via the SAM CLI's ``plan read`` subcommand.
 
     Routes task reads through the SAM CLI, keeping the hook backend-agnostic.
@@ -954,6 +959,14 @@ def handle_subagent_stop(hook_input: dict[str, Any], profile: HookProfile = Hook
     _cleanup_active_task_context(sub_agent_session_id, context_file)
 
 
+# Total wall-clock budget shared across every _call_sam_cli invocation made within
+# one handle_activity_update() run, kept safely below the 10-second PostToolUse
+# deadline in hooks/hooks.json. Each call below gets whatever budget remains rather
+# than its own full default -- two independent 8-second defaults could sum past the
+# outer deadline even though each call alone stays under it.
+_POST_TOOL_USE_BUDGET_SECONDS = 8.0
+
+
 def handle_activity_update(hook_input: dict[str, Any]) -> None:
     """Handle PostToolUse event - update LastActivity timestamp.
 
@@ -974,7 +987,9 @@ def handle_activity_update(hook_input: dict[str, Any]) -> None:
     if plan_addr is None or task_id is None:
         sys.exit(0)
 
-    current_task = _call_sam_task_read(plan_addr, task_id)
+    deadline = time.monotonic() + _POST_TOOL_USE_BUDGET_SECONDS
+
+    current_task = _call_sam_task_read(plan_addr, task_id, timeout=max(0.1, deadline - time.monotonic()))
     if current_task is None:
         print(
             f"[hook] PostToolUse: could not read task {task_id} from plan {plan_addr} via the SAM CLI — skipping",
@@ -983,8 +998,16 @@ def handle_activity_update(hook_input: dict[str, Any]) -> None:
     elif current_task.status == SamTaskStatus.COMPLETE:
         return
 
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        print(
+            f"[hook] PostToolUse: skipping last-activity update for {task_id} — shared time budget exhausted",
+            file=sys.stderr,
+        )
+        return
+
     timestamp = get_iso_timestamp()
-    _call_sam_task_update(plan_addr, task_id, {"last-activity": timestamp})
+    _call_sam_task_update(plan_addr, task_id, {"last-activity": timestamp}, timeout=remaining)
 
 
 def main() -> None:

--- a/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
+++ b/plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py
@@ -52,16 +52,16 @@ if str(_DH_PLUGIN_DIR) not in sys.path:
 
 _SAM_CLI_PATH = _DH_PLUGIN_DIR / "scripts" / "run_sam_cli.py"
 
+_DH_PLUGIN_SCRIPTS_DIR = str(_DH_PLUGIN_DIR / "scripts")
+if _DH_PLUGIN_SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _DH_PLUGIN_SCRIPTS_DIR)
+
 import dh_paths as _dh_paths
 
 _HOOK_REPO_ROOT = Path(__file__).resolve().parents[5]
 _HOOK_SAM_PACKAGES_DIR = str(_HOOK_REPO_ROOT / "packages")
 if _HOOK_SAM_PACKAGES_DIR not in sys.path:
     sys.path.insert(0, _HOOK_SAM_PACKAGES_DIR)
-
-_HOOK_REPO_SCRIPTS_DIR = str(_HOOK_REPO_ROOT / "scripts")
-if _HOOK_REPO_SCRIPTS_DIR not in sys.path:
-    sys.path.insert(0, _HOOK_REPO_SCRIPTS_DIR)
 
 # Import directly from submodules for concrete types (avoids lazy __getattr__ object).
 from sam_schema.core.addressing import AddressingError, resolve_plan_address

--- a/plugins/development-harness/tests/test_github_content_migration.py
+++ b/plugins/development-harness/tests/test_github_content_migration.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 from backlog_core.backends.github_content_migration import _GitHubContentCache, _GitHubContentMigration
 from backlog_core.file_cache import FileCache
+from backlog_core.file_cache_state import _CacheStateStore, _RejectedMutation
 from backlog_core.models import (
     ContentConflictError,
     ContentKind,
@@ -308,3 +309,42 @@ def test_list_content_surfaces_a_rejection_discovered_during_this_same_call(tmp_
 
     assert result.content == "remote content"
     assert result.conflict_reason
+
+
+def test_list_content_offline_fallback_preserves_a_prior_rejection(tmp_path: Path) -> None:
+    """list_content()'s offline/cached-fallback branch must also surface conflict_reason.
+
+    Regression test for a review finding on PR #3306: the offline fallback
+    branch (GitHub unreachable, or the online list call itself fails) builds
+    records manually from cached state instead of routing through
+    FileCache.get_content() -- it already derived `pending` this way but not
+    `conflict_reason`, so a plan rejected on an earlier call still loaded as
+    ordinary current state whenever a caller (e.g. an offline SAM process)
+    hit this fallback path rather than the online branch fixed above.
+    """
+    cache = FileCache(tmp_path)
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    cache.cache_content(ContentRecord(reference=reference, content="cached content", revision="rev-1"))
+    stale_rejected_write = ContentWrite(reference=reference, content="rejected", expected_revision="rev-1")
+    store = _CacheStateStore(tmp_path)
+    store.transaction(
+        lambda state: (
+            state.model_copy(
+                update={
+                    "rejected": [
+                        _RejectedMutation(
+                            idempotency_key="stale-key", write=stale_rejected_write, reason="precondition failed"
+                        )
+                    ]
+                }
+            ),
+            None,
+        )
+    )
+    offline_provider = _UnresolvablyFailingProvider(ContentConflictError("unused"))
+    content_cache = _GitHubContentCache(cache=cache, provider=offline_provider)
+
+    [result] = content_cache.list_content(ContentQuery(kind=ContentKind.PLAN))
+
+    assert result.content == "cached content"
+    assert result.conflict_reason == "precondition failed"

--- a/plugins/development-harness/tests/test_github_content_migration.py
+++ b/plugins/development-harness/tests/test_github_content_migration.py
@@ -194,5 +194,10 @@ def test_replay_pending_discards_mutation_that_can_never_land(
     content_cache.replay_pending()
 
     # Then: the unresolvable mutation is discarded, not left to retry forever
+    # -- but retained (with its failure surfaced) in the rejected bucket
+    # rather than lost outright.
     assert provider.write_calls == 1
     assert cache.pending_mutations() == []
+    [rejected] = cache.rejected_mutations()
+    assert rejected.write.content == "queued content"
+    assert rejected.reason

--- a/plugins/development-harness/tests/test_github_content_migration.py
+++ b/plugins/development-harness/tests/test_github_content_migration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from backlog_core.backends.github_content_migration import _GitHubContentCache, _GitHubContentMigration
@@ -201,3 +201,58 @@ def test_replay_pending_discards_mutation_that_can_never_land(
     [rejected] = cache.rejected_mutations()
     assert rejected.write.content == "queued content"
     assert rejected.reason
+
+
+class _OnlineProviderWithReadableContent:
+    """_OnlineContent double that is reachable and whose read always succeeds.
+
+    Its write always raises a non-retryable error, so a pending mutation
+    replayed against it is rejected rather than retried.
+    """
+
+    def __init__(self, error: BaseException, read_record: ContentRecord) -> None:
+        self._error = error
+        self._read_record = read_record
+
+    def try_get_github(self, repo: str = "") -> Repository | None:
+        return cast("Repository", object())
+
+    def _list_online_content(self, query: ContentQuery) -> list[ContentRecord]:
+        raise NotImplementedError
+
+    def _read_online_content(self, reference: ContentRef, cached: ContentRecord | None) -> ContentRecord:
+        return self._read_record
+
+    def _write_online_content(self, request: ContentWrite, cached: ContentRecord | None) -> ContentRecord:
+        raise self._error
+
+
+def test_get_content_surfaces_a_rejection_discovered_during_this_same_call(tmp_path: Path) -> None:
+    """A conflict discovered by replay_pending() inside get_content() must not vanish.
+
+    Regression test for a review finding on PR #3306: get_content() calls
+    replay_pending() as its first step whenever GitHub is reachable. If that
+    replay rejects the reference's pending mutation, the reference is no
+    longer "pending" (FileCache._is_pending treats a rejected reference as
+    not-pending by design), so get_content() falls through to the online-read
+    success branch -- which previously returned the freshly read provider
+    record directly instead of routing it through FileCache.get_content(),
+    the only place conflict_reason is derived. The caller who triggers the
+    very replay that discovers the conflict never saw it.
+    """
+    cache = FileCache(tmp_path)
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    cache.queue_write(
+        ContentRecord(reference=reference, content="", revision=""),
+        ContentWrite(reference=reference, content="queued content", expected_revision="stale-rev"),
+    )
+    fresh_record = ContentRecord(reference=reference, content="remote content", revision="remote-rev")
+    provider = _OnlineProviderWithReadableContent(
+        ContentConflictError("Content revision no longer matches"), fresh_record
+    )
+    content_cache = _GitHubContentCache(cache=cache, provider=provider)
+
+    result = content_cache.get_content(reference)
+
+    assert result.content == "remote content"
+    assert result.conflict_reason

--- a/plugins/development-harness/tests/test_github_content_migration.py
+++ b/plugins/development-harness/tests/test_github_content_migration.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from backlog_core.backends.github_content_migration import _GitHubContentMigration
-from backlog_core.models import ContentKind, ContentNotFoundError, ContentQuery, ContentRecord, ContentRef
+import pytest
+from backlog_core.backends.github_content_migration import _GitHubContentCache, _GitHubContentMigration
+from backlog_core.file_cache import FileCache
+from backlog_core.models import (
+    ContentConflictError,
+    ContentKind,
+    ContentNotFoundError,
+    ContentQuery,
+    ContentRecord,
+    ContentRef,
+    ContentWrite,
+    UnsupportedCapabilityError,
+)
 
 if TYPE_CHECKING:
+    from github.Repository import Repository
     from pytest_mock import MockerFixture
 
 
@@ -124,3 +137,62 @@ def test_read_legacy_resolves_artifact_provider_at_call_time(mocker: MockerFixtu
     container["provider"] = _FakeArtifactProvider("replacement")
 
     assert migration.read(reference).content == "replacement"
+
+
+class _UnresolvablyFailingProvider:
+    """_OnlineContent double whose write always raises a non-retryable error."""
+
+    def __init__(self, error: BaseException) -> None:
+        self._error = error
+        self.write_calls = 0
+
+    def try_get_github(self, repo: str = "") -> Repository | None:
+        return None
+
+    def _list_online_content(self, query: ContentQuery) -> list[ContentRecord]:
+        raise NotImplementedError
+
+    def _read_online_content(self, reference: ContentRef, cached: ContentRecord | None) -> ContentRecord:
+        raise NotImplementedError
+
+    def _write_online_content(self, request: ContentWrite, cached: ContentRecord | None) -> ContentRecord:
+        self.write_calls += 1
+        raise self._error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ContentConflictError("Content revision no longer matches"),
+        UnsupportedCapabilityError("Content reference is provider-private"),
+    ],
+)
+def test_replay_pending_discards_mutation_that_can_never_land(
+    tmp_path: Path, error: ContentConflictError | UnsupportedCapabilityError
+) -> None:
+    """Regression test for the pending-queue leak in _GitHubContentCache.replay_pending.
+
+    A ContentConflictError/UnsupportedCapabilityError means the queued write's
+    precondition is permanently violated -- retrying it on every future replay
+    can never succeed. The sane target behavior is to discard the mutation
+    (with its failure surfaced) rather than leave it silently stuck forever.
+    This assertion is expected to fail (RED) against the current bare
+    `except (...): continue`, which neither acknowledges nor discards it.
+    """
+    # Given: one durably queued write whose replay will always raise a
+    # non-retryable error
+    cache = FileCache(tmp_path)
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    cache.queue_write(
+        ContentRecord(reference=reference, content="", revision=""),
+        ContentWrite(reference=reference, content="queued content", expected_revision="stale-rev"),
+    )
+    provider = _UnresolvablyFailingProvider(error)
+    content_cache = _GitHubContentCache(cache=cache, provider=provider)
+
+    # When: reconciliation replays the durable queue
+    content_cache.replay_pending()
+
+    # Then: the unresolvable mutation is discarded, not left to retry forever
+    assert provider.write_calls == 1
+    assert cache.pending_mutations() == []

--- a/plugins/development-harness/tests/test_github_content_migration.py
+++ b/plugins/development-harness/tests/test_github_content_migration.py
@@ -256,3 +256,55 @@ def test_get_content_surfaces_a_rejection_discovered_during_this_same_call(tmp_p
 
     assert result.content == "remote content"
     assert result.conflict_reason
+
+
+class _OnlineProviderWithListableContent:
+    """_OnlineContent double that is reachable and whose list always succeeds.
+
+    Its write always raises a non-retryable error, so a pending mutation
+    replayed against it is rejected rather than retried.
+    """
+
+    def __init__(self, error: BaseException, list_records: list[ContentRecord]) -> None:
+        self._error = error
+        self._list_records = list_records
+
+    def try_get_github(self, repo: str = "") -> Repository | None:
+        return cast("Repository", object())
+
+    def _list_online_content(self, query: ContentQuery) -> list[ContentRecord]:
+        return self._list_records
+
+    def _read_online_content(self, reference: ContentRef, cached: ContentRecord | None) -> ContentRecord:
+        raise NotImplementedError
+
+    def _write_online_content(self, request: ContentWrite, cached: ContentRecord | None) -> ContentRecord:
+        raise self._error
+
+
+def test_list_content_surfaces_a_rejection_discovered_during_this_same_call(tmp_path: Path) -> None:
+    """list_content()'s online branch must also surface a conflict_reason.
+
+    Regression test for a review finding on PR #3306: ContentTaskProvider
+    loads plans through list_content(), not get_content(). The online branch
+    of list_content() returned raw provider records directly (no pending or
+    conflict_reason derivation at all), so a rejection replay_pending()
+    discovers as the first step of this same call was invisible to any
+    list-based consumer, exactly like the get_content() gap fixed above.
+    """
+    cache = FileCache(tmp_path)
+    reference = ContentRef(kind=ContentKind.PLAN, name="P1")
+    cache.queue_write(
+        ContentRecord(reference=reference, content="", revision=""),
+        ContentWrite(reference=reference, content="queued content", expected_revision="stale-rev"),
+    )
+    fresh_record = ContentRecord(reference=reference, content="remote content", revision="remote-rev")
+    provider = _OnlineProviderWithListableContent(
+        ContentConflictError("Content revision no longer matches"), [fresh_record]
+    )
+    content_cache = _GitHubContentCache(cache=cache, provider=provider)
+
+    [result] = content_cache.list_content(ContentQuery(kind=ContentKind.PLAN))
+
+    assert result.content == "remote content"
+    assert result.conflict_reason

--- a/plugins/development-harness/tests/test_github_content_safety.py
+++ b/plugins/development-harness/tests/test_github_content_safety.py
@@ -415,6 +415,46 @@ def test_replay_conflict_rejects_pending_mutation(tmp_path: Path, monkeypatch: p
     assert len(backend._cache.rejected_mutations()) == 1
 
 
+def test_replay_conflict_does_not_reject_mutation_that_superseded_it_mid_flight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mutation superseded while its own replay is in flight must survive a later rejection.
+
+    Regression test for a review finding on PR #3306: `replay_pending()` snapshots
+    `pending_mutations()` at loop start, then calls `_write_online_content()` per
+    entry -- a network call that can race with a fresh offline edit for the same
+    reference landing in between (simulated here inside the write double). If that
+    first mutation's write then raises `ContentConflictError`, rejecting by
+    `reference` alone (the pre-fix behavior) discards whatever now occupies that
+    reference -- the newer, never-attempted mutation -- instead of the one that
+    actually failed.
+    """
+    reference = ContentRef(kind=ContentKind.PLAN, name="P123")
+    cached = ContentRecord(reference=reference, content="cached", revision="current")
+    cache = FileCache(tmp_path / "github-cache")
+    cache.cache_content(cached)
+    first = cache.queue_write(cached, ContentWrite(reference=reference, content="first", expected_revision="current"))
+    backend = GitHubBackend(cache=cache, plan_persistence=_UnavailablePlanPersistence())
+    monkeypatch.setattr(backend, "try_get_github", MagicMock)
+
+    def write(request: ContentWrite, cached: ContentRecord | None) -> ContentRecord:
+        cache.queue_write(
+            cached or ContentRecord(reference=reference, content="", revision=""),
+            ContentWrite(reference=reference, content="second", expected_revision="current"),
+        )
+        raise ContentConflictError("conflict")
+
+    monkeypatch.setattr(backend, "_write_online_content", write)
+
+    backend._replay_pending_content()
+
+    pending = backend._cache.pending_mutations()
+    assert len(pending) == 1
+    assert pending[0].write.content == "second"
+    assert pending[0].idempotency_key != first.idempotency_key
+    assert all(entry.idempotency_key != pending[0].idempotency_key for entry in backend._cache.rejected_mutations())
+
+
 def test_replay_conflict_continues_to_later_mutation_and_acknowledges_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/plugins/development-harness/tests/test_github_content_safety.py
+++ b/plugins/development-harness/tests/test_github_content_safety.py
@@ -146,18 +146,22 @@ def test_online_artifact_read_remains_available(tmp_path: Path) -> None:
 
 
 def test_pending_artifact_manifest_write_is_not_clobbered_by_empty_legacy_read(tmp_path: Path) -> None:
-    """A queued manifest write that cannot land yet must stay visible to readers.
+    """A create-only manifest write that already exists on the legacy store is rejected, not stuck.
 
-    Regression test for backlog item #2899: ``artifact_register`` reported
-    success but the artifact was invisible to ``artifact_list``/``artifact_get``
-    immediately after. Root cause -- ``GitHubGistArtifactProvider.get_manifest``
-    (the legacy fallback ``read_legacy`` uses for ``ARTIFACT_MANIFEST``) never
-    raises ``ContentNotFoundError`` for an item with no manifest data yet; it
-    returns a valid, empty manifest instead. Before the fix, ``get_content``
-    trusted that empty read as authoritative and cached it over the top of the
-    still-pending queued write (e.g. one blocked by a branch-protection ruleset
-    that rejects direct Contents API commits), erasing the just-registered
-    artifact from view.
+    Regression test for backlog item #2899, updated for Leak B (sibling to
+    ``test_replay_conflict_rejects_pending_mutation``): ``artifact_register``
+    reported success but the artifact was invisible to
+    ``artifact_list``/``artifact_get`` immediately after. Root cause --
+    ``GitHubGistArtifactProvider.get_manifest`` (the legacy fallback
+    ``read_legacy`` uses for ``ARTIFACT_MANIFEST``) never raises
+    ``ContentNotFoundError`` for an item with no manifest data yet; it returns
+    a valid, empty manifest instead, so the create-only write's replay attempt
+    trips ``ContentConflictError`` ("Content already exists") against that
+    legacy record. That precondition can never be satisfied by retrying, so
+    the mutation is rejected out of the pending queue -- no longer shadowing
+    reads forever -- and a fresh, authoritative read is trusted again. The
+    write's content is not silently lost: it lands in ``rejected_mutations()``
+    intact for inspection.
     """
     reference = ContentRef(kind=ContentKind.ARTIFACT_MANIFEST, namespace="1", name="manifest")
     base = ContentRecord(reference=reference, content="", revision="")
@@ -174,9 +178,13 @@ def test_pending_artifact_manifest_write_is_not_clobbered_by_empty_legacy_read(t
 
     record = backend.get_content(reference)
 
-    assert (record.content, record.pending) == (manifest_with_entry, True)
+    assert record.pending is False
+    assert record.content != manifest_with_entry
     provider.get_manifest.assert_called()
-    assert len(backend._cache.pending_mutations()) == 1
+    assert backend._cache.pending_mutations() == []
+    rejected = backend._cache.rejected_mutations()
+    assert len(rejected) == 1
+    assert rejected[0].write.content == manifest_with_entry
 
 
 def test_pending_write_still_surfaces_integrity_error_on_underlying_reference(tmp_path: Path) -> None:
@@ -284,18 +292,18 @@ class _LegacyPlanStore:
 
 
 def test_list_content_does_not_clobber_pending_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A queued PLAN write stuck behind a conflicting legacy record must survive ``list_content()``.
+    """A queued PLAN write stuck behind a conflicting legacy record is rejected, not silently dropped.
 
-    Regression test for a review finding on PR #2906: ``list_content()``'s per-record
+    Regression test for a review finding on PR #2906, updated for Leak B (sibling to
+    ``test_replay_conflict_rejects_pending_mutation``): ``list_content()``'s per-record
     cache-refresh loop called ``FileCache.cache_content()`` unconditionally for every
     legacy/online record, with no pending guard -- unlike ``get_content()``'s guarded
     read path. A create-only write queued for a PLAN reference that conflicts with an
     existing legacy plan-index record can never land through replay
-    (``ContentConflictError`` on every attempt), so the reference stays pending
-    forever. Before the fix, the very next ``list_content()`` call clobbered that
-    cached pending record with the older legacy content and reset ``pending`` back to
-    ``False`` -- silently discarding the caller's own unacknowledged write and
-    reopening the exact clobber bug PR #2906 fixed for ``get_content()``.
+    (``ContentConflictError`` on every attempt), so under Leak B that mutation is
+    rejected out of the pending queue during ``list_content()``'s own replay pass --
+    not left to be silently clobbered later. The write's content is not lost: it
+    lands in ``rejected_mutations()`` intact.
     """
     reference = ContentRef(kind=ContentKind.PLAN, name="P123")
     legacy = ContentRecord(reference=reference, content="legacy content", revision="legacy-rev")
@@ -315,9 +323,10 @@ def test_list_content_does_not_clobber_pending_write(tmp_path: Path, monkeypatch
 
     backend.list_content(ContentQuery(kind=ContentKind.PLAN))
 
-    cached = backend._cache.get_content(reference)
-    assert (cached.content, cached.pending) == ("pending write", True)
-    assert len(backend._cache.pending_mutations()) == 1
+    assert backend._cache.pending_mutations() == []
+    rejected = backend._cache.rejected_mutations()
+    assert len(rejected) == 1
+    assert rejected[0].write.content == "pending write"
 
 
 class _UnavailablePlanPersistence:
@@ -381,7 +390,7 @@ def test_replay_oserror_keeps_pending_mutation_and_put_queues_latest_write(
     assert pending[0].write.content == "latest"
 
 
-def test_replay_conflict_keeps_pending_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_replay_conflict_rejects_pending_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     reference = ContentRef(kind=ContentKind.PLAN, name="P123")
     cached = ContentRecord(reference=reference, content="cached", revision="current")
     cache = FileCache(tmp_path / "github-cache")
@@ -397,7 +406,13 @@ def test_replay_conflict_keeps_pending_mutation(tmp_path: Path, monkeypatch: pyt
 
     backend._replay_pending_content()
 
-    assert len(backend._cache.pending_mutations()) == 1
+    # Intentional behavior change, not a regression: a ContentConflictError
+    # means this mutation's precondition can never be satisfied by retrying,
+    # so it is relocated out of the unbounded-retry pending queue into the
+    # rejected bucket instead of staying stuck in `pending_mutations()`
+    # forever. The mutation itself is retained, not lost.
+    assert backend._cache.pending_mutations() == []
+    assert len(backend._cache.rejected_mutations()) == 1
 
 
 def test_replay_conflict_continues_to_later_mutation_and_acknowledges_once(
@@ -431,12 +446,12 @@ def test_replay_conflict_continues_to_later_mutation_and_acknowledges_once(
     backend._replay_pending_content()
     backend._replay_pending_content()
 
-    assert [mutation.write.reference for mutation in cache.pending_mutations()] == [first_reference]
-    assert [call.args[0].reference for call in writes.call_args_list] == [
-        first_reference,
-        later_reference,
-        first_reference,
-    ]
+    # The conflicting first mutation is rejected on its first attempt and
+    # moved out of the pending queue, so the second replay call has nothing
+    # left to retry for it -- no wasted third write call.
+    assert cache.pending_mutations() == []
+    assert [mutation.write.reference for mutation in cache.rejected_mutations()] == [first_reference]
+    assert [call.args[0].reference for call in writes.call_args_list] == [first_reference, later_reference]
     assert acknowledge.call_count == 1
     assert [entry.record.reference for entry in acknowledge.call_args.args[0]] == [later_reference]
     assert cache.get_content(later_reference).pending is False

--- a/plugins/development-harness/tests/test_task_status_hook.py
+++ b/plugins/development-harness/tests/test_task_status_hook.py
@@ -1475,7 +1475,7 @@ def _write_activity_update_context(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     context_dir = dh_paths.context_dir()
     context_dir.mkdir(parents=True, exist_ok=True)
     context_file = context_dir / f"active-task-{session_id}.json"
-    context_file.write_text(json.dumps({"task_file_path": str(plan_file), "task_id": "T1"}))
+    context_file.write_text(json.dumps({"task_file_path": str(plan_file), "plan": "Pf4281187", "task_id": "T1"}))
 
     return {"cwd": str(tmp_path), "session_id": session_id, "hook_event_name": "PostToolUse"}
 

--- a/plugins/development-harness/tests/test_task_status_hook.py
+++ b/plugins/development-harness/tests/test_task_status_hook.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import importlib.util
 import inspect
 import json
-import signal
+import os
 import sys
 from pathlib import Path
 from subprocess import CompletedProcess, SubprocessError, TimeoutExpired
@@ -1396,13 +1396,18 @@ def test_timeout_defaults_are_below_outer_hook_deadline() -> None:
         assert default < 10, f"{func.__name__} timeout default is {default!r}, must be < 10"
 
 
-def test_call_sam_cli_kills_entire_process_group_on_timeout(mocker: MockerFixture) -> None:
-    """On timeout, _call_sam_cli kills the whole process group, not just the immediate pid.
+def test_call_sam_cli_delegates_timeout_cleanup_to_terminate_process_tree(mocker: MockerFixture) -> None:
+    """On timeout, _call_sam_cli delegates process-tree cleanup to run_bounded.terminate_process_tree.
 
-    subprocess.run(timeout=...) only ever calls .kill() on the immediate child
-    (the uv process). If `uv run --script` forks rather than execs into the
-    actual interpreter, that descendant survives — an orphaned process. The
-    fix kills the entire process group via os.killpg(os.getpgid(pid), SIGKILL).
+    Supersedes the hand-rolled os.killpg(os.getpgid(pid), SIGKILL) approach, which only
+    works on POSIX (os.killpg does not exist on Windows) and always jumps straight to
+    SIGKILL with no graceful-termination attempt. The repo already solves this — see
+    scripts/run_bounded.py's terminate_process_tree, already used the same way by
+    scripts/validate_codex_plugin_isolated.py.
+
+    Kept safe against the still-unfixed hand-rolled cleanup by stubbing os.getpgid/os.killpg
+    too, so this test cannot SIGKILL a real, unrelated process group on the test machine
+    while it is RED.
     """
     proc = _popen_timeout(pid=4242)
 
@@ -1410,19 +1415,23 @@ def test_call_sam_cli_kills_entire_process_group_on_timeout(mocker: MockerFixtur
     mocker.patch.object(Path, "exists", return_value=True)
     mocker.patch("subprocess.Popen", return_value=proc)
     mocker.patch("os.getpgid", return_value=4242)
-    mock_killpg = mocker.patch("os.killpg")
+    mocker.patch("os.killpg")
+    mock_terminate = mocker.patch.object(_hook_mod, "terminate_process_tree", create=True)
 
     result = _hook_mod._call_sam_cli(["plan", "read", "--address", "P1/T1"])
 
     assert result is None
-    mock_killpg.assert_called_once_with(4242, signal.SIGKILL)
+    mock_terminate.assert_called_once_with(proc)
 
 
-def test_call_sam_cli_launches_subprocess_in_new_session(mocker: MockerFixture) -> None:
-    """_call_sam_cli launches its subprocess with start_new_session=True.
+def test_call_sam_cli_uses_posix_session_flag(mocker: MockerFixture) -> None:
+    """_call_sam_cli launches its subprocess with start_new_session matching the platform.
 
-    A new session/process group is the prerequisite for os.killpg to be able
-    to target the whole process tree instead of just the immediate child pid.
+    POSIX process groups are the prerequisite for terminate_process_tree's group-wide
+    SIGTERM/SIGKILL escalation; Windows has no such concept and terminate_process_tree
+    instead walks the OS process tree by PID via taskkill (see
+    run_bounded.terminate_windows_process_tree). The assertion is written against
+    os.name == "posix" rather than a hardcoded True so it stays correct off of POSIX too.
     """
     proc = _popen_from_completed(CompletedProcess(args=[], returncode=0, stdout="{}", stderr=""), pid=1234)
 
@@ -1433,23 +1442,107 @@ def test_call_sam_cli_launches_subprocess_in_new_session(mocker: MockerFixture) 
     _hook_mod._call_sam_cli(["plan", "read", "--address", "P1/T1"])
 
     mock_popen.assert_called_once()
-    assert mock_popen.call_args.kwargs.get("start_new_session") is True
+    assert mock_popen.call_args.kwargs.get("start_new_session") == (os.name == "posix")
 
 
-def test_call_sam_cli_timeout_killpg_race_does_not_raise(mocker: MockerFixture) -> None:
-    """A ProcessLookupError from os.killpg (process already exited) does not propagate.
+# ---------------------------------------------------------------------------
+# PR #3306 review response, round 3 — handle_activity_update shares a single
+# wall-clock deadline across its two sequential _call_sam_cli-backed calls
+#
+# _call_sam_task_read then _call_sam_task_update are each individually kept
+# below the outer 10s PostToolUse hook deadline, but nothing today stops their
+# SUM from exceeding it: worst case ~8s + ~8s = ~16s, well past the 10s
+# external SIGKILL Claude Code enforces on the whole hook process. The fix
+# computes a shared remaining-budget deadline once (time.monotonic()) and
+# passes the REMAINING time to each call, skipping the update call outright
+# once the budget is exhausted rather than dispatching it with a doomed
+# near-zero/negative timeout.
+# ---------------------------------------------------------------------------
 
-    Between the timeout firing and the killpg call, the process may have already
-    exited on its own — a benign race, not a failure the hook should crash on.
+
+def _write_activity_update_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, session_id: str) -> dict[str, Any]:
+    """Set up a plan file + context file for handle_activity_update and return its hook_input.
+
+    Shared fixture setup for the two shared-deadline tests below — mirrors the setup
+    already used by test_handle_activity_update_calls_mcp_update.
     """
-    proc = _popen_timeout(pid=4242)
+    plan_file = tmp_path / "Pf4281187-feature.yaml"
+    plan_file.write_text("tasks:\n- id: T1\n  status: in-progress\n  title: Test\n")
 
-    mocker.patch("shutil.which", return_value="/usr/bin/uv")
-    mocker.patch.object(Path, "exists", return_value=True)
-    mocker.patch("subprocess.Popen", return_value=proc)
-    mocker.patch("os.getpgid", return_value=4242)
-    mocker.patch("os.killpg", side_effect=ProcessLookupError)
+    monkeypatch.setenv("DH_STATE_HOME", str(tmp_path / "dh_state"))
+    import dh_paths
 
-    result = _hook_mod._call_sam_cli(["plan", "read", "--address", "P1/T1"])
+    context_dir = dh_paths.context_dir()
+    context_dir.mkdir(parents=True, exist_ok=True)
+    context_file = context_dir / f"active-task-{session_id}.json"
+    context_file.write_text(json.dumps({"task_file_path": str(plan_file), "task_id": "T1"}))
 
-    assert result is None
+    return {"cwd": str(tmp_path), "session_id": session_id, "hook_event_name": "PostToolUse"}
+
+
+def test_handle_activity_update_shares_deadline_between_read_and_update(
+    mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The timeout passed to _call_sam_task_update reflects the budget remaining after the read call.
+
+    time.monotonic() is mocked to a 3-value sequence: [deadline computed, right before the
+    read call, right before the update call] = [0.0, 0.0, 6.0] — simulating the read call
+    alone consuming 6 of the shared budget's seconds. The update call must NOT receive its
+    own fresh ~8s default; it must receive whatever budget remains (< 8s).
+
+    RED on current code: handle_activity_update calls _call_sam_task_update(plan_addr,
+    task_id, set_fields) with no timeout= kwarg at all (it relies on the function's own
+    8s default), so mock_update.call_args.kwargs.get("timeout") is None here.
+    """
+    session_id = "sess-budget-shared"
+    hook_input = _write_activity_update_context(tmp_path, monkeypatch, session_id)
+
+    from sam_schema.core.models import Task, TaskStatus
+
+    mock_task = mocker.MagicMock(spec=Task)
+    mock_task.status = TaskStatus.IN_PROGRESS
+
+    mocker.patch("time.monotonic", side_effect=[0.0, 0.0, 6.0])
+    mocker.patch.object(_hook_mod, "_call_sam_task_read", return_value=mock_task, create=True)
+    mock_update = mocker.patch.object(_hook_mod, "_call_sam_task_update", return_value=True)
+
+    handle_activity_update(hook_input)
+
+    mock_update.assert_called_once()
+    passed_timeout = mock_update.call_args.kwargs.get("timeout")
+    assert passed_timeout is not None, (
+        "expected _call_sam_task_update to receive an explicit timeout= reflecting the "
+        "remaining shared budget, not fall back to its own default"
+    )
+    assert 0 < passed_timeout < 8, f"expected a reduced remaining-budget timeout, got {passed_timeout!r}"
+
+
+def test_handle_activity_update_skips_update_when_budget_exhausted(
+    mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_call_sam_task_update is skipped entirely once the shared budget is exhausted by the read call.
+
+    time.monotonic() simulates the read call alone consuming the entire shared budget
+    (remaining <= 0 by the time the update call would be dispatched). Rather than
+    dispatching _call_sam_task_update with a doomed near-zero/negative timeout, the fix
+    must skip it outright (logging to stderr) and return.
+
+    RED on current code: handle_activity_update unconditionally calls
+    _call_sam_task_update whenever the task isn't already COMPLETE — there is no budget
+    check at all, so mock_update.assert_not_called() fails (it WAS called).
+    """
+    session_id = "sess-budget-exhausted"
+    hook_input = _write_activity_update_context(tmp_path, monkeypatch, session_id)
+
+    from sam_schema.core.models import Task, TaskStatus
+
+    mock_task = mocker.MagicMock(spec=Task)
+    mock_task.status = TaskStatus.IN_PROGRESS
+
+    mocker.patch("time.monotonic", side_effect=[0.0, 0.0, 8.5])
+    mocker.patch.object(_hook_mod, "_call_sam_task_read", return_value=mock_task, create=True)
+    mock_update = mocker.patch.object(_hook_mod, "_call_sam_task_update", return_value=True)
+
+    handle_activity_update(hook_input)
+
+    mock_update.assert_not_called()

--- a/plugins/development-harness/tests/test_task_status_hook.py
+++ b/plugins/development-harness/tests/test_task_status_hook.py
@@ -50,7 +50,7 @@ extract_task_info_from_prompt = _hook_mod.extract_task_info_from_prompt
 handle_subagent_stop = _hook_mod.handle_subagent_stop
 handle_activity_update = _hook_mod.handle_activity_update
 HookProfile = _hook_mod.HookProfile
-_SAM_RUN_SERVER_PATH = _hook_mod._SAM_RUN_SERVER_PATH
+_SAM_CLI_PATH = _hook_mod._SAM_CLI_PATH
 
 
 # ---------------------------------------------------------------------------
@@ -58,15 +58,23 @@ _SAM_RUN_SERVER_PATH = _hook_mod._SAM_RUN_SERVER_PATH
 # ---------------------------------------------------------------------------
 
 
-def _mcp_success_response(data: dict[str, Any]) -> CompletedProcess[str]:
-    """Build a successful fastmcp CLI response wrapping inner JSON."""
-    outer = {"content": [{"text": json.dumps(data)}]}
-    return CompletedProcess(args=[], returncode=0, stdout=json.dumps(outer), stderr="")
+def _cli_success_response(data: dict[str, Any]) -> CompletedProcess[str]:
+    """Build a successful SAM CLI subprocess response — plain JSON stdout, no envelope."""
+    return CompletedProcess(args=[], returncode=0, stdout=json.dumps(data), stderr="")
 
 
 def _mcp_error_response(returncode: int = 1) -> CompletedProcess[str]:
-    """Build a failed fastmcp CLI response."""
+    """Build a failed SAM CLI subprocess response."""
     return CompletedProcess(args=[], returncode=returncode, stdout="", stderr="error")
+
+
+def _argv_after(cmd: list[str], token: str) -> list[str]:
+    """Return the tail of *cmd* starting at the first occurrence of *token*.
+
+    Isolates the subcommand-and-options shape from the uv/script invocation
+    prefix, which callers should not need to hardcode.
+    """
+    return cmd[cmd.index(token) :]
 
 
 # ---------------------------------------------------------------------------
@@ -289,12 +297,12 @@ def test_extract_task_info_from_prompt_empty_returns_none() -> None:
 
 
 def test_call_sam_task_state_routes_through_mcp_subprocess(tmp_path: Path) -> None:
-    """_call_sam_task_state calls fastmcp CLI with correct input JSON."""
+    """_call_sam_task_state calls the SAM CLI with the correct argv shape."""
     # Arrange
     plan_addr = "Pf4281187"
     task_id = "T1"
     status = "complete"
-    response = _mcp_success_response({"id": task_id, "status": status})
+    response = _cli_success_response({"id": task_id, "status": status})
 
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
@@ -307,37 +315,8 @@ def test_call_sam_task_state_routes_through_mcp_subprocess(tmp_path: Path) -> No
     # Assert
     assert result is True
     mock_run.assert_called_once()
-    call_kwargs = mock_run.call_args
-    cmd = call_kwargs[0][0]
-    assert "--target" in cmd
-    assert "sam_task" in cmd
-    assert "--input-json" in cmd
-    # Verify input JSON contains expected fields
-    input_json_idx = cmd.index("--input-json") + 1
-    input_data = json.loads(cmd[input_json_idx])
-    assert input_data["plan"] == plan_addr
-    assert input_data["task"] == task_id
-    assert input_data["config"]["action"] == "state"
-    assert input_data["config"]["status"] == status
-
-
-def test_call_sam_task_state_sets_env_suppression_flags(tmp_path: Path) -> None:
-    """_call_sam_task_state passes FASTMCP env vars to suppress banner and logs."""
-    # Arrange
-    response = _mcp_success_response({"id": "T1", "status": "complete"})
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/uv"),
-        patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=response) as mock_run,
-    ):
-        # Act
-        _call_sam_task_state("Pabc123", "T1", "complete")
-
-    # Assert
-    env_passed = mock_run.call_args[1]["env"]
-    assert env_passed["FASTMCP_SHOW_SERVER_BANNER"] == "false"
-    assert env_passed["FASTMCP_LOG_ENABLED"] == "false"
+    cmd = mock_run.call_args[0][0]
+    assert _argv_after(cmd, "plan") == ["plan", "state", "--address", f"{plan_addr}/{task_id}", "--new-status", status]
 
 
 # ---------------------------------------------------------------------------
@@ -434,12 +413,12 @@ def test_call_sam_task_state_returns_false_on_malformed_json_response() -> None:
 
 
 def test_call_sam_task_update_routes_through_mcp_subprocess() -> None:
-    """_call_sam_task_update calls fastmcp CLI with correct set_fields_json."""
+    """_call_sam_task_update calls the SAM CLI with the mapped --last-activity option."""
     # Arrange
     plan_addr = "Pf4281187"
     task_id = "T2"
     fields = {"last-activity": "2026-05-14T18:00:00+00:00"}
-    response = _mcp_success_response({"updated": True, "address": f"{plan_addr}/{task_id}"})
+    response = _cli_success_response({"updated": True, "address": f"{plan_addr}/{task_id}"})
 
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
@@ -452,18 +431,21 @@ def test_call_sam_task_update_routes_through_mcp_subprocess() -> None:
     # Assert
     assert result is True
     cmd = mock_run.call_args[0][0]
-    input_json_idx = cmd.index("--input-json") + 1
-    input_data = json.loads(cmd[input_json_idx])
-    assert input_data["plan"] == plan_addr
-    assert input_data["task"] == task_id
-    assert input_data["config"]["action"] == "update"
-    assert input_data["config"]["set_fields_json"] == fields
+    assert _argv_after(cmd, "plan") == [
+        "plan",
+        "update",
+        "--plan-address",
+        f"{plan_addr}/{task_id}",
+        "--last-activity",
+        fields["last-activity"],
+    ]
 
 
-def test_call_sam_task_update_sets_env_suppression_flags() -> None:
-    """_call_sam_task_update passes FASTMCP env vars to suppress banner and logs."""
+def test_call_sam_task_update_completed_maps_to_cli_option() -> None:
+    """_call_sam_task_update maps a 'completed' field to the --completed CLI option."""
     # Arrange
-    response = _mcp_success_response({"updated": True, "address": "Pabc/T1"})
+    timestamp = "2026-08-29T12:00:00+00:00"
+    response = _cli_success_response({"updated": True, "address": "Pabc123/T1"})
 
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
@@ -471,12 +453,49 @@ def test_call_sam_task_update_sets_env_suppression_flags() -> None:
         patch("subprocess.run", return_value=response) as mock_run,
     ):
         # Act
-        _call_sam_task_update("Pabc123", "T1", {"last-activity": "2026-05-14T00:00:00+00:00"})
+        result = _call_sam_task_update("Pabc123", "T1", {"completed": timestamp})
 
     # Assert
-    env_passed = mock_run.call_args[1]["env"]
-    assert env_passed["FASTMCP_SHOW_SERVER_BANNER"] == "false"
-    assert env_passed["FASTMCP_LOG_ENABLED"] == "false"
+    assert result is True
+    cmd = mock_run.call_args[0][0]
+    assert ["--completed", timestamp] == cmd[cmd.index("--completed") : cmd.index("--completed") + 2]
+
+
+def test_call_sam_task_update_last_activity_maps_to_cli_option() -> None:
+    """_call_sam_task_update maps a 'last-activity' field to the --last-activity CLI option."""
+    # Arrange
+    timestamp = "2026-08-29T12:00:00+00:00"
+    response = _cli_success_response({"updated": True, "address": "Pabc123/T1"})
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/uv"),
+        patch.object(Path, "exists", return_value=True),
+        patch("subprocess.run", return_value=response) as mock_run,
+    ):
+        # Act
+        result = _call_sam_task_update("Pabc123", "T1", {"last-activity": timestamp})
+
+    # Assert
+    assert result is True
+    cmd = mock_run.call_args[0][0]
+    assert ["--last-activity", timestamp] == cmd[cmd.index("--last-activity") : cmd.index("--last-activity") + 2]
+
+
+def test_call_sam_task_update_returns_false_for_unmapped_field() -> None:
+    """_call_sam_task_update returns False without calling subprocess for an unmapped field.
+
+    Only 'completed' and 'last-activity' map to CLI options. Any other key
+    (e.g. an arbitrary task field) is not a supported patch target for this
+    helper — it must fail closed rather than silently drop the field or crash.
+    """
+    # Arrange
+    with patch("subprocess.run") as mock_run:
+        # Act
+        result = _call_sam_task_update("Pabc123", "T1", {"title": "New title"})
+
+    # Assert
+    assert result is False
+    mock_run.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -690,14 +709,10 @@ def test_handle_subagent_stop_exits_cleanly_when_state_fails(tmp_path: Path, mon
 
 
 def test_call_sam_task_read_success_returns_task_object(mocker: MockerFixture) -> None:
-    """_call_sam_task_read returns a SamTask on a successful MCP response.
-
-    Verifies the new helper wraps sam_task(action='read') subprocess call and
-    deserialises the Task from the MCP JSON response. RED: function does not exist.
-    """
+    """_call_sam_task_read returns a SamTask on a successful CLI response."""
     from sam_schema.core.models import Task, TaskStatus
 
-    # Arrange — craft a minimal task JSON response matching MCP envelope
+    # Arrange — craft a minimal task JSON response matching the CLI's plain output
     task_data = {
         "id": "T1",
         "title": "Write the tests",
@@ -707,17 +722,14 @@ def test_call_sam_task_read_success_returns_task_object(mocker: MockerFixture) -
         "dependencies": [],
     }
     inner = {"task": task_data}
-    outer = {"content": [{"text": json.dumps(inner)}]}
-    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(outer), stderr="")
+    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(inner), stderr="")
 
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
     mock_run = mocker.patch("subprocess.run", return_value=response)
 
-    # Act — call the not-yet-existing helper
-    call_sam_task_read = getattr(_hook_mod, "_call_sam_task_read", None)
-    assert call_sam_task_read is not None, "_call_sam_task_read does not exist on module — refactor required (RED)"
-    result = call_sam_task_read("Pf4281187", "T1")
+    # Act
+    result = _hook_mod._call_sam_task_read("Pf4281187", "T1")
 
     # Assert
     assert result is not None
@@ -727,10 +739,7 @@ def test_call_sam_task_read_success_returns_task_object(mocker: MockerFixture) -
 
 
 def test_call_sam_task_read_sends_correct_mcp_input_json(mocker: MockerFixture) -> None:
-    """_call_sam_task_read sends plan and task in MCP input JSON with action='read'.
-
-    RED: _call_sam_task_read does not exist on current code.
-    """
+    """_call_sam_task_read calls the SAM CLI with plan read --address <plan>/<task>."""
     task_data = {
         "id": "T3",
         "title": "Refactor hook",
@@ -740,30 +749,19 @@ def test_call_sam_task_read_sends_correct_mcp_input_json(mocker: MockerFixture) 
         "dependencies": [],
     }
     inner = {"task": task_data}
-    outer = {"content": [{"text": json.dumps(inner)}]}
-    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(outer), stderr="")
+    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(inner), stderr="")
 
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
     mock_run = mocker.patch("subprocess.run", return_value=response)
 
-    call_sam_task_read = getattr(_hook_mod, "_call_sam_task_read", None)
-    assert call_sam_task_read is not None, "_call_sam_task_read does not exist — refactor required (RED)"
-
     # Act
-    call_sam_task_read("Pdec8934d", "T3")
+    _hook_mod._call_sam_task_read("Pdec8934d", "T3")
 
-    # Assert — correct MCP input JSON structure
+    # Assert — correct CLI argv shape
     mock_run.assert_called_once()
     cmd = mock_run.call_args[0][0]
-    assert "--target" in cmd
-    assert "sam_task" in cmd
-    assert "--input-json" in cmd
-    idx = cmd.index("--input-json") + 1
-    input_data = json.loads(cmd[idx])
-    assert input_data["plan"] == "Pdec8934d"
-    assert input_data["task"] == "T3"
-    assert input_data["config"]["action"] == "read"
+    assert _argv_after(cmd, "plan") == ["plan", "read", "--address", "Pdec8934d/T3"]
 
 
 def test_call_sam_task_read_returns_none_when_uv_missing(mocker: MockerFixture) -> None:
@@ -1016,11 +1014,9 @@ def test_resolve_active_task_context_returns_str_plan_id_from_mcp(mocker: Mocker
         "agent_transcript_path": str(transcript),
     }
 
-    # Build a realistic MCP response for sam_active_task(action='get')
+    # Build a realistic CLI response for `active-task get`
     active_task = {"active_task": {"plan": "Pf4281187", "task_id": "T1", "parent_issue_number": None}}
-    inner_json = json.dumps(active_task)
-    outer = {"content": [{"text": inner_json}]}
-    mcp_response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(outer), stderr="")
+    mcp_response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(active_task), stderr="")
 
     # Patch subprocess.run so _call_sam_active_task_get uses our response
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
@@ -1074,7 +1070,7 @@ def test_handle_subagent_stop_emits_stderr_when_mcp_read_returns_none(
 
     # Assert — diagnostic visible on stderr
     captured = capsys.readouterr()
-    assert f"could not read task {task_id} from plan {plan_id} via MCP" in captured.err
+    assert f"could not read task {task_id} from plan {plan_id} via the SAM CLI" in captured.err
     assert "skipping" in captured.err
 
 
@@ -1111,7 +1107,7 @@ def test_handle_activity_update_emits_stderr_when_mcp_read_returns_none(
 
     # Assert — diagnostic visible on stderr
     captured = capsys.readouterr()
-    assert "could not read task T1 from plan Pf4281187 via MCP" in captured.err
+    assert "could not read task T1 from plan Pf4281187 via the SAM CLI" in captured.err
     assert "skipping" in captured.err
 
     # Assert — update still proceeds (best-effort activity tracking continues)
@@ -1119,77 +1115,20 @@ def test_handle_activity_update_emits_stderr_when_mcp_read_returns_none(
 
 
 # ---------------------------------------------------------------------------
-# Change 1 — _call_sam_fastmcp target parameter
-# ---------------------------------------------------------------------------
-
-
-def test_call_sam_fastmcp_explicit_target_passed_to_subprocess(mocker: MockerFixture) -> None:
-    """_call_sam_fastmcp forwards an explicit target to --target in the subprocess arg list.
-
-    The function signature changed from _call_sam_fastmcp(input_data, timeout) to
-    _call_sam_fastmcp(input_data, timeout, target). This test proves the wiring:
-    the value passed as target appears at the position immediately after --target in
-    the subprocess command, not merely somewhere in the arg list.
-    """
-    # Arrange
-    outer = {"content": [{"text": json.dumps({"ok": True})}]}
-    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(outer), stderr="")
-    mocker.patch("shutil.which", return_value="/usr/bin/uv")
-    mocker.patch.object(Path, "exists", return_value=True)
-    mock_run = mocker.patch("subprocess.run", return_value=response)
-
-    # Act
-    _hook_mod._call_sam_fastmcp({"action": "get"}, timeout=10, target="sam_active_task")
-
-    # Assert — --target is present and its value is the explicit target, not the default
-    mock_run.assert_called_once()
-    cmd: list[str] = mock_run.call_args[0][0]
-    assert "--target" in cmd
-    target_value = cmd[cmd.index("--target") + 1]
-    assert target_value == "sam_active_task"
-
-
-def test_call_sam_fastmcp_default_target_is_sam_task(mocker: MockerFixture) -> None:
-    """_call_sam_fastmcp defaults to target='sam_task' when no target is supplied.
-
-    Verifies the default value is still wired correctly after the signature change,
-    ensuring callers that omit target (e.g. _call_sam_task_state, _call_sam_task_update)
-    continue to route to sam_task.
-    """
-    # Arrange
-    outer = {"content": [{"text": json.dumps({"ok": True})}]}
-    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(outer), stderr="")
-    mocker.patch("shutil.which", return_value="/usr/bin/uv")
-    mocker.patch.object(Path, "exists", return_value=True)
-    mock_run = mocker.patch("subprocess.run", return_value=response)
-
-    # Act — no target argument; rely on default
-    _hook_mod._call_sam_fastmcp({"action": "read"}, timeout=10)
-
-    # Assert — --target value is the default sam_task
-    mock_run.assert_called_once()
-    cmd: list[str] = mock_run.call_args[0][0]
-    assert "--target" in cmd
-    target_value = cmd[cmd.index("--target") + 1]
-    assert target_value == "sam_task"
-
-
-# ---------------------------------------------------------------------------
-# _call_sam_active_task_get — target wiring
+# _call_sam_active_task_get — CLI subcommand routing
 # ---------------------------------------------------------------------------
 
 
 def test_call_sam_active_task_get_passes_sam_active_task_target(mocker: MockerFixture) -> None:
-    """_call_sam_active_task_get forwards 'sam_active_task' as --target to the subprocess.
+    """_call_sam_active_task_get calls the SAM CLI's ``active-task get`` subcommand.
 
-    A bug where the wrapper passes 'sam_task' instead would silently route the
-    call to the wrong MCP tool and return (None, None, None) without any error,
-    making it a correctness failure invisible at the call site.
+    A bug where the wrapper routes to the wrong subcommand would silently
+    return (None, None, None) without any error, making it a correctness
+    failure invisible at the call site.
     """
     # Arrange — valid active task response so the call succeeds
     active_task_data = {"active_task": {"plan": "Pf4281187", "task_id": "T1", "parent_issue_number": None}}
-    outer = {"content": [{"text": json.dumps(active_task_data)}]}
-    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(outer), stderr="")
+    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(active_task_data), stderr="")
 
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
@@ -1198,24 +1137,21 @@ def test_call_sam_active_task_get_passes_sam_active_task_target(mocker: MockerFi
     # Act
     _hook_mod._call_sam_active_task_get("test-session-id")
 
-    # Assert — the value immediately after --target must be 'sam_active_task'
+    # Assert
     mock_run.assert_called_once()
     cmd: list[str] = mock_run.call_args[0][0]
-    assert "--target" in cmd
-    assert cmd[cmd.index("--target") + 1] == "sam_active_task"
+    assert _argv_after(cmd, "active-task") == ["active-task", "get", "--session-id", "test-session-id"]
 
 
 def test_call_sam_active_task_clear_passes_sam_active_task_target(mocker: MockerFixture) -> None:
-    """_call_sam_active_task_clear forwards 'sam_active_task' as --target to the subprocess.
+    """_call_sam_active_task_clear calls the SAM CLI's ``active-task clear`` subcommand.
 
-    A bug where the wrapper passes 'sam_task' instead would route the clear call
-    to the wrong MCP tool, leaving stale active-task context and causing the next
-    SubagentStop to read a ghost task.
+    A bug where the wrapper routes to the wrong subcommand would leave stale
+    active-task context, causing the next SubagentStop to read a ghost task.
     """
     # Arrange — clear response; wrapper only checks stdout is not None
     clear_data = {"cleared": True}
-    outer = {"content": [{"text": json.dumps(clear_data)}]}
-    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(outer), stderr="")
+    response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(clear_data), stderr="")
 
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
@@ -1224,11 +1160,10 @@ def test_call_sam_active_task_clear_passes_sam_active_task_target(mocker: Mocker
     # Act
     _hook_mod._call_sam_active_task_clear("test-session-id")
 
-    # Assert — the value immediately after --target must be 'sam_active_task'
+    # Assert
     mock_run.assert_called_once()
     cmd: list[str] = mock_run.call_args[0][0]
-    assert "--target" in cmd
-    assert cmd[cmd.index("--target") + 1] == "sam_active_task"
+    assert _argv_after(cmd, "active-task") == ["active-task", "clear", "--session-id", "test-session-id"]
 
 
 # ---------------------------------------------------------------------------
@@ -1364,3 +1299,20 @@ def test_read_task_context_fails_loudly_on_legacy_record_missing_plan_field(
     assert "[hook]" in captured.err
     assert "legacy context record" in captured.err
     assert str(context_file) in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — no fastmcp invocation left in the hook source
+# ---------------------------------------------------------------------------
+
+
+def test_hook_source_contains_no_fastmcp_invocation() -> None:
+    """task_status_hook.py's own source never mentions 'fastmcp'.
+
+    All task-state writes/reads now route through direct SAM CLI subprocess
+    calls (see _SAM_CLI_PATH). A reintroduced fastmcp invocation would bring
+    back the orphaned-process defect (keep_alive=True) and the ~10s PostToolUse
+    budget overrun this migration fixed.
+    """
+    source = _hook_path.read_text(encoding="utf-8")
+    assert "fastmcp" not in source.lower()

--- a/plugins/development-harness/tests/test_task_status_hook.py
+++ b/plugins/development-harness/tests/test_task_status_hook.py
@@ -1546,3 +1546,16 @@ def test_handle_activity_update_skips_update_when_budget_exhausted(
     handle_activity_update(hook_input)
 
     mock_update.assert_not_called()
+
+
+def test_terminate_process_tree_resolves_from_inside_the_plugin_package() -> None:
+    """Regression test for a review finding on PR #3306.
+
+    _call_sam_cli's terminate_process_tree import previously reached into a
+    repo-root-only scripts/ directory that a marketplace install never ships
+    (only plugins/development-harness itself is distributed). Assert the
+    imported function's own source file lives inside the plugin directory,
+    not the sibling repo-root scripts/ directory.
+    """
+    source_file = Path(_hook_mod.terminate_process_tree.__code__.co_filename).resolve()
+    assert _plugin_dir.resolve() in source_file.parents

--- a/plugins/development-harness/tests/test_task_status_hook.py
+++ b/plugins/development-harness/tests/test_task_status_hook.py
@@ -13,7 +13,9 @@ Covers:
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import json
+import signal
 import sys
 from pathlib import Path
 from subprocess import CompletedProcess, SubprocessError, TimeoutExpired
@@ -66,6 +68,37 @@ def _cli_success_response(data: dict[str, Any]) -> CompletedProcess[str]:
 def _mcp_error_response(returncode: int = 1) -> CompletedProcess[str]:
     """Build a failed SAM CLI subprocess response."""
     return CompletedProcess(args=[], returncode=returncode, stdout="", stderr="error")
+
+
+def _popen_from_completed(cp: CompletedProcess[str], pid: int = 4242) -> MagicMock:
+    """Build a fake Popen instance whose communicate()/.returncode mirror a CompletedProcess.
+
+    The implementation moves off subprocess.run onto subprocess.Popen + communicate() so it
+    can redirect a timeout's kill to the whole process group. This adapts tests that already
+    express expected results as CompletedProcess to that new contract.
+    """
+    proc = MagicMock()
+    proc.communicate.return_value = (cp.stdout, cp.stderr)
+    proc.returncode = cp.returncode
+    proc.poll.return_value = cp.returncode
+    proc.pid = pid
+    proc.__enter__.return_value = proc
+    proc.__exit__.return_value = False
+    return proc
+
+
+def _popen_timeout(timeout: float = 8, pid: int = 4242) -> MagicMock:
+    """Build a fake Popen instance whose communicate() times out once, then reaps cleanly.
+
+    A list side_effect (rather than a bare exception) tolerates an implementation that calls
+    communicate() a second time after killing the process group to reap pipes/avoid warnings.
+    """
+    proc = MagicMock()
+    proc.communicate.side_effect = [TimeoutExpired(cmd="uv", timeout=timeout), ("", "")]
+    proc.pid = pid
+    proc.__enter__.return_value = proc
+    proc.__exit__.return_value = False
+    return proc
 
 
 def _argv_after(cmd: list[str], token: str) -> list[str]:
@@ -307,15 +340,15 @@ def test_call_sam_task_state_routes_through_mcp_subprocess(tmp_path: Path) -> No
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=response) as mock_run,
+        patch("subprocess.Popen", return_value=_popen_from_completed(response)) as mock_popen,
     ):
         # Act
         result = _call_sam_task_state(plan_addr, task_id, status)
 
     # Assert
     assert result is True
-    mock_run.assert_called_once()
-    cmd = mock_run.call_args[0][0]
+    mock_popen.assert_called_once()
+    cmd = mock_popen.call_args[0][0]
     assert _argv_after(cmd, "plan") == ["plan", "state", "--address", f"{plan_addr}/{task_id}", "--new-status", status]
 
 
@@ -352,7 +385,7 @@ def test_call_sam_task_state_returns_false_on_nonzero_returncode() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=_mcp_error_response()),
+        patch("subprocess.Popen", return_value=_popen_from_completed(_mcp_error_response())),
     ):
         # Act
         result = _call_sam_task_state("Pabc123", "T1", "complete")
@@ -367,7 +400,9 @@ def test_call_sam_task_state_returns_false_on_timeout() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", side_effect=TimeoutExpired(cmd="uv", timeout=15)),
+        patch("subprocess.Popen", return_value=_popen_timeout()),
+        patch("os.getpgid", return_value=4242),
+        patch("os.killpg"),
     ):
         # Act
         result = _call_sam_task_state("Pabc123", "T1", "complete")
@@ -382,7 +417,7 @@ def test_call_sam_task_state_returns_false_on_subprocess_error() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", side_effect=SubprocessError("broken pipe")),
+        patch("subprocess.Popen", side_effect=SubprocessError("broken pipe")),
     ):
         # Act
         result = _call_sam_task_state("Pabc123", "T1", "complete")
@@ -398,7 +433,7 @@ def test_call_sam_task_state_returns_false_on_malformed_json_response() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=bad_response),
+        patch("subprocess.Popen", return_value=_popen_from_completed(bad_response)),
     ):
         # Act
         result = _call_sam_task_state("Pabc123", "T1", "complete")
@@ -423,14 +458,14 @@ def test_call_sam_task_update_routes_through_mcp_subprocess() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=response) as mock_run,
+        patch("subprocess.Popen", return_value=_popen_from_completed(response)) as mock_popen,
     ):
         # Act
         result = _call_sam_task_update(plan_addr, task_id, fields)
 
     # Assert
     assert result is True
-    cmd = mock_run.call_args[0][0]
+    cmd = mock_popen.call_args[0][0]
     assert _argv_after(cmd, "plan") == [
         "plan",
         "update",
@@ -450,14 +485,14 @@ def test_call_sam_task_update_completed_maps_to_cli_option() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=response) as mock_run,
+        patch("subprocess.Popen", return_value=_popen_from_completed(response)) as mock_popen,
     ):
         # Act
         result = _call_sam_task_update("Pabc123", "T1", {"completed": timestamp})
 
     # Assert
     assert result is True
-    cmd = mock_run.call_args[0][0]
+    cmd = mock_popen.call_args[0][0]
     assert ["--completed", timestamp] == cmd[cmd.index("--completed") : cmd.index("--completed") + 2]
 
 
@@ -470,14 +505,14 @@ def test_call_sam_task_update_last_activity_maps_to_cli_option() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=response) as mock_run,
+        patch("subprocess.Popen", return_value=_popen_from_completed(response)) as mock_popen,
     ):
         # Act
         result = _call_sam_task_update("Pabc123", "T1", {"last-activity": timestamp})
 
     # Assert
     assert result is True
-    cmd = mock_run.call_args[0][0]
+    cmd = mock_popen.call_args[0][0]
     assert ["--last-activity", timestamp] == cmd[cmd.index("--last-activity") : cmd.index("--last-activity") + 2]
 
 
@@ -489,13 +524,13 @@ def test_call_sam_task_update_returns_false_for_unmapped_field() -> None:
     helper — it must fail closed rather than silently drop the field or crash.
     """
     # Arrange
-    with patch("subprocess.run") as mock_run:
+    with patch("subprocess.Popen") as mock_popen:
         # Act
         result = _call_sam_task_update("Pabc123", "T1", {"title": "New title"})
 
     # Assert
     assert result is False
-    mock_run.assert_not_called()
+    mock_popen.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -520,7 +555,7 @@ def test_call_sam_task_update_returns_false_on_nonzero_returncode() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=_mcp_error_response()),
+        patch("subprocess.Popen", return_value=_popen_from_completed(_mcp_error_response())),
     ):
         # Act
         result = _call_sam_task_update("Pabc123", "T1", {"last-activity": "ts"})
@@ -535,7 +570,9 @@ def test_call_sam_task_update_returns_false_on_timeout() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", side_effect=TimeoutExpired(cmd="uv", timeout=15)),
+        patch("subprocess.Popen", return_value=_popen_timeout()),
+        patch("os.getpgid", return_value=4242),
+        patch("os.killpg"),
     ):
         # Act
         result = _call_sam_task_update("Pabc123", "T1", {"last-activity": "ts"})
@@ -551,7 +588,7 @@ def test_call_sam_task_update_returns_false_on_malformed_json() -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/uv"),
         patch.object(Path, "exists", return_value=True),
-        patch("subprocess.run", return_value=bad_response),
+        patch("subprocess.Popen", return_value=_popen_from_completed(bad_response)),
     ):
         # Act
         result = _call_sam_task_update("Pabc123", "T1", {"x": "y"})
@@ -726,7 +763,7 @@ def test_call_sam_task_read_success_returns_task_object(mocker: MockerFixture) -
 
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
-    mock_run = mocker.patch("subprocess.run", return_value=response)
+    mock_popen = mocker.patch("subprocess.Popen", return_value=_popen_from_completed(response))
 
     # Act
     result = _hook_mod._call_sam_task_read("Pf4281187", "T1")
@@ -735,7 +772,7 @@ def test_call_sam_task_read_success_returns_task_object(mocker: MockerFixture) -
     assert result is not None
     assert isinstance(result, Task)
     assert result.status == TaskStatus.IN_PROGRESS
-    mock_run.assert_called_once()
+    mock_popen.assert_called_once()
 
 
 def test_call_sam_task_read_sends_correct_mcp_input_json(mocker: MockerFixture) -> None:
@@ -753,14 +790,14 @@ def test_call_sam_task_read_sends_correct_mcp_input_json(mocker: MockerFixture) 
 
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
-    mock_run = mocker.patch("subprocess.run", return_value=response)
+    mock_popen = mocker.patch("subprocess.Popen", return_value=_popen_from_completed(response))
 
     # Act
     _hook_mod._call_sam_task_read("Pdec8934d", "T3")
 
     # Assert — correct CLI argv shape
-    mock_run.assert_called_once()
-    cmd = mock_run.call_args[0][0]
+    mock_popen.assert_called_once()
+    cmd = mock_popen.call_args[0][0]
     assert _argv_after(cmd, "plan") == ["plan", "read", "--address", "Pdec8934d/T3"]
 
 
@@ -787,7 +824,10 @@ def test_call_sam_task_read_returns_none_on_subprocess_failure(mocker: MockerFix
     """
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
-    mocker.patch("subprocess.run", return_value=CompletedProcess(args=[], returncode=1, stdout="", stderr="err"))
+    mocker.patch(
+        "subprocess.Popen",
+        return_value=_popen_from_completed(CompletedProcess(args=[], returncode=1, stdout="", stderr="err")),
+    )
 
     call_sam_task_read = getattr(_hook_mod, "_call_sam_task_read", None)
     assert call_sam_task_read is not None, "_call_sam_task_read does not exist (RED)"
@@ -802,11 +842,11 @@ def test_call_sam_task_read_returns_none_on_timeout(mocker: MockerFixture) -> No
 
     RED: function does not exist on current code.
     """
-    from subprocess import TimeoutExpired
-
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
-    mocker.patch("subprocess.run", side_effect=TimeoutExpired(cmd="uv", timeout=15))
+    mocker.patch("subprocess.Popen", return_value=_popen_timeout())
+    mocker.patch("os.getpgid", return_value=4242)
+    mocker.patch("os.killpg")
 
     call_sam_task_read = getattr(_hook_mod, "_call_sam_task_read", None)
     assert call_sam_task_read is not None, "_call_sam_task_read does not exist (RED)"
@@ -1018,10 +1058,10 @@ def test_resolve_active_task_context_returns_str_plan_id_from_mcp(mocker: Mocker
     active_task = {"active_task": {"plan": "Pf4281187", "task_id": "T1", "parent_issue_number": None}}
     mcp_response = CompletedProcess(args=[], returncode=0, stdout=json.dumps(active_task), stderr="")
 
-    # Patch subprocess.run so _call_sam_active_task_get uses our response
+    # Patch subprocess.Popen so _call_sam_active_task_get uses our response
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
-    mocker.patch("subprocess.run", return_value=mcp_response)
+    mocker.patch("subprocess.Popen", return_value=_popen_from_completed(mcp_response))
 
     # Act — let _resolve_active_task_context → _call_sam_active_task_get run naturally
     result = _hook_mod._resolve_active_task_context(hook_input)
@@ -1132,14 +1172,14 @@ def test_call_sam_active_task_get_passes_sam_active_task_target(mocker: MockerFi
 
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
-    mock_run = mocker.patch("subprocess.run", return_value=response)
+    mock_popen = mocker.patch("subprocess.Popen", return_value=_popen_from_completed(response))
 
     # Act
     _hook_mod._call_sam_active_task_get("test-session-id")
 
     # Assert
-    mock_run.assert_called_once()
-    cmd: list[str] = mock_run.call_args[0][0]
+    mock_popen.assert_called_once()
+    cmd: list[str] = mock_popen.call_args[0][0]
     assert _argv_after(cmd, "active-task") == ["active-task", "get", "--session-id", "test-session-id"]
 
 
@@ -1155,14 +1195,14 @@ def test_call_sam_active_task_clear_passes_sam_active_task_target(mocker: Mocker
 
     mocker.patch("shutil.which", return_value="/usr/bin/uv")
     mocker.patch.object(Path, "exists", return_value=True)
-    mock_run = mocker.patch("subprocess.run", return_value=response)
+    mock_popen = mocker.patch("subprocess.Popen", return_value=_popen_from_completed(response))
 
     # Act
     _hook_mod._call_sam_active_task_clear("test-session-id")
 
     # Assert
-    mock_run.assert_called_once()
-    cmd: list[str] = mock_run.call_args[0][0]
+    mock_popen.assert_called_once()
+    cmd: list[str] = mock_popen.call_args[0][0]
     assert _argv_after(cmd, "active-task") == ["active-task", "clear", "--session-id", "test-session-id"]
 
 
@@ -1316,3 +1356,100 @@ def test_hook_source_contains_no_fastmcp_invocation() -> None:
     """
     source = _hook_path.read_text(encoding="utf-8")
     assert "fastmcp" not in source.lower()
+
+
+# ---------------------------------------------------------------------------
+# PR #3306 review response — timeout ordering + process-group cleanup
+#
+# Two compounding defects fixed here:
+#   1. Every _call_sam_cli-family timeout default (15s, or 10s for the
+#      active-task helpers) is not safely below the outer 10s PostToolUse hook
+#      deadline Claude Code itself enforces — the external SIGKILL can beat
+#      subprocess's own internal timeout handling.
+#   2. subprocess.run(timeout=...) only kills the immediate child (uv); a
+#      descendant process uv forks (the real sam_schema/cli.py interpreter)
+#      can be left running — the orphaned-process failure mode this whole
+#      area of the codebase exists to prevent.
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_defaults_are_below_outer_hook_deadline() -> None:
+    """Every _call_sam_cli-family function's own timeout default must be < 10s.
+
+    The outer PostToolUse hook deadline is a hard 10s SIGKILL of the whole
+    hook process, enforced externally by Claude Code. An internal subprocess
+    timeout default at or above that value can never fire before the outer
+    kill does, so subprocess's own timeout/cleanup path never gets a chance
+    to run — this is the exact defect already fixed once for the old
+    fastmcp-call path, recurring here for the plain-CLI replacement.
+    """
+    funcs = [
+        _hook_mod._call_sam_cli,
+        _hook_mod._call_sam_task_state,
+        _hook_mod._call_sam_task_update,
+        _hook_mod._call_sam_task_read,
+        _hook_mod._call_sam_active_task_get,
+        _hook_mod._call_sam_active_task_clear,
+    ]
+    for func in funcs:
+        default = inspect.signature(func).parameters["timeout"].default
+        assert default < 10, f"{func.__name__} timeout default is {default!r}, must be < 10"
+
+
+def test_call_sam_cli_kills_entire_process_group_on_timeout(mocker: MockerFixture) -> None:
+    """On timeout, _call_sam_cli kills the whole process group, not just the immediate pid.
+
+    subprocess.run(timeout=...) only ever calls .kill() on the immediate child
+    (the uv process). If `uv run --script` forks rather than execs into the
+    actual interpreter, that descendant survives — an orphaned process. The
+    fix kills the entire process group via os.killpg(os.getpgid(pid), SIGKILL).
+    """
+    proc = _popen_timeout(pid=4242)
+
+    mocker.patch("shutil.which", return_value="/usr/bin/uv")
+    mocker.patch.object(Path, "exists", return_value=True)
+    mocker.patch("subprocess.Popen", return_value=proc)
+    mocker.patch("os.getpgid", return_value=4242)
+    mock_killpg = mocker.patch("os.killpg")
+
+    result = _hook_mod._call_sam_cli(["plan", "read", "--address", "P1/T1"])
+
+    assert result is None
+    mock_killpg.assert_called_once_with(4242, signal.SIGKILL)
+
+
+def test_call_sam_cli_launches_subprocess_in_new_session(mocker: MockerFixture) -> None:
+    """_call_sam_cli launches its subprocess with start_new_session=True.
+
+    A new session/process group is the prerequisite for os.killpg to be able
+    to target the whole process tree instead of just the immediate child pid.
+    """
+    proc = _popen_from_completed(CompletedProcess(args=[], returncode=0, stdout="{}", stderr=""), pid=1234)
+
+    mocker.patch("shutil.which", return_value="/usr/bin/uv")
+    mocker.patch.object(Path, "exists", return_value=True)
+    mock_popen = mocker.patch("subprocess.Popen", return_value=proc)
+
+    _hook_mod._call_sam_cli(["plan", "read", "--address", "P1/T1"])
+
+    mock_popen.assert_called_once()
+    assert mock_popen.call_args.kwargs.get("start_new_session") is True
+
+
+def test_call_sam_cli_timeout_killpg_race_does_not_raise(mocker: MockerFixture) -> None:
+    """A ProcessLookupError from os.killpg (process already exited) does not propagate.
+
+    Between the timeout firing and the killpg call, the process may have already
+    exited on its own — a benign race, not a failure the hook should crash on.
+    """
+    proc = _popen_timeout(pid=4242)
+
+    mocker.patch("shutil.which", return_value="/usr/bin/uv")
+    mocker.patch.object(Path, "exists", return_value=True)
+    mocker.patch("subprocess.Popen", return_value=proc)
+    mocker.patch("os.getpgid", return_value=4242)
+    mocker.patch("os.killpg", side_effect=ProcessLookupError)
+
+    result = _hook_mod._call_sam_cli(["plan", "read", "--address", "P1/T1"])
+
+    assert result is None

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -12,7 +12,13 @@ import pydantic
 import pytest
 from backlog_core import file_cache
 from backlog_core.file_cache import CacheCheckpoint, FileCache, ReplayAcknowledgement, _ProviderSnapshotCheckpoint
-from backlog_core.file_cache_state import PendingMutation, _CacheState, _CacheStateStore, _PendingWorkItemMutation
+from backlog_core.file_cache_state import (
+    PendingMutation,
+    _CacheState,
+    _CacheStateStore,
+    _PendingWorkItemMutation,
+    _RejectedMutation,
+)
 from backlog_core.models import (
     BacklogItem,
     ContentKind,
@@ -305,6 +311,93 @@ def test_file_cache_serializes_concurrent_instances_and_reopens_valid_state(tmp_
         CacheCheckpoint(reference=references[0], revision="rev-2", fingerprint="item-1-fp"),
         CacheCheckpoint(reference=references[1], revision="rev-2", fingerprint="item-2-fp"),
     ]
+
+
+def test_reject_pending_is_a_noop_when_the_targeted_mutation_was_superseded(tmp_path: Path) -> None:
+    """A stale idempotency key must not let reject_pending discard a superseding mutation.
+
+    Regression test for a review finding on PR #3306: reject_pending() looked up the
+    entry to move into `rejected` by `reference` alone. `queue_write()` deduplicates by
+    reference -- a newer queue_write() call for the same reference replaces the older
+    pending entry outright, so at most one pending entry per reference can ever exist.
+    If a replay attempt for the superseded (older) mutation later fails, rejecting by
+    reference alone would silently reject the newer, never-attempted mutation instead
+    of the one that actually failed. reject_pending must match by idempotency_key, so
+    it is inert once its target has already been superseded.
+    """
+    cache = FileCache(tmp_path)
+    reference = _reference("#1")
+    record = _record(reference, "before")
+    first = cache.queue_write(record, ContentWrite(reference=reference, content="first", expected_revision="rev-1"))
+    second = cache.queue_write(record, ContentWrite(reference=reference, content="second", expected_revision="rev-1"))
+    assert cache.pending_mutations() == [second]
+
+    cache.reject_pending(reference, first.idempotency_key, "stale replay failure")
+
+    assert cache.pending_mutations() == [second]
+    assert cache.rejected_mutations() == []
+
+
+def test_reject_pending_moves_the_matching_mutation_by_idempotency_key(tmp_path: Path) -> None:
+    """reject_pending still moves the correct mutation into `rejected` when it is current."""
+    cache = FileCache(tmp_path)
+    reference = _reference("#1")
+    record = _record(reference, "before")
+    mutation = cache.queue_write(record, ContentWrite(reference=reference, content="only", expected_revision="rev-1"))
+
+    cache.reject_pending(reference, mutation.idempotency_key, "precondition failed")
+
+    assert cache.pending_mutations() == []
+    rejected = cache.rejected_mutations()
+    assert len(rejected) == 1
+    assert rejected[0].idempotency_key == mutation.idempotency_key
+    assert rejected[0].reason == "precondition failed"
+
+
+def test_rejected_entry_is_cleared_once_a_superseding_write_is_acknowledged(tmp_path: Path) -> None:
+    """A rejected entry must not survive past a later successful write for the same reference.
+
+    Regression test for a review finding on PR #3306: discard_pending() clears both
+    `state.pending` and `state.rejected` for a reference, but acknowledge_replay() only
+    ever cleared `state.pending`. A reference whose earlier write was rejected (a genuine
+    terminal conflict), then edited and replayed again successfully, left the stale
+    rejected entry sitting in `rejected_mutations()` forever even though fresher content
+    had since landed for that reference. The rejected entry is seeded directly through
+    the durable state store here so this test exercises acknowledge_replay's own clearing
+    behavior independent of reject_pending's call signature.
+    """
+    cache = FileCache(tmp_path)
+    reference = _reference("#1")
+    record = _record(reference, "before")
+    cache.cache_content(record)
+    stale_rejected_write = ContentWrite(reference=reference, content="rejected", expected_revision="rev-1")
+    store = _CacheStateStore(tmp_path)
+    store.transaction(
+        lambda state: (
+            state.model_copy(
+                update={
+                    "rejected": [
+                        _RejectedMutation(
+                            idempotency_key="stale-key", write=stale_rejected_write, reason="precondition failed"
+                        )
+                    ]
+                }
+            ),
+            None,
+        )
+    )
+    assert len(cache.rejected_mutations()) == 1
+
+    retried = cache.queue_write(record, ContentWrite(reference=reference, content="retried", expected_revision="rev-1"))
+    cache.acknowledge_replay([
+        ReplayAcknowledgement(
+            idempotency_key=retried.idempotency_key,
+            record=_record(reference, "retried", revision="rev-2"),
+            fingerprint="fp-2",
+        )
+    ])
+
+    assert cache.rejected_mutations() == []
 
 
 def _populated_cache_state() -> _CacheState:

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -6,6 +6,7 @@ from multiprocessing import get_context
 from multiprocessing.synchronize import Barrier as ProcessBarrier
 from pathlib import Path
 from threading import Barrier, Thread
+from unittest.mock import MagicMock
 
 import pydantic
 import pytest
@@ -100,6 +101,22 @@ def test_file_cache_acknowledges_work_item_by_idempotency_key(tmp_path: Path) ->
 
     # Then: the acknowledged entry is removed
     assert cache._pending_work_item_mutations() == []
+
+
+def test_acknowledge_work_items_skips_transaction_for_empty_key_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Given: a durable work-item intent and a caller that acknowledges nothing
+    cache = FileCache(tmp_path)
+    cache._queue_work_item("#1", BacklogItem(title="One"))
+    spy = MagicMock(wraps=cache._state.transaction)
+    monkeypatch.setattr(cache._state, "transaction", spy)
+
+    # When: acknowledgement is called with an empty key set (every reconcile without acks)
+    cache._acknowledge_work_items(set())
+
+    # Then: no lock/load/write cycle runs for a no-op acknowledgement
+    spy.assert_not_called()
 
 
 def test_file_cache_lists_work_item_snapshots_by_stable_key(tmp_path: Path) -> None:

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -400,6 +400,37 @@ def test_rejected_entry_is_cleared_once_a_superseding_write_is_acknowledged(tmp_
     assert cache.rejected_mutations() == []
 
 
+def test_get_content_surfaces_the_rejection_reason_for_a_rejected_reference(tmp_path: Path) -> None:
+    """A caller reading content through get_content() must see why its write was dropped.
+
+    Regression test for a review finding on PR #3306: `rejected_mutations()` is a
+    private FileCache method absent from the logical ContentProvider interface, so a
+    caller whose offline write was later rejected during replay had no way to learn
+    about it through get_content() -- only a logger warning fired at replay time, which
+    the original caller (a different call, possibly a different process) never sees.
+    conflict_reason must be derived live from state.rejected, mirroring how `pending`
+    is already derived live from state.pending.
+    """
+    cache = FileCache(tmp_path)
+    reference = _reference("#1")
+    record = _record(reference, "before")
+    cache.cache_content(record)
+
+    unrejected = cache.get_content(reference)
+    assert unrejected.conflict_reason == ""
+
+    mutation = cache.queue_write(record, ContentWrite(reference=reference, content="doomed", expected_revision="rev-1"))
+    cache.reject_pending(reference, mutation.idempotency_key, "revision no longer matches")
+
+    rejected_view = cache.get_content(reference)
+    assert rejected_view.conflict_reason == "revision no longer matches"
+
+    # A fresh write for the same reference supersedes the rejection (Fix 2 above);
+    # get_content() must stop surfacing the stale reason once that happens.
+    cache.queue_write(record, ContentWrite(reference=reference, content="retry", expected_revision="rev-1"))
+    assert cache.get_content(reference).conflict_reason == ""
+
+
 def _populated_cache_state() -> _CacheState:
     # A realistic mix of the nested models actually persisted to cache.yaml.
     artifact_ref = _reference("#1")

--- a/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
+++ b/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from backlog_core.backends import github_work_items
 from backlog_core.backends._github_work_item_versions import root_revision
 from backlog_core.backends.github_backend import GitHubBackend, _GitHubPlanPersistence
 from backlog_core.file_cache import FileCache, _ProviderSnapshotCheckpoint
@@ -20,9 +21,10 @@ from backlog_core.models import (
     ProviderPatch,
     ProviderSnapshot,
     ReconcileRequest,
+    ReconcileResult,
     ReconcileScope,
 )
-from backlog_core.reconciliation import synchronized_fingerprint
+from backlog_core.reconciliation import ReconcilePlan, synchronized_fingerprint
 from sam_schema.core.plan_id_index import PlanIndexEntry
 
 
@@ -433,6 +435,71 @@ def test_github_queued_title_rename_survives_reconnect(tmp_path: Path) -> None:
     assert result.conflicts == 1
     assert [mutation.item.title for mutation in pending] == ["Renamed offline"]
     assert backend._apply_patches.call_args.args[0][0].body
+
+
+def test_github_work_item_ack_ignores_stable_reference_when_title_drifted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Given: a queued body-only edit whose patch will land successfully, while
+    # GitHub's title has drifted for reasons unrelated to the queued change
+    # (e.g. renamed by someone else after the item was queued locally).
+    cache = FileCache(tmp_path)
+    backend = GitHubBackend(cache=cache)
+    baseline = BacklogItem(title="Issue 1", description="provider body")
+    baseline.metadata.issue = "#1"
+    baseline.metadata.sync_fingerprint = synchronized_fingerprint(baseline)
+    local = baseline.model_copy(update={"description": "local body"})
+    backend.put_work_item(local)  # frozen queued title: "Issue 1"
+
+    backend._fetch_snapshot = MagicMock(
+        return_value=ProviderSnapshot(
+            items=[
+                ProviderItem(
+                    provider_id="node-1",
+                    reference="#1",
+                    title="Renamed on GitHub",
+                    body=backend.render_issue_body(baseline),
+                    state="OPEN",
+                    labels=[],
+                    revision="rev-1",
+                )
+            ],
+            sync_started_at="2026-08-12T02:00:00Z",
+            pages_fetched=1,
+        )
+    )
+    backend._apply_patches = MagicMock(
+        return_value=[PatchResult(provider_id="node-1", reference="#1", status="applied", revision="rev-2")]
+    )
+
+    # The pure reconcile engine has its own, separate title-conflict gate
+    # (reconciliation.py's `candidate.title != provider.title` check) that
+    # would otherwise co-fire alongside the acknowledgement guard under test
+    # and mask which one is responsible for the stuck entry. Substituting a
+    # clean patch-only plan isolates the acknowledgement guard itself.
+    def isolated_plan(records: object, snapshot: ProviderSnapshot, request: ReconcileRequest) -> ReconcilePlan:
+        return ReconcilePlan(
+            provider_patches=[
+                ProviderPatch(provider_id="node-1", reference="#1", expected_revision="rev-1", body="patched body")
+            ],
+            result=ReconcileResult(fetched_pages=snapshot.pages_fetched, fetched_items=len(snapshot.items)),
+            snapshot_checkpoint=snapshot.sync_started_at,
+        )
+
+    monkeypatch.setattr(github_work_items, "reconcile_backlog", isolated_plan)
+
+    # When: reconciliation applies the patch against a GitHub snapshot whose
+    # title no longer matches what was frozen at queue time
+    backend.reconcile(ReconcileRequest(scope=ReconcileScope.INCREMENTAL, references=["#1"]))
+
+    # Then: the mutation should be acknowledged -- it shares the same stable
+    # reference ("#1") and its patch landed -- but the frozen-title equality
+    # guard in `_acknowledge_work_items` (github_work_items.py) can never
+    # match a title that changed after the item was queued, so the mutation
+    # leaks in `pending_work_items` forever. This pins the sane target
+    # behavior (acknowledge by stable reference, not title text) and is
+    # expected to fail (RED) against the current guard.
+    assert FileCache(tmp_path)._pending_work_item_mutations() == []
 
 
 def test_github_plan_discovery_lists_all_owners_when_owner_is_omitted(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
+++ b/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
@@ -437,6 +437,162 @@ def test_github_queued_title_rename_survives_reconnect(tmp_path: Path) -> None:
     assert backend._apply_patches.call_args.args[0][0].body
 
 
+def _leak_a_baseline(title: str = "Issue 1", description: str = "provider body") -> BacklogItem:
+    """Return a baseline shaped the way ``_checkpoint`` would persist it.
+
+    ``_checkpoint`` (reconciliation.py) always receives a ``_compose``d
+    candidate, whose ``metadata.status`` is always ``provider.state.lower()``
+    -- never the empty string a bare ``BacklogItem()`` carries. The
+    ``_merged_title`` probe recomputes ``synchronized_fingerprint`` -- which
+    hashes ``metadata.status`` -- against this baseline's stored fingerprint,
+    so a baseline built with ``status == ""`` can never match the probe's
+    projection (whose status is always the real provider state). Every probe
+    call would then silently fall through to the safe ``local.title`` answer,
+    passing regardless of whether ``_merged_title`` actually works. Setting
+    ``status`` explicitly here is what makes these 5 tests a real exercise of
+    the merge logic instead of false-confidence passes.
+    """
+    baseline = BacklogItem(title=title, description=description)
+    baseline.metadata.issue = "#1"
+    baseline.metadata.status = "open"
+    baseline.metadata.sync_fingerprint = synchronized_fingerprint(baseline)
+    return baseline
+
+
+def _leak_a_snapshot(backend: GitHubBackend, *, title: str, body_item: BacklogItem) -> ProviderSnapshot:
+    return ProviderSnapshot(
+        items=[
+            ProviderItem(
+                provider_id="node-1",
+                reference="#1",
+                title=title,
+                body=backend.render_issue_body(body_item),
+                state="OPEN",
+                labels=[],
+                revision="rev-1",
+            )
+        ],
+        sync_started_at="2026-08-12T02:00:00Z",
+        pages_fetched=1,
+    )
+
+
+def _leak_a_applied_patches() -> MagicMock:
+    return MagicMock(
+        return_value=[PatchResult(provider_id="node-1", reference="#1", status="applied", revision="rev-2")]
+    )
+
+
+def test_github_reconcile_accepts_remote_rename_when_local_only_edited_body(tmp_path: Path) -> None:
+    """Remote renamed the title; local only edited the body. The fix's whole point:
+
+    this must NOT be treated as a title conflict. Fails (RED) without the
+    ``_merged_title`` fix, which would otherwise fall back to ``local.title``
+    and discard the remote rename as a spurious conflict.
+    """
+    cache = FileCache(tmp_path)
+    backend = GitHubBackend(cache=cache)
+    baseline = _leak_a_baseline()
+    local = baseline.model_copy(update={"description": "local body"})
+    backend.put_work_item(local)
+    backend._fetch_snapshot = MagicMock(
+        return_value=_leak_a_snapshot(backend, title="Renamed on GitHub", body_item=baseline)
+    )
+    backend._apply_patches = _leak_a_applied_patches()
+
+    result = backend.reconcile(ReconcileRequest(scope=ReconcileScope.INCREMENTAL, references=["#1"]))
+
+    assert result.conflicts == 0
+
+
+def test_github_reconcile_retains_local_rename_when_remote_title_unchanged(tmp_path: Path) -> None:
+    """DATA LOSS GUARD: local renamed the title offline; remote is unchanged.
+
+    The offline rename must surface as a conflict and be retained, never
+    silently overwritten by the provider's stale title. Must stay correct
+    forever.
+    """
+    cache = FileCache(tmp_path)
+    backend = GitHubBackend(cache=cache)
+    baseline = _leak_a_baseline()
+    renamed = baseline.model_copy(update={"title": "Renamed offline"})
+    backend.put_work_item(renamed)
+    backend._fetch_snapshot = MagicMock(return_value=_leak_a_snapshot(backend, title="Issue 1", body_item=baseline))
+    backend._apply_patches = _leak_a_applied_patches()
+
+    result = backend.reconcile(ReconcileRequest(scope=ReconcileScope.INCREMENTAL, references=["#1"]))
+
+    pending = FileCache(tmp_path)._pending_work_item_mutations()
+    assert result.conflicts == 1, "DATA LOSS: offline rename silently accepted the provider title"
+    assert [mutation.item.title for mutation in pending] == ["Renamed offline"]
+
+
+def test_github_reconcile_conflicts_when_remote_renamed_and_remote_body_changed(tmp_path: Path) -> None:
+    """Remote renamed the title AND the remote body changed in the same snapshot.
+
+    Documented, deliberate fallback ceiling: the merge probe can only prove a
+    remote-only rename by reproducing the baseline fingerprint with local's
+    title substituted in, which requires every other field (including body)
+    to match the baseline exactly. A concurrent remote body change breaks
+    that substitution, so this falls back to ``local.title`` and surfaces as
+    a conflict -- safe, just not optimized. Do not "fix" this without
+    re-reading the design rationale in reconciliation.py's ``_merged_title``.
+    """
+    cache = FileCache(tmp_path)
+    backend = GitHubBackend(cache=cache)
+    baseline = _leak_a_baseline()
+    remote_body_item = baseline.model_copy(update={"description": "remote body moved on"})
+    local = baseline.model_copy(update={"description": "local body"})
+    backend.put_work_item(local)
+    backend._fetch_snapshot = MagicMock(
+        return_value=_leak_a_snapshot(backend, title="Renamed on GitHub", body_item=remote_body_item)
+    )
+    backend._apply_patches = _leak_a_applied_patches()
+
+    result = backend.reconcile(ReconcileRequest(scope=ReconcileScope.INCREMENTAL, references=["#1"]))
+
+    assert result.conflicts == 1
+
+
+def test_github_reconcile_retains_local_rename_when_remote_body_also_changed(tmp_path: Path) -> None:
+    """DATA LOSS GUARD: local renamed offline while the remote body also moved on."""
+    cache = FileCache(tmp_path)
+    backend = GitHubBackend(cache=cache)
+    baseline = _leak_a_baseline()
+    remote_body_item = baseline.model_copy(update={"description": "remote body moved on"})
+    renamed = baseline.model_copy(update={"title": "Renamed offline"})
+    backend.put_work_item(renamed)
+    backend._fetch_snapshot = MagicMock(
+        return_value=_leak_a_snapshot(backend, title="Issue 1", body_item=remote_body_item)
+    )
+    backend._apply_patches = _leak_a_applied_patches()
+
+    result = backend.reconcile(ReconcileRequest(scope=ReconcileScope.INCREMENTAL, references=["#1"]))
+
+    pending = FileCache(tmp_path)._pending_work_item_mutations()
+    assert result.conflicts == 1
+    assert [mutation.item.title for mutation in pending] == ["Renamed offline"]
+
+
+def test_github_reconcile_retains_local_rename_when_both_sides_renamed_differently(tmp_path: Path) -> None:
+    """DATA LOSS GUARD: local renamed offline AND remote renamed differently."""
+    cache = FileCache(tmp_path)
+    backend = GitHubBackend(cache=cache)
+    baseline = _leak_a_baseline()
+    renamed = baseline.model_copy(update={"title": "Renamed offline"})
+    backend.put_work_item(renamed)
+    backend._fetch_snapshot = MagicMock(
+        return_value=_leak_a_snapshot(backend, title="Renamed on GitHub", body_item=baseline)
+    )
+    backend._apply_patches = _leak_a_applied_patches()
+
+    result = backend.reconcile(ReconcileRequest(scope=ReconcileScope.INCREMENTAL, references=["#1"]))
+
+    pending = FileCache(tmp_path)._pending_work_item_mutations()
+    assert result.conflicts == 1, "DATA LOSS: concurrent rename resolved to the provider title"
+    assert [mutation.item.title for mutation in pending] == ["Renamed offline"]
+
+
 def test_github_work_item_ack_ignores_stable_reference_when_title_drifted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
+++ b/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
@@ -278,6 +278,52 @@ def test_github_work_item_intent_replays_once_after_reconnect(tmp_path: Path) ->
     assert backend._apply_patches.call_count == 1
 
 
+def test_reconcile_does_not_acknowledge_pending_mutation_when_unlink_snapshot_save_fails(tmp_path: Path) -> None:
+    """A GitHub-deleted issue produces an unlink CacheAction whose ``record.item``
+
+    has ``metadata.issue`` already cleared to ``""`` (see ``_plan_item``'s
+    unlinked-copy construction). If the acknowledgement guard in
+    ``github_work_items.reconcile`` keys ``failed_cache_references`` off
+    ``action.record.item.metadata.issue`` it collects ``""`` instead of the
+    real reference, so a failed unlink write never blocks acknowledgement and
+    the still-pending local mutation is wrongly dropped. Fails (RED) against
+    the unfixed guard.
+    """
+    cache = FileCache(tmp_path)
+    backend = GitHubBackend(cache=cache)
+    local = BacklogItem(title="Issue 1", description="local body")
+    local.metadata.issue = "#1"
+    backend.put_work_item(local)
+    backend._fetch_snapshot = MagicMock(
+        return_value=ProviderSnapshot(
+            items=[
+                ProviderItem(
+                    provider_id="node-1",
+                    reference="#1",
+                    title="Issue 1",
+                    body="",
+                    state="OPEN",
+                    labels=[],
+                    revision="rev-1",
+                    exists=False,
+                )
+            ],
+            sync_started_at="2026-08-12T02:00:00Z",
+            pages_fetched=1,
+        )
+    )
+    cache._save_work_item_snapshot = MagicMock(side_effect=OSError("disk full"))
+
+    # When: reconciliation processes the unlink action and its cache write fails
+    backend.reconcile(ReconcileRequest(scope=ReconcileScope.INCREMENTAL, references=["#1"]))
+
+    # Then: the pending mutation must remain queued -- it was never durably unlinked
+    pending = FileCache(tmp_path)._pending_work_item_mutations()
+    assert [mutation.item.metadata.issue for mutation in pending] == ["#1"], (
+        "Mutation was acknowledged despite the unlink cache write failing"
+    )
+
+
 def test_github_reconcile_retains_mutation_queued_after_plan_construction(tmp_path: Path) -> None:
     # Given: a queued body change whose provider patch will succeed
     cache = FileCache(tmp_path)

--- a/plugins/development-harness/tests_backlog/test_github_sync_provider.py
+++ b/plugins/development-harness/tests_backlog/test_github_sync_provider.py
@@ -756,10 +756,12 @@ def test_github_content_provider_replay_preserves_concurrent_remote_revision(tmp
     # When: reconnect reads the authoritative remote content before replay
     current = backend.get_content(reference)
 
-    # Then: the remote wins and the conflicting queued mutation remains available for retry or diagnosis
+    # Then: the remote wins, and the conflicting queued mutation is relocated
+    # out of the unbounded-retry pending queue into the rejected bucket --
+    # still available for diagnosis, not lost, and no longer retried forever.
     assert current.content == "revision-two"
     assert remote["content"] == "revision-two"
-    assert [mutation.write.content for mutation in cache.pending_mutations()] == ["queued"]
+    assert [mutation.write.content for mutation in cache.rejected_mutations()] == ["queued"]
     artifact_provider.store_artifact_content.assert_not_called()
 
 

--- a/plugins/development-harness/tests_sam/test_cli_update.py
+++ b/plugins/development-harness/tests_sam/test_cli_update.py
@@ -388,6 +388,53 @@ class TestSamUpdateSetField:
 
 
 # ---------------------------------------------------------------------------
+# sam plan update -- --completed / --last-activity
+# ---------------------------------------------------------------------------
+
+
+class TestSamUpdateTimestampFields:
+    """Test ``sam plan update`` with --completed and --last-activity.
+
+    Tests: CLI acceptance and persistence of task completion/activity timestamps.
+    How: Update T1 with both flags using an ISO string with a UTC offset (the
+        exact shape ``datetime.now(UTC).isoformat(timespec="seconds")`` produces),
+        read back and verify both values round-tripped unchanged.
+    Why: The task-status hook writes these fields via the CLI post-migration from
+        fastmcp; an unverified option here means task completion timestamps would
+        silently stop being recorded (the hook returns False but the harness sees
+        exit 0).
+    """
+
+    def test_update_accepts_completed_and_last_activity(
+        self, plan_dir: Path, content_backend: ContentTaskProvider
+    ) -> None:
+        timestamp = "2026-08-29T12:00:00+00:00"
+
+        result = runner.invoke(
+            app,
+            [
+                "plan",
+                "update",
+                "--plan-address",
+                f"{plan_dir.name}/T1",
+                "--completed",
+                timestamp,
+                "--last-activity",
+                timestamp,
+                "--plan-dir",
+                str(plan_dir),
+            ],
+            env={"NO_COLOR": "1"},
+        )
+
+        assert result.exit_code == 0, result.stdout
+        plan_data = _stored_plan(content_backend, plan_dir)
+        task = plan_data["tasks"][0]
+        assert task["completed"] == timestamp
+        assert task["last_activity"] == timestamp
+
+
+# ---------------------------------------------------------------------------
 # sam plan update -- append-section
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two independent fixes for the CPU/latency/orphaned-process problems investigated tonight, both root-caused via find-cause protocol.

### 1. Shared cache pending-queue leaks (`backlog_core/`)

Follow-up to #3292 (merged — JSON codec fix). Two bugs let state pile up forever in the per-project shared cache, amplifying the cost of every read/write on top of the codec fix:

- **Leak A** — `reconciliation.py`'s `_candidate()` took `local.title` unconditionally whenever both sides changed, so a genuine remote-side title rename could never be accepted once the local side also edited the body. 91% of real `pending_work_items` entries were stuck on this. Fixed with `_merged_title()`: probes whether substituting `local.title` into the remote projection reproduces the stored `sync_fingerprint` baseline — no schema change, existing stuck entries self-heal.
- **Leak B** — `github_content_migration.py`'s `replay_pending()` swallowed `ContentConflictError`/`UnsupportedCapabilityError` with a bare `continue`, leaving a permanently-unsatisfiable write stuck in `pending` forever and shadowing `get_content()` with stale content. Fixed by moving such mutations into a new bounded `rejected` bucket, keyed by reference with replace-on-write (same shape as the existing `checkpoints` field) — content retained, not discarded.
- `_acknowledge_work_items` no longer rewrites the entire cache file for an empty acknowledgement set.

### 2. Orphaned `fastmcp call` processes (`task_status_hook.py`)

`task_status_hook.py` (fires on every Write/Edit/Bash during SAM task work) called `fastmcp call --command "uv run --script run_sam_server.py" --target sam_task ...` — a 3-level nested subprocess spawning a full MCP protocol handshake just to make one tool call. Two compounding bugs:

1. Upstream `fastmcp`'s CLI `call` command builds its `StdioTransport` without `keep_alive=False`, skipping the `disconnect()` call that triggers proper stdio shutdown. Confirmed not fixed in 3.4.7 (latest stable) or `main`/`v4.0.0b5`.
2. The hook's two sequential MCP round-trips measured ~11.3s total, exceeding Claude Code's own 10s PostToolUse timeout — Claude Code SIGKILLs the hook before its own cleanup can run.

Fixed by migrating the hook off `fastmcp call` entirely onto the existing plain CLI (`sam_schema/cli.py` via `scripts/run_sam_cli.py`) — same backend-agnostic design goal, ~1.29s per call (4x inside budget), never touches the buggy fastmcp CLI machinery. Shipped in the same change: `sam plan update --completed`/`--last-activity` (a hard prerequisite — the hook's only two write fields, previously inexpressible via the CLI), plus a matching alias fix in `TaskFieldsUpdate` that was silently dropping the `last-activity` wire key. Backend parity (YAML/content and Beads) verified via a new regression test. A path-scoped guardrail (`.claude/rules/hook-subprocess-invocation.md`) prevents this pattern from being reintroduced, without imposing token cost on agents that never touch hooks.

## Test plan

- [x] `uv run pytest plugins/development-harness/tests_backlog/ plugins/development-harness/sam_schema/tests/ plugins/development-harness/tests_sam/ plugins/development-harness/tests/ --no-cov` — 1697+ passed, 0 failures across both fixes
- [x] `uv run ty check` on all touched source files — clean
- [x] Data-loss safety guards confirmed still passing for both fixes (title-rename retention, conflicting-write retention)
- [x] Regression tests written first (TDD) for every fix, verified RED against unpatched code
- [x] Live process measurements: cache transaction ~9s→~20ms; `fastmcp call`→CLI ~5.65s→~1.29s per hook call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UTscRv1zUtDGw114cwd3K