### PR TITLE
fix(receiving-pr-reviews): autodetect owner/repo instead of hardcoding it

### DIFF
--- a/.agents/skills/receiving-pr-reviews/SKILL.md
+++ b/.agents/skills/receiving-pr-reviews/SKILL.md
@@ -44,7 +44,7 @@ description: Work through every unresolved review thread on a PR to completion â
 
 <gotchas>
 
-- All commands default `--owner`/`--repo` to this checkout; pass them explicitly to target a different repository.
+- `fetch`/`watch`/`reply` detect this checkout's own repository via `gh repo view`; pass `--github owner/repo` to target a different one, or when detection fails.
 - `--gh-timeout-seconds` is unbounded by default on `fetch` and `watch`. One snapshot is seven sequential `gh api` calls, some of them paginating a large PR, so choose a bound against your own network. Inside `watch` it applies to the first fetch only; each poll is bounded by the time left before `--timeout-seconds`.
 - `reply`'s `--comment-id` is a comment's `databaseId` and `resolve`'s `--thread-id` is a thread's `id` â€” both come straight from step 1's output. When a thread already has more than one comment, pass the *first* comment's `databaseId`: `comments` is in creation order, and GitHub rejects a reply targeted at another reply.
 - A `reviews_with_body`/`unresponded_reviews` entry is not a thread, so it cannot be replied to or resolved through this script. Address it and post the response on the PR itself per step 6.

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -24,6 +24,7 @@ from pr_review_models import (
     IssueComment,
     PullRequestHeadState,
     Reaction,
+    RepoIdentity,
     Reviewability,
     ReviewNode,
     ReviewsConnection,
@@ -154,6 +155,33 @@ def run_gh(args: list[str], *, timeout: float | None = None) -> str:
     """
     result = subprocess.run([_GH, *args], stdout=subprocess.PIPE, text=True, timeout=timeout, check=True)
     return result.stdout
+
+
+def detect_repo_identity(*, gh_timeout: float | None = None) -> tuple[str, str]:
+    """Detect this checkout's own GitHub `(owner, repo)` via `gh repo view`.
+
+    Relies entirely on `gh`'s own remote resolution (the same one `gh pr view`, `gh pr comment`
+    etc. use for this checkout) -- this function adds no guessing of its own. A wrong owner/repo
+    would send a reply to the wrong repository, so a caller unable to detect must stop rather than
+    fall back to a default (CLAUDE.md, "No invented constraints").
+
+    Args:
+        gh_timeout: Seconds to bound the `gh` call to, or `None` for no bound -- see `run_gh`.
+
+    Returns:
+        The `(owner, repo)` pair `gh` reports for this checkout.
+
+    Raises:
+        FileNotFoundError: `gh` is not on PATH.
+        subprocess.CalledProcessError: `gh` could not resolve a repository for this checkout --
+            no remote, not a git repository, or `gh` is unauthenticated.
+        subprocess.TimeoutExpired: the command exceeded `gh_timeout`.
+        pydantic.ValidationError: `gh`'s output does not match the expected shape.
+    """
+    raw = run_gh(["repo", "view", "--json", "nameWithOwner"], timeout=gh_timeout)
+    identity = RepoIdentity.model_validate(json.loads(raw))
+    owner, repo = identity.nameWithOwner.split("/", 1)
+    return owner, repo
 
 
 def _fetch_pages(owner: str, repo: str, pr: int, *, gh_timeout: float | None) -> list[ReviewThreadsConnection]:

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
@@ -25,6 +25,7 @@ __all__ = [
     "IssueComment",
     "PullRequestHeadState",
     "Reaction",
+    "RepoIdentity",
     "ReviewNode",
     "Reviewability",
     "UnresolvedThread",
@@ -61,6 +62,18 @@ class Author(GitHubResponseModel):
     """A GitHub account login, as GraphQL returns it for a comment/review/reaction author."""
 
     login: str
+
+
+class RepoIdentity(GitHubResponseModel):
+    """This checkout's own `owner/repo`, as `gh repo view --json nameWithOwner` reports it.
+
+    `nameWithOwner` is `gh`'s own canonical `"owner/repo"` string (always exactly one `/`, since
+    neither half of a GitHub repository identity may itself contain one) -- the shape
+    `pr_review_gh.detect_repo_identity` splits into the `(owner, repo)` pair every other `gh` call
+    in this script takes as separate query variables.
+    """
+
+    nameWithOwner: str
 
 
 class CommentNode(GitHubResponseModel):

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -36,14 +36,10 @@ import time
 from typing import Annotated
 
 import typer
+from pydantic import ValidationError
 
-from pr_review_gh import RESOLVE_THREAD_MUTATION, build_fetch_result, run_gh
+from pr_review_gh import RESOLVE_THREAD_MUTATION, build_fetch_result, detect_repo_identity, run_gh
 from pr_review_models import WatchResult
-
-# This checkout's own owner/repo — override with --owner/--repo to target any other repository;
-# every `gh` call below takes them as explicit query variables, so nothing here is repo-specific.
-DEFAULT_OWNER = "Jamie-BitFlight"
-DEFAULT_REPO = "claude_skills"
 
 app = typer.Typer(help="GitHub PR review-thread operations (fetch/watch/reply/resolve) via gh.")
 
@@ -60,11 +56,80 @@ _DEFAULT_WATCH_INTERVAL_SECONDS = 90
 _DEFAULT_WATCH_TIMEOUT_SECONDS = 270
 
 
+def _validate_github_option(value: str | None) -> str | None:
+    """Typer callback: reject a malformed `--github` value before any command body runs.
+
+    Args:
+        value: The raw `--github` argument, or `None` when the flag was not passed.
+
+    Returns:
+        `value` unchanged, once confirmed to be `None` or `"owner/repo"` with both halves
+        non-empty.
+
+    Raises:
+        typer.BadParameter: `value` is not exactly one `/` with both halves non-empty.
+    """
+    if value is None:
+        return None
+    owner, separator, repo = value.partition("/")
+    if not separator or not owner or not repo or "/" in repo:
+        message = "must be 'owner/repo' -- exactly one '/', with both halves non-empty"
+        raise typer.BadParameter(message)
+    return value
+
+
+# Shared by every command that targets a specific repository (`fetch`, `watch`, `reply`) so the
+# flag, its help text, and its format validation stay identical across all three rather than
+# duplicated per command.
+GithubOption = Annotated[
+    str | None,
+    typer.Option(
+        "--github",
+        help="Target repository as 'owner/repo'. Detected via `gh repo view` when omitted.",
+        callback=_validate_github_option,
+    ),
+]
+
+
+def _owner_repo(github: str | None, *, gh_timeout: float | None) -> tuple[str, str]:
+    """Resolve the `(owner, repo)` to operate on: an explicit `--github` override, or autodetected.
+
+    Detection relies entirely on `gh repo view`'s own remote resolution for this checkout -- see
+    `pr_review_gh.detect_repo_identity`. A wrong owner/repo would send a reply to the wrong
+    repository, so a failed detection stops the command rather than falling back to a guess
+    (CLAUDE.md, "No invented constraints").
+
+    Args:
+        github: The `--github` value, already format-validated by `_validate_github_option`, or
+            `None` to autodetect.
+        gh_timeout: Seconds to bound the detection `gh` call to, or `None` for no bound.
+
+    Returns:
+        The `(owner, repo)` pair to query.
+
+    Raises:
+        typer.Exit: Autodetection was attempted (no `--github` given) and failed -- `gh` is
+            missing, unauthenticated, or this checkout has no GitHub remote `gh` recognizes.
+            Exits with code 1; nothing else is printed to stdout.
+    """
+    if github is not None:
+        owner, repo = github.split("/", 1)
+        return owner, repo
+    try:
+        return detect_repo_identity(gh_timeout=gh_timeout)
+    except (FileNotFoundError, subprocess.CalledProcessError, ValidationError) as exc:
+        typer.echo(
+            f"Could not detect this checkout's GitHub repository via `gh repo view` ({exc}). "
+            "Pass --github owner/repo to specify it explicitly.",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+
+
 @app.command()
 def fetch(
     pr: Annotated[int, typer.Option(help="Pull request number.")],
-    owner: Annotated[str, typer.Option(help="Repository owner.")] = DEFAULT_OWNER,
-    repo: Annotated[str, typer.Option(help="Repository name.")] = DEFAULT_REPO,
+    github: GithubOption = None,
     gh_timeout_seconds: Annotated[
         float | None, typer.Option(min=0, help="Seconds to bound each `gh` call to. Unbounded by default.")
     ] = None,
@@ -94,6 +159,7 @@ def fetch(
     `unresolved` array there means "nothing can happen yet", not "nothing to do". Read it before
     concluding a PR is clean. An empty `blockers` means reviews can proceed.
     """
+    owner, repo = _owner_repo(github, gh_timeout=gh_timeout_seconds)
     result = build_fetch_result(owner, repo, pr, gh_timeout=gh_timeout_seconds)
     typer.echo(result.model_dump_json())
 
@@ -102,8 +168,7 @@ def fetch(
 def watch(
     pr: Annotated[int, typer.Option(help="Pull request number.")],
     *,
-    owner: Annotated[str, typer.Option(help="Repository owner.")] = DEFAULT_OWNER,
-    repo: Annotated[str, typer.Option(help="Repository name.")] = DEFAULT_REPO,
+    github: GithubOption = None,
     interval_seconds: Annotated[
         int, typer.Option(min=1, help="Seconds to sleep between polls. Must be positive.")
     ] = _DEFAULT_WATCH_INTERVAL_SECONDS,
@@ -164,6 +229,7 @@ def watch(
     ending rather than a failure; a non-zero `gh` exit never is — see the two handlers below.
     """
     deadline = time.monotonic() + timeout_seconds
+    owner, repo = _owner_repo(github, gh_timeout=gh_timeout_seconds)
     # The first fetch is mandatory and is *not* deadline-bounded: with `--timeout-seconds 0` the
     # deadline is already spent, and starving this call would turn the documented immediate
     # snapshot into a `TimeoutExpired`. Only the polls below race the deadline.
@@ -231,13 +297,13 @@ def reply(
     pr: Annotated[int, typer.Option(help="Pull request number.")],
     comment_id: Annotated[int, typer.Option(help="Review comment databaseId, from `fetch`.")],
     body: Annotated[str, typer.Option(help="Reply text.")],
-    owner: Annotated[str, typer.Option(help="Repository owner.")] = DEFAULT_OWNER,
-    repo: Annotated[str, typer.Option(help="Repository name.")] = DEFAULT_REPO,
+    github: GithubOption = None,
     gh_timeout_seconds: Annotated[
         float | None, typer.Option(min=0, help="Seconds to bound the `gh` call to. Unbounded by default.")
     ] = None,
 ) -> None:
     """Reply to a review comment. Prints gh's created-comment response as compact JSON."""
+    owner, repo = _owner_repo(github, gh_timeout=gh_timeout_seconds)
     raw = run_gh(
         ["api", "-X", "POST", f"repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies", "-f", f"body={body}"],
         timeout=gh_timeout_seconds,

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -71,6 +71,19 @@ if TYPE_CHECKING:
 
 runner = CliRunner()
 
+
+@pytest.fixture(autouse=True)
+def _default_github_detection(mocker: MockerFixture) -> None:
+    """Stub `--github` autodetection for every test in this module by default.
+
+    Every `fetch`/`watch`/`reply` invocation below that omits `--github` would otherwise shell out
+    to the real `gh repo view` during the test run. The tests under "--github: autodetect vs
+    explicit override" re-patch `detect_repo_identity` themselves to cover detection directly; this
+    fixture only keeps every other test's `--github`-less invocation decoupled from it.
+    """
+    mocker.patch.object(pr_review_threads, "detect_repo_identity", return_value=("o", "r"))
+
+
 _AGENT_LOGIN = "reviewing-agent"
 _OLD_COMMIT_DATE = datetime(2025, 12, 1, tzinfo=UTC)
 
@@ -861,8 +874,8 @@ def test_internal_result_models_are_not_strict() -> None:
 @pytest.mark.parametrize(
     "argv",
     [
-        ["fetch", "--pr", "3208", "--gh-timeout-seconds", "7"],
-        ["reply", "--pr", "3208", "--comment-id", "1", "--body", "x", "--gh-timeout-seconds", "7"],
+        ["fetch", "--pr", "3208", "--github", "o/r", "--gh-timeout-seconds", "7"],
+        ["reply", "--pr", "3208", "--comment-id", "1", "--body", "x", "--github", "o/r", "--gh-timeout-seconds", "7"],
         ["resolve", "--thread-id", "T1", "--gh-timeout-seconds", "7"],
     ],
     ids=["fetch", "reply", "resolve"],
@@ -882,6 +895,69 @@ def test_every_gh_backed_command_accepts_a_timeout_bound(argv: list[str], mocker
     assert result.exit_code == 0, result.output
     if argv[0] != "fetch":
         assert run_gh_mock.call_args.kwargs["timeout"] == pytest.approx(7)
+
+
+# --- --github: autodetect vs explicit override ---------------------------------------------------
+
+
+def test_fetch_uses_detected_github_when_not_overridden(mocker: MockerFixture) -> None:
+    """Without `--github`, `fetch` autodetects this checkout's own `owner/repo` and uses it."""
+    detect_mock = mocker.patch.object(
+        pr_review_threads, "detect_repo_identity", return_value=("detected-owner", "detected-repo")
+    )
+    fetch_mock = mocker.patch.object(pr_review_threads, "build_fetch_result", return_value=_state())
+
+    result = runner.invoke(app, ["fetch", "--pr", "3208"])
+
+    assert result.exit_code == 0, result.output
+    detect_mock.assert_called_once()
+    assert fetch_mock.call_args.args[:2] == ("detected-owner", "detected-repo")
+
+
+def test_fetch_exits_nonzero_and_names_github_flag_when_detection_fails(mocker: MockerFixture) -> None:
+    """When autodetection fails, `fetch` exits non-zero and names `--github` as the way out.
+
+    A wrong owner/repo would send a reply to the wrong repository, so a failed detection must stop
+    the command rather than fall back to a guess (CLAUDE.md, "No invented constraints" — the same
+    principle rules out silently guessing an identity here).
+    """
+    mocker.patch.object(pr_review_threads, "detect_repo_identity", side_effect=subprocess.CalledProcessError(1, ["gh"]))
+    fetch_mock = mocker.patch.object(pr_review_threads, "build_fetch_result")
+
+    result = runner.invoke(app, ["fetch", "--pr", "3208"])
+
+    assert result.exit_code != 0
+    assert "--github" in result.output
+    fetch_mock.assert_not_called()
+
+
+def test_fetch_uses_explicit_github_override_and_skips_detection(mocker: MockerFixture) -> None:
+    """`--github owner/repo` is used as-is, and autodetection is never attempted."""
+    detect_mock = mocker.patch.object(pr_review_threads, "detect_repo_identity")
+    fetch_mock = mocker.patch.object(pr_review_threads, "build_fetch_result", return_value=_state())
+
+    result = runner.invoke(app, ["fetch", "--pr", "3208", "--github", "acme/widgets"])
+
+    assert result.exit_code == 0, result.output
+    detect_mock.assert_not_called()
+    assert fetch_mock.call_args.args[:2] == ("acme", "widgets")
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["no-slash-here", "/repo", "owner/", "owner/repo/extra"],
+    ids=["no-slash", "empty-owner", "empty-repo", "too-many-slashes"],
+)
+def test_fetch_rejects_a_malformed_github_override(value: str, mocker: MockerFixture) -> None:
+    """A `--github` value must be exactly one `owner/repo` pair with both halves non-empty."""
+    detect_mock = mocker.patch.object(pr_review_threads, "detect_repo_identity")
+    build_mock = mocker.patch.object(pr_review_threads, "build_fetch_result")
+
+    result = runner.invoke(app, ["fetch", "--pr", "3208", "--github", value])
+
+    assert result.exit_code != 0
+    detect_mock.assert_not_called()
+    build_mock.assert_not_called()
 
 
 # --- reviewability -------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `pr_review_threads.py` hardcoded `DEFAULT_OWNER = "Jamie-BitFlight"` / `DEFAULT_REPO = "claude_skills"`, forcing an edit on every copy of this skill into another repository — each edit is a chance for copies to diverge.
- `fetch`/`watch`/`reply` now detect the checkout's own `owner/repo` via `gh repo view --json nameWithOwner` (validated through a Pydantic boundary model, `RepoIdentity`, consistent with this file's other `gh` ingress models).
- `--owner`/`--repo` are replaced by a single `--github "owner/repo"` option. A malformed value (not exactly one `/`, or an empty half) is rejected at the Typer callback boundary before any command body runs.
- A failed detection (no `gh`, unauthenticated, or no GitHub remote) exits non-zero and names `--github` as the way out — it never falls back to a guessed identity, since a wrong owner/repo would send a reply to the wrong repository.
- Corrected `AGENTS.md`'s claim, inherited into this task, that `gh` cannot auto-detect the remote because of a `127.0.0.1` proxy — verified false in this checkout (`gh repo view` and `git remote get-url origin` both resolve correctly), so detection was safe to build on.
- `SKILL.md`'s gotchas section updated to describe detection + `--github`, kept to one line, word count 916 → 923.

## Test plan
- [x] Wrote 4 new tests first (detection succeeds / detection fails / override supplied / override malformed) against the pre-change code and confirmed all 73 tests in the module error out (`detect_repo_identity` doesn't exist yet) — red phase.
- [x] Implemented the feature; all 73 tests pass.
- [x] `uv run -q --locked prek run ruff --all-files` — passed
- [x] `uv run -q --locked prek run ruff-format --all-files` — passed
- [x] `uv run -q --locked ty check .` — all checks passed
- [x] `uv run pytest .agents/skills/receiving-pr-reviews/scripts/ -q` — 73 passed
- [x] End-to-end against a real PR (`#3348`) from the worktree: autodetection resolved `Jamie-BitFlight/claude_skills` and fetched successfully with no `--github` passed; `--github Jamie-BitFlight/claude_skills` explicit override also worked; a malformed `--github not-a-valid-value` exited 2 with a clear Typer error; running from a directory with no git remote exited 1 naming `--github`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc