### PR TITLE
fix(receiving-pr-reviews): port remaining skilllint-side hygiene fixes

### DIFF
--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
@@ -32,7 +32,7 @@ __all__ = [
 ]
 
 
-class _GitHubResponseModel(BaseModel):
+class GitHubResponseModel(BaseModel):
     """Base for every model that ingests a raw GitHub response, GraphQL or REST.
 
     `strict=True` so a producer-shape mismatch — GitHub or `gh` returning a string where the
@@ -57,13 +57,13 @@ class _GitHubResponseModel(BaseModel):
 GitHubTimestamp = Annotated[datetime, Field(strict=False)]
 
 
-class Author(_GitHubResponseModel):
+class Author(GitHubResponseModel):
     """A GitHub account login, as GraphQL returns it for a comment/review/reaction author."""
 
     login: str
 
 
-class CommentNode(_GitHubResponseModel):
+class CommentNode(GitHubResponseModel):
     """A single review comment, in the shape GitHub's GraphQL API returns it.
 
     `author` is `None` for a comment left by an account that has since been deleted — GitHub's
@@ -77,7 +77,7 @@ class CommentNode(_GitHubResponseModel):
     author: Author | None
 
 
-class PageInfo(_GitHubResponseModel):
+class PageInfo(GitHubResponseModel):
     """The `hasNextPage` half of a GraphQL connection's `pageInfo`.
 
     `endCursor` is consumed entirely by `gh api graphql --paginate` itself and never read by this
@@ -87,7 +87,7 @@ class PageInfo(_GitHubResponseModel):
     hasNextPage: bool
 
 
-class CommentsConnection(_GitHubResponseModel):
+class CommentsConnection(GitHubResponseModel):
     """One page's `comments` connection, nested inside a `reviewThreads` node."""
 
     totalCount: int
@@ -95,7 +95,7 @@ class CommentsConnection(_GitHubResponseModel):
     nodes: list[CommentNode]
 
 
-class ReviewThreadNode(_GitHubResponseModel):
+class ReviewThreadNode(GitHubResponseModel):
     """One review thread, in the shape GitHub's GraphQL API returns it."""
 
     id: str
@@ -104,7 +104,7 @@ class ReviewThreadNode(_GitHubResponseModel):
     comments: CommentsConnection
 
 
-class ReviewThreadsConnection(_GitHubResponseModel):
+class ReviewThreadsConnection(GitHubResponseModel):
     """One page's `reviewThreads` connection, already unwrapped from `data.repository.pullRequest`.
 
     `pr_review_gh._fetch_pages` pulls this dict straight out of each slurped page by subscripting
@@ -118,7 +118,7 @@ class ReviewThreadsConnection(_GitHubResponseModel):
     nodes: list[ReviewThreadNode]
 
 
-class ReviewNode(_GitHubResponseModel):
+class ReviewNode(GitHubResponseModel):
     """A top-level review submission, in the shape GitHub's GraphQL API returns it.
 
     Distinct from a review *comment* (`CommentNode`): this is the review object itself — its
@@ -151,7 +151,7 @@ class ReviewNode(_GitHubResponseModel):
     url: str
 
 
-class ReviewsConnection(_GitHubResponseModel):
+class ReviewsConnection(GitHubResponseModel):
     """One page's `reviews` connection, already unwrapped — see `ReviewThreadsConnection`."""
 
     totalCount: int
@@ -162,7 +162,7 @@ class UnresolvedThread(BaseModel):
     """One unresolved review thread and its full comment history, as emitted to the caller.
 
     Assembled by `pr_review_gh.build_fetch_result` from already-validated `ReviewThreadNode`
-    values, so it is an output shape rather than an ingress one — see `_GitHubResponseModel`.
+    values, so it is an output shape rather than an ingress one — see `GitHubResponseModel`.
     """
 
     id: str
@@ -171,7 +171,7 @@ class UnresolvedThread(BaseModel):
     comments_truncated: bool
 
 
-class IssueComment(_GitHubResponseModel):
+class IssueComment(GitHubResponseModel):
     """One PR-level (issue) comment, in the shape GitHub's REST API returns it.
 
     `pr_review_gh._unresponded_reviews` treats a comment authored by the currently-authenticated
@@ -187,7 +187,7 @@ class IssueComment(_GitHubResponseModel):
     body: str
 
 
-class Reaction(_GitHubResponseModel):
+class Reaction(GitHubResponseModel):
     """One reaction left on the PR itself, in the shape GitHub's REST reactions API returns it.
 
     `user` is `None` for a reaction left by an account that has since been deleted, same null
@@ -202,13 +202,13 @@ class Reaction(_GitHubResponseModel):
     created_at: GitHubTimestamp
 
 
-class GitHubCommitDate(_GitHubResponseModel):
+class GitHubCommitDate(GitHubResponseModel):
     """The `committedDate` field of a GraphQL `Commit` object."""
 
     committedDate: GitHubTimestamp
 
 
-class HeadCommitNode(_GitHubResponseModel):
+class HeadCommitNode(GitHubResponseModel):
     """One commit from GraphQL's `pullRequest.commits(last: 1)` connection.
 
     Requesting `last: 1` asks the server directly for the tail element — GraphQL's connection
@@ -220,13 +220,13 @@ class HeadCommitNode(_GitHubResponseModel):
     commit: GitHubCommitDate
 
 
-class HeadCommitsConnection(_GitHubResponseModel):
+class HeadCommitsConnection(GitHubResponseModel):
     """The `commits(last: 1)` connection nested inside `PullRequestHeadState`."""
 
     nodes: list[HeadCommitNode]
 
 
-class PullRequestHeadState(_GitHubResponseModel):
+class PullRequestHeadState(GitHubResponseModel):
     """The PR-level fields `pr_review_gh._fetch_head_state` reads in one GraphQL query.
 
     All four live on the same `pullRequest` object, so they cost one round trip together: the head
@@ -237,7 +237,7 @@ class PullRequestHeadState(_GitHubResponseModel):
     `DIRTY`, `BLOCKED`, `BEHIND`, `UNSTABLE`, `DRAFT`, `HAS_HOOKS`, or `UNKNOWN`. Both are kept as
     plain strings rather than enums: GitHub can add a state at any time, and an unrecognized one
     must reach the caller as data instead of failing validation on a PR that is otherwise fine.
-    Strict against that string type, though — `strict=True` via `_GitHubResponseModel` means a
+    Strict against that string type, though — `strict=True` via `GitHubResponseModel` means a
     number or a null arriving where a state name belongs is rejected rather than stringified, and
     `isDraft` must be a real boolean rather than `"false"`. None of the three is a timestamp, so
     none needs the `GitHubTimestamp` relaxation.
@@ -269,7 +269,7 @@ class Reviewability(BaseModel):
     it on every poll, and `fetch` is cheap to re-run.
 
     Derived by `pr_review_gh._reviewability` from an already-validated `PullRequestHeadState`, so
-    it is an output shape rather than an ingress one and does not inherit `_GitHubResponseModel` —
+    it is an output shape rather than an ingress one and does not inherit `GitHubResponseModel` —
     same reason as `UnresolvedThread` and `FetchResult`.
     """
 
@@ -279,7 +279,7 @@ class Reviewability(BaseModel):
     blockers: list[str]
 
 
-class ForcePushEvent(_GitHubResponseModel):
+class ForcePushEvent(GitHubResponseModel):
     """One `HeadRefForcePushedEvent` GraphQL timeline item.
 
     `createdAt` is when GitHub's server recorded the force-push itself — independent of any

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -98,6 +98,7 @@ def fetch(
 @app.command()
 def watch(
     pr: Annotated[int, typer.Option(help="Pull request number.")],
+    *,
     owner: Annotated[str, typer.Option(help="Repository owner.")] = DEFAULT_OWNER,
     repo: Annotated[str, typer.Option(help="Repository name.")] = DEFAULT_REPO,
     interval_seconds: Annotated[

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -7,6 +7,19 @@
 #   "pytest",
 #   "pytest-mock",
 # ]
+# [tool.ty.environment]
+# # ty 0.0.75 treats any file carrying PEP 723 inline script metadata as an
+# # isolated single-file script and ignores [tool.ty.environment].extra-paths
+# # from pyproject.toml entirely, so this table (not the one in pyproject.toml)
+# # is what ty actually reads for this file. Relative extra-paths declared here
+# # resolve relative to this script's own directory, not the invocation cwd or
+# # the project root -- "." is therefore this directory, which is where the
+# # sibling pr_review_threads, pr_review_gh, and pr_review_models modules live.
+# # `ty check` already passes without this table (pyproject.toml's own
+# # extra-paths entry for this directory covers it in practice), but it is
+# # added here for parity with skilllint's copy of this script and to remove
+# # the dependency on pyproject.toml staying in sync with this file's location.
+# extra-paths = ["."]
 # ///
 """Tests for pr_review_threads.py, pr_review_gh.py, and pr_review_models.py.
 
@@ -810,7 +823,7 @@ def test_ingress_models_reject_a_coerced_producer_shape(model: type[BaseModel], 
     """A `gh` response whose scalar types do not match the schema fails at the boundary.
 
     In lax mode `"3"` silently becomes `3` and `"false"` becomes `True` — a producer-shape change
-    would then reach review state looking valid. `_GitHubResponseModel` sets `strict=True` so it
+    would then reach review state looking valid. `GitHubResponseModel` sets `strict=True` so it
     raises here instead.
     """
     with pytest.raises(ValidationError):
@@ -836,7 +849,7 @@ def test_internal_result_models_are_not_strict() -> None:
     """`FetchResult`/`WatchResult`/`UnresolvedThread` are output shapes, not ingress.
 
     They are assembled from already-validated values, so they deliberately do not inherit
-    `_GitHubResponseModel` — see its docstring.
+    `GitHubResponseModel` — see its docstring.
     """
     for model in (pr_review_models.FetchResult, pr_review_models.WatchResult, pr_review_models.UnresolvedThread):
         assert model.model_config.get("strict") is not True


### PR DESCRIPTION
## Summary

Ports the remaining skilllint-side deltas of `.agents/skills/receiving-pr-reviews/` into this repo's three-file layout (`pr_review_threads.py` / `pr_review_gh.py` / `pr_review_models.py`), following the timeout-sourcing (#3341), rebase-branch (#3340), and reviewability (#3343) PRs that already landed today.

## Moved

1. **PEP 723 `[tool.ty.environment] extra-paths = ["."]`** in `test_pr_review_threads.py`'s script header (skilllint#157/#158 parity). `ty` treats a PEP-723-tagged file as an isolated single-file script and ignores `[tool.ty.environment].extra-paths` from `pyproject.toml`, so the config has to live in the script itself for that guarantee to hold regardless of `pyproject.toml`. **Verified with and without this addition: `ty check` passes both ways** — `pyproject.toml`'s own `extra-paths` entry for this directory already covers it in practice, so this is added for parity and independence from that entry, not to fix a failure. Comment wording is adapted from skilllint's (which names only its one sibling module) to name all three sibling modules this test file actually imports (`pr_review_threads`, `pr_review_gh`, `pr_review_models`).
2. **`GitHubResponseModel` rename** (skilllint#160) — dropped the leading underscore in `pr_review_models.py` and its two docstring references in `test_pr_review_threads.py`. No behavior change; not part of the module's `__all__` either before or after.
3. **`watch()` parameters keyword-only** — added `*,` after `pr` in `pr_review_threads.py`'s `watch()` (matches skilllint's ruff `PLR0917` fix; `fetch`/`reply`/`resolve` stay under the positional-arg threshold and are unchanged, matching skilllint's own scoping). Typer binds by name, so no behavior change.

## Deliberately skipped

- **Float equality → `pytest.approx`** — already landed upstream verbatim (`test_gh_timeout_budget_*` in `test_pr_review_threads.py` already use `pytest.approx` in all three assertions, matching skilllint's copy exactly). Nothing to port.
- **`DEFAULT_OWNER`/`DEFAULT_REPO`** — left as `Jamie-BitFlight`/`claude_skills`; not touched.
- **`_run_gh`/`run_gh` docstring (D417)** — upstream's `run_gh` in `pr_review_gh.py` already has a complete Args/Returns/Raises docstring; confirmed still correct, no action needed.
- **skilllint#158 comment corrections** — described skilllint's own CI (`ty check packages/`), which doesn't apply here; not ported.

## Found in the diff but out of scope for this PR

Diffing `SKILL.md` directory-to-directory turned up a **much larger, pre-existing design divergence** in the `watch` subcommand's "new activity" detection that is unrelated to any of the four items above:

- This repo's current `watch` (post-#3337, "make watch stateless") triggers on **absolute counts** from a fresh, non-diffed snapshot each call (`state.unresolved_count > 0`, `state.unresponded_reviews`, `state.codex_approved`).
- skilllint's current `watch` instead does **baseline-diffing** — each call takes a baseline fetch and reports `new_thread_ids`/`new_reviews_with_body` relative to it.

These are two different designs, not a wording difference, and reconciling them was not in scope (not listed in the four items to move, and doing so would rewrite `watch`'s behavior and this repo's `SKILL.md` well beyond a hygiene port). Flagging for a separate, deliberate decision rather than silently carrying one side's behavior into the other. `SKILL.md` was not touched by this PR.

## Test plan

Run from this repo's root:

- [x] `uv run pytest .agents/skills/receiving-pr-reviews/scripts/ -q` — 66 passed (before and after)
- [x] `uv run ruff check --no-fix .agents/skills/receiving-pr-reviews/scripts/` — All checks passed (before and after)
- [x] `uv run ty check .agents/skills/receiving-pr-reviews/scripts/` — **without** the PEP 723 addition: All checks passed. **With** it (current state): All checks passed.
- [x] `prek run --files .agents/skills/receiving-pr-reviews/scripts/pr_review_models.py .agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py .agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py` — all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc