### PR TITLE
docs(backlog-schema): fix field drift; refactor T0 dispatch and QG doc bloat

### DIFF
--- a/plugins/development-harness/docs/backlog-item-groomed-schema.md
+++ b/plugins/development-harness/docs/backlog-item-groomed-schema.md
@@ -2,25 +2,25 @@
 
 **Purpose**: Define the structure of groomed content written into backlog item files. Grooming (backlog refinement) transforms items from vague ("this problem happens") to ready for planning — problem is clear, facts are verified, resources are mapped, effort is estimated, and blockers are surfaced. The agent does this autonomously: fact-checking claims, searching the codebase for related work, and identifying gaps. It does NOT produce architecture, task decomposition, or implementation plans — those happen in the SAM planning phase.
 
-**Location**: Groomed content lives in the **body** of `~/.dh/projects/{slug}/backlog/{priority}-{slug}.md` (resolved via `dh_paths.backlog_dir()`). Frontmatter uses the research-style `metadata:` block (aligned with `./research/` entries). Body has no duplication of frontmatter — only extra fields when present, plus `## Groomed` when groomed.
+**Scope**: This document defines the groomed *content* schema — frontmatter shape, body sections, and `## Groomed` subsections — passed through `backlog_groom(groomed_content=...)`. This content is identical regardless of which backend (github, sqlite, memory, beads) stores it; physical storage format and location are backend internals (see `plugins/development-harness/AGENTS.md` §Backend Providers) and are out of scope here. Frontmatter uses the research-style `metadata:` block (aligned with `./research/` entries). Body has no duplication of frontmatter — only extra fields when present, plus `## Groomed` when groomed.
 
 ---
 
 ## Frontmatter (Research-Style)
 
-Aligned with [research/README.md](../../research/README.md) metadata format:
+Aligned with [research/README.md](../../../research/README.md) metadata format:
 
 ```yaml
 ---
-name: "Item title"
+title: "Item title"
 description: "Main problem statement or description"
 metadata:
   topic: "slug-from-title"
   source: "Source description"
   added: "YYYY-MM-DD"
-  priority: P0|P1|P2|Ideas
+  priority: P0|P1|P2|Ideas|completed  # "completed" is set internally on completion, not chosen by the groomer
   type: Feature|Bug|Refactor|Docs|Chore
-  status: open|in-progress|done|resolved
+  status: open|done|in-progress|needs-grooming|closed
   # optional:
   issue: "#N"
   plan: "path/to/plan.md"
@@ -43,7 +43,7 @@ Body is **empty** when un-groomed and no extra details. When present, body conta
 - **Files** — when applicable
 - **## Groomed (YYYY-MM-DD)** — when groomed (see below)
 
-Do **not** duplicate `name`, `description`, `source`, `added`, `priority`, `type`, `issue` in the body — they live in frontmatter.
+Do **not** duplicate `title`, `description`, `source`, `added`, `priority`, `type`, `issue` in the body — they live in frontmatter.
 
 ---
 

--- a/plugins/development-harness/skills/complete-implementation/SKILL.md
+++ b/plugins/development-harness/skills/complete-implementation/SKILL.md
@@ -5,16 +5,11 @@ user-invocable: true
 description: "Use when all tasks for a feature are marked COMPLETE — runs holistic quality gates including code review, feature verification, integration check, documentation drift audit and update, and context refinement. Creates follow-up plans when issues are found."
 compatibility: Python 3.11+
 metadata:
-  version: 2.1.0
-  last_updated: '2026-06-04'
+  version: 2.2.0
+  last_updated: '2026-08-30'
 ---
 
 # Complete Implementation (Quality Gates + Recursion)
-
-You MUST validate that the implemented feature meets its goals and quality gates. If follow-up plans
-are created, route them to backlog items first, then recurse only when the follow-up matches the
-current scope and priority (see Recursive Follow-up Handling section).
-
 
 <input>
 $ARGUMENTS
@@ -41,8 +36,6 @@ never the invocation prefix. Prepend the command in <sam_cli/> above to every on
 
 Parse `$ARGUMENTS` to determine the input type before proceeding. A plan address is an opaque
 logical identifier returned by `sam_plan`; pass it through unchanged.
-
-The following diagram is the authoritative procedure for Input Format Detection. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
 
 ```mermaid
 flowchart TD
@@ -84,8 +77,6 @@ Stop.
 **Step 2 -- Check for linked plan**:
 
 Read the `plan` field from the response.
-
-The following diagram is the authoritative procedure for Resolve Issue Step 2 linked plan check. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
 
 ```mermaid
 flowchart TD
@@ -189,11 +180,9 @@ dispatch loop.
 
 **Step 4 -- SAM dispatch loop**:
 
-Use the same SAM Dispatch Loop as the existing 7-phase flow (see "SAM Dispatch Loop (Phases T0-T6)" section). The loop operates identically — 5 tasks instead of 7 is the only structural difference. The proportional plan omits T0 (Multi-Perspective Review) and T6 (Context Refinement) to stay proportional, but retains the T4/T5 documentation pass.
+Use the same SAM Dispatch Loop as the full-plan flow (see "SAM Dispatch Loop (Phases T0-T6)" section). The loop operates identically — 5 tasks instead of 7 is the only structural difference. The proportional plan omits T0 (Multi-Perspective Review) and T6 (Context Refinement), but retains the T4/T5 documentation pass.
 
 **Phase-specific post-dispatch actions for proportional gates**:
-
-The following diagram is the authoritative procedure for Proportional Quality Gates phase-specific post-dispatch actions. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
 
 ```mermaid
 flowchart TD
@@ -213,49 +202,14 @@ flowchart TD
     T5Post --> Continue
 ```
 
-**Detecting drift in T4 output**: The `@dh:doc-drift-auditor` agent returns a `Total findings: {count}` line in its `ARTIFACTS` block and registers the full drift report as the `audit-report` artifact. No drift = `Total findings: 0` → skip T5. Drift = `Total findings` of 1 or more → dispatch T5. If the count line is absent, read the `audit-report` artifact and treat a non-empty `## Findings by Category` as drift. This is the same drift-detection rule the full SAM path applies to its T4 phase.
+**Detecting drift in T4 output**: The `@dh:doc-drift-auditor` agent returns a `Total findings: {count}` line in its `ARTIFACTS` block and registers the full drift report as the `audit-report` artifact. No drift = `Total findings: 0` → skip T5. Drift = `Total findings` of 1 or more → dispatch T5. If the count line is absent, read the `audit-report` artifact and treat a non-empty `## Findings by Category` as drift.
 
 **Step 5 -- Completion verification gate**:
 
-After the dispatch loop exits, verify all phases (defined by `build_quality_gate_plan` in `sam_schema/core/quality_gates.py`) reached terminal status:
-
-```bash
-uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" plan status --plan-address "{pqg_plan_address}"
-```
-
-All 5 tasks must have `status == 'complete'`, with one exception: T5 (Documentation Update) may have `status == 'skipped'` when T4 found no drift. Any other task with `status == 'skipped'` is an unauthorized skip — treat as a failure. This skip whitelist matches the full SAM path's Completion Verification Gate.
-
-The following diagram is the authoritative procedure for Proportional Quality Gates completion verification. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
-
-```mermaid
-flowchart TD
-    Status["sam_plan(plan='{pqg_plan_address}', config={action:'status'})"] --> Iter["Iterate over all 5 tasks"]
-    Iter --> Check{For each task:<br>check status}
-    Check -->|"status == 'complete'"| PassTask["Task passes"]
-    Check -->|"status == 'skipped' AND task_id == 'T5'"| PassTask
-    Check -->|"status == 'skipped' AND task_id != 'T5'"| FailUnauth["FAIL — unauthorized skip"]
-    Check -->|"any other status"| FailIncomplete["FAIL — task incomplete or blocked"]
-    PassTask --> AllPassed{All 5 tasks<br>passed?}
-    AllPassed -->|Yes| Proceed["Proceed to Step 6"]
-    AllPassed -->|No| Stop["STOP — report failures, do NOT apply label"]
-    FailUnauth --> AllPassed
-    FailIncomplete --> AllPassed
-```
-
-On verification failure:
-
-```text
-COMPLETION BLOCKED — Proportional Quality Gate Incomplete
-
-Failed tasks:
-  {task_id} ({phase_name}): status={status}
-  [repeat for each failing task]
-
-To resume: re-run /complete-implementation {item_ref}
-BLOCKED tasks will be reset to NOT_STARTED automatically.
-```
-
-Stop. Do not apply the `status:verified` label.
+Execute the shared procedure in
+[./references/completion-verification-gate.md](./references/completion-verification-gate.md) with
+`{plan_address}` = `{pqg_plan_address}`, `{gate_name}` = "Proportional Quality Gate Incomplete",
+`{resume_arg}` = `{item_ref}`, `{next_step}` = "Step 6".
 
 **Step 6 -- Apply status:verified label**:
 
@@ -284,7 +238,7 @@ Stop. Do not proceed to the Final Step commit.
 
 **Step 7 -- No recursive follow-up handling**:
 
-The issue-only path does not produce follow-up plans. Skip directly to "Final Step: Commit and Push Remaining Changes", then "Team Shutdown", then "Resolve the Issue".
+The issue-only path does not produce follow-up plans. Skip directly to "Final Step: Commit and Push Remaining Changes", then "Confirm All Workers Finished", then "Resolve the Issue".
 
 ---
 
@@ -309,8 +263,6 @@ The artifact content contains a list of per-criterion `BookendVerification` reco
 `acceptance-criteria-structured` entry. There is no top-level `verdict` field. Aggregate the verdict
 by scanning all records: the overall result is FAIL if any record has `status: regressed`;
 otherwise PASS.
-
-The following diagram is the authoritative procedure for Pre-Phase 1 TN Verification Check. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
 
 ```mermaid
 flowchart TD
@@ -396,8 +348,6 @@ Use the `{slug}` resolved from the implementation plan's `feature` field.
 uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" plan list --search "qg-{slug}"
 ```
 
-The following diagram is the authoritative procedure for Quality Gate Plan Creation Step 1 check for existing QG plan. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
-
 ```mermaid
 flowchart TD
     List["sam_plan(config={action:'list', search:'qg-{slug}'})"] --> Found{QG plan found?}
@@ -473,15 +423,6 @@ This allows re-running `complete-implementation` to resume from the blocked phas
 | T5 | Documentation Update | service-docs-maintainer |
 | T6 | Context Refinement | context-refinement |
 
-### Team Setup
-
-Check for an existing implementation team before dispatching QG agents:
-
-- `team_name = "impl-{slug}"` (same team created by `implement-feature`)
-- If the team exists (config at `~/.claude/teams/impl-{slug}/config.json`), reuse it for QG agent dispatch
-- If no team exists, create one: `TeamCreate(team_name="impl-{slug}")`
-- Store `team_name` for use in agent dispatch and the Team Shutdown step below
-
 ### Dispatch Loop
 
 Repeat until `sam_plan(plan="{qg_plan_address}", config={"action": "ready"})` returns a
@@ -495,25 +436,57 @@ uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" plan ready --plan-address "{qg_
 
 If the result is empty, exit the loop and proceed to Completion Verification Gate.
 
-**2. Load the start-task skill:**
+**2. Dispatch the task:**
 
-```text
-Skill(skill="start-task", args="{qg_plan_address} --task {task_id}")
+```mermaid
+flowchart TD
+    Ready["Next ready task_id"] --> IsT0{task_id == 'T0'?}
+    IsT0 -->|"Yes"| Direct["Run T0 directly — see below"]
+    IsT0 -->|"No"| Delegate["Run the start-task workflow<br>against {qg_plan_address} --task {task_id}"]
 ```
 
-Pass `team_name="{team_name}"` when spawning QG agents so they join the existing implementation team.
-
-`start-task` claims the task and marks it COMPLETE on finish via the SubagentStop hook. Do not call
+**T1-T6 — delegate:** run the `dh:start-task` workflow (name it in prose — a harness-specific
+invocation form reaches only the harness that defines it) against `{qg_plan_address} --task
+{task_id}`. `start-task` claims the task and marks it complete on finish. Do not call
 `sam_task(plan="{qg_plan_address}", task="{task_id}", config={"action": "claim"})` in the
 orchestrator before this step — claiming here causes a double-claim that causes `start-task` to
 receive `claimed: false` and stop without executing the task body.
+
+**T0 — run it directly, in your own context; do not delegate it.** Its agent is
+`dh:multi-perspective-review (orchestrated)` — a workflow that already dispatches its own
+reviewers, so a delegated worker would only add a hop to reach the same call.
+
+1. Commit any outstanding changes (`git add -A && git commit ...`).
+2. Read `sam_plan(plan="{plan_address}", config={"action": "read"}).context` for
+   `**Implementation base SHA**: <sha>` (`implement-feature`'s "Record the Implementation Base
+   SHA" step). If absent, or if `git cat-file -e "<sha>"` fails (the commit no longer resolves),
+   stop:
+
+   ```text
+   COMPLETION BLOCKED — No Implementation Base SHA
+
+   This plan has no recorded starting commit for T0's diff review. Every ref-based substitute
+   (a branch name, a merge-base) can silently miss commits once this plan's own work reaches
+   origin/main — falling back to one would report success without reviewing everything changed.
+
+   To resume: determine the correct starting commit and record it —
+   sam_plan(plan="{plan_address}", config={"action": "update", "context": "**Implementation
+   base SHA**: <sha>\n\n{existing context}"}) — then re-run /complete-implementation.
+   ```
+
+   Do not proceed to Step 1 (no QG plan is created); do not apply `status:verified`.
+3. Run the workflow (name it in prose) with `--diff "<sha>..HEAD"`, adding `--issue {item_ref}`
+   when known.
+
+There is no subagent here to claim or complete the task, so do that yourself:
+`sam_task(plan="{qg_plan_address}", task="T0", config={"action": "claim"})` before running the
+workflow, `sam_task(plan="{qg_plan_address}", task="T0", config={"action": "state", "status":
+"complete"})` after — then continue to Step 3 below exactly as for any other completed task.
 
 **3. Phase-specific post-dispatch actions:**
 
 After each dispatched phase completes, run the phase-specific processing before querying
 `sam_plan(plan="{qg_plan_address}", config={"action": "ready"})` again:
-
-The following diagram is the authoritative procedure for SAM Dispatch Loop phase-specific post-dispatch actions. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
 
 ```mermaid
 flowchart TD
@@ -534,55 +507,17 @@ flowchart TD
     StoreDiv --> Continue
 ```
 
-**Detecting drift in T4 output**: The `@dh:doc-drift-auditor` agent returns a `Total findings: {count}` line in its `ARTIFACTS` block and registers the full drift report as the `audit-report` artifact. No drift = `Total findings: 0`. Drift = `Total findings` of 1 or more. If the count line is absent, read the `audit-report` artifact and treat a non-empty `## Findings by Category` as drift.
+**Detecting drift in T4 output**: same rule as Proportional Quality Gates Step 4 above.
 
 ---
 
 ## Completion Verification Gate
 
-After the SAM dispatch loop exits, verify all phases reached terminal status before allowing label application.
-
-```bash
-uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" plan status --plan-address "{qg_plan_address}"
-```
-
-The following diagram is the authoritative procedure for Completion Verification Gate. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
-
-```mermaid
-flowchart TD
-    Status["sam_plan(plan='{qg_plan_address}', config={action:'status'})"] --> Iter["Iterate over all tasks in the plan"]
-    Iter --> Check{For each task:<br>check status}
-    Check -->|"status == 'complete'"| PassTask["Task passes"]
-    Check -->|"status == 'skipped' AND task_id == 'T5'"| PassTask
-    Check -->|"status == 'skipped' AND task_id != 'T5'"| FailUnauth["FAIL — unauthorized skip"]
-    Check -->|"status == 'not-started' OR 'in-progress'"| FailIncomplete["FAIL — incomplete phase"]
-    Check -->|"status == 'blocked'"| FailBlocked["FAIL — blocked phase"]
-    PassTask --> AllPassed{All tasks<br>passed?}
-    AllPassed -->|Yes| Proceed["Proceed to Recursive Follow-up Handling"]
-    AllPassed -->|No| Stop["STOP — report failures, do NOT apply label"]
-    FailUnauth --> AllPassed
-    FailIncomplete --> AllPassed
-    FailBlocked --> AllPassed
-```
-
-**Skip whitelist**: ONLY T5 (Documentation Update) may have `status: skipped`. Any other task with `status: skipped` is an unauthorized skip — treat as a failure.
-
-**On verification failure**, output:
-
-```text
-COMPLETION BLOCKED — Quality Gate Incomplete
-
-Failed tasks:
-  {task_id} ({phase_name}): status={status}
-  [repeat for each failing task]
-
-To resume: re-run /complete-implementation {plan_address}
-BLOCKED tasks will be reset to NOT_STARTED automatically.
-```
-
-Stop. Do not apply the `status:verified` label.
-
-**On verification success**, proceed to Recursive Follow-up Handling.
+After the SAM dispatch loop exits, execute the shared procedure in
+[./references/completion-verification-gate.md](./references/completion-verification-gate.md) with
+`{plan_address}` = `{qg_plan_address}`, `{gate_name}` = "Quality Gate Incomplete", `{resume_arg}` =
+`{plan_address}` (the original feature plan address), `{next_step}` = "Recursive Follow-up
+Handling".
 
 ---
 
@@ -604,7 +539,7 @@ If absent, no additional output is needed — the feature proceeds normally.
 
 ## Recursive Follow-up Handling
 
-## Constants
+### Constants
 
 `DH_RECURSIVE_REVIEW_TASK_DEPTH = 5`
 
@@ -732,23 +667,12 @@ Push after committing; skip if the working tree is clean.
 
 ---
 
-## Team Shutdown
+## Confirm All Workers Finished
 
-After commit+push, release the implementation team:
-
-```text
-TeamDelete(team_name="{team_name}")
-```
-
-Deleting the team releases every teammate in it. Delete it only once every task the team owns is
-terminal — read that through `sam_plan(config={"action": "status"})`, never by assuming a silent
-teammate has finished.
-
-`TeamDelete` is a release step, not a shutdown mechanism: it fails while any teammate is still
-active, and a teammate that finished its task stays alive and idle until something shuts it down.
-Shut each teammate down through the harness's teammate-shutdown mechanism first. This step runs
-after commit+push, so a failed release cannot cost committed work — treat it as a release that did
-not happen, wait for the named teammate, and retry.
+After commit+push, confirm every dispatched worker has reached a terminal state — read that
+through `sam_plan(config={"action": "status"})`, never by assuming a silent worker has finished.
+Each worker was dispatched independently and terminates on its own once its task completes; there
+is no shared group object to release.
 
 ---
 

--- a/plugins/development-harness/skills/complete-implementation/references/completion-verification-gate.md
+++ b/plugins/development-harness/skills/complete-implementation/references/completion-verification-gate.md
@@ -1,0 +1,48 @@
+# Completion Verification Gate
+
+Shared procedure for both the Proportional Quality Gates path and the full SAM path. The caller
+supplies `{plan_address}` (`{pqg_plan_address}` or `{qg_plan_address}`), `{gate_name}` (for the
+failure banner), `{resume_arg}` (for the re-run command), and `{next_step}` (what "Proceed" leads
+to).
+
+After the dispatch loop exits, verify all tasks in the plan reached terminal status before allowing
+label application:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" plan status --plan-address "{plan_address}"
+```
+
+```mermaid
+flowchart TD
+    Status["sam_plan(plan='{plan_address}', config={action:'status'})"] --> Iter["Iterate over all tasks in the plan"]
+    Iter --> Check{For each task:<br>check status}
+    Check -->|"status == 'complete'"| PassTask["Task passes"]
+    Check -->|"status == 'skipped' AND task_id == 'T5'"| PassTask
+    Check -->|"status == 'skipped' AND task_id != 'T5'"| FailUnauth["FAIL — unauthorized skip"]
+    Check -->|"any other status"| FailIncomplete["FAIL — task incomplete or blocked"]
+    PassTask --> AllPassed{All tasks<br>passed?}
+    AllPassed -->|Yes| Proceed["Proceed to {next_step}"]
+    AllPassed -->|No| Stop["STOP — report failures, do NOT apply label"]
+    FailUnauth --> AllPassed
+    FailIncomplete --> AllPassed
+```
+
+**Skip whitelist**: ONLY T5 (Documentation Update) may have `status: skipped`. Any other task with
+`status: skipped` is an unauthorized skip — treat as a failure.
+
+**On verification failure**, output:
+
+```text
+COMPLETION BLOCKED — {gate_name}
+
+Failed tasks:
+  {task_id} ({phase_name}): status={status}
+  [repeat for each failing task]
+
+To resume: re-run /complete-implementation {resume_arg}
+BLOCKED tasks will be reset to NOT_STARTED automatically.
+```
+
+Stop. Do not apply the `status:verified` label.
+
+**On verification success**, proceed to `{next_step}`.

--- a/plugins/development-harness/skills/implement-feature/SKILL.md
+++ b/plugins/development-harness/skills/implement-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement-feature
-description: Executes the SAM implementation loop when a task plan exists — dispatches ready tasks to specialist agents in parallel, manages bookend tasks (T0 baseline capture and TN verification), tracks concerns and contract violations per task, and relies on hooks to update task status. Use when the plan_ref returned by add-new-feature is provided. Manages task batches via sam_plan and sam_task MCP tools.
+description: Use when the plan_ref returned by add-new-feature is provided. Executes the SAM implementation loop — dispatches ready tasks to specialist agents in parallel, manages bookend tasks (T0 baseline capture and TN verification), tracks concerns and contract violations per task, and relies on hooks to update task status. Manages task batches via sam_plan and sam_task MCP tools.
 argument-hint: "<plan_ref>"
 user-invocable: true
 ---
@@ -33,6 +33,17 @@ Confirm the plan exists:
 ```bash
 uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" plan status --plan-address "{plan_ref}"
 ```
+
+## Record the Implementation Base SHA
+
+Read `sam_plan(plan="{plan_ref}", config={"action": "read"}).context`. If it already contains a
+line matching `**Implementation base SHA**: <sha>`, skip this step — a prior run already recorded
+it, and re-running this step now would capture a later commit instead of the true starting point.
+
+Otherwise, before the Progress Loop makes its first commit: run `git rev-parse HEAD` and prepend
+`**Implementation base SHA**: {sha}\n\n` to the existing context (do not replace it —
+`sam_plan(action='update', context=...)` overwrites the whole field), then write it back via
+`sam_plan(plan="{plan_ref}", config={"action": "update", "context": "{updated context}"})`.
 
 ---
 
@@ -70,10 +81,7 @@ uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" plan ready --plan-address "{pla
 
 > **Call `mcp__plugin_dh_sam__sam_plan(config={"action": "ready"}, plan="{plan_ref}")` (or
 > `backlog_get_ready_sam_tasks`) ONCE per batch.** Store the returned task list. Loop over the stored list
-> without fetching ready tasks again.
-> After all tasks in the current batch are dispatched and completed, use
-> `uv run "${CLAUDE_PLUGIN_ROOT}/sam_schema/cli.py" plan status --plan-address "{plan_ref}"` to check whether more tasks remain.
-> Fetch the next ready batch only after the previous batch is fully dispatched.
+> without fetching ready tasks again — step 5 below governs when the next batch is fetched.
 
 3. Dispatch based on `autonomy_mode`:
 
@@ -116,31 +124,11 @@ For each task being dispatched:
 
 ### Agent Health Check (While Waiting)
 
-After dispatching a batch, the orchestrator waits for completion messages. Trigger a health check when any of these occur:
-
-- No message received from any dispatched agent after ~10 minutes of silence
-- User asks about agent status
-- `git log` shows no new commits when implementation work should be in progress
-
-**Never read JSONL session files directly in the orchestrator context.** Session files can exceed 40K tokens. Always delegate to `agentskill-kaizen:transcript-analyst` with an empty context window.
-
-Session JSONL files are at `~/.claude/projects/{project-slug}/*.jsonl`, filterable by `agentId` field. The `{project-slug}` is the absolute project path with `/` replaced by `-` (e.g. `/home/user/repos/myproject` → `-home-user-repos-myproject`).
-
-```mermaid
-flowchart TD
-    Trigger([Health check triggered]) --> Spawn
-    Spawn["Task is session health summary<br>subagent_type='agentskill-kaizen:transcript-analyst'<br>Context: agent name or teammate ID to check,<br>JSONL dir ~/.claude/projects/{project-slug}/*.jsonl<br>Report: last turn timestamp, last tool call,<br>verdict of crashed / idle / active"]
-    Spawn --> Verdict{Analyst verdict}
-    Verdict -->|"Crashed — session ended abruptly<br>after sam_task(action=claim) with no further turns"| Confirm
-    Confirm["Confirm task state via sam_task read<br>using plan_ref + task_id<br>Verify task is still CLAIMED"] --> Respawn
-    Respawn["Re-spawn agent with the same plan_ref and task ID<br>SubagentStop hook updates status on completion"]
-    Verdict -->|"Idle — no tool calls for 5+ min<br>agent appears stuck mid-task"| Activity["Read the task via sam_task read<br>Note its last-activity timestamp<br>Wait 2 minutes and read it again"]
-    Activity --> ActCheck{last-activity advanced?}
-    ActCheck -->|"Yes — the agent is still writing task state"| Waiting
-    ActCheck -->|"No — task state is frozen"| Respawn
-    Verdict -->|"Active — tool calls within last 2–3 min"| Waiting
-    Waiting[Continue waiting] --> Later["Re-check after 5–10 min<br>if completion message still absent"]
-```
+After dispatching a batch, the orchestrator waits for completion messages. Trigger a health check
+when any of these occur: no message from any dispatched agent after ~10 minutes of silence, the
+user asks about agent status, or `git log` shows no new commits when implementation work should be
+in progress. Execute the full check — crash/idle/active branches and re-spawn logic — defined in
+[./references/agent-health-check.md](./references/agent-health-check.md).
 
 4. After each agent returns, check its output for a `<concerns>` block. If present, append each concern to the backlog item as a checklist entry:
 

--- a/plugins/development-harness/skills/implement-feature/references/agent-health-check.md
+++ b/plugins/development-harness/skills/implement-feature/references/agent-health-check.md
@@ -1,0 +1,27 @@
+# Agent Health Check Procedure
+
+Full procedure for `implement-feature`'s Agent Health Check step. Reached only when one of the
+trigger conditions in the main skill fires — most dispatches never reach this file.
+
+**Never read JSONL session files directly in the orchestrator context.** Session files can exceed
+40K tokens. Always delegate to `agentskill-kaizen:transcript-analyst` with an empty context window.
+
+Session JSONL files are at `~/.claude/projects/{project-slug}/*.jsonl`, filterable by `agentId`
+field. The `{project-slug}` is the absolute project path with `/` replaced by `-` (e.g.
+`/home/user/repos/myproject` → `-home-user-repos-myproject`).
+
+```mermaid
+flowchart TD
+    Trigger([Health check triggered]) --> Spawn
+    Spawn["Task is session health summary<br>subagent_type='agentskill-kaizen:transcript-analyst'<br>Context: agent name or teammate ID to check,<br>JSONL dir ~/.claude/projects/{project-slug}/*.jsonl<br>Report: last turn timestamp, last tool call,<br>verdict of crashed / idle / active"]
+    Spawn --> Verdict{Analyst verdict}
+    Verdict -->|"Crashed — session ended abruptly<br>after sam_task(action=claim) with no further turns"| Confirm
+    Confirm["Confirm task state via sam_task read<br>using plan_ref + task_id<br>Verify task is still CLAIMED"] --> Respawn
+    Respawn["Re-spawn agent with the same plan_ref and task ID<br>SubagentStop hook updates status on completion"]
+    Verdict -->|"Idle — no tool calls for 5+ min<br>agent appears stuck mid-task"| Activity["Read the task via sam_task read<br>Note its last-activity timestamp<br>Wait 2 minutes and read it again"]
+    Activity --> ActCheck{last-activity advanced?}
+    ActCheck -->|"Yes — the agent is still writing task state"| Waiting
+    ActCheck -->|"No — task state is frozen"| Respawn
+    Verdict -->|"Active — tool calls within last 2–3 min"| Waiting
+    Waiting[Continue waiting] --> Later["Re-check after 5–10 min<br>if completion message still absent"]
+```

--- a/plugins/development-harness/skills/multi-perspective-review/SKILL.md
+++ b/plugins/development-harness/skills/multi-perspective-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi-perspective-review
-argument-hint: "--diff <git-range> [--issue <N>]"
+argument-hint: "--diff <git-range> [--issue <N>] [--slug <str>]"
 user-invocable: true
 description: "Use when a diff needs four parallel perspective reviewers (Security, Performance, Quality, Accessibility). Creates an ephemeral SAM plan, collects structured verdicts, synthesizes them into one deduplicated cross-referenced punch list, prints one summary line per perspective, and exits non-zero if any perspective returns REJECT. SKIP is a passing outcome."
 ---
@@ -9,12 +9,9 @@ description: "Use when a diff needs four parallel perspective reviewers (Securit
 
 ## Role
 
-Orchestrates four independent perspective reviewers in parallel against a diff. Each reviewer
-specialises in a single dimension: Security, Performance, Quality, or Accessibility. The skill
-creates an ephemeral SAM plan, dispatches four `dh:task-worker` teammates via `TeamCreate`,
-dispatches a fifth worker that reads the four verdict blocks back and synthesizes them into one
-deduplicated punch list, applies the gate logic to that punch list, and prints one canonical
-summary line per perspective.
+Dispatches every worker — the four reviewers and the synthesizer — as `dh:task-worker`, never a
+specialist agent directly, so each can claim and close its own SAM task (see Behavioral Rules). The
+gate in Step 7 applies to the synthesizer's punch list, not to the four raw verdicts.
 
 Activate `dh:review-verdict-contract` before the first verdict-schema operation.
 
@@ -22,7 +19,7 @@ Activate `dh:review-verdict-contract` before the first verdict-schema operation.
 
 | Argument | Type | Description |
 |----------|------|-------------|
-| `--diff <git-range>` | **required** | Git range passed to `git diff --name-only`. Examples: `HEAD~1..HEAD`, `main..feature-branch`, `abc123..def456`. |
+| `--diff <git-range>` | **required** | Passed to `git diff --name-only`. Commit outstanding changes first, then pass `<base>..HEAD`, where `<base>` is a commit SHA captured before this work's first commit — the caller is responsible for supplying one that still resolves. |
 | `--issue <N>` | optional | GitHub issue number used for ephemeral plan linkage and slug derivation. |
 | `--slug <str>` | optional | Explicit slug override. When omitted, derived from `--issue` or current git branch. |
 
@@ -164,13 +161,7 @@ result has `task_count=5`.
 
 ---
 
-## Step 4: TeamCreate and Dispatch Four Workers in Parallel
-
-Create the team:
-
-```text
-TeamCreate(team_name="multi-{review_slug}")
-```
+## Step 4: Dispatch Four Workers in Parallel
 
 Dispatch all four workers simultaneously. Do NOT wait between spawns — all four are independent
 and must run in parallel. Each worker receives a minimal prompt that tells it to run the
@@ -188,12 +179,10 @@ Every prompt names the same output destination: the `Review Results` section of 
 task. That section is the only channel the synthesizer reads in Step 6 — a reviewer that does not
 write it is a missing verdict, and the punch list records it as one. The loaded profile — not the
 dispatch prompt — performs that write: each reviewer agent's own SOP ends with a mandatory write
-to `Review Results` as part of what `dh:start-task` executes. Do not instruct the worker to write
-the section itself before running `dh:start-task`.
+to `Review Results` as part of what `dh:start-task` executes.
 
 ```text
 Agent(
-  team_name="multi-{review_slug}",
   name="{worker}",
   subagent_type="dh:task-worker",
   prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are working on {lens} review. Your task: {PA}/{task}.\n\nRun the dh:start-task skill against {PA} --task {task}. The loaded profile writes your structured verdict block into the task's Review Results section — that is where the punch list reads your verdict. Do not write that section yourself first; the profile's own SOP performs the single write."
@@ -231,12 +220,10 @@ Dispatch one more worker against `T5`. It reads the four `Review Results` sectio
 findings that name the same defect across perspectives into single entries, and writes the
 punch-list block into `T5`'s own `Punch List` section. As with the four reviewer workers, the
 `dh:review-synthesizer` profile — loaded by `dh:start-task` — performs that write as its own Step
-5; the dispatch prompt only tells the worker where to look and where its output is read, not to
-write the section itself.
+5.
 
 ```text
 Agent(
-  team_name="multi-{review_slug}",
   name="synthesis-worker",
   subagent_type="dh:task-worker",
   prompt="Before starting work, load these skills: dh:subagent-contract\n\nYou are synthesizing the four perspective verdicts on plan {PA} into one punch list. Your task: {PA}/T5.\n\nRun the dh:start-task skill against {PA} --task T5. The loaded profile writes your punch-list block into the task's Punch List section — that is where the gate reads your output. Do not write that section yourself first; the profile's own SOP performs the single write."
@@ -288,9 +275,8 @@ rests on these two checks, so both run on every synthesis, not only when somethi
 **Punch list not produced:** a terminal `T5` whose `Punch List` section is absent, does not
 parse as JSON, or fails any validation check above is synthesis that did not happen. FAIL with
 `Punch list not produced`, name the check that failed, report which perspectives did write a
-`Review Results` section so the run is diagnosable, then run `TeamDelete(team_name="multi-{review_slug}")`
-and exit non-zero — this failure happens before Step 7, so its own team cleanup and exit are the
-only ones that will run for it.
+`Review Results` section so the run is diagnosable, then exit non-zero — this failure happens
+before Step 7, so this exit is the only one that will run for it.
 
 ---
 
@@ -332,19 +318,15 @@ Take each `{token}` from the verdict-to-token mapping in
 `review-verdict-contract` §2.2, which also shows a fully
 rendered example line.
 
-### Exit and Cleanup
+### Exit
 
-1. If gate FAILED (missing verdict or any REJECT): print the summary line, then TeamDelete, then
-   exit non-zero.
+1. If gate FAILED (missing verdict or any REJECT): print the summary line, then exit non-zero.
 2. If gate PASSED (all-SKIP warning applies): print the summary line, then print the warning
-   line `NOTE: No perspectives reviewed — all skipped`, then TeamDelete, then exit 0.
-3. If gate PASSED (normal): print the summary line, then TeamDelete, then exit 0.
+   line `NOTE: No perspectives reviewed — all skipped`, then exit 0.
+3. If gate PASSED (normal): print the summary line, then exit 0.
 
-TeamDelete cleans up the team after all workers are done:
-
-```text
-TeamDelete(team_name="multi-{review_slug}")
-```
+Each of the four reviewer workers and the synthesis worker terminates on its own once its task
+completes — there is no shared group object to release.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes #3332: corrects `docs/backlog-item-groomed-schema.md`'s frontmatter field list, priority/status vocabularies, a broken relative link, and backend-specific "Location" framing against `backlog_core/models.py` and the plugin's multi-backend design.
- Moves T0 (Multi-Perspective Review) dispatch in `complete-implementation`'s SAM Dispatch Loop from a delegated `task-worker` subagent to a direct orchestrator invocation — the workflow it runs is already self-orchestrating, so delegating it only added an unneeded agent hop. Also drops `TeamCreate`/`TeamDelete` from both `complete-implementation` and `multi-perspective-review` in favor of independent parallel dispatch.
- Fixes the diff range T0 reviews against: `HEAD~1..HEAD` only saw the latest commit and missed uncommitted/staged changes; a branch-name base (`main`, `origin/main`, or a merge-base against either) can silently collapse to `HEAD` or drift once the work's own commits are pushed. `implement-feature` now records a frozen starting SHA in the plan's context before its first commit; `complete-implementation` reads it back for T0's diff base and blocks explicitly — rather than silently degrading — when it's missing or unresolvable.
- Addresses an adversarial writing-for-agents audit of the three touched skill files: removes duplicated Mermaid-authority boilerplate, extracts the duplicated Completion Verification Gate procedure into a shared reference, collapses restated drift-detection prose, fixes a stale cross-reference, front-loads `implement-feature`'s trigger clause, and discloses the rarely-triggered Agent Health Check procedure to a reference file instead of loading it on every dispatch.

## Test plan
- [ ] `docs/backlog-item-groomed-schema.md` frontmatter/status/priority examples match `backlog_core/models.py:721,723,1011-1013` member-for-member
- [ ] `../../../research/README.md` link resolves from the doc's location
- [ ] `complete-implementation`/`implement-feature`/`multi-perspective-review` SKILL.md files parse as valid Mermaid + markdown (no orphaned pointers)
- [ ] `implement-feature`'s base-SHA capture is idempotent across a resumed run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KM7bCvTWL2X4bhbvWvWhf