### PR TITLE
fix(rebase): name <branch> in the rebase invocation instead of relying on the checkout

### DIFF
--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -56,8 +56,24 @@ No-conflict files (branch-only): path/a.py, path/b.py
 ### Step 5 — Execute the rebase
 
 ```bash
-git rebase <target>
+git rebase <target> <branch>
 ```
+
+Pass `<branch>` — the same one Steps 1-4 analysed. `git rebase`'s positional form is
+`[<upstream> [<branch>]]`; omitting `<branch>` rebases whatever is currently checked out, which
+is a different branch whenever the analysis targeted one you are not standing on. That rewrites
+commits the plan never looked at and leaves the requested branch untouched.
+
+Naming `<branch>` makes git check it out first, which fails with `fatal: '<branch>' is already
+used by worktree at ...` when another worktree holds it. Run the rebase from the worktree that
+owns the branch:
+
+```bash
+git worktree list          # find the worktree whose HEAD is <branch>
+```
+
+Then run the `git rebase <target> <branch>` above from that directory. Do not free the branch by
+detaching or switching the other worktree — another session may be mid-task in it.
 
 On each conflict:
 
@@ -69,5 +85,6 @@ After completing, verify with `git log --oneline` and run the test suite.
 ## Rules
 
 - Write the Step 4 plan before running `git rebase`.
+- Name `<branch>` in the `git rebase` invocation — never rely on the current checkout matching it.
 - Resolve each conflict according to the plan — check before accepting either side.
 - Read file-level diffs (Step 2); commit message titles are not a substitute.


### PR DESCRIPTION
One file, one paragraph of guidance, no dependencies.

Step 5 of the rebase skill said:

```bash
git rebase <target>
```

`git rebase`'s positional form is `[<upstream> [<branch>]]`, so omitting `<branch>` rebases **whatever is currently checked out** — a different branch whenever Steps 1-4 analysed one you are not standing on. The skill then rewrites commits its own disposition plan never looked at, and leaves the branch it was asked to rebase untouched. This bit a live session directly, running several worktrees across several branches.

Step 5 now names the branch, and covers the failure that naming it introduces: git checks the branch out first, so it fails with `fatal: '<branch>' is already used by worktree at ...` when another worktree holds it. The fix is to run the rebase from the worktree that owns the branch — explicitly **not** to free it by detaching or switching that worktree, since another session may be mid-task in it.

## Provenance

Found by Codex review of this skill's vendored copy in [`bitflight-devops/skilllint`](https://github.com/bitflight-devops/skilllint) and fixed there in bitflight-devops/skilllint#134. `.agents/skills/` and `.claude/skills/` are vendored downstream, so a fix that lands only there is reverted by the next sync. This is the canonical home. Tracking issue: bitflight-devops/skilllint#135.

## Why this is on its own

Split out of #3338, which carried this alongside six fixes to `receiving-pr-reviews`. #3337 has since rewritten that skill, so those six need re-implementing against the new split layout — see the follow-up PR. This file was untouched by #3337, is byte-identical to #3338's base, and merges clean, so it has no reason to wait.

## Verification

`prek run --files .claude/skills/rebase/SKILL.md` — all applicable hooks passed, including `markdownlint-cli2` and `skilllint check --fix`. No Python touched, so pytest/ruff/ty are not in scope for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc
