### PR TITLE
feat(development-harness): inject ASD-STE100/BLUF writing style every turn

### DIFF
--- a/plugins/development-harness/hooks/hooks.json
+++ b/plugins/development-harness/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Development-harness plugin hooks — task completion reminders, session hygiene, and context write enforcement",
+  "description": "Development-harness plugin hooks — task completion reminders, session hygiene, context write enforcement, and writing-style context injection",
   "hooks": {
     "SessionStart": [
       {
@@ -7,6 +7,22 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-session-id.cjs\"",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/inject-style-guide.cjs\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/inject-style-guide.cjs\"",
             "timeout": 5000
           }
         ]

--- a/plugins/development-harness/hooks/inject-style-guide.cjs
+++ b/plugins/development-harness/hooks/inject-style-guide.cjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * SessionStart + UserPromptSubmit hook — injects the ASD-STE100 / BLUF writing
+ * style as additionalContext so it's re-asserted every turn, not just once.
+ *
+ * Scope: plugin (development-harness)
+ * Fires on: SessionStart (no matcher), UserPromptSubmit (no matcher)
+ *
+ * Test:
+ *   echo '{"hook_event_name":"SessionStart"}' | node ./hooks/inject-style-guide.cjs
+ *   echo '{"hook_event_name":"UserPromptSubmit","prompt":"hi"}' | node ./hooks/inject-style-guide.cjs
+ */
+
+const STYLE_GUIDE = [
+  'Write in ASD-STE100 structure: one instruction per sentence, active voice, present tense, no synonyms for the same concept.',
+  'Keep procedural sentences to 20 words and descriptive sentences to 25.',
+  'Put the bottom line first (BLUF): after each task, state what the user can act on before you give the supporting detail.',
+].join(' ');
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  let data = {};
+  try {
+    data = JSON.parse(input || '{}');
+  } catch {
+    data = {};
+  }
+
+  const hookEventName = data.hook_event_name || 'SessionStart';
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName,
+        additionalContext: STYLE_GUIDE,
+      },
+    }),
+  );
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary
- Add `inject-style-guide.cjs` hook: outputs `hookSpecificOutput.additionalContext` with the ASD-STE100 (Simplified Technical English) writing structure and BLUF (bottom-line-up-front) instruction.
- Wire it into `SessionStart` and `UserPromptSubmit` in the `dh` plugin's `hooks.json`, so the style is re-asserted at startup and on every user turn, not just once.

## Test plan
- [x] `node inject-style-guide.cjs` tested directly against `SessionStart`, `UserPromptSubmit`, and empty-stdin payloads — all emit valid JSON with the expected `additionalContext`.
- [x] `hooks.json` validated as well-formed JSON.
- [x] `node -c` syntax check on the new script.
- [x] Local commit passed all pre-commit hooks (shebang/executable check, plugin manifest auto-sync, plugin validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gckt79M43ctUVaZ7hbgM3s