### PR TITLE
fix(development-harness): correct MCP tool doc drift in 5 dh:* skills

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2552,7 +2552,11 @@ async def backlog_groom(
     selector: Annotated[
         str,
         Field(
-            description="Item selector: GitHub issue URL, #N, bare number, or title substring, or beads nanoid (e.g. bd-a3f8)"
+            description=(
+                "Item selector: GitHub issue URL, #N, bare number, or title substring, or beads "
+                "nanoid (e.g. bd-a3f8) — do not prefix a beads nanoid with '#'; only a bare "
+                "GitHub number takes that prefix, a '#'-prefixed nanoid resolves neither form"
+            )
         ),
     ],
     section: Annotated[
@@ -2624,6 +2628,10 @@ async def backlog_groom(
     Returns:
         Dict with groomed item title, synced status, and output
         messages/warnings. On error, dict contains an error key.
+        When mark_groomed=True and the post-write item re-lookup fails to resolve the
+        selector, the status advance is skipped and the dict additionally contains
+        mark_groomed_skipped=True and mark_groomed_skip_reason (str) explaining why —
+        callers checking mark_groomed's effect should test for this key.
     """
     out = Output()
     if sections is not None and any((section, content, entry_id, replace_section, reason, append)):

--- a/plugins/development-harness/skills/create-artifact/SKILL.md
+++ b/plugins/development-harness/skills/create-artifact/SKILL.md
@@ -66,6 +66,9 @@ One of the recognized type strings:
 | `T0-baseline` | t0-baseline-capture | Pre-implementation baseline of acceptance criteria |
 | `TN-verification` | tn-verification-gate | Post-implementation verification results |
 | `research` | any research agent | Investigation findings, coverage analysis, rationale |
+| `task-plan` | `sam_plan` (internal, auto-registered) | Never call `artifact_register` directly for this type — see [task-plan](#task-plan) below |
+| `dispatch-plan` | `dispatch_create_plan` (internal, auto-registered) | Milestone dispatch plan; created automatically by the `dispatch_create_plan` MCP tool, not by direct registration |
+| `audit-report` | doc-drift-auditor | Documentation drift audit findings for a completed work item |
 
 ### `artifact_id`
 
@@ -127,7 +130,7 @@ mcp__plugin_dh_backlog__artifact_register(
 
 ### task-plan
 
-Task plans live exclusively in SAM plan storage. Create them with
+`task-plan` is a valid `artifact_register` type, but it is written internally — `sam_plan(config={"action": "create", "issue": N, ...})` auto-registers it, making the plan readable via `artifact_read`/`artifact_list` for worktree-isolated agents. Never call `artifact_register(artifact_type="task-plan", ...)` directly; create plans with
 `mcp__plugin_dh_sam__sam_plan(config={"action": "create", ...})` and retrieve them with
 `mcp__plugin_dh_sam__sam_plan(plan="{plan_ref}", config={"action": "read"})`.
 

--- a/plugins/development-harness/skills/create-artifact/SKILL.md
+++ b/plugins/development-harness/skills/create-artifact/SKILL.md
@@ -130,7 +130,7 @@ mcp__plugin_dh_backlog__artifact_register(
 
 ### task-plan
 
-`task-plan` is a valid `artifact_register` type, but it is written internally — `sam_plan(config={"action": "create", "issue": N, ...})` auto-registers it, making the plan readable via `artifact_read`/`artifact_list` for worktree-isolated agents. Never call `artifact_register(artifact_type="task-plan", ...)` directly; create plans with
+`task-plan` is a valid `artifact_register` type, but it is written internally — `sam_plan(config={"action": "create", "issue": N, ...})` auto-registers it, making the plan readable via `artifact_read`/`artifact_list` for worktree-isolated agents. Never register this type directly through `artifact_register`; create plans with
 `mcp__plugin_dh_sam__sam_plan(config={"action": "create", ...})` and retrieve them with
 `mcp__plugin_dh_sam__sam_plan(plan="{plan_ref}", config={"action": "read"})`.
 

--- a/plugins/development-harness/skills/groom-backlog-item/references/groomer-output-validation.md
+++ b/plugins/development-harness/skills/groom-backlog-item/references/groomer-output-validation.md
@@ -91,10 +91,10 @@ No graceful degradation. `blocked` is an explicit terminal state, not a fallback
 
 ### Post-Write Skip Signal Check
 
-After calling `backlog_groom(mark_groomed=True)`, inspect the response for `mark_groomed_skipped`:
+After calling `backlog_groom(mark_groomed=True)`, inspect the response for `mark_groomed_skipped` (see `backlog_groom`'s own docstring for when this field is set):
 
 - `mark_groomed_skipped` absent or `false` → status advanced normally, grooming complete
-- `mark_groomed_skipped: true` → re-lookup of the item by selector failed after content was written; status was NOT advanced
+- `mark_groomed_skipped: true` → status was NOT advanced
 
 When `mark_groomed_skipped` is `true`:
 1. Check `mark_groomed_skip_reason` in the response for the failing selector

--- a/plugins/development-harness/skills/groom-milestone/SKILL.md
+++ b/plugins/development-harness/skills/groom-milestone/SKILL.md
@@ -42,7 +42,7 @@ flowchart TD
     GapCheck -->|"Gaps found"| ProposeAdd["Step 3a: Propose Additions<br>Action: Present gaps to user with<br>suggested new items or existing<br>backlog items to associate<br>Output: user decision per gap"]
     GapCheck -->|"No gaps"| GroomGate
 
-    ProposeAdd --> AddItems["Step 3b: Execute Additions<br>Action: create-backlog-item or<br>backlog_update to assign milestone<br>Output: updated milestone item list"]
+    ProposeAdd --> AddItems["Step 3b: Execute Additions<br>Action: create-backlog-item, then<br>github_project_setup.py issue set-milestone<br>to assign it (see MCP Tools Used)<br>Output: updated milestone item list"]
     AddItems --> GroomGate
 
     GroomGate{"Step 4: Groom Check<br>Any items with groomed=false?<br>Observable: groomed field in<br>backlog_list_issues response"}
@@ -86,7 +86,7 @@ flowchart TD
 - `backlog_list_issues(milestone=N)` — load milestone items and groomed status
 - `backlog_view(selector)` — read individual item Impact Radius and metadata
 - `backlog_groom(selector)` — trigger grooming for ungroomed items
-- `backlog_update(selector, ...)` — assign milestone, update item fields
+- `backlog_update(selector, ...)` — update item fields (status, title, description, plan, etc.); has no `milestone` parameter — milestone assignment is done via `github_project_setup.py issue set-milestone` (see `/group-items-to-milestone`), not through this tool
 
 ## MCP Tools — Dispatch (Backlog Server)
 

--- a/plugins/development-harness/skills/groom-milestone/SKILL.md
+++ b/plugins/development-harness/skills/groom-milestone/SKILL.md
@@ -86,7 +86,7 @@ flowchart TD
 - `backlog_list_issues(milestone=N)` — load milestone items and groomed status
 - `backlog_view(selector)` — read individual item Impact Radius and metadata
 - `backlog_groom(selector)` — trigger grooming for ungroomed items
-- `backlog_update(selector, ...)` — update item fields (status, title, description, plan, etc.); has no `milestone` parameter — milestone assignment is done via `github_project_setup.py issue set-milestone` (see `/group-items-to-milestone`), not through this tool
+- `backlog_update(selector, ...)` — update item fields; has no `milestone` parameter — milestone assignment is done via `github_project_setup.py issue set-milestone` (see `/group-items-to-milestone`), not through this tool
 
 ## MCP Tools — Dispatch (Backlog Server)
 

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -147,8 +147,7 @@ flowchart TD
 ```text
 mcp__plugin_dh_backlog__backlog_groom(
     selector="{issue}",  # {issue} is str | int — GitHub integer ID or beads string ID.
-                         # No '#' prefix: find_item resolves a bare GitHub number or a
-                         # bare beads nanoid, but a '#'-prefixed nanoid resolves neither.
+                         # See the tool's own selector parameter description for format rules.
     section="Concerns",
     content="- [ ] {concern text} (reported by {agent_name} on {task_id})",
     append=True

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/close/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/close/start.md
@@ -217,7 +217,7 @@ If operation is `resolve`:
 
 12. Before emitting Handoff E, determine whether all milestone issues are resolved:
 
-    a. Read the `milestone` field from the `backlog_resolve` response. If the resolved item has no `milestone` field (or `milestone` is null/empty), skip Handoff E — no milestone context exists.
+    a. Read the `milestone` field from Step 5.2's `backlog_view` response (`backlog_resolve`'s own response carries no `milestone` field). If the item has no `milestone` value (null or empty), skip Handoff E — no milestone context exists.
 
     b. If a milestone is present, call:
 

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/groom/finalize.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/groom/finalize.md
@@ -286,7 +286,7 @@ backlog groom --selector "{item_ref}" --section "RT-ICA" --content "{rt_ica_fina
 - Advances the item's status from `needs-grooming` to `groomed`
 - Safe to call multiple times — idempotent if already in `groomed` status
 
-**Check the result for `mark_groomed_skipped`**: After the batch write, verify the response dict does not contain `mark_groomed_skipped: true`. This field is set when the post-write item re-lookup returns `None` (the selector no longer resolves after content is written). When `mark_groomed_skipped` is present, the status advance did NOT happen — re-run `backlog_groom(selector='{item_ref}', mark_groomed=True)` once to retry the status transition:
+**Check the result for `mark_groomed_skipped`**: After the batch write, verify the response dict does not contain `mark_groomed_skipped: true` (see `backlog_groom`'s own docstring for when this field is set). When present, the status advance did NOT happen — re-run `backlog_groom(selector='{item_ref}', mark_groomed=True)` once to retry the status transition:
 
 ```text
 # Verify status advanced — if mark_groomed_skipped is present, retry once


### PR DESCRIPTION
## Summary

- Fixes backlog item #3336 (P1, `recurring-pattern`): the same drift mechanism found in #3329 (deleted `dh:backlog` skill — hand-written MCP tool docs drifting from the live FastMCP schema) confirmed present in 5 more files during a full grooming swarm's audit.
- `create-artifact/SKILL.md` — `artifact_type` table listed only 7 of 10 live enum values and directly contradicted the schema on `task-plan` (claimed invalid; it's valid, just written internally by `sam_plan`).
- `groom-milestone/SKILL.md` — fixed a false `backlog_update` "assign milestone" claim in two places (the tool list *and* a flowchart node repeating it — caught by an independent review pass).
- `implement-feature/SKILL.md` — relocated a selector-format caveat out of skill-local prose into `backlog_groom`'s own docstring (the tool's live schema).
- `groom/finalize.md` + `groomer-output-validation.md` — de-duplicated an independently-drifting `mark_groomed_skipped`/`mark_groomed_skip_reason` field description into one source of truth (`backlog_groom`'s docstring).
- `close/start.md` — `backlog_resolve`'s response has no `milestone` field (verified against `operations.py`); repointed the read at the earlier `backlog_view` call that does carry it.

## Test plan

- [x] `uv run ty check plugins/development-harness/backlog_core/server.py` — passed
- [x] `uvx skilllint@latest check plugins/development-harness` — no new findings on touched files
- [x] `uv run pytest plugins/development-harness/tests/ -k groom` — 184 passed, 2 skipped
- [x] `uv run prek run --files <all changed files>` — all hooks passed
- [x] Independent review of all 6 md diffs against the `writing-for-agents` skill's criteria (context pointers, duplication, no-ops) — found and fixed one remaining contradiction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFDUbZPaBTwKxMZgG2Da93