### PR TITLE
fix(dh): stop FastMCP Rich tracebacks from masking real MCP tool errors

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/scripts/dh_mcp_preinit.py
+++ b/plugins/development-harness/scripts/dh_mcp_preinit.py
@@ -1,14 +1,25 @@
-"""Shared MCP entrypoint pre-init: parse --project-dir before package imports.
+"""Shared MCP entrypoint pre-init: runs before any ``fastmcp``-importing module.
 
 ``backlog_core.models`` resolves the repo root at import time.  Parsing
 ``--project-dir`` here and setting ``DH_PROJECT_ROOT`` ensures the path is
 visible before any ``backlog_core`` or ``sam_schema`` import.
+
+Also disables FastMCP's Rich logging/traceback handler (see module-level
+block below) before ``fastmcp`` is imported anywhere in the process.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+
+# FastMCP attaches a RichHandler with rich_tracebacks=True. rich/logging.py
+# lazily imports rich.traceback inside emit(), so a broken rich install turns
+# any tool exception into "No module named 'rich.traceback'" and hides the real
+# error. These servers speak stdio to an AI agent — Rich rendering has no reader.
+# setdefault, so a developer can re-enable it by exporting the var.
+os.environ.setdefault("FASTMCP_ENABLE_RICH_LOGGING", "false")
+os.environ.setdefault("FASTMCP_ENABLE_RICH_TRACEBACKS", "false")
 
 
 def apply_project_dir_from_argv() -> None:

--- a/plugins/development-harness/scripts/run_backlog_server.py
+++ b/plugins/development-harness/scripts/run_backlog_server.py
@@ -10,7 +10,6 @@
 #   "markdown-it-py>=3.0.0",
 #   "ruamel.yaml>=0.18.0",
 #   "tiktoken>=0.12.0",
-#   "typer>=0.21.2",
 #   "python-dotenv>=1.0.0",
 # ]
 #

--- a/plugins/development-harness/scripts/run_sam_server.py
+++ b/plugins/development-harness/scripts/run_sam_server.py
@@ -10,7 +10,6 @@
 #   "markdown-it-py>=3.0.0",
 #   "ruamel.yaml>=0.18.0",
 #   "tiktoken>=0.12.0",
-#   "typer>=0.21.2",
 # ]
 #
 # [tool.ty.environment]

--- a/plugins/development-harness/tests_backlog/test_mcp_rich_disabled.py
+++ b/plugins/development-harness/tests_backlog/test_mcp_rich_disabled.py
@@ -1,0 +1,94 @@
+"""Regression test: MCP servers disable FastMCP's Rich logging/tracebacks.
+
+Why: FastMCP attaches a ``RichHandler(rich_tracebacks=True)`` to its logger.
+``rich/logging.py`` lazily imports ``rich.traceback`` *inside* ``emit()`` — only
+when an exception is logged. A broken ``rich`` install then turns any dh tool
+exception into ``No module named 'rich.traceback'``, masking the real error.
+``dh_mcp_preinit`` sets ``FASTMCP_ENABLE_RICH_LOGGING`` /
+``FASTMCP_ENABLE_RICH_TRACEBACKS`` to ``"false"`` before either MCP server
+imports ``fastmcp``, so FastMCP falls back to a plain ``StreamHandler`` and no
+lazy ``rich.traceback`` import ever runs.
+
+Also asserts the ``typer`` dependency — never imported by either server, only
+by dh's human-facing CLIs — is not declared in the server PEP 723 headers.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+_PREINIT = _SCRIPTS_DIR / "dh_mcp_preinit.py"
+_SERVER_SCRIPTS = [_SCRIPTS_DIR / "run_backlog_server.py", _SCRIPTS_DIR / "run_sam_server.py"]
+
+
+def _extract_pep723_block(path: Path) -> str:
+    """Extract the TOML content from a PEP 723 '# /// script' block.
+
+    Mirrors ``tests_backlog/test_task_status_hook_beads.py::_extract_pep723_block``.
+    """
+    in_block = False
+    block_lines: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.rstrip() == "# /// script":
+            in_block = True
+            continue
+        if in_block:
+            if line.rstrip() == "# ///":
+                break
+            block_lines.append(line.removeprefix("# "))
+    return "\n".join(block_lines)
+
+
+@pytest.mark.unit
+def test_preinit_disables_fastmcp_rich_by_default() -> None:
+    """Importing dh_mcp_preinit sets both FASTMCP_ENABLE_RICH_* vars to false."""
+    code = (
+        "import os, sys; "
+        f"sys.path.insert(0, {str(_SCRIPTS_DIR)!r}); "
+        "import dh_mcp_preinit; "
+        "print(os.environ.get('FASTMCP_ENABLE_RICH_LOGGING')); "
+        "print(os.environ.get('FASTMCP_ENABLE_RICH_TRACEBACKS'))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True, env={}, cwd=str(_SCRIPTS_DIR)
+    )
+    logging_val, tracebacks_val = result.stdout.splitlines()
+    assert logging_val == "false"
+    assert tracebacks_val == "false"
+
+
+@pytest.mark.unit
+def test_preinit_does_not_override_explicit_env() -> None:
+    """setdefault semantics: an operator-set value survives the import."""
+    code = (
+        "import os, sys; "
+        f"sys.path.insert(0, {str(_SCRIPTS_DIR)!r}); "
+        "import dh_mcp_preinit; "
+        "print(os.environ['FASTMCP_ENABLE_RICH_LOGGING'])"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={"FASTMCP_ENABLE_RICH_LOGGING": "true"},
+        cwd=str(_SCRIPTS_DIR),
+    )
+    assert result.stdout.strip() == "true"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("script", _SERVER_SCRIPTS, ids=lambda p: p.name)
+def test_server_pep723_header_omits_typer(script: Path) -> None:
+    """Neither MCP server imports typer; it must not be declared as a dependency."""
+    metadata = tomllib.loads(_extract_pep723_block(script))
+    deps = metadata.get("dependencies", [])
+    assert not any(dep.startswith("typer") for dep in deps), (
+        f"{script.name} declares an unused typer dependency: {deps}"
+    )


### PR DESCRIPTION
## Summary

- Reported symptom: every `mcp__plugin_dh_backlog__*` call, including read-only `backlog_list`, failed with `No module named 'rich.traceback'` — filed as a server-side missing dependency.
- Actual defect: `dh` code never imports `rich`. FastMCP attaches a `RichHandler(rich_tracebacks=True)` at `import fastmcp` time; `rich/logging.py` lazily imports `rich.traceback` **inside** `emit()` — only when an exception is actually logged. Any partial corruption of `rich` (this repo's `~/.cache/uv` is a global, cross-session-shared cache) turns any real dh tool error into that `ModuleNotFoundError`, destroying the original message. These servers speak stdio to an AI agent, which gets no benefit from ANSI-rendered tracebacks anyway.
- `plugins/development-harness/scripts/dh_mcp_preinit.py` now sets `FASTMCP_ENABLE_RICH_LOGGING`/`FASTMCP_ENABLE_RICH_TRACEBACKS` to `"false"` (via `setdefault`, so an operator can still opt back in) before either MCP server imports `fastmcp` — falls back to a plain `StreamHandler`, and the fragile lazy import never runs.
- Dropped the `typer` PEP 723 dependency line from both server launchers (`run_backlog_server.py`, `run_sam_server.py`) — proven unused by either server's actual import graph (neither imports `typer`; it was dead weight, only redundant where `fastmcp[tasks]`'s `pydocket` transitive dep already pulls it in).
- Added `tests_backlog/test_mcp_rich_disabled.py` (4 tests) asserting the env-var defaulting and the absence of the `typer` dependency.

## Test plan

- [x] Both server launchers still start cleanly (`uv run --script scripts/run_backlog_server.py --help`, `... run_sam_server.py --help`)
- [x] New regression tests pass (`uv run --script tests/run_pytest.py tests_backlog/test_mcp_rich_disabled.py`) — 4 passed
- [x] Full plugin test suite passes: 5384 passed, 1 pre-existing unrelated failure (a `ruff`-not-on-`PATH` lint-gate test in `progressive_markdown`, confirmed to fail identically on unmodified `main`)
- [x] Before/after repro against a deliberately corrupted `rich` install, in the exact site-packages env `run_sam_server.py` resolves to: before the fix, logging the real exception raises `ModuleNotFoundError: No module named 'rich.traceback'` at `rich/logging.py:150` instead of surfacing it; after the fix, the same corrupted env logs the real exception correctly with `handlers: ['StreamHandler']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVCqtmNnyL553g4ZvTRZrh