### PR TITLE
feat(development-harness): provider-neutral cache-bypass for backlog_list/backlog_view

### DIFF
--- a/.claude/agents/backlog-mcp-validator.md
+++ b/.claude/agents/backlog-mcp-validator.md
@@ -11,7 +11,7 @@ mcpServers:
     - python
     - -m
     - backlog_core.server
-    cwd: .claude/skills/backlog
+    cwd: plugins/development-harness
 ---
 
 # Backlog MCP Validator
@@ -21,10 +21,10 @@ You are a validation specialist for the `backlog` FastMCP server. You know every
 ## Server Location
 
 ```text
-Package : .claude/skills/backlog/backlog_core/
-Server  : .claude/skills/backlog/backlog_core/server.py
-CLI     : .claude/skills/backlog/scripts/backlog.py
-Tests   : .claude/skills/backlog/tests/
+Package : plugins/development-harness/backlog_core/
+Server  : plugins/development-harness/backlog_core/server.py
+CLI     : plugins/development-harness/sam_schema/cli.py (backlog subcommand)
+Tests   : plugins/development-harness/backlog_core/tests/
 ```
 
 All validation uses native MCP tool calls — Bash, Read, Write, and Edit are disallowed.
@@ -51,37 +51,60 @@ Parameters:
   description   str   required  Item description
   source        str   optional  Where this item came from  (default: "Not specified")
   type          str   optional  "Feature"|"Bug"|"Refactor"|"Docs"|"Chore"  (default: "Feature")
-  create_issue  bool  optional  Create GitHub issue  (default: true)
   force         bool  optional  Skip fuzzy duplicate check  (default: false)
 
 Returns: {file_path, title, priority, issue?, messages, warnings}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py add --title X --priority P1 --description D
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog add --title X --priority P1 --description D
 ```
+
+There is no `create_issue` toggle. Issue creation is unconditional — the backend always attempts
+to create a native issue for a new item; `issue` is empty only when backend creation fails or is
+unavailable.
 
 ### backlog_list
 
 ```text
 Parameters:
-  from_github   bool      optional  Refresh cache from GitHub first  (default: false)
-  label         str|null  optional  Filter by GitHub label  (default: null)
-  section       str|null  optional  Filter by section name  (default: null)
-  status        str|null  optional  Filter by status string (e.g. "resolved")  (default: null)
-  title         str|null  optional  Filter by title substring  (default: null)
-  type          str|null  optional  Filter by metadata.type — case-insensitive exact match
-                                    e.g. "Bug", "Feature", "Refactor", "Docs", "Chore"
-                                    Items missing metadata.type are excluded when active.
-                                    (default: null)
-  topic         str|null  optional  Filter by metadata.topic — case-insensitive substring match
-                                    Items missing metadata.topic are excluded when active.
-                                    (default: null)
+  refresh          bool       optional  Refresh cache from the backend first  (default: false)
+  label            str|null   optional  Filter by GitHub label  (default: null)
+  section          str|null   optional  Filter by section name  (default: null)
+  status           str|null   optional  Filter by status string (e.g. "resolved")  (default: null)
+  title            str|null   optional  Filter by title substring  (default: null)
+  type             str|null   optional  Filter by metadata.type — case-insensitive exact match
+                                        e.g. "Bug", "Feature", "Refactor", "Docs", "Chore"
+                                        Items missing metadata.type are excluded when active.
+                                        (default: null)
+  topic            str|null   optional  Filter by metadata.topic — case-insensitive substring match
+                                        Items missing metadata.topic are excluded when active.
+                                        (default: null)
+  filter_by_key    dict|null  optional  key=value filters applied after type/topic/status, AND-composed
+                                        (default: null)
+  include_closed   bool       optional  Include closed/done/resolved items  (default: false)
+  search           str|null   optional  Full-text search across title, section, topic, type,
+                                        description, and section body text; supports OR/AND/NOT,
+                                        regex, and field-specific syntax (title:, type:, topic:, body:)
+                                        (default: null)
+  offset           int        optional  Skip the first N items (pagination)  (default: 0)
+  limit            int        optional  Max items to return; 0 = auto-paginate to a token budget
+                                        (default: 0)
+  count_only       bool       optional  Return only {"count": N}  (default: false)
+  match_context    bool       optional  Include per-item search match snippets  (default: false)
+  snippet_context  int        optional  Char budget for match snippet windows  (default: 1024)
+  item_depth       int        optional  0-3, controls per-item content richness  (default: 0)
+  page             int        optional  Page of match_context output  (default: 1)
+  tokens_per_page  int        optional  Token budget per match_context page  (default: 1000)
+  page_token_limit int        optional  Total match-token threshold before paging activates
+                                        (default: 4000)
+  fields           list|null  optional  Restrict each returned item to only the listed fields
+                                        (default: null)
 
-Returns: {items: [{title, priority, issue, plan, type, topic}],
+Returns: {items: [{title, priority, issue, plan, type, topic}], count?, pagination: {offset, limit, total, has_more},
           backend: {name, availability, open_count, total_count,
                     cache_open_count, cache_total_count, last_sync, error},
           messages, warnings}
           availability values: "reachable" | "not_checked" | "needs_authentication" | "rate_limited" | "error"
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py list --format json [--with-status]
-         [--type Bug] [--topic matching]
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog list [--type Bug] [--topic matching]
+         [--include-closed] [--filter key=value]
 ```
 
 `type` and `topic` filters compose with AND logic. All active filters must match for an item to
@@ -92,22 +115,38 @@ appear. The `type` and `topic` fields are always present in each returned item d
 
 ```text
 Parameters:
-  selector     str      required  GitHub issue URL | "#N" | bare number | title substring | beads nanoid (e.g. bd-a3f8)
-  offset       int      optional  Skip N lines from body  (default: 0)
-  limit        int      optional  Max lines to return (0 = all)  (default: 0)
-  map          bool     optional  Return structured TOC map of item sections with ordinals
-                                  and token estimates instead of body content  (default: false)
-  navigate     str|null optional  Ordinal to resolve to full section content  (default: null)
-                                  Accepts: N, N.M, N.M.K (deep sub-heading), N.M.code.K (code fence)
-                                  Pattern: ^\d+(\.\d+)*(\.code\.\d+)?$
-  head         int|null optional  Max tokens to return (1–25000); activates extraction mode
-                                  with skip_tokens= for continuation  (default: null)
-  skip_tokens  int      optional  Token offset for pagination continuation  (default: 0)
+  selector        str       required  GitHub issue URL | "#N" | bare number | title substring | beads nanoid (e.g. bd-a3f8)
+  refresh         bool      optional  Bypass the local cache and validate against the live backend
+                                      (default: false)
+  summary         bool      optional  Return a compact routing manifest (sections_index + hints)
+                                      instead of the full body  (default: true)
+  include_content bool      optional  Return full body/entries; false = section names + entry
+                                      counts only  (default: true)
+  offset          int       optional  Skip N entry blocks from body start  (default: 0)
+  limit           int       optional  Show at most N entry blocks (0 = all)  (default: 0)
+  show            str|null  optional  Entry filter: "all"|"last"|"first"|"struck"|integer N
+                                      (default: null)
+  since           str|null  optional  ISO date/datetime — only entries at/after this timestamp
+                                      (default: null)
+  section         str|null  optional  Section filter: numeric index, comma-separated indices,
+                                      regex, or substring match  (default: null)
+  sections        list|null optional  Restrict the returned sections dict to these named sections
+                                      (default: null)
+  map             bool      optional  Return structured TOC map of item sections with ordinals
+                                      and token estimates instead of body content  (default: false)
+  navigate        str|null  optional  Ordinal to resolve to full section content  (default: null)
+                                      Accepts: N, N.M, N.M.K (deep sub-heading), N.M.code.K (code fence)
+                                      Pattern: ^\d+(\.\d+)*(\.code\.\d+)?$
+  head            int|null  optional  Max tokens to return (1–25000); activates extraction mode
+                                      with skip_tokens= for continuation  (default: null)
+  skip_tokens     int       optional  Token offset for pagination continuation  (default: 0)
 
-Returns: {title, priority, issue, plan, file_path, body, groomed, messages, warnings}
+Returns: When summary=true (default): {issue_number, title, labels, status, plan_address,
+           sections_index, _full_chars, _hint, messages, warnings}
+         When summary=false: {title, priority, issue, plan, file_path, body, sections, messages, warnings}
          When navigate is set: {ordinal, title, content, total_tokens, truncated,
            child_map: str|null, has_children: bool}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py view "<selector>" --format json
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog view --selector "<selector>"
 ```
 
 ### backlog_sync
@@ -117,34 +156,46 @@ Parameters:
   dry_run  bool  optional  Preview without changes  (default: false)
 
 Returns: {created, pushed, messages, warnings}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py sync [--dry-run]
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog sync [--dry-run]
 ```
 
 ### backlog_close
 
 ```text
 Parameters:
-  selector       str   required  GitHub issue URL | "#N" | bare number | title substring | beads nanoid (e.g. bd-a3f8)
-  plan           str   required  Plan path or completion summary
-  checklist_pass bool  optional  Must be true to close  (default: false)
-  cleanup        bool  optional  Remove local file after close  (default: false)
-  force          bool  optional  Close even with open PRs  (default: false)
+  selector   str   required  GitHub issue URL | "#N" | bare number | title substring
+  reason     str   required  Why the item is being dismissed: duplicate | out_of_scope | superseded
+                             | wontfix | blocked
+  reference  str   optional  Related item reference: #N, URL, or title of the item this
+                             duplicates/is superseded by  (default: "")
+  comment    str   optional  Additional context about why this item is being closed  (default: "")
+  cleanup    bool  optional  Remove local file after close; index link becomes GitHub issue URL
+                             (default: false)
+  force      bool  optional  Close even if open PRs reference the issue  (default: false)
 
 Returns: {title, issue?, messages, warnings}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py close "<title>" --plan PATH --checklist-pass
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog close --selector "<selector>" --reason "duplicate"
 ```
+
+`selector` does NOT accept a beads nanoid on this tool — see Beads Backend Notes below.
 
 ### backlog_resolve
 
 ```text
 Parameters:
-  selector  str   required  GitHub issue URL | "#N" | bare number | title substring | beads nanoid (e.g. bd-a3f8)
-  reason    str   required  Reason for resolving
-  cleanup   bool  optional  Remove local file after resolve  (default: false)
-  force     bool  optional  Resolve even with open PRs  (default: false)
+  selector    str       required  GitHub issue URL | "#N" | bare number | title substring | beads nanoid (e.g. bd-a3f8)
+  summary     str       required  What was done — 1-2 sentence completion summary
+  plan        str|null  optional  Plan path or completion reference  (default: null)
+  method      str|null  optional  How the work was done — approach taken  (default: null)
+  notes       str|null  optional  Problems found, surprises, or other comments  (default: null)
+  follow_ups  str|null  optional  Created follow-up tickets (comma-separated refs)  (default: null)
+  findings    str|null  optional  Retrospective learnings from this work  (default: null)
+  cleanup     bool      optional  Remove local file after resolve; index link becomes GitHub issue URL
+                                  (default: false)
+  force       bool      optional  Resolve even if open PRs reference the issue  (default: false)
 
 Returns: {title, summary, issue?, messages, warnings}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py resolve "<title>" --reason "..."
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog resolve --selector "<selector>" --summary "..."
 ```
 
 ### backlog_update
@@ -152,30 +203,51 @@ CLI:     uv run .claude/skills/backlog/scripts/backlog.py resolve "<title>" --re
 ```text
 Parameters:
   selector        str       required  GitHub issue URL | "#N" | bare number | title substring | beads nanoid (e.g. bd-a3f8)
-  plan            str|null  optional  Plan file path to attach
-  status          str|null  optional  "in-progress" | "groomed" | etc.
-  create_issue    bool      optional  Create GitHub issue if missing  (default: false)
-  groomed_content str|null  optional  Full groomed content (replaces groomed section)
-  section         str|null  optional  Section name for incremental update
-  content         str|null  optional  Content for named section
-  title           str|null  optional  Rename item title
-  description     str|null  optional  Update item description
+  plan            str|null  optional  Path to a plan file to attach to the item  (default: null)
+  status          str|null  optional  "in-progress" | "groomed" | etc.  (default: null)
+  section         str|null  optional  Section name for content update (use with content)  (default: null)
+  content         str|null  optional  Content for the named section  (default: null)
+  title           str|null  optional  New title; updates local file and linked GitHub issue title
+                                      (default: null)
+  description     str|null  optional  New description text; local file only, no GitHub sync
+                                      (default: null)
+  entry_id        str|null  optional  ID of an existing entry to replace within the section
+                                      (default: null)
+  replace_section bool      optional  Strike all existing entries in the section and append new
+                                      content  (default: false)
+  reason          str|null  optional  Reason for striking entries (required when
+                                      replace_section=true)  (default: null)
+  verified        bool      optional  Mark the linked work item as verified (post quality-gate
+                                      signal)  (default: false)
 
 Returns: {title, changes: {field: value, ...}, messages, warnings}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py update "<title>" [--plan P] [--status S]
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog update --selector "<selector>" [--plan P] [--status S]
 ```
 
 ### backlog_groom
 
 ```text
 Parameters:
-  selector        str       required  GitHub issue URL | "#N" | bare number | title substring | beads nanoid (e.g. bd-a3f8)
-  groomed_content str|null  optional  Full groomed content
-  section         str|null  optional  Section name for incremental update
-  content         str|null  optional  Content for named section
+  selector        str        required  GitHub issue URL | "#N" | bare number | title substring | beads nanoid (e.g. bd-a3f8)
+  section         str|null   optional  Section name for incremental update (use with content)
+                                       (default: null)
+  content         str|null   optional  Content for the named section  (default: null)
+  entry_id        str|null   optional  ID of an existing entry to replace within the section
+                                       (default: null)
+  replace_section bool       optional  Strike all existing entries in the section and append new
+                                       content  (default: false)
+  reason          str|null   optional  Reason for striking entries (required when
+                                       replace_section=true)  (default: null)
+  append          bool       optional  Append after existing section content instead of replacing
+                                       it, no entry-block wrapping  (default: false)
+  sections        dict|null  optional  Batch section writes {name: content}; mutually exclusive
+                                       with section/content/entry_id/replace_section/reason/append
+                                       (default: null)
+  mark_groomed    bool       optional  Advance item status to "groomed" after content is written
+                                       (default: false)
 
 Returns: {title, synced, messages, warnings}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py groom "<title>" --section S --content C
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog groom --selector "<selector>" --section S --content C
 ```
 
 ### backlog_normalize
@@ -185,20 +257,23 @@ Parameters:
   dry_run  bool  optional  Preview without modifying files  (default: false)
 
 Returns: {normalized, messages, warnings}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py normalize [--dry-run]
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog normalize [--dry-run]
 ```
 
 ### backlog_pull
 
 ```text
 Parameters:
-  selector  str|null  optional  Pull a single issue: GitHub URL | "#N" | bare number | title substring
-                                | beads nanoid (e.g. bd-a3f8). When omitted, pulls all issues.
+  selector  str|null  optional  Pull a single issue: GitHub URL | "#N" | bare number | title substring.
+                                When omitted, pulls all issues.  (default: null)
   dry_run   bool      optional  Preview without modifying local files  (default: false)
-  force     bool      optional  Overwrite even if local version is newer  (default: false)
+  force     bool      optional  Overwrite even if local version is newer or longer  (default: false)
+  diff      bool      optional  Include entry-level diff output showing local vs remote changes
+                                (default: false)
 
 Returns: {pulled, messages, warnings}
-CLI:     uv run .claude/skills/backlog/scripts/backlog.py pull [--dry-run] [--force]
+CLI:     uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog pull-all [--dry-run] [--force] [--diff]
+         uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" backlog pull --selector "<selector>" [--diff]
 ```
 
 ### backlog_strike_entry
@@ -315,12 +390,12 @@ response shape is identical regardless of whether the missing ordinal is numeric
 The `backlog` server is configured in this agent's `mcpServers` frontmatter. It starts automatically when you are invoked. You have direct access to all 10 tools as native MCP tools. Use them directly:
 
 ```text
-mcp__plugin_dh_backlog__backlog_add(title="test", priority="P2", description="test", create_issue=false)
+mcp__plugin_dh_backlog__backlog_add(title="test", priority="P2", description="test")
 mcp__plugin_dh_backlog__backlog_list()
 mcp__plugin_dh_backlog__backlog_view(selector="test")
 mcp__plugin_dh_backlog__backlog_sync(dry_run=true)
-mcp__plugin_dh_backlog__backlog_close(selector="test", plan="test", checklist_pass=true)
-mcp__plugin_dh_backlog__backlog_resolve(selector="test", reason="test")
+mcp__plugin_dh_backlog__backlog_close(selector="test", reason="duplicate")
+mcp__plugin_dh_backlog__backlog_resolve(selector="test", summary="test")
 mcp__plugin_dh_backlog__backlog_update(selector="test", status="in-progress")
 mcp__plugin_dh_backlog__backlog_groom(selector="test", section="Test", content="test content")
 mcp__plugin_dh_backlog__backlog_normalize(dry_run=true)
@@ -353,19 +428,24 @@ For each tool, call it via native MCP and verify the response contract:
 
 ### Step 4: Run Lifecycle Scenario
 
-End-to-end test using a throwaway item. Run with `create_issue=false` on ALL calls to avoid GitHub API side effects:
+End-to-end test using a throwaway item. `backlog_add` has no `create_issue` toggle — the backend
+always attempts to create a native issue when a new item is created, so treat issue creation as
+unconditional and plan cleanup accordingly:
 
 ```text
-1. backlog_add    — create "mcp-validator-test" item, priority P2, create_issue=false
+1. backlog_add    — create "mcp-validator-test" item, priority P2
 2. backlog_list   — confirm item appears in result
 3. backlog_view   — view item by title substring; record whether "issue" field is set
-4. backlog_update — set status (use create_issue=false); do NOT use create_issue=true
-5. backlog_groom  — write a test section; do NOT allow GitHub issue creation
-6. backlog_resolve — resolve with reason "Validation test item", cleanup=true
+4. backlog_update — set status
+5. backlog_groom  — write a test section
+6. backlog_resolve — resolve with summary "Validation test item", cleanup=true
 7. backlog_list   — confirm item is gone from local list
 ```
 
-**CRITICAL**: Never pass `create_issue=true` on any call during validation. Some operations (like `backlog_groom`) may auto-create GitHub issues as a side effect — if Step 3's `backlog_view` shows an `issue` field appeared despite `create_issue=false`, record it as a finding and ensure Step 6 (Cleanup Verification) closes it.
+**CRITICAL**: Because issue creation is unconditional, expect Step 3's `backlog_view` to show a
+populated `issue` field. Record whether it does; if an issue was created, Step 6 (Cleanup
+Verification) must use `backlog_close` (which also closes the GitHub issue) instead of
+`backlog_resolve` (local file only).
 
 ### Step 5: Error Path Validation
 
@@ -374,8 +454,9 @@ Verify error handling:
 ```text
 - backlog_add with duplicate title → error key or DuplicateItemError converted to error
 - backlog_view with non-existent selector → error key present
-- backlog_close with checklist_pass=false → error key present
-- backlog_resolve with empty reason → error key present
+- backlog_close with an invalid `reason` (not one of duplicate/out_of_scope/superseded/wontfix/blocked)
+  → error key present
+- backlog_resolve with empty summary → error key present
 ```
 
 ### Step 6: Cleanup Verification (MANDATORY)
@@ -386,9 +467,9 @@ After all validation is complete, verify no test artifacts remain. This step run
 1. backlog_list(title="mcp-validator-test") — check for any items matching the test prefix
 2. For EACH match found:
    a. backlog_view(selector="{title}") — check if "issue" field contains a GitHub issue number
-   b. If issue exists: backlog_close(selector="{title}", plan="Validator cleanup — test artifact",
-      checklist_pass=true, cleanup=true, force=true)
-   c. If no issue: backlog_resolve(selector="{title}", reason="Validator cleanup — test artifact",
+   b. If issue exists: backlog_close(selector="{title}", reason="wontfix",
+      comment="Validator cleanup — test artifact", cleanup=true, force=true)
+   c. If no issue: backlog_resolve(selector="{title}", summary="Validator cleanup — test artifact",
       cleanup=true)
 3. backlog_list(title="mcp-validator-test") — confirm zero matches remain
 4. If any items still remain, report them in the FAIL section with their titles
@@ -455,8 +536,8 @@ Details:
 ## Scope Rules
 
 - Run ONLY validation code — do not modify backlog items or files except for the lifecycle throwaway item
-- Use `create_issue=false` on ALL add, update, and groom calls during validation to prevent GitHub issue creation
-- NEVER pass `create_issue=true` during validation — this is the primary cause of orphaned test artifacts
+- `backlog_add` has no `create_issue` toggle — issue creation is unconditional; always check the
+  `issue` field after add/groom calls and route cleanup through `backlog_close` when one was created
 - Step 6 (Cleanup Verification) is MANDATORY and runs even if earlier steps fail
 - If cleanup fails, report item titles and issue numbers in a `## Cleanup Failures` section — never leave artifacts silently
 - Report what you observed, not what you expect — if output doesn't match spec, cite the actual value

--- a/docs/dh-backend-beads/comparison-research/03-dh-github-backlog.md
+++ b/docs/dh-backend-beads/comparison-research/03-dh-github-backlog.md
@@ -150,7 +150,7 @@ Auto-pagination: when `limit=0`, binary-searches for the largest slice that fits
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `from_github` | bool | `False` | Refresh local cache from GitHub before listing |
+| `refresh` | bool | `False` | Refresh local cache from GitHub before listing |
 | `label` | str\|None | `None` | Filter by GitHub label (e.g. `'priority:p1'`, `'type:bug'`) |
 | `section` | str\|None | `None` | Filter by priority section: P0, P1, P2, Ideas |
 | `status` | str\|None | `None` | Filter by status value (e.g. `'needs-grooming'`, `'status:in-progress'`) |

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.4.7",
+  "version": "10.4.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "10.4.6",
+  "version": "10.4.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.4.7",
+  "version": "9.4.8",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "9.4.6",
+  "version": "9.4.7",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.4.6",
+  "version": "6.4.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "6.4.7",
+  "version": "6.4.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/disclosure_handler.py
+++ b/plugins/development-harness/backlog_core/disclosure_handler.py
@@ -300,7 +300,9 @@ class BacklogViewDisclosureHandler:
         self._normalizer = normalizer if normalizer is not None else ItemContentNormalizer()
         self._extractor = extractor if extractor is not None else TokenBoundedExtractor()
 
-    def handle(self, selector: str, request: DisclosureRequest) -> MapResponse | NavigateResponse | BoundedResponse:
+    def handle(
+        self, selector: str, request: DisclosureRequest, refresh: bool = False
+    ) -> MapResponse | NavigateResponse | BoundedResponse:
         """Fetch item content and dispatch to the appropriate disclosure handler.
 
         Calls ``operations.view_item(selector)`` once (un-gated, full content),
@@ -311,6 +313,9 @@ class BacklogViewDisclosureHandler:
                 to ``operations.view_item()``.
             request: Validated ``DisclosureRequest`` produced by
                 ``DisclosureRequestParser``.
+            refresh: Forwarded unchanged to ``operations.view_item()``. Drop this
+                and ``refresh=True`` silently no-ops under map/navigate/extract —
+                the bug this parameter fixes.
 
         Returns:
             ``MapResponse``, ``NavigateResponse``, or ``BoundedResponse``
@@ -327,7 +332,7 @@ class BacklogViewDisclosureHandler:
         # Un-gated fetch (ADR-5): call via module reference so spy on
         # ``backlog_core.operations.view_item`` intercepts the call.
         # ``include_content=True`` is the default — full body and sections.
-        view_result = operations.view_item(selector)
+        view_result = operations.view_item(selector, refresh=refresh)
         sections = self._normalizer.normalize(view_result)
 
         # Fresh mapper per call — OrdinalPathMapper is stateful per-item.

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -2945,7 +2945,7 @@ def view_item(
     result: ViewItemResult = view_result_from_local_item(item) if item else ViewItemResult()
 
     if item:
-        if refresh:
+        if issue_num or refresh:
             live_id = _live_lookup_id(item, issue_num, selector)
             enriched = view_enrich_from_github(result, live_id, repo) if live_id else False
             if not enriched:

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -2920,12 +2920,12 @@ def view_item(
             numeric index (``"2"``), comma-separated indices (``"0,2"``),
             regex (``"/impact.*/``), or substring match.
         refresh: When True, forces a live-backend check through the authoritative
-            resolution chain for every selector shape, including a title
-            substring that already resolved locally. When False (default), a
-            selector that already resolves to a local item returns the cached
-            copy without a network call; a selector with no local match still
-            triggers a live lookup regardless of this flag, since that is the
-            only way to resolve its identity at all.
+            resolution chain for a title-substring selector that already resolved
+            locally. A selector that resolves via a numeric/#N/URL match is always
+            validated against the live backend regardless of this flag — that
+            behavior is unchanged and predates this parameter. A selector with no
+            local match still triggers a live lookup regardless of this flag,
+            since that is the only way to resolve its identity at all.
 
     Returns:
         ViewItemResult with item/issue details. When ``include_content=True``,

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -2851,6 +2851,28 @@ def _assemble_view_content(
 # ---------------------------------------------------------------------------
 
 
+def _live_lookup_id(item: BacklogItem | None, issue_num: str | None, selector: str) -> str | None:
+    """Resolve the identifier to pass to view_enrich_from_github() for a live check.
+
+    Precedence: an already-parsed numeric selector; else the cached item's own
+    known issue number/id (for a title-selector match — never the raw title
+    text, which the GitHub backend cannot resolve); else the raw selector
+    (bare beads nanoid with no local match yet).
+
+    Returns:
+        The identifier to pass to view_enrich_from_github(), or None when no
+        identifier of any kind is resolvable. Never an empty string.
+    """
+    if issue_num:
+        return issue_num
+    if item is not None:
+        number = getattr(item, "number", None)
+        if number:
+            return str(number)
+        return item.issue.lstrip("#") or None
+    return selector.strip() or None
+
+
 def view_item(
     selector: str,
     repo: str = "",
@@ -2861,6 +2883,7 @@ def view_item(
     output: Output | None = None,
     include_content: bool = True,
     section: str | None = None,
+    refresh: bool = False,
 ) -> ViewItemResult:
     """View a backlog item or GitHub issue by URL, #N, bare number, or title.
 
@@ -2896,6 +2919,13 @@ def view_item(
             For backend-owned structured items with structured sections but no raw body, supports
             numeric index (``"2"``), comma-separated indices (``"0,2"``),
             regex (``"/impact.*/``), or substring match.
+        refresh: When True, forces a live-backend check through the authoritative
+            resolution chain for every selector shape, including a title
+            substring that already resolved locally. When False (default), a
+            selector that already resolves to a local item returns the cached
+            copy without a network call; a selector with no local match still
+            triggers a live lookup regardless of this flag, since that is the
+            only way to resolve its identity at all.
 
     Returns:
         ViewItemResult with item/issue details. When ``include_content=True``,
@@ -2914,23 +2944,24 @@ def view_item(
 
     result: ViewItemResult = view_result_from_local_item(item) if item else ViewItemResult()
 
-    if issue_num:
-        enriched = view_enrich_from_github(result, issue_num, repo)
-        if not enriched:
-            if not item:
-                raise ItemNotFoundError(selector)
-            out.warnings.append("backend unreachable — sections_index reflects provider-backed record, may be stale")
+    if item:
+        if refresh:
+            live_id = _live_lookup_id(item, issue_num, selector)
+            enriched = view_enrich_from_github(result, live_id, repo) if live_id else False
+            if not enriched:
+                out.warnings.append(
+                    "backend unreachable — sections_index reflects provider-backed record, may be stale"
+                )
         # Restore groomed date from local item — the enrichment path has no
         # access to backend-owned metadata, so preserve the date string.
-        if item:
-            result.groomed = item.metadata.groomed
-    elif not item:
-        if get_config().backend.issue_id_type == "string":
-            enriched = view_enrich_from_github(result, selector.strip(), repo)
-            if not enriched:
-                raise ItemNotFoundError(selector)
-        else:
+        result.groomed = item.metadata.groomed
+    elif issue_num or get_config().backend.issue_id_type == "string":
+        live_id = _live_lookup_id(item, issue_num, selector)
+        enriched = view_enrich_from_github(result, live_id, repo) if live_id else False
+        if not enriched:
             raise ItemNotFoundError(selector)
+    else:
+        raise ItemNotFoundError(selector)
 
     # MCP clients send numeric show values as strings; convert before forwarding.
     parsed_show: str | int | None = show

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1764,7 +1764,7 @@ def _build_list_entry(item: BacklogItem, status_map: dict[int, IssueStatus]) -> 
 
 
 def list_items(
-    from_github: bool = False,
+    refresh: bool = False,
     label: str | None = None,
     section: str | None = None,
     status: str | None = None,
@@ -1776,10 +1776,10 @@ def list_items(
     output: Output | None = None,
     filter_by_key: dict[str, str] | None = None,
 ) -> dict[str, int | list[str] | list[dict[str, str | bool]]]:
-    """List backlog items. Default reads provider-backed record only. Use from_github=True to refresh first.
+    """List backlog items. Default reads provider-backed record only. Use refresh=True to refresh first.
 
     Args:
-        from_github: Refresh provider-backed record from GitHub Issues before listing.
+        refresh: Refresh the provider-backed record from the configured backend before listing.
         label: Filter by GitHub label (applied during refresh).
         section: Filter by priority section — P0, P1, P2, or Ideas (case-insensitive).
         status: Filter by status value e.g. 'needs-grooming', 'status:in-progress'.
@@ -1803,7 +1803,7 @@ def list_items(
         file_path, groomed, status, and milestone fields for items with a GitHub issue).
     """
     out = output or Output()
-    if from_github:
+    if refresh:
         refresh_local_cache_from_github(repo, label, output=out)
     items = get_config().backend.list_work_items()
     # Start with non-skipped items that have a section. The skip flag may be set

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -2920,12 +2920,10 @@ def view_item(
             numeric index (``"2"``), comma-separated indices (``"0,2"``),
             regex (``"/impact.*/``), or substring match.
         refresh: When True, forces a live-backend check through the authoritative
-            resolution chain for a title-substring selector that already resolved
-            locally. A selector that resolves via a numeric/#N/URL match is always
-            validated against the live backend regardless of this flag — that
-            behavior is unchanged and predates this parameter. A selector with no
-            local match still triggers a live lookup regardless of this flag,
-            since that is the only way to resolve its identity at all.
+            resolution chain for an already-cached title-substring selector.
+            A numeric/#N/URL match, or a selector with no local match, is always
+            live-checked regardless of this flag — the only case this flag gates
+            is a cached title-substring selector.
 
     Returns:
         ViewItemResult with item/issue details. When ``include_content=True``,

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2398,6 +2398,22 @@ async def backlog_view(
             description="Item selector: GitHub issue URL, #N, bare number, or title substring, or beads nanoid (e.g. bd-a3f8)"
         ),
     ],
+    refresh: Annotated[
+        bool,
+        Field(
+            description=(
+                "Bypass the local cache and validate against the live backend. For GitHub, "
+                "resolves content through the authoritative head-pointer/audit-comment record "
+                "(never the raw issue body) — same resolution the write/reconcile path uses. "
+                "Applies to every selector shape: a title-substring selector that already "
+                "resolves locally gets the same live-check opportunity a numeric/#N/URL "
+                "selector does. When False (default), a selector that already resolves to a "
+                "local item returns the cached copy without a network call; a selector with no "
+                "local match still triggers a live lookup regardless of this flag, since that is "
+                "the only way to resolve its identity at all."
+            )
+        ),
+    ] = False,
     summary: Annotated[
         bool,
         Field(
@@ -2600,6 +2616,7 @@ async def backlog_view(
             since=since,
             section=section,
             output=out,
+            refresh=refresh,
         )
         full_response = result.model_dump()
         if not summary:

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2402,15 +2402,12 @@ async def backlog_view(
         bool,
         Field(
             description=(
-                "Bypass the local cache and validate against the live backend. For GitHub, "
-                "resolves content through the authoritative head-pointer/audit-comment record "
-                "(never the raw issue body) — same resolution the write/reconcile path uses. "
-                "Applies to every selector shape: a title-substring selector that already "
-                "resolves locally gets the same live-check opportunity a numeric/#N/URL "
-                "selector does. When False (default), a selector that already resolves to a "
-                "local item returns the cached copy without a network call; a selector with no "
-                "local match still triggers a live lookup regardless of this flag, since that is "
-                "the only way to resolve its identity at all."
+                "Bypass the local cache and validate against the live backend for a "
+                "title-substring selector that already resolves locally. Selectors that "
+                "resolve via a numeric/#N/URL match are always validated against the live "
+                "backend regardless of this flag — that behavior is unchanged and predates "
+                "this parameter. For GitHub, resolves content through the authoritative "
+                "head-pointer/audit-comment record, never the raw issue body."
             )
         ),
     ] = False,

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1933,7 +1933,9 @@ def _resolve_effective_limit(all_items: list[dict[str, str | bool]], offset: int
     )
 )
 async def backlog_list(
-    from_github: Annotated[bool, Field(description="Refresh local cache from GitHub Issues before listing")] = False,
+    refresh: Annotated[
+        bool, Field(description="Refresh the local cache from the configured backend before listing")
+    ] = False,
     label: Annotated[str | None, Field(description="Filter by GitHub label (e.g. 'priority:p1', 'type:bug')")] = None,
     section: Annotated[
         str | None, Field(description="Filter by priority section: P0, P1, P2, or Ideas (case-insensitive)")
@@ -2101,7 +2103,7 @@ async def backlog_list(
 ) -> dict:
     """List all open backlog items.
 
-    Use from_github=true to refresh the local cache from GitHub before listing.
+    Use refresh=true to refresh the local cache from the backend before listing.
     Use label to filter items by a specific GitHub label.
     Use section to filter by priority section (P0, P1, P2, Ideas).
     Use status to filter by status value (e.g. needs-grooming, status:in-progress).
@@ -2140,7 +2142,7 @@ async def backlog_list(
         result, backend_status = await asyncio.gather(
             asyncio.to_thread(
                 operations.list_items,
-                from_github=from_github,
+                refresh=refresh,
                 label=label,
                 section=section,
                 status=status,

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2359,7 +2359,9 @@ def _build_over_budget_view(result: _models.ViewItemResult, full_chars: int, sel
     return compact
 
 
-def _execute_disclosure_or_passthrough(selector: str, req: DisclosureRequest) -> dict[str, object] | None:
+def _execute_disclosure_or_passthrough(
+    selector: str, req: DisclosureRequest, refresh: bool = False
+) -> dict[str, object] | None:
     """Execute a non-PASSTHROUGH progressive disclosure request synchronously.
 
     Intended for ``asyncio.to_thread``.  The caller guards on
@@ -2370,6 +2372,13 @@ def _execute_disclosure_or_passthrough(selector: str, req: DisclosureRequest) ->
     error dicts so the ``to_thread`` caller receives a clean return value with
     no exception.
 
+    Args:
+        selector: Issue selector forwarded to the disclosure handler.
+        req: Validated disclosure request (mode + ordinal/token params).
+        refresh: Forwarded to ``BacklogViewDisclosureHandler.handle()`` so
+            map/navigate/extract calls get the same bypass-cache live check
+            as the passthrough path.
+
     Returns:
         Serialised response dict for MAP/NAVIGATE/EXTRACT, None for PASSTHROUGH
         (safety net only), or an error dict when OrdinalNotFoundError or
@@ -2378,7 +2387,7 @@ def _execute_disclosure_or_passthrough(selector: str, req: DisclosureRequest) ->
     if req.mode == DisclosureMode.PASSTHROUGH:
         return None  # safety net — caller should never reach this branch
     try:
-        response = BacklogViewDisclosureHandler().handle(selector, req)
+        response = BacklogViewDisclosureHandler().handle(selector, req, refresh=refresh)
         return dataclasses.asdict(response)
     except OrdinalNotFoundError as exc:
         return {"error": str(exc), "requested_ordinal": exc.requested, "valid_ordinals": exc.valid_ordinals}
@@ -2402,12 +2411,12 @@ async def backlog_view(
         bool,
         Field(
             description=(
-                "Bypass the local cache and validate against the live backend for a "
-                "title-substring selector that already resolves locally. Selectors that "
-                "resolve via a numeric/#N/URL match are always validated against the live "
-                "backend regardless of this flag — that behavior is unchanged and predates "
-                "this parameter. For GitHub, resolves content through the authoritative "
-                "head-pointer/audit-comment record, never the raw issue body."
+                "Bypass the cache and live-check an already-cached title-substring selector "
+                "against the backend. Numeric/#N/URL selectors are always live-checked "
+                "regardless of this flag. For GitHub, prefers the authoritative "
+                "head-pointer/audit-comment record; on a resolution failure it silently "
+                "falls back to the raw issue body, with no signal in the response that "
+                "this happened."
             )
         ),
     ] = False,
@@ -2586,7 +2595,9 @@ async def backlog_view(
     try:
         disclosure_req = DisclosureRequestParser().parse(map=map, navigate=navigate, head=head, skip_tokens=skip_tokens)
         if disclosure_req.mode != DisclosureMode.PASSTHROUGH:
-            disclosure_result = await asyncio.to_thread(_execute_disclosure_or_passthrough, selector, disclosure_req)
+            disclosure_result = await asyncio.to_thread(
+                _execute_disclosure_or_passthrough, selector, disclosure_req, refresh
+            )
     except DisclosureParamError as exc:
         disclosure_result = {"error": str(exc), "invalid_params": exc.invalid_params}
 

--- a/plugins/development-harness/backlog_core/tests/unit/test_disclosure_handler.py
+++ b/plugins/development-harness/backlog_core/tests/unit/test_disclosure_handler.py
@@ -630,6 +630,50 @@ class TestUngatedViewItemPath:
 
     @_skip_without_2515
     @_skip_without_real_enc
+    def test_handle_forwards_refresh_true_to_view_item(
+        self, view_result_2515: ViewItemResult, mocker: MockerFixture
+    ) -> None:
+        """handle(refresh=True) forwards refresh=True to view_item(), not the default False.
+
+        Regression guard: combining refresh=True with map/navigate/head must not
+        silently drop the bypass-cache request — the disclosure path must get the
+        same live-backend check as the passthrough (summary/default) path.
+        """
+        view_item_spy = mocker.patch("backlog_core.operations.view_item", return_value=view_result_2515)
+
+        BacklogViewDisclosureHandler().handle("#2515", DisclosureRequestParser().parse(map=True), refresh=True)
+
+        call_args = view_item_spy.call_args
+        assert call_args is not None, "view_item() must have been called."
+        pos_args = list(call_args.args) if call_args.args else []
+        kw_args = call_args.kwargs or {}
+        pos_refresh = pos_args[1] if len(pos_args) > 1 else None
+        kw_refresh = kw_args.get("refresh")
+        assert pos_refresh is True or kw_refresh is True, (
+            f"view_item() must receive refresh=True as positional or keyword arg.\n"
+            f"Got positional[1]={pos_refresh!r}, keyword refresh={kw_refresh!r}."
+        )
+
+    @_skip_without_2515
+    @_skip_without_real_enc
+    def test_handle_defaults_refresh_to_false(self, view_result_2515: ViewItemResult, mocker: MockerFixture) -> None:
+        """handle() with no refresh argument forwards refresh=False (unchanged default)."""
+        view_item_spy = mocker.patch("backlog_core.operations.view_item", return_value=view_result_2515)
+
+        BacklogViewDisclosureHandler().handle("#2515", DisclosureRequestParser().parse(map=True))
+
+        call_args = view_item_spy.call_args
+        assert call_args is not None, "view_item() must have been called."
+        pos_args = list(call_args.args) if call_args.args else []
+        kw_args = call_args.kwargs or {}
+        pos_refresh = pos_args[1] if len(pos_args) > 1 else None
+        kw_refresh = kw_args.get("refresh", False)
+        failure_detail = f"Got positional[1]={pos_refresh!r}, keyword refresh={kw_refresh!r}."
+        assert pos_refresh in (False, None), f"view_item() must default to refresh=False.\n{failure_detail}"
+        assert kw_refresh is False, f"view_item() must default to refresh=False.\n{failure_detail}"
+
+    @_skip_without_2515
+    @_skip_without_real_enc
     def test_overbudget_item_produces_non_empty_map_text(
         self, view_result_2515: ViewItemResult, mocker: MockerFixture
     ) -> None:

--- a/plugins/development-harness/sam_schema/backlog.py
+++ b/plugins/development-harness/sam_schema/backlog.py
@@ -110,6 +110,9 @@ def list_items(
 @app.command("view")
 def view(
     selector: Annotated[str, typer.Option("--selector", help="Item selector")],
+    refresh: Annotated[
+        bool, typer.Option("--refresh", help="Bypass the local cache and validate against the live backend")
+    ] = False,
     repo: Annotated[str, typer.Option("--repo", help="Repository (owner/name)")] = "",
     offset: Annotated[int, typer.Option("--offset", min=0, help="Pagination offset")] = 0,
     limit: Annotated[int, typer.Option("--limit", min=0, help="Maximum items to return (0 = all)")] = 0,
@@ -120,7 +123,15 @@ def view(
     """View a single backlog item by selector."""
     output = Output()
     result = operations.view_item(
-        selector=selector, repo=repo, offset=offset, limit=limit, show=show, since=since, output=output, section=section
+        selector=selector,
+        repo=repo,
+        offset=offset,
+        limit=limit,
+        show=show,
+        since=since,
+        output=output,
+        section=section,
+        refresh=refresh,
     )
     _emit(result, output)
 

--- a/plugins/development-harness/sam_schema/backlog.py
+++ b/plugins/development-harness/sam_schema/backlog.py
@@ -92,7 +92,7 @@ def list_items(
     """List backlog items, optionally filtered."""
     output = Output()
     result = operations.list_items(
-        from_github=refresh,
+        refresh=refresh,
         label=label,
         section=section,
         status=status,

--- a/plugins/development-harness/sam_schema/tests/test_backlog_cli.py
+++ b/plugins/development-harness/sam_schema/tests/test_backlog_cli.py
@@ -76,6 +76,45 @@ class TestBacklogAddErrorContract:
         assert json.loads(result.stdout) == {"title": "new item", "priority": "P1", "item_ref": "#123"}
 
 
+class TestBacklogViewRefreshForwarding:
+    """``backlog view`` forwards the ``--refresh`` flag to ``operations.view_item``."""
+
+    def test_refresh_flag_forwards_true(self, mocker: MockerFixture) -> None:
+        """``--refresh`` forwards ``refresh=True`` into ``operations.view_item``."""
+        mock_view = mocker.patch(
+            "sam_schema.backlog.operations.view_item", return_value={"title": "Item", "issue": "#42"}
+        )
+
+        result = runner.invoke(app, ["backlog", "view", "--selector", "#42", "--refresh"], env=_CLI_ENV)
+
+        assert result.exit_code == 0, result.stderr
+        assert mock_view.call_args.kwargs["refresh"] is True
+
+    def test_no_refresh_flag_forwards_false(self, mocker: MockerFixture) -> None:
+        """Omitting ``--refresh`` forwards ``refresh=False`` into ``operations.view_item``."""
+        mock_view = mocker.patch(
+            "sam_schema.backlog.operations.view_item", return_value={"title": "Item", "issue": "#42"}
+        )
+
+        result = runner.invoke(app, ["backlog", "view", "--selector", "#42"], env=_CLI_ENV)
+
+        assert result.exit_code == 0, result.stderr
+        assert mock_view.call_args.kwargs["refresh"] is False
+
+
+class TestBacklogListRefreshForwarding:
+    """``backlog list`` forwards the ``--refresh`` flag to ``operations.list_items``."""
+
+    def test_refresh_flag_forwards_true(self, mocker: MockerFixture) -> None:
+        """``--refresh`` forwards ``refresh=True`` into ``operations.list_items``."""
+        mock_list = mocker.patch("sam_schema.backlog.operations.list_items", return_value={"items": []})
+
+        result = runner.invoke(app, ["backlog", "list", "--refresh"], env=_CLI_ENV)
+
+        assert result.exit_code == 0, result.stderr
+        assert mock_list.call_args.kwargs["refresh"] is True
+
+
 class TestBacklogSyncFallback:
     """The ``backlog sync`` fallback invokes a command that actually exists."""
 

--- a/plugins/development-harness/skills/backlog/README.md
+++ b/plugins/development-harness/skills/backlog/README.md
@@ -221,7 +221,7 @@ backlog add \
 
 ```python
 mcp__plugin_dh_backlog__backlog_list(
-    from_github=False,  # refresh local cache from GitHub first
+    refresh=False,  # refresh local cache from the backend first
     label="priority:p1",  # filter by GitHub label
     section="P1",  # filter by priority: P0, P1, P2, Ideas
     status="needs-grooming",  # filter by status value
@@ -250,7 +250,7 @@ Note: the CLI's `backlog list` has no `--search` flag — full-text search acros
 topic, type, description, and body has no CLI path as of 2026-08-05 (backlog item #2793). Use the
 MCP `backlog_list(search=...)` tool for full-text search.
 
-The `backend` dict is always present in the response, regardless of the `from_github` parameter.
+The `backend` dict is always present in the response, regardless of the `refresh` parameter.
 It reports the GitHub API availability status checked on every `backlog_list` call.
 
 ```python
@@ -280,7 +280,7 @@ It reports the GitHub API availability status checked on every `backlog_list` ca
 | `rate_limited` | Received 403 from GitHub API |
 | `error` | Other error during the availability probe |
 
-The probe runs on every `backlog_list` call regardless of the `from_github` parameter.
+The probe runs on every `backlog_list` call regardless of the `refresh` parameter.
 No automatic sync is performed — the tool reports status only.
 
 `type` and `topic` filters compose with AND logic. Items missing the filtered field are excluded
@@ -324,6 +324,7 @@ human-authored backlog titles.
 ```python
 mcp__plugin_dh_backlog__backlog_view(
     selector="#142",  # GitHub issue URL, #N, bare number, or title substring
+    refresh=False,  # bypass the local cache and validate a title-substring selector against the live backend
     offset=0,  # skip N entry blocks (for pagination)
     limit=0,  # show at most N entry blocks (0 = all, no truncation)
 )
@@ -334,6 +335,9 @@ CLI equivalent:
 
 ```bash
 backlog view --selector "#142" --offset 0 --limit 0
+
+# bypass the local cache and validate against the live backend
+backlog view --selector "Fix duplicate detection" --refresh
 ```
 
 ### `backlog_sync` — Sync to GitHub

--- a/plugins/development-harness/skills/backlog/SKILL.md
+++ b/plugins/development-harness/skills/backlog/SKILL.md
@@ -90,7 +90,7 @@ View a single backlog item in detail. Supports pagination for long bodies.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `selector` | `str` | required | GitHub issue URL, `#N`, bare number, or title substring |
-| `refresh` | `bool` | `False` | Bypass the local cache and validate against the live backend for a title-substring selector that already resolves locally. Selectors that resolve via a numeric/#N/URL match are always validated against the live backend regardless of this flag — that behavior is unchanged and predates this parameter. For GitHub, resolves content through the authoritative head-pointer/audit-comment record, never the raw issue body. |
+| `refresh` | `bool` | `False` | Bypass the cache and live-check an already-cached title-substring selector against the backend, including under `map`/`navigate`/`head`. Numeric/#N/URL selectors are always live-checked regardless of this flag. For GitHub, prefers the authoritative head-pointer/audit-comment record; on a resolution failure it silently falls back to the raw issue body, with no signal in the response that this happened. |
 | `include_content` | `bool` | `True` | When True (default), returns full body and section entries. When False, returns metadata and section inventory only (section names with entry counts, no body or entry content). |
 | `offset` | `int` | `0` | Skip N entry blocks from body start (for pagination) |
 | `limit` | `int` | `0` | Show at most N entry blocks (`0` = all, no truncation) |

--- a/plugins/development-harness/skills/backlog/SKILL.md
+++ b/plugins/development-harness/skills/backlog/SKILL.md
@@ -51,7 +51,7 @@ List open backlog items with optional filters.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `from_github` | `bool` | `False` | Refresh local cache from GitHub before listing |
+| `refresh` | `bool` | `False` | Refresh the local cache from the configured backend before listing |
 | `label` | `str \| None` | `None` | Filter by GitHub label (e.g. `"priority:p1"`) |
 | `section` | `str \| None` | `None` | Filter by priority section: `P0`, `P1`, `P2`, or `Ideas` |
 | `status` | `str \| None` | `None` | Filter by status (e.g. `"needs-grooming"`, `"status:in-progress"`) |
@@ -90,6 +90,7 @@ View a single backlog item in detail. Supports pagination for long bodies.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `selector` | `str` | required | GitHub issue URL, `#N`, bare number, or title substring |
+| `refresh` | `bool` | `False` | Bypass the local cache and validate against the live backend for a title-substring selector that already resolves locally. Selectors that resolve via a numeric/#N/URL match are always validated against the live backend regardless of this flag — that behavior is unchanged and predates this parameter. For GitHub, resolves content through the authoritative head-pointer/audit-comment record, never the raw issue body. |
 | `include_content` | `bool` | `True` | When True (default), returns full body and section entries. When False, returns metadata and section inventory only (section names with entry counts, no body or entry content). |
 | `offset` | `int` | `0` | Skip N entry blocks from body start (for pagination) |
 | `limit` | `int` | `0` | Show at most N entry blocks (`0` = all, no truncation) |

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -1403,6 +1403,141 @@ class TestViewItem:
         assert "rt_ica" not in sections, f"Raw storage key leaked into sections: {list(sections.keys())}"
         assert "RT-ICA" in sections, f"Expected 'RT-ICA' in sections, got: {list(sections.keys())}"
 
+    # -----------------------------------------------------------------
+    # refresh cache-bypass control flow (#3275)
+    #
+    # Scenario 5 from the plan ("no cached item + beads nanoid selector +
+    # refresh=False -> live lookup still fires") already has coverage via
+    # TestViewItemBeadsNanoidUncached.test_view_item_beads_nanoid_uncached_calls_enrich
+    # below — that test calls view_item("bd-e2f4") with no local item and no
+    # explicit refresh kwarg (i.e. the refresh=False default) against a
+    # BeadsBackend (issue_id_type="string") and asserts the live enrich call
+    # fires. Adding a second test for the identical scenario would duplicate
+    # it, so this class covers only the remaining five refresh scenarios.
+    # -----------------------------------------------------------------
+
+    def test_view_item_title_selector_refresh_true_uses_item_identifier(self, mocker: MockerFixture) -> None:
+        """Cached item + title-substring selector + refresh=True calls enrich with the item's id.
+
+        Tests: view_item's opt-in live check for Case H (title selector, refresh=True).
+        How: Write a local item with a known issue number; call view_item with a title
+             substring and refresh=True; assert view_enrich_from_github was called with
+             the item's issue-derived identifier, never the raw title text.
+        Why: A naive implementation could forward the title substring straight into
+             view_enrich_from_github(), which crashes downstream (int(issue_num) in
+             gh_client.py). _live_lookup_id() must resolve the cached item's own id.
+        """
+        import backlog_core.models as models
+
+        fake_dir: Path = models.get_backlog_dir()
+        _write_item(fake_dir, title="Refreshable Title Item", priority="P1", topic="refreshable-title", issue="77")
+        mock_enrich = mocker.patch("backlog_core.operations.view_enrich_from_github", return_value=True)
+
+        view_item("Refreshable Title", refresh=True)
+
+        mock_enrich.assert_called_once()
+        selector_arg = mock_enrich.call_args.args[1]
+        assert selector_arg == "77"
+        assert selector_arg != "Refreshable Title Item"
+
+    def test_view_item_title_selector_refresh_false_skips_live_check(self, mocker: MockerFixture) -> None:
+        """Cached item + title-substring selector + refresh=False (default) does not call enrich.
+
+        Tests: view_item's new default for Case H — the live check is opt-in only.
+             REGRESSION GUARD: locks in that a title-selector hit on a cached item
+             makes no network call unless refresh=True is passed explicitly.
+        How: Write a local item; call view_item with a title substring and no
+             refresh kwarg; assert view_enrich_from_github was never called.
+        Why: Before this plan, no live-check path existed at all for title
+             selectors. The new opt-in capability must not become an unconditional
+             call — that would silently add a network call to every title-based
+             view for an item that already has a local, cached copy.
+        """
+        import backlog_core.models as models
+
+        fake_dir: Path = models.get_backlog_dir()
+        _write_item(fake_dir, title="Cached Title Item", priority="P1", topic="cached-title-item", issue="88")
+        mock_enrich = mocker.patch("backlog_core.operations.view_enrich_from_github", return_value=True)
+
+        view_item("Cached Title Item")
+
+        mock_enrich.assert_not_called()
+
+    def test_view_item_numeric_selector_refresh_false_still_calls_enrich(self, mocker: MockerFixture) -> None:
+        """Cached item + numeric selector + refresh=False still calls enrich (Case A/B).
+
+        Tests: view_item's unconditional live check for an already-cached item
+             matched by numeric selector. REGRESSION GUARD: confirms Case A/B
+             stayed unconditional (today's pre-existing behavior) and was not
+             accidentally gated behind refresh alongside the new Case H opt-in.
+        How: Write a local item with issue="55"; call view_item("55") with no
+             refresh kwarg; assert view_enrich_from_github was called with "55".
+        Why: 52 pre-existing tests elsewhere in the suite (via
+             backlog_core/tests/_view_test_helpers.py::_configure_memory_view)
+             depend on this unconditional call for numeric selectors. `refresh`
+             is additive-only (ADR-3, corrected) — it must never remove this
+             existing behavior.
+        """
+        import backlog_core.models as models
+
+        fake_dir: Path = models.get_backlog_dir()
+        _write_item(fake_dir, title="Numeric Selector Item", priority="P1", topic="numeric-selector-item", issue="55")
+        mock_enrich = mocker.patch("backlog_core.operations.view_enrich_from_github", return_value=True)
+
+        # show="1" (MCP clients send numeric `show` values as strings) also exercises
+        # view_item's str->int show conversion alongside the refresh control flow.
+        view_item("55", show="1")
+
+        mock_enrich.assert_called_once()
+        assert mock_enrich.call_args.args[1] == "55"
+
+    def test_view_item_no_cached_item_numeric_selector_refresh_false_still_resolves(
+        self, mocker: MockerFixture
+    ) -> None:
+        """No cached item + numeric selector + refresh=False still performs a live lookup.
+
+        Tests: view_item's unconditional identity-resolution live call (Case C/D).
+             REGRESSION GUARD (ADR-3): a not-yet-synced item must still resolve via
+             a live lookup regardless of refresh, or it would raise a false
+             ItemNotFoundError.
+        How: Write NO local item; call view_item("999") with no refresh kwarg and
+             enrich mocked to succeed; assert enrich was called with "999" and no
+             exception was raised.
+        Why: Gating the identity-resolution call behind refresh would break every
+             not-yet-synced item lookup — the exact bug ADR-3 exists to prevent.
+        """
+        mock_enrich = mocker.patch("backlog_core.operations.view_enrich_from_github", return_value=True)
+
+        # show="not-a-number" exercises the ValueError fallback branch of view_item's
+        # str->int show conversion alongside the identity-resolution control flow.
+        view_item("999", show="not-a-number")
+
+        mock_enrich.assert_called_once()
+        assert mock_enrich.call_args.args[1] == "999"
+
+    def test_view_item_refresh_true_no_identifier_appends_warning_without_call(self, mocker: MockerFixture) -> None:
+        """Cached item with no resolvable id + refresh=True appends a warning, no call, no raise.
+
+        Tests: view_item's guard against calling enrich with no identifier at all.
+        How: Write a local item with no issue number set; call view_item by title
+             with refresh=True; assert enrich was never called, no exception was
+             raised, and the "backend unreachable" warning was appended.
+        Why: _live_lookup_id() must never return an empty string, and its None
+             return means the caller has no identifier to send to the backend —
+             the correct outcome is a warning, not a crash or a call with an
+             invalid argument.
+        """
+        import backlog_core.models as models
+
+        fake_dir: Path = models.get_backlog_dir()
+        _write_item(fake_dir, title="No Identifier Item", priority="P1", topic="no-identifier-item", issue="")
+        mock_enrich = mocker.patch("backlog_core.operations.view_enrich_from_github", return_value=True)
+
+        result = view_item("No Identifier Item", refresh=True)
+
+        mock_enrich.assert_not_called()
+        assert "backend unreachable — sections_index reflects provider-backed record, may be stale" in result.warnings
+
 
 # ---------------------------------------------------------------------------
 # close_item

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -447,7 +447,7 @@ class TestAddItemCreatesLocalFile:
         mocker.patch("backlog_core.operations.batch_fetch_statuses", return_value={})
         add_item(title="Pending Local Only Item", description="desc", priority="P2")
 
-        listed = list_items(from_github=False)
+        listed = list_items(refresh=False)
         list_entries = cast("list[dict[str, str | bool]]", listed["items"])
         entry = next(it for it in list_entries if it["title"] == "Pending Local Only Item")
         assert entry["issue"] == ""
@@ -709,7 +709,7 @@ class TestListItemsEmpty:
         """
         mocker.patch("backlog_core.operations.batch_fetch_statuses", return_value={})
 
-        result = list_items(from_github=False)
+        result = list_items(refresh=False)
 
         assert result["items"] == []
         assert result["count"] == 0
@@ -732,7 +732,7 @@ class TestListItemsFiltering:
         _seed_items([active, done])
         mocker.patch("backlog_core.operations.batch_fetch_statuses", return_value={})
 
-        result = list_items(from_github=False)
+        result = list_items(refresh=False)
 
         items = cast("list[dict[str, str | bool]]", result["items"])
         titles = [it["title"] for it in items]
@@ -755,7 +755,7 @@ class TestListItemsFiltering:
             return_value={7: IssueStatus(status="status:in-progress", milestone="v2")},
         )
 
-        result = list_items(from_github=False, status="status:in-progress")
+        result = list_items(refresh=False, status="status:in-progress")
 
         mock_batch.assert_called_once()
         items = cast("list[dict[str, str | bool]]", result["items"])
@@ -777,16 +777,16 @@ class TestListItemsFiltering:
         _write_item(fake_dir, title="No Status Item", priority="P2", topic="no-status-item")
         mock_batch = mocker.patch("backlog_core.operations.batch_fetch_statuses", return_value={})
 
-        list_items(from_github=False)
+        list_items(refresh=False)
 
         mock_batch.assert_called_once()
 
-    def test_list_items_from_github_calls_refresh(self, mocker: MockerFixture) -> None:
-        """Verify list_items with from_github=True triggers a cache refresh.
+    def test_list_items_refresh_calls_refresh_local_cache(self, mocker: MockerFixture) -> None:
+        """Verify list_items with refresh=True triggers a cache refresh.
 
-        Tests: from_github refresh path.
-        How: Patch refresh_local_cache_from_github; call list_items(from_github=True).
-        Why: from_github must invoke the refresh before returning local data.
+        Tests: refresh refresh path.
+        How: Patch refresh_local_cache_from_github; call list_items(refresh=True).
+        Why: refresh must invoke the refresh before returning local data.
         """
         mock_refresh = mocker.patch(
             "backlog_core.operations.refresh_local_cache_from_github",
@@ -794,7 +794,7 @@ class TestListItemsFiltering:
         )
         mocker.patch("backlog_core.operations.batch_fetch_statuses", return_value={})
 
-        list_items(from_github=True)
+        list_items(refresh=True)
 
         mock_refresh.assert_called_once()
 
@@ -841,7 +841,7 @@ class TestListItemsBeadsBackend:
         _seed_items([])
         mock_batch = mocker.patch("backlog_core.operations.batch_fetch_statuses")
 
-        list_items(from_github=False)
+        list_items(refresh=False)
 
         mock_batch.assert_not_called()
 
@@ -865,7 +865,7 @@ class TestListItemsBeadsBackend:
         )
         mocker.patch.object(backend, "list_work_items", return_value=[beads_item])
 
-        result = list_items(from_github=False)
+        result = list_items(refresh=False)
 
         items = cast("list[dict[str, str | bool]]", result["items"])
         assert len(items) == 1
@@ -891,7 +891,7 @@ class TestListItemsBeadsBackend:
         )
         mocker.patch.object(backend, "list_work_items", return_value=[beads_item])
 
-        result = list_items(from_github=False)
+        result = list_items(refresh=False)
 
         items = cast("list[dict[str, str | bool]]", result["items"])
         assert len(items) == 1
@@ -1757,7 +1757,7 @@ def test_list_items_section_derived_from_priority(
     _write_item(fake_dir, title=f"{priority} Item", priority=priority, topic=topic)
     mocker.patch("backlog_core.operations.batch_fetch_statuses", return_value={})
 
-    result = list_items(from_github=False)
+    result = list_items(refresh=False)
 
     items = cast("list[dict[str, str | bool]]", result["items"])
     assert len(items) == 1

--- a/plugins/development-harness/tests/test_backlog_core_server.py
+++ b/plugins/development-harness/tests/test_backlog_core_server.py
@@ -194,19 +194,19 @@ async def test_backlog_list_success_returns_items():
 
     mock_list.assert_called_once()
     call_kwargs = mock_list.call_args.kwargs
-    assert call_kwargs["from_github"] is False
+    assert call_kwargs["refresh"] is False
     assert call_kwargs["label"] is None
     assert response["items"][0]["title"] == "Item A"
 
 
 async def test_backlog_list_passes_filter_params():
-    """backlog_list forwards from_github and label flags."""
+    """backlog_list forwards refresh and label flags."""
     op_result = {"items": []}
     with patch("dh_core.operations.list_items", return_value=op_result) as mock_list:
-        await _call("backlog_list", {"from_github": True, "label": "priority:p0"})
+        await _call("backlog_list", {"refresh": True, "label": "priority:p0"})
 
     call_kwargs = mock_list.call_args.kwargs
-    assert call_kwargs["from_github"] is True
+    assert call_kwargs["refresh"] is True
     assert call_kwargs["label"] == "priority:p0"
 
 

--- a/plugins/development-harness/tests/test_backlog_core_server.py
+++ b/plugins/development-harness/tests/test_backlog_core_server.py
@@ -812,6 +812,26 @@ async def test_backlog_view_passes_pagination_params():
     assert call_kwargs["limit"] == 20
 
 
+async def test_backlog_view_forwards_refresh_true():
+    """backlog_view forwards refresh=True to operations.view_item when requested."""
+    op_result = _make_view_result({"title": "Item", "body": "line1\nline2\nline3"})
+    with patch("dh_core.operations.view_item", return_value=op_result) as mock_view:
+        await _call("backlog_view", {"selector": "Item", "refresh": True})
+
+    call_kwargs = mock_view.call_args.kwargs
+    assert call_kwargs["refresh"] is True
+
+
+async def test_backlog_view_forwards_refresh_false_by_default():
+    """backlog_view forwards refresh=False to operations.view_item when the key is omitted."""
+    op_result = _make_view_result({"title": "Item", "body": "line1\nline2\nline3"})
+    with patch("dh_core.operations.view_item", return_value=op_result) as mock_view:
+        await _call("backlog_view", {"selector": "Item"})
+
+    call_kwargs = mock_view.call_args.kwargs
+    assert call_kwargs["refresh"] is False
+
+
 async def test_backlog_view_backlog_error_returns_error_key():
     """backlog_view catches BacklogError when item is not found."""
     with patch("dh_core.operations.view_item", side_effect=BacklogError("No item found for: #999")):

--- a/plugins/development-harness/tests/test_scenarios.py
+++ b/plugins/development-harness/tests/test_scenarios.py
@@ -113,10 +113,10 @@ class TestWorkBacklogItem:
             assert "milestone" in item
 
     # Scenario 3: list sourced from GitHub (refresh_local_cache_from_github path)
-    async def test_list_from_github(self, backlog_dir, mock_github, provider_state):
+    async def test_list_with_refresh(self, backlog_dir, mock_github, provider_state):
         provider_state.return_value = ReconcileResult(fetched_items=2, local_updates=1)
 
-        result = await _call("backlog_list", {"from_github": True})
+        result = await _call("backlog_list", {"refresh": True})
 
         assert isinstance(result["items"], list)
         assert result["count"] >= 0
@@ -1513,8 +1513,8 @@ class TestResolveVerifiedGate:
 
         provider_state.side_effect = reconcile_closed
 
-        # Trigger reconciliation via from_github=True
-        result = await _call("backlog_list", {"from_github": True, "include_closed": True})
+        # Trigger reconciliation via refresh=True
+        result = await _call("backlog_list", {"refresh": True, "include_closed": True})
 
         assert isinstance(result["items"], list)
         provider_state.assert_called_once_with(ReconcileRequest(scope=ReconcileScope.INCREMENTAL, references=["#206"]))

--- a/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
+++ b/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
@@ -108,7 +108,7 @@ def test_unscoped_refresh_forwards_cached_references(sync_provider) -> None:
 
 def test_list_wrapper_forwards_label_to_reconciliation(sync_provider) -> None:
     # Given: a GitHub-backed list restricted to one label
-    list_items(from_github=True, label="review")
+    list_items(refresh=True, label="review")
 
     # Then: its refresh uses the same typed snapshot filter
     assert sync_provider.requests == [ReconcileRequest(scope=ReconcileScope.INCREMENTAL, label="review")]


### PR DESCRIPTION
## Summary
- Renames `backlog_list`'s GitHub-specific `from_github` parameter to the provider-neutral `refresh`, across the MCP tool, `operations.list_items()`, and the CLI's internal forwarding.
- Adds a `refresh` bypass-cache parameter to `backlog_view` (MCP) and CLI `view`, threaded into a restructured `operations.view_item()` that live-checks a title-substring selector against the existing GitHub head-pointer/audit-comment resolution chain (`view_enrich_from_github` → `work_item_version()`). Numeric/`#N`/URL selectors keep their pre-existing unconditional live-check behavior unchanged — confirmed necessary mid-implementation after the original design (gating that unconditional check behind `refresh`) was found to regress 52 existing tests.
- Fixes secondary CLI-flag documentation drift discovered by the quality gate's doc-drift audit: positional-vs-`--selector` CLI examples and stale/missing parameters across `backlog_close`/`resolve`/`update`/`groom`/`pull`/`list`/`view` in `.claude/agents/backlog-mcp-validator.md`, plus a `from_github`→`refresh` rename in a beads-comparison doc.

## Test plan
- [x] `backlog_core/tests/`, `tests_backlog/`, `sam_schema/tests/test_backlog_cli.py` — 1163 passed, 1 failed (pre-existing, unrelated: `tests_backlog/test_github_sync_provider.py::test_github_content_provider_replay_preserves_concurrent_remote_revision` — confirmed untouched file, no import of any module this branch modified; tracked separately)
- [x] Full SAM quality gate plan (multi-perspective review, code review, feature verification, integration check, doc-drift audit + fix, context refinement) — all passed
- [x] Issue #3275 resolved and marked `verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xpdTSDmnBgF6bHKQn4zAz