### PR TITLE
chore(deps): bump pyproject-fmt hook to v1.1.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
 
   # TOML sorting and formatting
   - repo: https://github.com/bitflight-devops/pyproject-fmt
-    rev: v1.1.11
+    rev: v1.1.12
     hooks:
       - id: pypfmt
         name: Sort and format pyproject.toml with pypfmt


### PR DESCRIPTION
`uv run prek autoupdate`. One rev moved:

| hook repo | before | after |
|---|---|---|
| bitflight-devops/pyproject-fmt | v1.1.11 | v1.1.12 |

Unchanged: `pre-commit/pre-commit-hooks` v6.0.0, `astral-sh/ruff-pre-commit` v0.16.5, `DavidAnson/markdownlint-cli2` v0.23.2, `rhysd/actionlint` v1.7.12, `pecigonzalo/pre-commit-shfmt` v2.2.0.

**Ruff dependency sync:** not needed. The ruff hook did not move; v0.16.5 already matches `ruff>=0.16.5` in `pyproject.toml` and `ruff 0.16.5` in `uv.lock`. Same for `ty` (0.0.75, local hook, no rev). No hook-vs-dependency drift here.

**Gate:** baseline captured in a throwaway worktree on `origin/main`, then re-run on this branch. `ty check .` and all 26 runnable `prek` hooks — including `pypfmt`, the bumped one — pass identically before and after. No file was modified by any hook.

**Two node hooks could not run, on baseline or after.** prek's bundled Node 26.8.1 cannot start on this machine: `dyld: Symbol not found: (__ZNSt3__122__libcpp_verbose_abortEPKcz)`, because macOS 12.7.6's `libc++.1.dylib` predates that symbol. That makes `biome-check` and `markdownlint-cli2` uninstallable locally at any rev — a pre-existing machine fault, reproduced on `origin/main` first and unrelated to this bump. Neither hook's rev changed here, and CI runs both on its own Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc