### PR TITLE
fix(types): restore TypedDict NotRequired metadata in DH boundary modules

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.4",
+  "version": "11.0.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -5,19 +5,19 @@ dicts. Each public function accepts an optional ``output: Output | None``
 parameter and returns ``{...result, **out.to_dict()}``.
 """
 
-from __future__ import annotations
-
 import operator
 import re
 import sys
 from collections import defaultdict
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, NotRequired, TypeGuard
+from typing import Any, Final, NotRequired, TypeGuard
 
 from dispatch_schema.core.constants import MIN_CONFLICT_GROUP_SIZE
 from dispatch_schema.core.models import ConflictGroup
-from github import GithubException, GithubObject  # GithubObject used only by create_milestone (ADR-004)
+from github import GithubException, GithubObject
+from github.Repository import Repository  # GithubObject used only by create_milestone (ADR-004)
 from ruamel.yaml.error import YAMLError
 from sam_schema.core.backends.content import parse_plan_content
 from sam_schema.core.dependencies import SUCCESSFUL_STATUSES as _SAM_CORE_SUCCESSFUL_STATUSES
@@ -107,12 +107,6 @@ class _SamTaskLookupResult(TypedDict):
     messages: list[str]
     warnings: list[str]
     errors: list[str]
-
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
-
-    from github.Repository import Repository
 
 
 # ---------------------------------------------------------------------------
@@ -5239,6 +5233,23 @@ def _parse_impact_radius_paths(impact_radius: str) -> set[str]:
     return paths
 
 
+class ImpactRadiusItem(TypedDict, total=False):
+    """Typed structure for items passed to :func:`analyze_impact_radius_conflicts`.
+
+    Attributes:
+        title: Item title used in ConflictGroup.items list.
+        issue: GitHub issue number (present but unused in conflict output).
+        impact_radius: Markdown section body containing file paths, one per
+            line, optionally prefixed with bullet markers (``-`` / ``*``).
+            Items without this key, or with an empty/whitespace-only value,
+            are excluded from conflict analysis.
+    """
+
+    title: str
+    issue: int
+    impact_radius: str
+
+
 def _collect_items_with_paths(items: list[ImpactRadiusItem]) -> tuple[list[str], list[set[str]]]:
     """Filter items to those with a non-empty impact_radius and parse their paths.
 
@@ -5309,23 +5320,6 @@ def _build_conflict_groups(titles: list[str], path_sets: list[set[str]]) -> list
         group_id += 1
 
     return conflict_groups
-
-
-class ImpactRadiusItem(TypedDict, total=False):
-    """Typed structure for items passed to :func:`analyze_impact_radius_conflicts`.
-
-    Attributes:
-        title: Item title used in ConflictGroup.items list.
-        issue: GitHub issue number (present but unused in conflict output).
-        impact_radius: Markdown section body containing file paths, one per
-            line, optionally prefixed with bullet markers (``-`` / ``*``).
-            Items without this key, or with an empty/whitespace-only value,
-            are excluded from conflict analysis.
-    """
-
-    title: str
-    issue: int
-    impact_radius: str
 
 
 def analyze_impact_radius_conflicts(items: list[ImpactRadiusItem]) -> list[ConflictGroup]:

--- a/plugins/development-harness/sam_schema/core/task_backend_types.py
+++ b/plugins/development-harness/sam_schema/core/task_backend_types.py
@@ -5,20 +5,18 @@ and backend implementations. Pydantic models remain the canonical validation
 layer; conversion happens in the query layer, not in the backends.
 
 All types follow the pattern established in backlog_core/backend_protocol.py:
-- ``from __future__ import annotations`` for deferred evaluation
+- no ``from __future__ import annotations``: PEP 563 stringifies annotations,
+  which stops ``NotRequired`` from being recognised at class creation
 - ``typing_extensions.TypedDict`` for consistency with existing codebase
 - ``NotRequired`` for optional fields that may be absent in input payloads
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Annotated, Any, NotRequired, TypeAlias
+from typing import Annotated, Any, NotRequired, TypeAlias
 
 from pydantic import AliasChoices, Field
 from typing_extensions import TypedDict
 
-if TYPE_CHECKING:
-    from sam_schema.core.models import PlanState
+from sam_schema.core.models import PlanState
 
 __all__ = [
     "DocumentData",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -379,7 +379,12 @@ max-complexity = 12
 ]
 # operations.py calls _-prefixed BacklogBackend protocol methods — these are part of the public protocol surface
 # SLF001 — private-name access is intentional: protocol interface defines _-prefixed methods by design
-"**/backlog_core/operations.py" = ["private-member-access"]
+# I002 — PEP 563 stringifies annotations, so TypedDict cannot classify NotRequired at
+# class creation and __optional_keys__ comes back empty. This module defines TypedDicts.
+"**/backlog_core/operations.py" = [
+    "missing-required-import",
+    "private-member-access",
+]
 # FastMCP lifespan hook requires async def + yield without await — RUF029 is a false positive
 # SLF001 — server.py calls _startup_sync_loop via module reference for test mockability;
 # underscore prefix marks it as a background-task entry point, not a user-facing tool
@@ -400,6 +405,8 @@ max-complexity = 12
     "private-member-access",
     "too-many-public-methods",
 ]
+# I002 — same PEP 563 / NotRequired problem: this module is entirely TypedDict declarations
+"**/sam_schema/core/task_backend_types.py" = ["missing-required-import"]
 # FastMCP @mcp.tool uses get_type_hints() at decoration time to build tool schemas — annotated
 # parameter types (PlanActionConfig, TaskActionConfig, ActiveTaskActionConfig, etc.) must be
 # present in the module's global namespace even with `from __future__ import annotations`.


### PR DESCRIPTION
## Problem

`from __future__ import annotations` (PEP 563) turns every annotation into a string. `_TypedDictMeta` cannot classify a string forward-ref at class creation, so `NotRequired[...]` is never recognised — `__optional_keys__` comes back empty and every key lands in `__required_keys__`.

Measured on Python 3.13.14 against `origin/main` `f8e467a0e`:

| TypedDict | declared `NotRequired` | `__optional_keys__` before |
|---|---|---|
| `sam_schema.core.task_backend_types.PlanData` | 8 | `[]` |
| `sam_schema.core.task_backend_types.TaskData` | 16 | `[]` |
| `sam_schema.core.task_backend_types.PlanSummary` | 3 | `[]` |
| `sam_schema.core.task_backend_types.DocumentHandle` / `DocumentData` | 1 each | `[]` |
| `backlog_core.operations.BacklogListItem` | 4 | `[]` |
| `backlog_core.operations._ProjectsV2Node` | 1 | `[]` |

Reproduced identically on Python **3.11, 3.12, 3.13 and 3.14** — PEP 649 does not rescue a module that opts in to PEP 563 explicitly. `typing_extensions.TypedDict` is affected exactly like `typing.TypedDict`.

## Is it live or latent?

**Latent.** Nothing in this repo reads `__required_keys__` / `__optional_keys__` / `get_type_hints` / `is_typeddict`. The one runtime consumer of this metadata is `TypeAdapter(PlanData)` in `sam_schema/core/backends/content.py`, and Pydantic is *not* affected: it re-resolves annotations itself rather than trusting `__required_keys__`. Verified by validating a `PlanData` payload with every declared-optional key absent — accepted, both before and after this change.

So this fixes wrong metadata before something starts trusting it, not a live outage.

## Fix

`I002` exempted for exactly the two affected modules, then the future import removed. Making the annotations evaluate eagerly needed three supporting moves:

- `task_backend_types.py` — `PlanState` promoted from `TYPE_CHECKING` to a runtime import. `sam_schema.core.models` does not import this module, so there is no cycle.
- `operations.py` — `collections.abc.Callable` / `Mapping` and `github.Repository.Repository` promoted to runtime imports (`github` is already imported at runtime on the line above).
- `operations.py` — the `ImpactRadiusItem` TypedDict moved above its first use in `_collect_items_with_paths`. That was the module's **only** intra-file forward reference; found by removing the future import and importing until clean.

`TC001`/`TC002`/`TC003` are already globally ignored in this repo, so the promoted imports do not fight the linter.

## Verification

- `__optional_keys__` printed before and after against the committed tree.
- Ruff proof the exemption is live: with it, `--select I002` on both files passes; with an isolated config carrying the same `required-imports` and no exemption, 2 errors.
- `prek run --files pyproject.toml <both modules>` — all hooks pass (`ruff`, `ruff-format`, `ty`, `check-compat-annotations`, `pypfmt`). No `SKIP=`.
- `pytest plugins/development-harness/{tests,tests_backlog} backlog_core/tests` — 4190 passed, 41 skipped, 5 xfailed.
- `pytest plugins/development-harness/{tests_sam,sam_schema/tests}` — 1097 passed, 3 skipped.

## Not changed

Other modules in this repo carry the future import alongside `TypedDict`, but declare only `total=False` and no `NotRequired`/`Required` — `plugin-creator/scripts/auto_sync_manifests.py`, `scripts/process-research-integration.py`. `total=False` is a class keyword, not an annotation, so it is evaluated correctly under PEP 563 (verified). Nothing to fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc