### PR TITLE
chore(ruff): drop known-local-folder to match standard isort config

### DIFF
--- a/plugins/scientific-method/.claude-plugin/plugin.json
+++ b/plugins/scientific-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scientific-method",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/scientific-method/.codex-plugin/plugin.json
+++ b/plugins/scientific-method/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scientific-method",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/scientific-method/mcp/experiment-registry/server.py
+++ b/plugins/scientific-method/mcp/experiment-registry/server.py
@@ -26,10 +26,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
+from models import StepExtension
 from project_root import resolve_project_root
 from pydantic import Field
-
-from models import StepExtension
 from registry_loader import RegistryLoader
 from state_manager import StateManager
 

--- a/plugins/scientific-method/mcp/experiment-registry/tests/test_registry_loader.py
+++ b/plugins/scientific-method/mcp/experiment-registry/tests/test_registry_loader.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from models import StepDefinition, StepExtension, ValidationRule
 from registry_loader import RegistryLoader
 

--- a/plugins/scientific-method/mcp/experiment-registry/tests/test_state_manager.py
+++ b/plugins/scientific-method/mcp/experiment-registry/tests/test_state_manager.py
@@ -15,7 +15,6 @@ import json
 from typing import TYPE_CHECKING
 
 import pytest
-
 from models import ArtefactIntegrity, ExperimentState, StepDefinition, ValidationRule
 from state_manager import StateManager
 

--- a/plugins/scientific-method/mcp/experiment-registry/tests/test_validators.py
+++ b/plugins/scientific-method/mcp/experiment-registry/tests/test_validators.py
@@ -14,7 +14,6 @@ import hashlib
 from typing import TYPE_CHECKING
 
 import pytest
-
 from models import ArtefactIntegrity, StepDefinition, ValidationRule
 from validators import (
     CONTENT_VALIDATION_FAILED,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,12 +317,6 @@ docstring-quotes = "double"
 combine-as-imports = true
 force-single-line = false
 force-wrap-aliases = false
-known-local-folder = [
-    "models",
-    "registry_loader",
-    "state_manager",
-    "validators",
-]
 required-imports = ["from __future__ import annotations"]
 split-on-trailing-comma = false
 


### PR DESCRIPTION
## What

Removes `known-local-folder = ["models", "registry_loader", "state_manager", "validators"]` from `[tool.ruff.lint.isort]`, then reruns the import-order fix and formatter.

## Why

This repo was the only one of 14 surveyed that set `known-local-folder`.

Ruff sorts an unlisted bare module as third-party, so `models` sorted **after** `pydantic` here and **before** it everywhere else. The list was also already incomplete — `project_root` is a sibling local module that was missing from it, so the setting was not even internally consistent with the code it was meant to describe.

## Commits

1. `chore(ruff)` — config-only: delete the key.
2. `style(scientific-method)` — the 4 files ruff reorders as a result, all under `plugins/scientific-method/mcp/experiment-registry/`. `ruff format` changed nothing beyond that.

Kept separate so the config change is reviewable on its own.

## Follow-up (deliberately NOT fixed here)

`src` lists `plugins`, but the packages actually live two levels down at `plugins/development-harness/sam_schema`. As a result `backlog_core` and `dh_core` also resolve as third-party. Worth a separate PR.

## Tooling version check (no change needed)

Audited every place this repo pins `ruff` and `ty` against the current releases. Both are already current, so this PR contains no version bump.

| Location | Pinned | Current release |
| --- | --- | --- |
| `pyproject.toml` `[dependency-groups] dev` | `ruff>=0.16.5` | ruff 0.16.5 |
| `pyproject.toml` `[dependency-groups] dev` | `ty>=0.0.75` | ty 0.0.75 |
| `uv.lock` | ruff 0.16.5 / ty 0.0.75 | same |
| `.pre-commit-config.yaml` `astral-sh/ruff-pre-commit` | `rev: v0.16.5` | v0.16.5 |
| `.pre-commit-config.yaml` `ty` hook | `repo: local`, `uv run --frozen --with ty ty check` — no rev to pin | n/a |
| `.github/workflows/*.yml` | no version pins (`uv run --locked`) | n/a |

Latest versions confirmed via PyPI JSON API, `gh api repos/astral-sh/{ruff,ty}/releases/latest`, and `uvx --no-cache {ruff,ty}@latest --version`. `prek autoupdate --repo https://github.com/astral-sh/ruff-pre-commit` exits 0 with no diff. The pre-commit rev and the `pyproject` constraint agree at ruff 0.16.5.

## Verification

- `uv run prek run --all-files` — all 28 hooks passed
- `uv run pytest` — 5530 passed, 44 skipped, 5 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc
