### PR TITLE
fix(backlog): MCP docstring truth audit + cache.yaml/JSON durability fix

### DIFF
--- a/.claude/agent-memory/python-engineering-adversarial-solution-design/MEMORY.md
+++ b/.claude/agent-memory/python-engineering-adversarial-solution-design/MEMORY.md
@@ -1,3 +1,4 @@
 # Adversarial Solution Design — Memory Index
 
 - [backlog_view architecture traps](backlog_view_architecture.md) — where the tool lives, over-budget empty-content path, name-keyed sections dict
+- [file_cache_state cache store](backlog_core_file_cache_state.md) — cache.yaml holds JSON since #3292, live dirs are a JSON/YAML mix, idempotency keys are local join keys not remote tokens, how to run tests_backlog

--- a/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
+++ b/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
@@ -1,0 +1,56 @@
+# file_cache_state.py — cache state store mechanics
+
+`plugins/development-harness/backlog_core/file_cache_state.py`
+
+## On-disk reality (verified 2026-08-31 against `~/.dh/projects/*/github-cache/`)
+
+`_STATE_FILE = "cache.yaml"` but `_save()` writes `state.model_dump_json()` since
+PR #3292 (`849ceda2c`, 2026-08-29, "replace ruamel YAML codec with JSON in cache
+state store"). Live user dirs on this machine are a **mix**: some `cache.yaml`
+files start `{"records":[...` (post-#3292 JSON), others start `checkpoints: []\n`
+(real ruamel-emitted YAML, last saved before #3292 or by an older installed
+plugin copy). The YAML fallback in `load()` is **live, not dead legacy** — any
+rename/migration must carry it.
+
+Files reach 2.3 MB single-line JSON. `cache.lock` (flock) sits beside it and its
+name is unchanged across versions, so old and new code still mutually exclude.
+
+## Idempotency keys are LOCAL join keys, not remote dedup tokens
+
+Never sent to GitHub. `queue_write` computes
+`sha256(json.dumps(rebased_write.model_dump(mode="json"), sort_keys=True, separators=(",",":")))`;
+`_queue_work_item` computes `sha256(f"{key}:{item_payload}")`. Both are
+re-derivable purely from the stored entry. Consumed only within one in-process
+replay pass (`acknowledge_replay`, `reject_pending`, `_acknowledge_work_items`)
+to match acknowledgements back to queue entries. A garbage key is
+self-consistent and harmless.
+
+Real hazard from a hand-edit is NOT the key — it is
+`github_work_items.py:557-564` `load_records()`, which gives a queued
+`pending_work_items` mutation **precedence over the on-disk snapshot**. A
+hand-appended entry becomes the winning local view and is pushed to GitHub as a
+patch on the next `reconcile()`.
+
+Latent (tamper-only) bug: `acknowledge_replay` does
+`remaining = [e for e in state.pending if e.idempotency_key not in acknowledged_keys]`
+— duplicate keys mean one successful replay silently drops the other entry.
+Unreachable from code paths (keys are content-derived, one entry per reference).
+
+## Robustness gap
+
+`load()` catches only `pydantic.ValidationError` before falling back to
+`YAML(typ="safe")`. A truncated/corrupt file raises an uncaught
+`ruamel.yaml.YAMLError` out of every cache read.
+
+## Running the tests
+
+`tests_backlog/` is NOT in root `pyproject.toml` testpaths (only in coverage
+`omit`). Root addopts force `--cov`, so a bare `-p no:cov` fails; use:
+
+```bash
+uv run pytest plugins/development-harness/tests_backlog/test_file_cache.py -q --no-cov
+```
+
+25 tests, ~7s. `test_file_cache.py:434-554` already covers the JSON/YAML dual-read
+matrix (legacy YAML read, new JSON read, JSON-is-valid-YAML forward compat,
+save-emits-JSON, missing file, corrupt file raises).

--- a/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
+++ b/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
@@ -2,45 +2,69 @@
 
 `plugins/development-harness/backlog_core/file_cache_state.py`
 
-## On-disk reality (verified 2026-08-31 against `~/.dh/projects/*/github-cache/`)
+## On-disk reality (as of the cache.yaml→cache.json rename, PR #3358)
 
-`_STATE_FILE = "cache.yaml"` but `_save()` writes `state.model_dump_json()` since
-PR #3292 (`849ceda2c`, 2026-08-29, "replace ruamel YAML codec with JSON in cache
-state store"). Live user dirs on this machine are a **mix**: some `cache.yaml`
-files start `{"records":[...` (post-#3292 JSON), others start `checkpoints: []\n`
-(real ruamel-emitted YAML, last saved before #3292 or by an older installed
-plugin copy). The YAML fallback in `load()` is **live, not dead legacy** — any
-rename/migration must carry it.
+`_STATE_FILE = "cache.json"`; `_LEGACY_STATE_FILE = "cache.yaml"`. `_save()` has
+written pure JSON (`state.model_dump_json()`) since PR #3292
+(`849ceda2c`, 2026-08-29) — the rename just fixed the filename to match. A
+legacy `cache.yaml` (real YAML, or JSON still wearing the old extension) is
+migrated to `cache.json` inside `transaction()`, under the lock; `load()` stays
+read-only and never migrates (doing it there self-deadlocks — see
+`_migrate_legacy_state_file`'s docstring). `FileCache._load_state()` also calls
+`_CacheStateStore.ensure_migrated()` first, so every read accessor
+(`pending_mutations`, `get_content`, reconciliation's `load_records`, ...) sees
+migrated state immediately, not only after some unrelated `transaction()`
+happens to run. Both files present (e.g. an older plugin copy recreating
+`cache.yaml` after `cache.json` already exists) merges all five queue/
+dead-letter fields into `cache.json` before superseding the legacy file to
+`cache.yaml.superseded` — never deleted, so a crash or a corrupt legacy file
+mid-migration is recoverable.
 
 Files reach 2.3 MB single-line JSON. `cache.lock` (flock) sits beside it and its
 name is unchanged across versions, so old and new code still mutually exclude.
 
-## Idempotency keys are LOCAL join keys, not remote dedup tokens
+## Idempotency keys ARE now checked, not just local join keys
 
-Never sent to GitHub. `queue_write` computes
-`sha256(json.dumps(rebased_write.model_dump(mode="json"), sort_keys=True, separators=(",",":")))`;
-`_queue_work_item` computes `sha256(f"{key}:{item_payload}")`. Both are
-re-derivable purely from the stored entry. Consumed only within one in-process
-replay pass (`acknowledge_replay`, `reject_pending`, `_acknowledge_work_items`)
-to match acknowledgements back to queue entries. A garbage key is
-self-consistent and harmless.
+`queue_write` computes
+`sha256(json.dumps(rebased_write.model_dump(mode="json"), sort_keys=True, separators=(",",":")))`
+via the shared `_content_mutation_key` helper; `_queue_work_item` computes
+`sha256(f"{key}:{item_payload}")` via `_work_item_mutation_key`. On every load
+(not just the salvage path — see `_verify_queue_keys`'s docstring for why a
+forged-but-schema-complete entry needs this to run unconditionally), each
+`pending`/`pending_work_items` entry's stored key is recomputed from its own
+content and compared. A mismatch is **not** treated as harmless: the entry is
+moved to `rejected`/`rejected_work_items` (inert, inspectable, never replayed)
+rather than left in place or silently dropped.
 
-Real hazard from a hand-edit is NOT the key — it is
-`github_work_items.py:557-564` `load_records()`, which gives a queued
-`pending_work_items` mutation **precedence over the on-disk snapshot**. A
-hand-appended entry becomes the winning local view and is pushed to GitHub as a
-patch on the next `reconcile()`.
+This closes most of what used to be the real hand-edit hazard: `load_records()`
+(`github_work_items.py`) still gives a queued `pending_work_items` mutation
+precedence over the on-disk snapshot with no validation of its own, but a
+hand-appended entry with a garbage key never reaches that code anymore — it's
+dead-lettered at load time, before `reconcile()` ever sees it. `load_records()`
+itself is unchanged; the defense moved upstream of it, not into it.
 
-Latent (tamper-only) bug: `acknowledge_replay` does
-`remaining = [e for e in state.pending if e.idempotency_key not in acknowledged_keys]`
+Known limitation, deliberately not built here (see backlog #2287): dead-lettering
+is one-way. A version-skew false positive (an older reader dropping a field a
+newer writer included, per pydantic's `extra="ignore"`, which changes the
+recomputed hash for a legitimate entry) is preserved but never automatically
+retried or promoted back to `pending` by a later-version load that could
+resolve it correctly.
+
+Schema-invalid entries (fails `model_validate`, not just a key mismatch) are
+handled the same way, one level further: `pending`/`pending_work_items`/
+`rejected`/`rejected_work_items` are all routed through
+`_salvage_queue_list`, which preserves the raw, unvalidated payload in
+`corrupt_queue_entries` (a `raw: Any` field — never itself fails validation,
+so it's the terminal fallback with nothing further to preserve it from) rather
+than dropping the entry. `reconcile()`'s `rejected_mutations` count includes
+`corrupt_queue_entries` alongside both rejected buckets, so a dead-lettered
+entry is never invisible in sync output.
+
+Latent (tamper-only) bug, still present, unrelated to the above: `acknowledge_replay`
+does `remaining = [e for e in state.pending if e.idempotency_key not in acknowledged_keys]`
 — duplicate keys mean one successful replay silently drops the other entry.
-Unreachable from code paths (keys are content-derived, one entry per reference).
-
-## Robustness gap
-
-`load()` catches only `pydantic.ValidationError` before falling back to
-`YAML(typ="safe")`. A truncated/corrupt file raises an uncaught
-`ruamel.yaml.YAMLError` out of every cache read.
+Unreachable from normal code paths (keys are content-derived, one entry per
+reference); worth knowing if it ever surfaces.
 
 ## Running the tests
 
@@ -51,9 +75,8 @@ Unreachable from code paths (keys are content-derived, one entry per reference).
 uv run pytest plugins/development-harness/tests_backlog/test_file_cache.py -q --no-cov
 ```
 
-`test_file_cache.py` already covers the JSON/YAML dual-read matrix (legacy YAML
-read, new JSON read, JSON-is-valid-YAML forward compat, save-emits-JSON,
-missing file, corrupt file raises), plus migration, dead-letter, and
-idempotency-key-consistency coverage added since this note was written --
-check the file directly for current test names and counts rather than trusting
-a count here.
+`test_file_cache.py` covers the JSON/YAML dual-read matrix, migration (both
+directions, both-files-present merge, cross-thread lock safety), per-entry and
+per-collection dead-lettering (schema failure, key mismatch, version skew), and
+the corrupt-file typed-error path — check the file directly for current test
+names and counts rather than trusting a number here.

--- a/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
+++ b/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
@@ -51,6 +51,9 @@ Unreachable from code paths (keys are content-derived, one entry per reference).
 uv run pytest plugins/development-harness/tests_backlog/test_file_cache.py -q --no-cov
 ```
 
-25 tests, ~7s. `test_file_cache.py:434-554` already covers the JSON/YAML dual-read
-matrix (legacy YAML read, new JSON read, JSON-is-valid-YAML forward compat,
-save-emits-JSON, missing file, corrupt file raises).
+`test_file_cache.py` already covers the JSON/YAML dual-read matrix (legacy YAML
+read, new JSON read, JSON-is-valid-YAML forward compat, save-emits-JSON,
+missing file, corrupt file raises), plus migration, dead-letter, and
+idempotency-key-consistency coverage added since this note was written --
+check the file directly for current test names and counts rather than trusting
+a count here.

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.5",
+  "version": "11.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/ARCHITECTURE.md
+++ b/plugins/development-harness/backlog_core/ARCHITECTURE.md
@@ -475,6 +475,14 @@ only runtime component permitted to read or write backlog YAML and cached plan o
 - Last acknowledged provider revision and synchronization fingerprint
 - Pending mutations created while the provider is unreachable
 
+**On-disk layout**, under the cache root (`<state_root>/github-cache/` for the GitHub backend):
+
+- `cache.json` — the durable state above, as JSON (`_CacheStateStore` in `file_cache_state.py`). A
+  legacy `cache.yaml` from before this file was renamed is migrated automatically on first write.
+- `cache.lock` — cross-process/cross-version mutual exclusion for the state file; never renamed.
+- `items/**/*.yaml` — per-item provider snapshots, written by `yaml_io.py`. These genuinely are
+  YAML, unlike `cache.json` — don't confuse the two when reasoning about this cache's format.
+
 **Offline behavior**:
 
 - Reads return the latest cached value with explicit stale-state metadata.

--- a/plugins/development-harness/backlog_core/backends/github_work_items.py
+++ b/plugins/development-harness/backlog_core/backends/github_work_items.py
@@ -526,9 +526,13 @@ class _GitHubReconciliation:
                 and mutation.item.metadata.issue not in failed_cache_references
                 and (patch_statuses.get(mutation.item.metadata.issue, "no_patch") in {"no_patch", "applied"})
             })
-        pending_mutations = len(self._cache.pending_mutations()) + len(self._cache._pending_work_item_mutations())
         return outcome.result.model_copy(
-            update={"pending_mutations": pending_mutations, "rejected_mutations": len(self._cache.rejected_mutations())}
+            update={
+                "pending_mutations": len(self._cache.pending_mutations())
+                + len(self._cache._pending_work_item_mutations()),
+                "rejected_mutations": len(self._cache.rejected_mutations())
+                + len(self._cache._rejected_work_item_mutations()),
+            }
         )
 
     def load_records(

--- a/plugins/development-harness/backlog_core/backends/github_work_items.py
+++ b/plugins/development-harness/backlog_core/backends/github_work_items.py
@@ -530,8 +530,13 @@ class _GitHubReconciliation:
             update={
                 "pending_mutations": len(self._cache.pending_mutations())
                 + len(self._cache._pending_work_item_mutations()),
+                # Schema-invalid entries dead-lettered into corrupt_queue_entries
+                # (see _CacheStateStore._salvage_queue_list) count as rejected
+                # too: like a key mismatch, they're terminal and need manual
+                # recovery, not silently invisible zero pending/zero rejected.
                 "rejected_mutations": len(self._cache.rejected_mutations())
-                + len(self._cache._rejected_work_item_mutations()),
+                + len(self._cache._rejected_work_item_mutations())
+                + len(self._cache._corrupt_queue_entries()),
             }
         )
 

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -470,6 +470,14 @@ class FileCache:
         return destination
 
     def _load_state(self) -> _CacheState:
+        # ensure_migrated() first: a legacy-recreated cache.yaml (an older
+        # plugin copy queuing new offline writes into a fresh file of its own)
+        # otherwise stays invisible to every read accessor -- pending_mutations(),
+        # get_content(), reconciliation's load_records() -- until some
+        # unrelated transaction() happens to run and trigger migration as a
+        # side effect. Not just replay_pending()'s concern; every reader here
+        # needs current state, so the check lives once, at the shared root.
+        self._state.ensure_migrated()
         return self._state.load()
 
     @staticmethod

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import contextlib
-import hashlib
-import json
 import os
 import tempfile
 import warnings
@@ -20,9 +18,11 @@ from .file_cache_state import (
     ReplayAcknowledgement,
     _CacheState,
     _CacheStateStore,
+    _content_mutation_key,
     _PendingWorkItemMutation,
     _ProviderSnapshotCheckpoint,
     _RejectedMutation,
+    _work_item_mutation_key,
 )
 from .models import BacklogItem, ContentRecord, ContentRef, ContentUnavailableError, ContentWrite, parse_issue_number
 from .yaml_io import load_item, load_item_text, save_item
@@ -150,8 +150,7 @@ class FileCache:
                     "expected_revision": prior.write.expected_revision if prior is not None else write.expected_revision
                 }
             )
-            payload = json.dumps(rebased.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
-            mutation = PendingMutation(idempotency_key=hashlib.sha256(payload.encode()).hexdigest(), write=rebased)
+            mutation = PendingMutation(idempotency_key=_content_mutation_key(rebased), write=rebased)
             pending: list[PendingMutation] = []
             inserted = False
             for entry in state.pending:
@@ -252,10 +251,7 @@ class FileCache:
         self._state.transaction(reject)
 
     def _queue_work_item(self, key: str, item: BacklogItem) -> _PendingWorkItemMutation:
-        payload = json.dumps(item.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
-        mutation = _PendingWorkItemMutation(
-            idempotency_key=hashlib.sha256(f"{key}:{payload}".encode()).hexdigest(), key=key, item=item
-        )
+        mutation = _PendingWorkItemMutation(idempotency_key=_work_item_mutation_key(key, item), key=key, item=item)
         return self._state.transaction(
             lambda state: (
                 state.model_copy(

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -19,6 +19,7 @@ from .file_cache_state import (
     _CacheState,
     _CacheStateStore,
     _content_mutation_key,
+    _CorruptQueueEntry,
     _PendingWorkItemMutation,
     _ProviderSnapshotCheckpoint,
     _RejectedMutation,
@@ -279,6 +280,14 @@ class FileCache:
         than replayed or discarded.
         """
         return list(self._load_state().rejected_work_items)
+
+    def _corrupt_queue_entries(self) -> list[_CorruptQueueEntry]:
+        """Return pending/pending_work_items entries that failed schema validation on load.
+
+        See :meth:`_CacheStateStore._salvage_queue_list` -- stored as raw
+        payloads for manual recovery, since they never became typed models.
+        """
+        return list(self._load_state().corrupt_queue_entries)
 
     def _acknowledge_work_items(self, idempotency_keys: set[str]) -> None:
         if not idempotency_keys:

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -470,15 +470,15 @@ class FileCache:
         return destination
 
     def _load_state(self) -> _CacheState:
-        # ensure_migrated() first: a legacy-recreated cache.yaml (an older
-        # plugin copy queuing new offline writes into a fresh file of its own)
-        # otherwise stays invisible to every read accessor -- pending_mutations(),
+        # load_after_migration(), not migrate-then-load as two calls: a
+        # legacy-recreated cache.yaml (an older plugin copy queuing new
+        # offline writes into a fresh file of its own) otherwise stays
+        # invisible to every read accessor -- pending_mutations(),
         # get_content(), reconciliation's load_records() -- until some
         # unrelated transaction() happens to run and trigger migration as a
-        # side effect. Not just replay_pending()'s concern; every reader here
-        # needs current state, so the check lives once, at the shared root.
-        self._state.ensure_migrated()
-        return self._state.load()
+        # side effect. One lock acquisition also closes the race where a
+        # second recreation lands in the gap between two separate calls.
+        return self._state.load_after_migration()
 
     @staticmethod
     def _replace_record(records: list[ContentRecord], replacement: ContentRecord) -> list[ContentRecord]:

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -22,6 +22,7 @@ from .file_cache_state import (
     _PendingWorkItemMutation,
     _ProviderSnapshotCheckpoint,
     _RejectedMutation,
+    _RejectedWorkItemMutation,
     _work_item_mutation_key,
 )
 from .models import BacklogItem, ContentRecord, ContentRef, ContentUnavailableError, ContentWrite, parse_issue_number
@@ -268,6 +269,16 @@ class FileCache:
 
     def _pending_work_item_mutations(self) -> list[_PendingWorkItemMutation]:
         return list(self._load_state().pending_work_items)
+
+    def _rejected_work_item_mutations(self) -> list[_RejectedWorkItemMutation]:
+        """Return work-item mutations dead-lettered for a key/content mismatch.
+
+        See :meth:`_CacheStateStore._verify_queue_keys` -- a mismatch here is
+        not proof of a hand-edit; a legitimate entry from a newer plugin
+        version can trip it too, so these are preserved for inspection rather
+        than replayed or discarded.
+        """
+        return list(self._load_state().rejected_work_items)
 
     def _acknowledge_work_items(self, idempotency_keys: set[str]) -> None:
         if not idempotency_keys:

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -207,6 +207,19 @@ class _CacheStateStore:
             self._save(state)
         return result
 
+    def ensure_migrated(self) -> None:
+        """Run the legacy-file migration if needed, without a state transform.
+
+        ``load()`` itself stays read-only (see :meth:`_migrate_legacy_state_file`
+        for why running migration there would deadlock), so a read accessor
+        that enumerates the queue -- replay, reconciliation -- would otherwise
+        see a legacy-recreated ``cache.yaml``'s entries only after some
+        unrelated :meth:`transaction` happens to run first. Call this before
+        that kind of read.
+        """
+        with self._lock():
+            self._migrate_legacy_state_file()
+
     @contextlib.contextmanager
     def _lock(self) -> Iterator[None]:
         self._root.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -277,16 +290,21 @@ class _CacheStateStore:
             self._legacy_state_path.replace(self._state_path)
 
     def _merge_legacy_queue_entries_and_supersede(self) -> None:
-        """Merge a recreated legacy file's queue entries into cache.json, then supersede it.
+        """Merge a recreated legacy file's queue and dead-letter entries into cache.json, then supersede it.
 
         Called when both files exist. cache.json is authoritative for
         records/checkpoints/snapshot_checkpoint -- load() already prefers it,
         and the legacy copy's version of those is discarded here as
-        regenerable. pending/pending_work_items are different: an older
-        plugin copy unaware of the rename could have written new offline
-        mutations into a fresh cache.yaml of its own (see the ponytail note on
-        :meth:`_migrate_legacy_state_file`), and those are real, unreplayed
-        user intent -- merged in by idempotency_key rather than discarded.
+        regenerable. The five queue/dead-letter fields are different: an
+        older plugin copy unaware of the rename could have written new
+        offline mutations into a fresh cache.yaml of its own (see the
+        ponytail note on :meth:`_migrate_legacy_state_file`), or its own read
+        of that file could have dead-lettered an entry via the same
+        :meth:`_verify_queue_keys`/:meth:`_salvage` this method itself calls.
+        Superseding the file has a fixed target name -- a second occurrence
+        of this scenario would silently overwrite the first ``.superseded``
+        copy, so anything worth keeping has to be merged into cache.json now,
+        not left for someone to notice the file before that happens.
         """
         try:
             text = self._legacy_state_path.read_text(encoding="utf-8")
@@ -299,7 +317,13 @@ class _CacheStateStore:
                 exc,
             )
         else:
-            if legacy_state.pending or legacy_state.pending_work_items:
+            if (
+                legacy_state.pending
+                or legacy_state.pending_work_items
+                or legacy_state.rejected
+                or legacy_state.rejected_work_items
+                or legacy_state.corrupt_queue_entries
+            ):
                 current = self.load()
                 existing_pending_keys = {entry.idempotency_key for entry in current.pending}
                 merged_pending = [
@@ -315,10 +339,41 @@ class _CacheStateStore:
                         if entry.idempotency_key not in existing_work_item_keys
                     ),
                 ]
-                if merged_pending != current.pending or merged_work_items != current.pending_work_items:
-                    self._save(
-                        current.model_copy(update={"pending": merged_pending, "pending_work_items": merged_work_items})
-                    )
+                existing_rejected_keys = {entry.idempotency_key for entry in current.rejected}
+                merged_rejected = [
+                    *current.rejected,
+                    *(entry for entry in legacy_state.rejected if entry.idempotency_key not in existing_rejected_keys),
+                ]
+                existing_rejected_work_item_keys = {entry.idempotency_key for entry in current.rejected_work_items}
+                merged_rejected_work_items = [
+                    *current.rejected_work_items,
+                    *(
+                        entry
+                        for entry in legacy_state.rejected_work_items
+                        if entry.idempotency_key not in existing_rejected_work_item_keys
+                    ),
+                ]
+                # No idempotency_key to dedupe by -- these never became typed
+                # models -- so fall back to full-entry equality.
+                merged_corrupt = [
+                    *current.corrupt_queue_entries,
+                    *(
+                        entry
+                        for entry in legacy_state.corrupt_queue_entries
+                        if entry not in current.corrupt_queue_entries
+                    ),
+                ]
+                merged = current.model_copy(
+                    update={
+                        "pending": merged_pending,
+                        "pending_work_items": merged_work_items,
+                        "rejected": merged_rejected,
+                        "rejected_work_items": merged_rejected_work_items,
+                        "corrupt_queue_entries": merged_corrupt,
+                    }
+                )
+                if merged != current:
+                    self._save(merged)
         superseded = self._legacy_state_path.with_name(self._legacy_state_path.name + ".superseded")
         self._legacy_state_path.replace(superseded)
 

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -3,29 +3,34 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
+import json
+import logging
 import os
 import tempfile
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from threading import Lock
-from typing import Final, TypeVar
+from typing import Final, TypeVar, cast
 
 import pydantic
 from pydantic import BaseModel, ConfigDict, Field
-from ruamel.yaml import YAML
+from ruamel.yaml import YAML, YAMLError
 
-from .models import BacklogItem, ContentRecord, ContentRef, ContentWrite
+from .models import BacklogItem, CacheStateCorruptError, ContentRecord, ContentRef, ContentWrite
 
 if os.name == "nt":
     import msvcrt
 else:
     import fcntl
 
-_STATE_FILE: Final = "cache.yaml"
+_STATE_FILE: Final = "cache.json"
+_LEGACY_STATE_FILE: Final = "cache.yaml"
 _LOCK_FILE: Final = "cache.lock"
 _T = TypeVar("_T")
 _THREAD_LOCKS: Final[dict[Path, Lock]] = {}
 _THREAD_LOCKS_GUARD: Final = Lock()
+_log = logging.getLogger(__name__)
 
 
 class PendingMutation(BaseModel):
@@ -92,25 +97,77 @@ class _CacheState(BaseModel):
     snapshot_checkpoint: _ProviderSnapshotCheckpoint | None = None
 
 
+# Fields whose loss discards a user's unreplayed offline write (logged at error,
+# not warning) -- distinct from the other three fields, which are pure cache and
+# regenerable from the provider.
+_QUEUE_FIELDS: Final = frozenset({"pending", "pending_work_items"})
+
+
+def _content_mutation_key(write: ContentWrite) -> str:
+    """Reproducible idempotency key for a queued content write.
+
+    Shared by :meth:`FileCache.queue_write` (derivation) and
+    :meth:`_CacheStateStore._verify_queue_keys` (self-consistency check on
+    load) so the formula lives in exactly one place.
+
+    Returns:
+        The hex-encoded sha256 digest of the write's canonical JSON.
+    """
+    payload = json.dumps(write.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _work_item_mutation_key(key: str, item: BacklogItem) -> str:
+    """Reproducible idempotency key for a queued work-item mutation.
+
+    Shared by :meth:`FileCache._queue_work_item` (derivation) and
+    :meth:`_CacheStateStore._verify_queue_keys` (self-consistency check on load).
+
+    Returns:
+        The hex-encoded sha256 digest of the key and the item's canonical JSON.
+    """
+    payload = json.dumps(item.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(f"{key}:{payload}".encode()).hexdigest()
+
+
 class _CacheStateStore:
     """Serialize state transactions across threads and processes."""
 
     def __init__(self, root: Path) -> None:
         self._root = root
         self._state_path = root / _STATE_FILE
+        self._legacy_state_path = root / _LEGACY_STATE_FILE
 
     def load(self) -> _CacheState:
-        if not self._state_path.exists():
+        """Return the current state, salvaging what it can from a damaged file.
+
+        Read-only -- never migrates or writes. A legacy-only root is read
+        straight from ``cache.yaml`` without touching disk; migration only runs
+        from :meth:`transaction`, which already holds the write lock (see
+        :meth:`_migrate_legacy_state_file` for why doing it here would deadlock).
+        """
+        path = self._state_path if self._state_path.exists() else self._legacy_state_path
+        if not path.exists():
             return _CacheState()
-        raw_text = self._state_path.read_text(encoding="utf-8")
+        return self._read(path)
+
+    def _read(self, path: Path) -> _CacheState:
+        text = path.read_text(encoding="utf-8")
         try:
-            return _CacheState.model_validate_json(raw_text)
+            state = _CacheState.model_validate_json(text)
         except pydantic.ValidationError:
-            yaml = YAML(typ="safe")
-            return _CacheState.model_validate(yaml.load(raw_text))
+            raw = self._parse_relaxed(text, path)
+            state = self._salvage(raw, path)
+        # Runs on every load, not only the salvage branch above: a hand-edited
+        # entry with a fabricated-but-syntactically-valid idempotency_key is
+        # structurally complete, so it passes model_validate_json's fast path
+        # without ever touching _salvage. The self-consistency check is a
+        # semantic property pydantic's schema validation can't express.
+        return self._verify_queue_keys(state, path)
 
     def transaction(self, transform: Callable[[_CacheState], tuple[_CacheState, _T]]) -> _T:
         with self._lock():
+            self._migrate_legacy_state_file()
             state, result = transform(self.load())
             self._save(state)
         return result
@@ -136,6 +193,211 @@ class _CacheStateStore:
                         fcntl.flock(lock_fd, fcntl.LOCK_UN)
             finally:
                 os.close(lock_fd)
+
+    def _migrate_legacy_state_file(self) -> None:
+        """Move a pre-rename ``cache.yaml`` onto ``cache.json``.
+
+        Must only be called while already holding ``_lock()`` (from
+        :meth:`transaction`) -- doing this from :meth:`load` would self-deadlock:
+        ``_THREAD_LOCKS`` holds a non-reentrant ``threading.Lock``, and ``_lock()``
+        opens a fresh fd each call, so a second ``flock(LOCK_EX)`` in the same
+        process also blocks. Idempotent and self-healing: a crash mid-migration
+        leaves ``cache.yaml`` in place, which :meth:`load` still reads, and the
+        next transaction retries.
+
+        ponytail: accepts a narrow, deliberate loss -- an older plugin copy that
+        never observes this migration (a sequential downgrade, or two plugin
+        versions sharing one ``~/.dh`` root concurrently) sees no ``cache.yaml``,
+        takes ``cache.lock`` (never renamed, so both versions still exclude each
+        other), and durably writes a fresh empty state. ``records``/``checkpoints``
+        just cost a full resync; the real loss is any unreplayed
+        ``pending``/``pending_work_items`` queued before that point. Upgrade to a
+        signed/versioned handoff if this is ever observed in practice.
+        """
+        if not self._legacy_state_path.exists():
+            return
+        if self._state_path.exists():
+            # Both present (e.g. post-downgrade-then-upgrade): cache.json is
+            # authoritative -- load() already prefers it. Supersede the stale
+            # legacy file so it stops looking like something safe to hand-edit,
+            # without reading or altering its content.
+            superseded = self._legacy_state_path.with_name(self._legacy_state_path.name + ".superseded")
+            self._legacy_state_path.replace(superseded)
+            return
+        text = self._legacy_state_path.read_text(encoding="utf-8")
+        try:
+            json.loads(text)
+        except json.JSONDecodeError:
+            # Genuine legacy YAML: parse, salvage what validates, write as JSON,
+            # then supersede (not delete) the original -- no data destroyed, no
+            # longer named like something safe to hand-edit.
+            raw = self._parse_yaml(text, self._legacy_state_path)
+            state = self._verify_queue_keys(self._salvage(raw, self._legacy_state_path), self._legacy_state_path)
+            self._save(state)
+            superseded = self._legacy_state_path.with_name(self._legacy_state_path.name + ".superseded")
+            self._legacy_state_path.replace(superseded)
+        else:
+            # Already JSON, just wearing the old extension. Rename with no
+            # rewrite: _CacheState uses pydantic's default extra="ignore", so a
+            # parse-and-rewrite would silently drop any field a newer plugin
+            # version wrote that this version doesn't know about yet.
+            self._legacy_state_path.replace(self._state_path)
+
+    @staticmethod
+    def _parse_yaml(text: str, path: Path) -> dict[str, object]:
+        try:
+            raw = YAML(typ="safe").load(text)
+        except YAMLError as exc:
+            raise CacheStateCorruptError(f"Cache state file is not valid YAML: {path}") from exc
+        if not isinstance(raw, dict):
+            raise CacheStateCorruptError(f"Cache state file did not parse to a mapping: {path}")
+        return raw
+
+    @staticmethod
+    def _parse_relaxed(text: str, path: Path) -> dict[str, object]:
+        """Parse a state file that failed strict JSON-schema validation.
+
+        Returns:
+            The parsed mapping, ready for per-entry salvage.
+
+        Raises:
+            CacheStateCorruptError: The text is neither valid JSON nor valid
+                YAML, or it parses to something other than a mapping.
+        """
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError:
+            return _CacheStateStore._parse_yaml(text, path)
+        if not isinstance(raw, dict):
+            raise CacheStateCorruptError(f"Cache state file did not parse to a mapping: {path}")
+        return raw
+
+    def _salvage(self, raw: dict[str, object], path: Path) -> _CacheState:
+        """Validate each entry of a partially-malformed state dict independently.
+
+        Drops individual malformed entries instead of failing the whole load --
+        a hand-edit or a schema change from an older plugin version should cost
+        one entry, not the entire durable cache. The two most likely causes of a
+        single bad entry in an otherwise-valid document: a hand-edit (bypassing
+        this store's normal write path), or schema evolution (a model gaining a
+        required field invalidates entries queued by an older plugin version).
+        Whole-document corruption (e.g. truncation) never reaches this method --
+        it fails earlier, in :meth:`_parse_relaxed`, with a typed error, because
+        per-entry salvage cannot help when the document itself doesn't parse.
+
+        Returns:
+            A state built only from entries that validated; malformed ones are
+            logged and dropped.
+        """
+        # Runtime shape is guaranteed by _salvage_list's own model.model_validate()
+        # call; the casts below narrow it back for the type checker, which can't
+        # express that generically without an overload per field.
+        records = cast("list[ContentRecord]", self._salvage_list(raw, "records", ContentRecord, path))
+        checkpoints = cast("list[CacheCheckpoint]", self._salvage_list(raw, "checkpoints", CacheCheckpoint, path))
+        pending = cast("list[PendingMutation]", self._salvage_list(raw, "pending", PendingMutation, path))
+        rejected = cast("list[_RejectedMutation]", self._salvage_list(raw, "rejected", _RejectedMutation, path))
+        pending_work_items = cast(
+            "list[_PendingWorkItemMutation]",
+            self._salvage_list(raw, "pending_work_items", _PendingWorkItemMutation, path),
+        )
+        # Idempotency-key self-consistency is checked once, uniformly, in
+        # _verify_queue_keys -- not here, so it also runs on states that took
+        # the model_validate_json fast path (see _read).
+        checkpoint = self._salvage_checkpoint(raw, path)
+        return _CacheState(
+            records=records,
+            checkpoints=checkpoints,
+            pending=pending,
+            rejected=rejected,
+            pending_work_items=pending_work_items,
+            snapshot_checkpoint=checkpoint,
+        )
+
+    @staticmethod
+    def _salvage_list(raw: dict[str, object], field_name: str, model: type[BaseModel], path: Path) -> list[BaseModel]:
+        value = raw.get(field_name, [])
+        log = _log.error if field_name in _QUEUE_FIELDS else _log.warning
+        if not isinstance(value, list):
+            log("Cache state %s: %r is not a list (%r) -- dropping all entries", path, field_name, value)
+            return []
+        survivors: list[BaseModel] = []
+        for entry in value:
+            try:
+                survivors.append(model.model_validate(entry))
+            except pydantic.ValidationError as exc:
+                log("Cache state %s: dropping malformed %s entry: %s", path, field_name, exc)
+        return survivors
+
+    @staticmethod
+    def _salvage_checkpoint(raw: dict[str, object], path: Path) -> _ProviderSnapshotCheckpoint | None:
+        value = raw.get("snapshot_checkpoint")
+        if value is None:
+            return None
+        try:
+            return _ProviderSnapshotCheckpoint.model_validate(value)
+        except pydantic.ValidationError as exc:
+            # A lost watermark just forces a full resync -- warning, not error;
+            # the cache is regenerable, unlike a dropped offline write.
+            _log.warning("Cache state %s: dropping malformed snapshot_checkpoint: %s", path, exc)
+            return None
+
+    @staticmethod
+    def _verify_queue_keys(state: _CacheState, path: Path) -> _CacheState:
+        """Drop any pending/pending_work_items entry whose key doesn't match its content.
+
+        Runs on every load (both the model_validate_json fast path and the
+        _salvage path) and during migration, before a legacy file's converted
+        content is saved -- not folded into _salvage, because a structurally
+        complete but forged entry never fails schema validation and would
+        otherwise skip this check entirely. rejected entries are exempt: they're
+        inert inspection records, never replayed, so a stale key there is
+        harmless.
+
+        Returns:
+            ``state``, or a copy with the inconsistent entries dropped.
+        """
+        pending = [
+            entry
+            for entry in state.pending
+            if _CacheStateStore._key_is_consistent(
+                path, "pending", entry.idempotency_key, _content_mutation_key(entry.write)
+            )
+        ]
+        pending_work_items = [
+            entry
+            for entry in state.pending_work_items
+            if _CacheStateStore._key_is_consistent(
+                path, "pending_work_items", entry.idempotency_key, _work_item_mutation_key(entry.key, entry.item)
+            )
+        ]
+        if pending == state.pending and pending_work_items == state.pending_work_items:
+            return state
+        return state.model_copy(update={"pending": pending, "pending_work_items": pending_work_items})
+
+    @staticmethod
+    def _key_is_consistent(path: Path, field_name: str, stored_key: str, expected_key: str) -> bool:
+        """Self-consistency check: does a queue entry's key match its own content?
+
+        A key mismatch means the entry didn't come from this store's own
+        `queue_write`/`_queue_work_item` -- most plausibly a hand-edit, since
+        those are the only two places an idempotency_key is ever assigned. This
+        is not tamper-proofing (anyone reading this code can compute the hash);
+        it only guards against the accident/confusion case, which is the actual
+        threat model here.
+
+        Returns:
+            True if the entry's key matches its own content, False otherwise
+            (also logs the mismatch at error level).
+        """
+        if stored_key == expected_key:
+            return True
+        _log.error(
+            "Cache state %s: dropping %s entry %s -- idempotency_key does not match its content",
+            path,
+            field_name,
+            stored_key,
+        )
+        return False
 
     def _save(self, state: _CacheState) -> None:
         temporary_path: Path | None = None

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -370,7 +370,11 @@ class _CacheStateStore:
         `replay_pending()` applying a stale entry after a newer one landed.
         current's entry wins on a shared reference/key; legacy's superseded
         entry is dead-lettered into rejected/rejected_work_items, not
-        silently dropped.
+        silently dropped. A final cross-check then removes any key left in
+        both a pending list and its own terminal counterpart (current.pending
+        holding a key legacy.rejected already has, or vice versa) -- the two
+        per-field merges above only dedupe within one field, not across a
+        queue and its terminal state, so the terminal classification wins.
 
         Returns:
             ``current``, with each of the five fields extended by whatever
@@ -388,15 +392,30 @@ class _CacheStateStore:
         pending_work_items, superseded_work_items = _CacheStateStore._merge_pending_work_items_by_key(
             current.pending_work_items, legacy.pending_work_items
         )
+        rejected = [*merged_by_key(current.rejected, legacy.rejected), *superseded_pending]
+        rejected_work_items = [
+            *merged_by_key(current.rejected_work_items, legacy.rejected_work_items),
+            *superseded_work_items,
+        ]
+        # A key can end up in both a pending list and its own terminal
+        # counterpart: current.pending might hold a key legacy.rejected
+        # already has (or vice versa) -- the two per-field merges above don't
+        # cross-check between a queue and its own terminal state, only
+        # within each one. The terminal state wins: replaying an entry
+        # already classified terminal elsewhere risks a second, redundant
+        # rejection once verification catches up.
+        rejected_keys = {entry.idempotency_key for entry in rejected}
+        pending = [entry for entry in pending if entry.idempotency_key not in rejected_keys]
+        rejected_work_item_keys = {entry.idempotency_key for entry in rejected_work_items}
+        pending_work_items = [
+            entry for entry in pending_work_items if entry.idempotency_key not in rejected_work_item_keys
+        ]
         return current.model_copy(
             update={
                 "pending": pending,
                 "pending_work_items": pending_work_items,
-                "rejected": [*merged_by_key(current.rejected, legacy.rejected), *superseded_pending],
-                "rejected_work_items": [
-                    *merged_by_key(current.rejected_work_items, legacy.rejected_work_items),
-                    *superseded_work_items,
-                ],
+                "rejected": rejected,
+                "rejected_work_items": rejected_work_items,
                 "corrupt_queue_entries": [
                     *current.corrupt_queue_entries,
                     *(entry for entry in legacy.corrupt_queue_entries if entry not in current.corrupt_queue_entries),

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -11,7 +11,7 @@ import tempfile
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from threading import Lock
-from typing import Final, TypeVar, cast
+from typing import Any, Final, TypeVar, cast
 
 import pydantic
 from pydantic import BaseModel, ConfigDict, Field
@@ -96,6 +96,25 @@ class _RejectedWorkItemMutation(BaseModel):
     reason: str
 
 
+class _CorruptQueueEntry(BaseModel):
+    """A pending/pending_work_items entry that failed schema validation on load.
+
+    Stored as its raw, unvalidated payload -- unlike a key mismatch, a
+    schema-invalid entry never became a typed model, so there is no
+    well-formed object to preserve otherwise. The most likely cause is
+    schema evolution (a model gaining a required field invalidates entries
+    an older plugin version queued), not corruption, so the payload is very
+    likely a perfectly good write that this version just can't parse yet --
+    kept for manual recovery rather than silently discarded.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    field: str
+    raw: Any
+    reason: str
+
+
 class ReplayAcknowledgement(BaseModel):
     """Applied provider mutation and its resulting checkpoint."""
 
@@ -115,13 +134,8 @@ class _CacheState(BaseModel):
     rejected: list[_RejectedMutation] = Field(default_factory=list)
     pending_work_items: list[_PendingWorkItemMutation] = Field(default_factory=list)
     rejected_work_items: list[_RejectedWorkItemMutation] = Field(default_factory=list)
+    corrupt_queue_entries: list[_CorruptQueueEntry] = Field(default_factory=list)
     snapshot_checkpoint: _ProviderSnapshotCheckpoint | None = None
-
-
-# Fields whose loss discards a user's unreplayed offline write (logged at error,
-# not warning) -- distinct from the other three fields, which are pure cache and
-# regenerable from the provider.
-_QUEUE_FIELDS: Final = frozenset({"pending", "pending_work_items"})
 
 
 def _content_mutation_key(write: ContentWrite) -> str:
@@ -226,24 +240,22 @@ class _CacheStateStore:
         leaves ``cache.yaml`` in place, which :meth:`load` still reads, and the
         next transaction retries.
 
-        ponytail: accepts a narrow, deliberate loss -- an older plugin copy that
-        never observes this migration (a sequential downgrade, or two plugin
-        versions sharing one ``~/.dh`` root concurrently) sees no ``cache.yaml``,
-        takes ``cache.lock`` (never renamed, so both versions still exclude each
-        other), and durably writes a fresh empty state. ``records``/``checkpoints``
-        just cost a full resync; the real loss is any unreplayed
-        ``pending``/``pending_work_items`` queued before that point. Upgrade to a
-        signed/versioned handoff if this is ever observed in practice.
+        ponytail: an older plugin copy that never observes this migration (a
+        sequential downgrade, or two plugin versions sharing one ``~/.dh`` root
+        concurrently) sees no ``cache.yaml``, takes ``cache.lock`` (never
+        renamed, so both versions still exclude each other), and durably
+        writes a fresh ``cache.yaml`` containing just its own new offline
+        writes. The "both present" branch below merges that recreated file's
+        pending/pending_work_items into cache.json's before superseding it, so
+        that queued intent survives; records/checkpoints/snapshot_checkpoint
+        from the legacy copy are still discarded on that path -- regenerable,
+        so an accepted, narrower loss than before. Upgrade to a
+        signed/versioned handoff if even that is ever observed as a problem.
         """
         if not self._legacy_state_path.exists():
             return
         if self._state_path.exists():
-            # Both present (e.g. post-downgrade-then-upgrade): cache.json is
-            # authoritative -- load() already prefers it. Supersede the stale
-            # legacy file so it stops looking like something safe to hand-edit,
-            # without reading or altering its content.
-            superseded = self._legacy_state_path.with_name(self._legacy_state_path.name + ".superseded")
-            self._legacy_state_path.replace(superseded)
+            self._merge_legacy_queue_entries_and_supersede()
             return
         text = self._legacy_state_path.read_text(encoding="utf-8")
         try:
@@ -263,6 +275,52 @@ class _CacheStateStore:
             # parse-and-rewrite would silently drop any field a newer plugin
             # version wrote that this version doesn't know about yet.
             self._legacy_state_path.replace(self._state_path)
+
+    def _merge_legacy_queue_entries_and_supersede(self) -> None:
+        """Merge a recreated legacy file's queue entries into cache.json, then supersede it.
+
+        Called when both files exist. cache.json is authoritative for
+        records/checkpoints/snapshot_checkpoint -- load() already prefers it,
+        and the legacy copy's version of those is discarded here as
+        regenerable. pending/pending_work_items are different: an older
+        plugin copy unaware of the rename could have written new offline
+        mutations into a fresh cache.yaml of its own (see the ponytail note on
+        :meth:`_migrate_legacy_state_file`), and those are real, unreplayed
+        user intent -- merged in by idempotency_key rather than discarded.
+        """
+        try:
+            text = self._legacy_state_path.read_text(encoding="utf-8")
+            raw = self._parse_relaxed(text, self._legacy_state_path)
+            legacy_state = self._verify_queue_keys(self._salvage(raw, self._legacy_state_path), self._legacy_state_path)
+        except CacheStateCorruptError as exc:
+            _log.error(
+                "Cache state %s: could not read for merge before superseding, any queued writes in it are lost: %s",
+                self._legacy_state_path,
+                exc,
+            )
+        else:
+            if legacy_state.pending or legacy_state.pending_work_items:
+                current = self.load()
+                existing_pending_keys = {entry.idempotency_key for entry in current.pending}
+                merged_pending = [
+                    *current.pending,
+                    *(entry for entry in legacy_state.pending if entry.idempotency_key not in existing_pending_keys),
+                ]
+                existing_work_item_keys = {entry.idempotency_key for entry in current.pending_work_items}
+                merged_work_items = [
+                    *current.pending_work_items,
+                    *(
+                        entry
+                        for entry in legacy_state.pending_work_items
+                        if entry.idempotency_key not in existing_work_item_keys
+                    ),
+                ]
+                if merged_pending != current.pending or merged_work_items != current.pending_work_items:
+                    self._save(
+                        current.model_copy(update={"pending": merged_pending, "pending_work_items": merged_work_items})
+                    )
+        superseded = self._legacy_state_path.with_name(self._legacy_state_path.name + ".superseded")
+        self._legacy_state_path.replace(superseded)
 
     @staticmethod
     def _parse_yaml(text: str, path: Path) -> dict[str, object]:
@@ -306,25 +364,36 @@ class _CacheStateStore:
         it fails earlier, in :meth:`_parse_relaxed`, with a typed error, because
         per-entry salvage cannot help when the document itself doesn't parse.
 
+        Schema-invalid pending/pending_work_items entries are different from
+        the other four fields: those are pure cache, safely dropped and
+        logged (:meth:`_salvage_list`). Losing a pending entry is losing a
+        user's unreplayed offline write, so :meth:`_salvage_queue_list`
+        preserves its raw payload in ``corrupt_queue_entries`` instead.
+
         Returns:
-            A state built only from entries that validated; malformed ones are
-            logged and dropped.
+            A state built only from entries that validated; malformed
+            non-queue entries are logged and dropped, malformed queue
+            entries are preserved in ``corrupt_queue_entries``.
         """
         # Runtime shape is guaranteed by _salvage_list's own model.model_validate()
         # call; the casts below narrow it back for the type checker, which can't
         # express that generically without an overload per field.
         records = cast("list[ContentRecord]", self._salvage_list(raw, "records", ContentRecord, path))
         checkpoints = cast("list[CacheCheckpoint]", self._salvage_list(raw, "checkpoints", CacheCheckpoint, path))
-        pending = cast("list[PendingMutation]", self._salvage_list(raw, "pending", PendingMutation, path))
         rejected = cast("list[_RejectedMutation]", self._salvage_list(raw, "rejected", _RejectedMutation, path))
-        pending_work_items = cast(
-            "list[_PendingWorkItemMutation]",
-            self._salvage_list(raw, "pending_work_items", _PendingWorkItemMutation, path),
-        )
         rejected_work_items = cast(
             "list[_RejectedWorkItemMutation]",
             self._salvage_list(raw, "rejected_work_items", _RejectedWorkItemMutation, path),
         )
+        existing_corrupt = cast(
+            "list[_CorruptQueueEntry]", self._salvage_list(raw, "corrupt_queue_entries", _CorruptQueueEntry, path)
+        )
+        pending_raw, corrupt_pending = self._salvage_queue_list(raw, "pending", PendingMutation, path)
+        pending = cast("list[PendingMutation]", pending_raw)
+        work_items_raw, corrupt_work_items = self._salvage_queue_list(
+            raw, "pending_work_items", _PendingWorkItemMutation, path
+        )
+        pending_work_items = cast("list[_PendingWorkItemMutation]", work_items_raw)
         # Idempotency-key self-consistency is checked once, uniformly, in
         # _verify_queue_keys -- not here, so it also runs on states that took
         # the model_validate_json fast path (see _read).
@@ -336,23 +405,60 @@ class _CacheStateStore:
             rejected=rejected,
             pending_work_items=pending_work_items,
             rejected_work_items=rejected_work_items,
+            corrupt_queue_entries=[*existing_corrupt, *corrupt_pending, *corrupt_work_items],
             snapshot_checkpoint=checkpoint,
         )
 
     @staticmethod
     def _salvage_list(raw: dict[str, object], field_name: str, model: type[BaseModel], path: Path) -> list[BaseModel]:
+        """Validate each entry of one non-queue field independently, dropping failures.
+
+        Not used for pending/pending_work_items -- see :meth:`_salvage_queue_list`.
+
+        Returns:
+            The entries that validated; malformed ones are logged and dropped.
+        """
         value = raw.get(field_name, [])
-        log = _log.error if field_name in _QUEUE_FIELDS else _log.warning
         if not isinstance(value, list):
-            log("Cache state %s: %r is not a list (%r) -- dropping all entries", path, field_name, value)
+            _log.warning("Cache state %s: %r is not a list (%r) -- dropping all entries", path, field_name, value)
             return []
         survivors: list[BaseModel] = []
         for entry in value:
             try:
                 survivors.append(model.model_validate(entry))
             except pydantic.ValidationError as exc:
-                log("Cache state %s: dropping malformed %s entry: %s", path, field_name, exc)
+                _log.warning("Cache state %s: dropping malformed %s entry: %s", path, field_name, exc)
         return survivors
+
+    @staticmethod
+    def _salvage_queue_list(
+        raw: dict[str, object], field_name: str, model: type[BaseModel], path: Path
+    ) -> tuple[list[BaseModel], list[_CorruptQueueEntry]]:
+        """Validate each entry of pending/pending_work_items, preserving failures instead of dropping them.
+
+        Returns:
+            The entries that validated, and the raw payload of each one that
+            didn't (see :class:`_CorruptQueueEntry` for why the raw form,
+            not a typed model, is what gets preserved here).
+        """
+        value = raw.get(field_name, [])
+        if not isinstance(value, list):
+            _log.error("Cache state %s: %r is not a list (%r) -- dropping all entries", path, field_name, value)
+            return [], []
+        survivors: list[BaseModel] = []
+        corrupt: list[_CorruptQueueEntry] = []
+        for entry in value:
+            try:
+                survivors.append(model.model_validate(entry))
+            except pydantic.ValidationError as exc:
+                _log.error(
+                    "Cache state %s: dead-lettering malformed %s entry (raw payload preserved): %s",
+                    path,
+                    field_name,
+                    exc,
+                )
+                corrupt.append(_CorruptQueueEntry(field=field_name, raw=entry, reason=str(exc)))
+        return survivors, corrupt
 
     @staticmethod
     def _salvage_checkpoint(raw: dict[str, object], path: Path) -> _ProviderSnapshotCheckpoint | None:

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -419,36 +419,47 @@ class _CacheStateStore:
         it fails earlier, in :meth:`_parse_relaxed`, with a typed error, because
         per-entry salvage cannot help when the document itself doesn't parse.
 
-        Schema-invalid pending/pending_work_items entries are different from
-        the other four fields: those are pure cache, safely dropped and
-        logged (:meth:`_salvage_list`). Losing a pending entry is losing a
-        user's unreplayed offline write, so :meth:`_salvage_queue_list`
-        preserves its raw payload in ``corrupt_queue_entries`` instead.
+        records/checkpoints are different from the other four fields: those
+        are pure cache, safely dropped and logged (:meth:`_salvage_list`).
+        pending/pending_work_items/rejected/rejected_work_items are all
+        precious -- a schema-invalid entry there is more likely a legitimate
+        write this version can't parse yet (schema evolution) than genuine
+        corruption, including in the two terminal dead-letter buckets
+        themselves (a stored ``rejected``/``rejected_work_items`` entry is
+        the only recovery record for whatever it holds; losing it too on a
+        later load would be worse than the mismatch that put it there).
+        :meth:`_salvage_queue_list` preserves each one's raw payload in
+        ``corrupt_queue_entries`` instead of dropping it. That field is the
+        terminal fallback and isn't routed through the same path itself:
+        its ``raw: Any`` member can't fail model validation, so there's
+        nothing further to preserve it from.
 
         Returns:
             A state built only from entries that validated; malformed
-            non-queue entries are logged and dropped, malformed queue
-            entries are preserved in ``corrupt_queue_entries``.
+            records/checkpoints entries are logged and dropped, malformed
+            entries in the four precious fields are preserved in
+            ``corrupt_queue_entries``.
         """
-        # Runtime shape is guaranteed by _salvage_list's own model.model_validate()
-        # call; the casts below narrow it back for the type checker, which can't
-        # express that generically without an overload per field.
+        # Runtime shape is guaranteed by _salvage_list's/_salvage_queue_list's own
+        # model.model_validate() calls; the casts below narrow the result back
+        # for the type checker, which can't express that generically without an
+        # overload per field. Driven by a loop rather than one named pair of
+        # locals per field, to stay under ruff's too-many-locals limit.
         records = cast("list[ContentRecord]", self._salvage_list(raw, "records", ContentRecord, path))
         checkpoints = cast("list[CacheCheckpoint]", self._salvage_list(raw, "checkpoints", CacheCheckpoint, path))
-        rejected = cast("list[_RejectedMutation]", self._salvage_list(raw, "rejected", _RejectedMutation, path))
-        rejected_work_items = cast(
-            "list[_RejectedWorkItemMutation]",
-            self._salvage_list(raw, "rejected_work_items", _RejectedWorkItemMutation, path),
-        )
-        existing_corrupt = cast(
+        corrupt = cast(
             "list[_CorruptQueueEntry]", self._salvage_list(raw, "corrupt_queue_entries", _CorruptQueueEntry, path)
         )
-        pending_raw, corrupt_pending = self._salvage_queue_list(raw, "pending", PendingMutation, path)
-        pending = cast("list[PendingMutation]", pending_raw)
-        work_items_raw, corrupt_work_items = self._salvage_queue_list(
-            raw, "pending_work_items", _PendingWorkItemMutation, path
-        )
-        pending_work_items = cast("list[_PendingWorkItemMutation]", work_items_raw)
+        survivors: dict[str, list[BaseModel]] = {}
+        for field_name, model in (
+            ("pending", PendingMutation),
+            ("pending_work_items", _PendingWorkItemMutation),
+            ("rejected", _RejectedMutation),
+            ("rejected_work_items", _RejectedWorkItemMutation),
+        ):
+            entries, bad = self._salvage_queue_list(raw, field_name, model, path)
+            survivors[field_name] = entries
+            corrupt.extend(bad)
         # Idempotency-key self-consistency is checked once, uniformly, in
         # _verify_queue_keys -- not here, so it also runs on states that took
         # the model_validate_json fast path (see _read).
@@ -456,11 +467,11 @@ class _CacheStateStore:
         return _CacheState(
             records=records,
             checkpoints=checkpoints,
-            pending=pending,
-            rejected=rejected,
-            pending_work_items=pending_work_items,
-            rejected_work_items=rejected_work_items,
-            corrupt_queue_entries=[*existing_corrupt, *corrupt_pending, *corrupt_work_items],
+            pending=cast("list[PendingMutation]", survivors["pending"]),
+            rejected=cast("list[_RejectedMutation]", survivors["rejected"]),
+            pending_work_items=cast("list[_PendingWorkItemMutation]", survivors["pending_work_items"]),
+            rejected_work_items=cast("list[_RejectedWorkItemMutation]", survivors["rejected_work_items"]),
+            corrupt_queue_entries=corrupt,
             snapshot_checkpoint=checkpoint,
         )
 
@@ -489,17 +500,24 @@ class _CacheStateStore:
     def _salvage_queue_list(
         raw: dict[str, object], field_name: str, model: type[BaseModel], path: Path
     ) -> tuple[list[BaseModel], list[_CorruptQueueEntry]]:
-        """Validate each entry of pending/pending_work_items, preserving failures instead of dropping them.
+        """Validate each entry of a precious field, preserving failures instead of dropping them.
+
+        Used for pending/pending_work_items/rejected/rejected_work_items --
+        every field where losing an entry outright would discard something
+        no longer recoverable elsewhere.
 
         Returns:
-            The entries that validated, and the raw payload of each one that
-            didn't (see :class:`_CorruptQueueEntry` for why the raw form,
-            not a typed model, is what gets preserved here).
+            The entries that validated, and a :class:`_CorruptQueueEntry` for
+            each one that didn't -- or, if ``field_name`` itself isn't a
+            list, a single entry preserving the whole raw value, rather than
+            silently discarding the entire field.
         """
         value = raw.get(field_name, [])
         if not isinstance(value, list):
-            _log.error("Cache state %s: %r is not a list (%r) -- dropping all entries", path, field_name, value)
-            return [], []
+            _log.error(
+                "Cache state %s: %r is not a list (%r) -- preserving as a single corrupt entry", path, field_name, value
+            )
+            return [], [_CorruptQueueEntry(field=field_name, raw=value, reason="value is not a list")]
         survivors: list[BaseModel] = []
         corrupt: list[_CorruptQueueEntry] = []
         for entry in value:

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import tempfile
+import time as _time
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from threading import Lock
@@ -207,18 +208,28 @@ class _CacheStateStore:
             self._save(state)
         return result
 
-    def ensure_migrated(self) -> None:
-        """Run the legacy-file migration if needed, without a state transform.
+    def load_after_migration(self) -> _CacheState:
+        """Migrate the legacy file if needed, then load -- one lock acquisition, not two.
 
         ``load()`` itself stays read-only (see :meth:`_migrate_legacy_state_file`
         for why running migration there would deadlock), so a read accessor
         that enumerates the queue -- replay, reconciliation -- would otherwise
         see a legacy-recreated ``cache.yaml``'s entries only after some
-        unrelated :meth:`transaction` happens to run first. Call this before
-        that kind of read.
+        unrelated :meth:`transaction` happens to run first. Call this instead
+        of :meth:`load` for that kind of read.
+
+        Migration and the read that follows share one lock acquisition
+        deliberately, not two separate calls: another process recreating
+        ``cache.yaml`` in the gap between a migrate-then-release and a
+        separate later load would be invisible to that load, the same race
+        :meth:`transaction` already avoids by holding the lock across both.
+
+        Returns:
+            The state after any pending migration has been applied.
         """
         with self._lock():
             self._migrate_legacy_state_file()
+            return self.load()
 
     @contextlib.contextmanager
     def _lock(self) -> Iterator[None]:
@@ -304,18 +315,27 @@ class _CacheStateStore:
         Superseding the file has a fixed target name -- a second occurrence
         of this scenario would silently overwrite the first ``.superseded``
         copy, so anything worth keeping has to be merged into cache.json now,
-        not left for someone to notice the file before that happens.
+        not left for someone to notice the file before that happens. A legacy
+        file too corrupt to parse at all can't be merged this way -- it gets
+        a uniquely-named backup instead of the fixed ``.superseded`` name, so
+        a second corrupt-legacy-file occurrence doesn't overwrite the first.
         """
         try:
             text = self._legacy_state_path.read_text(encoding="utf-8")
             raw = self._parse_relaxed(text, self._legacy_state_path)
             legacy_state = self._verify_queue_keys(self._salvage(raw, self._legacy_state_path), self._legacy_state_path)
         except CacheStateCorruptError as exc:
+            unparsable_backup = self._legacy_state_path.with_name(
+                f"{self._legacy_state_path.name}.corrupt.{_time.time_ns()}"
+            )
             _log.error(
-                "Cache state %s: could not read for merge before superseding, any queued writes in it are lost: %s",
+                "Cache state %s: could not read for merge before superseding, preserving as %s instead: %s",
                 self._legacy_state_path,
+                unparsable_backup,
                 exc,
             )
+            self._legacy_state_path.replace(unparsable_backup)
+            return
         else:
             if (
                 legacy_state.pending
@@ -325,57 +345,44 @@ class _CacheStateStore:
                 or legacy_state.corrupt_queue_entries
             ):
                 current = self.load()
-                existing_pending_keys = {entry.idempotency_key for entry in current.pending}
-                merged_pending = [
-                    *current.pending,
-                    *(entry for entry in legacy_state.pending if entry.idempotency_key not in existing_pending_keys),
-                ]
-                existing_work_item_keys = {entry.idempotency_key for entry in current.pending_work_items}
-                merged_work_items = [
-                    *current.pending_work_items,
-                    *(
-                        entry
-                        for entry in legacy_state.pending_work_items
-                        if entry.idempotency_key not in existing_work_item_keys
-                    ),
-                ]
-                existing_rejected_keys = {entry.idempotency_key for entry in current.rejected}
-                merged_rejected = [
-                    *current.rejected,
-                    *(entry for entry in legacy_state.rejected if entry.idempotency_key not in existing_rejected_keys),
-                ]
-                existing_rejected_work_item_keys = {entry.idempotency_key for entry in current.rejected_work_items}
-                merged_rejected_work_items = [
-                    *current.rejected_work_items,
-                    *(
-                        entry
-                        for entry in legacy_state.rejected_work_items
-                        if entry.idempotency_key not in existing_rejected_work_item_keys
-                    ),
-                ]
-                # No idempotency_key to dedupe by -- these never became typed
-                # models -- so fall back to full-entry equality.
-                merged_corrupt = [
-                    *current.corrupt_queue_entries,
-                    *(
-                        entry
-                        for entry in legacy_state.corrupt_queue_entries
-                        if entry not in current.corrupt_queue_entries
-                    ),
-                ]
-                merged = current.model_copy(
-                    update={
-                        "pending": merged_pending,
-                        "pending_work_items": merged_work_items,
-                        "rejected": merged_rejected,
-                        "rejected_work_items": merged_rejected_work_items,
-                        "corrupt_queue_entries": merged_corrupt,
-                    }
-                )
+                merged = self._merge_queue_state(current, legacy_state)
                 if merged != current:
                     self._save(merged)
         superseded = self._legacy_state_path.with_name(self._legacy_state_path.name + ".superseded")
         self._legacy_state_path.replace(superseded)
+
+    @staticmethod
+    def _merge_queue_state(current: _CacheState, legacy: _CacheState) -> _CacheState:
+        """Union all five queue/dead-letter fields from ``legacy`` into ``current``.
+
+        ``current``'s copy of an entry wins on a shared ``idempotency_key``.
+        ``corrupt_queue_entries`` has no key to dedupe by -- its entries never
+        became typed models -- so full-entry equality is used instead.
+
+        Returns:
+            ``current``, with each of the five fields extended by whatever
+            ``legacy`` holds that ``current`` doesn't already have.
+        """
+
+        def merged_by_key(current_entries: list[Any], legacy_entries: list[Any]) -> list[Any]:
+            existing_keys = {entry.idempotency_key for entry in current_entries}
+            return [
+                *current_entries,
+                *(entry for entry in legacy_entries if entry.idempotency_key not in existing_keys),
+            ]
+
+        return current.model_copy(
+            update={
+                "pending": merged_by_key(current.pending, legacy.pending),
+                "pending_work_items": merged_by_key(current.pending_work_items, legacy.pending_work_items),
+                "rejected": merged_by_key(current.rejected, legacy.rejected),
+                "rejected_work_items": merged_by_key(current.rejected_work_items, legacy.rejected_work_items),
+                "corrupt_queue_entries": [
+                    *current.corrupt_queue_entries,
+                    *(entry for entry in legacy.corrupt_queue_entries if entry not in current.corrupt_queue_entries),
+                ],
+            }
+        )
 
     @staticmethod
     def _parse_yaml(text: str, path: Path) -> dict[str, object]:

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -355,9 +355,22 @@ class _CacheStateStore:
     def _merge_queue_state(current: _CacheState, legacy: _CacheState) -> _CacheState:
         """Union all five queue/dead-letter fields from ``legacy`` into ``current``.
 
-        ``current``'s copy of an entry wins on a shared ``idempotency_key``.
-        ``corrupt_queue_entries`` has no key to dedupe by -- its entries never
-        became typed models -- so full-entry equality is used instead.
+        ``rejected``/``rejected_work_items``/``corrupt_queue_entries`` are
+        pure accumulated history -- duplicates across sources are harmless,
+        so those three just union (deduped by ``idempotency_key``, or full
+        equality for ``corrupt_queue_entries``, which has no key). pending
+        and pending_work_items are different: ``queue_write()``/
+        ``_queue_work_item()`` each maintain "at most one entry per
+        reference/key" as an invariant, coalescing on every call within one
+        process -- but that invariant says nothing about two *different*
+        writes for the *same* reference arriving from two independently-
+        evolved sources (current vs. a legacy file recreated by older code).
+        Deduping only by ``idempotency_key`` would let both survive,
+        breaking the invariant every other code path relies on and risking
+        `replay_pending()` applying a stale entry after a newer one landed.
+        current's entry wins on a shared reference/key; legacy's superseded
+        entry is dead-lettered into rejected/rejected_work_items, not
+        silently dropped.
 
         Returns:
             ``current``, with each of the five fields extended by whatever
@@ -371,18 +384,90 @@ class _CacheStateStore:
                 *(entry for entry in legacy_entries if entry.idempotency_key not in existing_keys),
             ]
 
+        pending, superseded_pending = _CacheStateStore._merge_pending_by_reference(current.pending, legacy.pending)
+        pending_work_items, superseded_work_items = _CacheStateStore._merge_pending_work_items_by_key(
+            current.pending_work_items, legacy.pending_work_items
+        )
         return current.model_copy(
             update={
-                "pending": merged_by_key(current.pending, legacy.pending),
-                "pending_work_items": merged_by_key(current.pending_work_items, legacy.pending_work_items),
-                "rejected": merged_by_key(current.rejected, legacy.rejected),
-                "rejected_work_items": merged_by_key(current.rejected_work_items, legacy.rejected_work_items),
+                "pending": pending,
+                "pending_work_items": pending_work_items,
+                "rejected": [*merged_by_key(current.rejected, legacy.rejected), *superseded_pending],
+                "rejected_work_items": [
+                    *merged_by_key(current.rejected_work_items, legacy.rejected_work_items),
+                    *superseded_work_items,
+                ],
                 "corrupt_queue_entries": [
                     *current.corrupt_queue_entries,
                     *(entry for entry in legacy.corrupt_queue_entries if entry not in current.corrupt_queue_entries),
                 ],
             }
         )
+
+    @staticmethod
+    def _merge_pending_by_reference(
+        current: list[PendingMutation], legacy: list[PendingMutation]
+    ) -> tuple[list[PendingMutation], list[_RejectedMutation]]:
+        """Union two pending-write queues, keeping at most one entry per reference.
+
+        Returns:
+            The merged queue (current's entries plus legacy's that don't
+            collide by reference or idempotency_key), and a dead-lettered
+            _RejectedMutation for each legacy entry superseded by a
+            same-reference entry current already has.
+        """
+        existing_keys = {entry.idempotency_key for entry in current}
+        # ContentRef isn't hashable (nested fields), so this stays a list
+        # membership check rather than a set, unlike existing_keys above.
+        existing_references = [entry.write.reference for entry in current]
+        survivors = list(current)
+        superseded: list[_RejectedMutation] = []
+        for entry in legacy:
+            if entry.idempotency_key in existing_keys:
+                continue
+            if entry.write.reference in existing_references:
+                superseded.append(
+                    _RejectedMutation(
+                        idempotency_key=entry.idempotency_key,
+                        write=entry.write,
+                        reason="superseded by cache.json's entry for the same reference during legacy-file merge",
+                    )
+                )
+                continue
+            survivors.append(entry)
+        return survivors, superseded
+
+    @staticmethod
+    def _merge_pending_work_items_by_key(
+        current: list[_PendingWorkItemMutation], legacy: list[_PendingWorkItemMutation]
+    ) -> tuple[list[_PendingWorkItemMutation], list[_RejectedWorkItemMutation]]:
+        """Union two pending-work-item queues, keeping at most one entry per ``key``.
+
+        Returns:
+            The merged queue, and a dead-lettered _RejectedWorkItemMutation
+            for each legacy entry superseded by a same-key entry current
+            already has -- see :meth:`_merge_pending_by_reference` for why
+            idempotency_key alone isn't enough here.
+        """
+        existing_keys = {entry.idempotency_key for entry in current}
+        existing_work_keys = {entry.key for entry in current}
+        survivors = list(current)
+        superseded: list[_RejectedWorkItemMutation] = []
+        for entry in legacy:
+            if entry.idempotency_key in existing_keys:
+                continue
+            if entry.key in existing_work_keys:
+                superseded.append(
+                    _RejectedWorkItemMutation(
+                        idempotency_key=entry.idempotency_key,
+                        key=entry.key,
+                        item=entry.item,
+                        reason="superseded by cache.json's entry for the same key during legacy-file merge",
+                    )
+                )
+                continue
+            survivors.append(entry)
+        return survivors, superseded
 
     @staticmethod
     def _parse_yaml(text: str, path: Path) -> dict[str, object]:

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -493,6 +493,18 @@ class _CacheStateStore:
         outright would be silent data loss for that case; dead-lettering keeps
         the entry recoverable and inspectable either way.
 
+        Known limitation, deliberately not fixed here: this is a one-way,
+        permanent move. Once dead-lettered, an entry is never re-verified or
+        automatically promoted back to pending/pending_work_items, even by a
+        later load from a plugin version that could have recomputed a matching
+        key. A false-positive version-skew entry is therefore preserved but
+        not automatically delivered to the backend -- recoverable by manual
+        inspection of rejected/rejected_work_items, not by anything automatic.
+        Building real self-healing (re-verify on every load, with the
+        version-detection and backoff that needs to not thrash) is the kind
+        of provenance/recovery machinery already called out as deferred scope
+        on backlog #2287, not a rider on this fix.
+
         Returns:
             ``state``, or a copy with the inconsistent entries moved to the
             corresponding rejected list.

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -76,6 +76,26 @@ class _RejectedMutation(BaseModel):
     reason: str
 
 
+class _RejectedWorkItemMutation(BaseModel):
+    """Durable work-item mutation whose idempotency_key doesn't match its own content.
+
+    Mirrors :class:`_RejectedMutation` for the work-item queue -- inspectable
+    and never replayed, but not destroyed. A mismatch is not proof of a
+    hand-edit: an older plugin version reading an entry a newer version wrote
+    silently drops any field it doesn't recognize (pydantic's default
+    ``extra="ignore"``), which changes the recomputed hash for a perfectly
+    legitimate entry too. Dropping outright would be silent data loss for
+    that case; dead-lettering here keeps the entry recoverable either way.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    idempotency_key: str
+    key: str
+    item: BacklogItem
+    reason: str
+
+
 class ReplayAcknowledgement(BaseModel):
     """Applied provider mutation and its resulting checkpoint."""
 
@@ -94,6 +114,7 @@ class _CacheState(BaseModel):
     pending: list[PendingMutation] = Field(default_factory=list)
     rejected: list[_RejectedMutation] = Field(default_factory=list)
     pending_work_items: list[_PendingWorkItemMutation] = Field(default_factory=list)
+    rejected_work_items: list[_RejectedWorkItemMutation] = Field(default_factory=list)
     snapshot_checkpoint: _ProviderSnapshotCheckpoint | None = None
 
 
@@ -300,6 +321,10 @@ class _CacheStateStore:
             "list[_PendingWorkItemMutation]",
             self._salvage_list(raw, "pending_work_items", _PendingWorkItemMutation, path),
         )
+        rejected_work_items = cast(
+            "list[_RejectedWorkItemMutation]",
+            self._salvage_list(raw, "rejected_work_items", _RejectedWorkItemMutation, path),
+        )
         # Idempotency-key self-consistency is checked once, uniformly, in
         # _verify_queue_keys -- not here, so it also runs on states that took
         # the model_validate_json fast path (see _read).
@@ -310,6 +335,7 @@ class _CacheStateStore:
             pending=pending,
             rejected=rejected,
             pending_work_items=pending_work_items,
+            rejected_work_items=rejected_work_items,
             snapshot_checkpoint=checkpoint,
         )
 
@@ -343,47 +369,81 @@ class _CacheStateStore:
 
     @staticmethod
     def _verify_queue_keys(state: _CacheState, path: Path) -> _CacheState:
-        """Drop any pending/pending_work_items entry whose key doesn't match its content.
+        """Dead-letter any pending/pending_work_items entry whose key doesn't match its content.
 
         Runs on every load (both the model_validate_json fast path and the
         _salvage path) and during migration, before a legacy file's converted
         content is saved -- not folded into _salvage, because a structurally
         complete but forged entry never fails schema validation and would
-        otherwise skip this check entirely. rejected entries are exempt: they're
-        inert inspection records, never replayed, so a stale key there is
-        harmless.
+        otherwise skip this check entirely. rejected/rejected_work_items entries
+        are exempt from the check themselves: they're inert inspection records,
+        never replayed, so a stale key there is harmless.
+
+        A mismatch moves the entry to rejected/rejected_work_items instead of
+        deleting it -- it is not proof of a hand-edit. An older plugin version
+        reading an entry a newer version wrote silently drops any field it
+        doesn't recognize (pydantic's default extra="ignore"), which changes
+        the recomputed hash for a perfectly legitimate entry too. Dropping
+        outright would be silent data loss for that case; dead-lettering keeps
+        the entry recoverable and inspectable either way.
 
         Returns:
-            ``state``, or a copy with the inconsistent entries dropped.
+            ``state``, or a copy with the inconsistent entries moved to the
+            corresponding rejected list.
         """
-        pending = [
-            entry
-            for entry in state.pending
-            if _CacheStateStore._key_is_consistent(
-                path, "pending", entry.idempotency_key, _content_mutation_key(entry.write)
-            )
-        ]
-        pending_work_items = [
-            entry
-            for entry in state.pending_work_items
-            if _CacheStateStore._key_is_consistent(
-                path, "pending_work_items", entry.idempotency_key, _work_item_mutation_key(entry.key, entry.item)
-            )
-        ]
-        if pending == state.pending and pending_work_items == state.pending_work_items:
+        pending: list[PendingMutation] = []
+        rejected = list(state.rejected)
+        for entry in state.pending:
+            expected = _content_mutation_key(entry.write)
+            if _CacheStateStore._key_is_consistent(path, "pending", entry.idempotency_key, expected):
+                pending.append(entry)
+            else:
+                rejected.append(
+                    _RejectedMutation(
+                        idempotency_key=entry.idempotency_key,
+                        write=entry.write,
+                        reason="idempotency_key does not match its content",
+                    )
+                )
+        pending_work_items: list[_PendingWorkItemMutation] = []
+        rejected_work_items = list(state.rejected_work_items)
+        for wi_entry in state.pending_work_items:
+            expected = _work_item_mutation_key(wi_entry.key, wi_entry.item)
+            if _CacheStateStore._key_is_consistent(path, "pending_work_items", wi_entry.idempotency_key, expected):
+                pending_work_items.append(wi_entry)
+            else:
+                rejected_work_items.append(
+                    _RejectedWorkItemMutation(
+                        idempotency_key=wi_entry.idempotency_key,
+                        key=wi_entry.key,
+                        item=wi_entry.item,
+                        reason="idempotency_key does not match its content",
+                    )
+                )
+        if (
+            pending == state.pending
+            and pending_work_items == state.pending_work_items
+            and rejected == state.rejected
+            and rejected_work_items == state.rejected_work_items
+        ):
             return state
-        return state.model_copy(update={"pending": pending, "pending_work_items": pending_work_items})
+        return state.model_copy(
+            update={
+                "pending": pending,
+                "pending_work_items": pending_work_items,
+                "rejected": rejected,
+                "rejected_work_items": rejected_work_items,
+            }
+        )
 
     @staticmethod
     def _key_is_consistent(path: Path, field_name: str, stored_key: str, expected_key: str) -> bool:
         """Self-consistency check: does a queue entry's key match its own content?
 
-        A key mismatch means the entry didn't come from this store's own
-        `queue_write`/`_queue_work_item` -- most plausibly a hand-edit, since
-        those are the only two places an idempotency_key is ever assigned. This
-        is not tamper-proofing (anyone reading this code can compute the hash);
-        it only guards against the accident/confusion case, which is the actual
-        threat model here.
+        A key mismatch does not by itself prove a hand-edit -- see
+        :meth:`_verify_queue_keys` for why a legitimate, version-skewed entry
+        can trip this too. Either way the entry is dead-lettered, not trusted
+        for replay, by the caller.
 
         Returns:
             True if the entry's key matches its own content, False otherwise
@@ -392,7 +452,7 @@ class _CacheStateStore:
         if stored_key == expected_key:
             return True
         _log.error(
-            "Cache state %s: dropping %s entry %s -- idempotency_key does not match its content",
+            "Cache state %s: dead-lettering %s entry %s -- idempotency_key does not match its content",
             path,
             field_name,
             stored_key,

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -487,6 +487,10 @@ class BacklogError(Exception):
     """General backlog operation error."""
 
 
+class CacheStateCorruptError(BacklogError):
+    """Raised when a provider-private cache state file is neither valid JSON nor YAML."""
+
+
 class ContentProviderError(Exception):
     """Base error for logical content capability failures."""
 

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1124,10 +1124,11 @@ async def _backlog_lifespan(_server: object) -> AsyncGenerator[dict[str, object]
 mcp = FastMCP(
     "backlog",
     instructions=(
-        "Backlog management server. The configured backend is the source of truth; this server keeps "
-        "a local cache that syncs with it. Always use these tools for backlog CRUD (add, list, view, "
-        "update, groom, close, resolve, sync) — never read or edit backlog files directly, even if a "
-        "tool call fails; report the failure instead."
+        "Backlog management server. The configured backend is the source of truth; backends that "
+        "support offline queuing keep a local cache that syncs with it, others read and write it "
+        "directly. Always use these tools for backlog CRUD (add, list, view, update, groom, close, "
+        "resolve, sync) — never read or edit backlog files directly, even if a tool call fails; "
+        "report the failure instead."
     ),
     version="0.1.0",
     lifespan=_backlog_lifespan,

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1,4 +1,13 @@
-"""FastMCP 3.x server exposing all backlog operations as MCP tools."""
+"""FastMCP 3.x server exposing all backlog operations as MCP tools.
+
+Exists to guarantee what raw file or API access cannot:
+1. Correct, durable, audit-preserving backlog state across whichever backend is
+   configured, under concurrent writers.
+2. A structured, resource-bounded interface for the calling agent — safety
+   annotations, typed errors, token-budget-aware pagination — in place of
+   CLI/stderr parsing or unbounded reads.
+3. Crash-safe tracking of multi-agent dispatch, wave, and task execution state.
+"""
 
 from __future__ import annotations
 
@@ -1115,9 +1124,10 @@ async def _backlog_lifespan(_server: object) -> AsyncGenerator[dict[str, object]
 mcp = FastMCP(
     "backlog",
     instructions=(
-        "Backlog management server. Manages per-item markdown files in ~/.dh/projects/{slug}/backlog/, "
-        "syncs with GitHub Issues (source of truth), and provides CRUD operations for "
-        "backlog items including add, list, view, update, groom, close, resolve, and sync."
+        "Backlog management server. The configured backend is the source of truth; this server keeps "
+        "a local cache that syncs with it. Always use these tools for backlog CRUD (add, list, view, "
+        "update, groom, close, resolve, sync) — never read or edit backlog files directly, even if a "
+        "tool call fails; report the failure instead."
     ),
     version="0.1.0",
     lifespan=_backlog_lifespan,

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -2666,8 +2666,8 @@ async def backlog_pull(
 ) -> dict:
     """Reconcile linked issue content.
 
-    Only backends that support reconciliation act on this (currently GitHub) —
-    on other backends this is a no-op; check the returned messages.
+    Only backends that support reconciliation act on this — on other backends
+    this is a no-op; check the returned messages.
 
     Auto-migrates P0/P1 items lacking GitHub Issues by creating them.
     Merges by section using entry-aware merge (keeps longer entries, preserves strikes).

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1260,13 +1260,10 @@ async def backlog_add(
 ) -> dict:
     """Add a new item through the configured backend and optionally create its native issue.
 
-    Use priority P0 for must-have, P1 for should-have, P2 for could-have,
-    or Ideas for exploratory items.
-
     For guided creation with classification and research support, use
     /dh:work-backlog-item create instead of calling this tool directly — it applies
-    the same description template below plus duplicate detection (also enforced
-    here unconditionally) and item-type classification.
+    the same description template below plus item-type classification. Duplicate
+    detection here runs unless force=True.
 
     Returns:
         Dict with file_path, title, priority, issue number (if created),
@@ -1660,35 +1657,19 @@ async def backlog_list(
 ) -> dict:
     """List all open backlog items.
 
-    Use refresh=true to refresh the local cache from the backend before listing.
-    Use label to filter items by a specific GitHub label.
-    Use section to filter by priority section (P0, P1, P2, Ideas).
-    Use status to filter by status value (e.g. needs-grooming, status:in-progress).
-    Use title to filter by title substring (case-insensitive).
-    Use type_ to filter by metadata.type exact match (e.g. Bug, Feature).
-    Use topic to filter by metadata.topic substring match.
-    Use include_closed=true to include items with terminal status (done, resolved, closed).
-    Use search for full-text search across the complete item content (title, section, topic,
-    type, description, and all section body text including acceptance criteria and impact radius).
-    Search supports OR/AND/NOT operators (e.g. 'auth OR deploy', 'backlog NOT quality'),
-    parenthetical grouping ((auth OR deploy) AND quality), regex (/pattern/ or regex:pattern),
-    field-specific syntax (title:auth, type:bug, topic:devops, body:sdlc-layers), and plain substring matching.
-    Use count_only=true to return only {"count": N} without fetching item content.
-    Use offset and limit to paginate results. When limit=0, auto-pagination keeps the
-    response under 4400 tokens (cl100k_base encoding). When has_more=true, call again
-    with the offset shown in next_call.
     When match_context=True, use page/tokens_per_page/page_token_limit to control
-    token-based pagination of match output. When match_pages.paginated=true, use
+    token-based pagination of match output; when match_pages.paginated=true, use
     page=2..N to retrieve subsequent pages.
 
     Returns:
         Dict with items list, count, pagination object, and output messages/warnings.
-        Each item includes state (open/closed) and status (workflow status from status:* labels).
+        Each item includes status (workflow status from status:* labels).
         pagination contains offset, limit, total, and has_more. When has_more=true,
         next_call provides the suggested follow-up call string.
         When match_context=True, match_pages contains current_page, total_pages,
         tokens_per_page, total_match_tokens, and paginated flag.
-        When count_only=True, returns only {"count": N}.
+        When count_only=True, the count key is present; a running background sync
+        may add sync_state/warnings alongside it.
         On error, dict contains an error key.
         Items are deduplicated by issue number — if the cache contained duplicate
         entries, only the first occurrence of each issue number is returned.
@@ -1995,7 +1976,12 @@ async def backlog_view(
     limit: Annotated[int, Field(ge=0, description="Show at most N entry blocks (0 = all, no truncation)")] = 0,
     show: Annotated[
         str | None,
-        Field(description="Entry filter: 'all', 'last', 'first', 'struck', or integer N (first N active entries)"),
+        Field(
+            description=(
+                "Entry filter: 'all', 'last', 'first', 'struck', integer N (first N active "
+                "entries), or negative integer -N (last N active entries)"
+            )
+        ),
     ] = None,
     since: Annotated[
         str | None,
@@ -2013,7 +1999,8 @@ async def backlog_view(
         str | None,
         Field(
             description=(
-                "Section filter for YAML items (no effect on GitHub-only items with a raw body). "
+                "Section filter, matched against ## / ### headings — works on raw GitHub issue "
+                "bodies too, not just structured YAML items. "
                 "Accepts: numeric index '2', comma-separated indices '0,2,4', "
                 "regex '/impact.*/', or substring match 'RT-ICA'. "
                 "When provided, body and sections in the response reflect only the matched section(s)."
@@ -2040,8 +2027,8 @@ async def backlog_view(
             description=(
                 "When True, returns a flat ordinal dot-path map of the item's structure. "
                 "Each line shows an ordinal (e.g. '4.0'), section title, estimated token count, "
-                "and a content preview. Response is always under 2,000 tokens regardless of item size. "
-                "Mutually exclusive with navigate. Use this first to discover valid ordinals."
+                "and a content preview. Mutually exclusive with navigate. Use this first to "
+                "discover valid ordinals."
             )
         ),
     ] = False,
@@ -2086,49 +2073,16 @@ async def backlog_view(
 ) -> dict:
     r"""View a single backlog item or GitHub issue in detail.
 
-    Accepts a GitHub issue URL, #N, bare number, or title substring as selector.
-    Use offset and limit to paginate long issue bodies.
-    Use show and since to filter entry blocks within sections.
-    Use include_content=False to get a compact response with section names and
-    entry counts only, omitting the full body and entry content.
-    Use summary=False to receive the full response; summary=True (default) returns
-    a compact routing manifest that always includes sections_index so callers know
-    exactly which sections exist before deciding what to load.
-    Use section to filter the response to specific sections by index, title, or regex.
-    Use sections=[...] to return only the named sections plus identity fields
-    (number, title, status, type, priority).
-    Use map=True to see the item's ordinal structure (always under 2,000 tokens).
-    Use navigate=<ordinal> to fetch the full content at a specific ordinal.
-    Use navigate=<ordinal> + head=N to extract a token-bounded window (EXTRACT mode);
-    iterate using the next_call hint until truncated=False.
     Ordinal format: ^\d+(\.\d+)*(\.code\.\d+)?$. Examples:
         "4.0"        — section entry (level-2)
         "4.0.1"      — sub-heading within an entry (level-3+)
         "4.0.code.0" — first code fence in an entry's direct body
 
-    Pagination parameter distinction (architect spec §5.7):
-        offset — entry-block index: skip N entry blocks from the start of the body.
-        skip_tokens — within-content token offset for EXTRACT mode pagination only.
-        These are distinct concerns; do not substitute one for the other.
-
-    Progressive disclosure pattern (new, three-layer):
-        Step 1 — call with map=True to see ordinal structure.
-        Step 2 — call with navigate=<ordinal> to fetch a section or entry.
-            navigate="4.0.1" fetches a sub-heading within that entry.
-            navigate="4.0.code.0" fetches the first code fence in that entry.
-        Step 3 — if truncated, page through large content using the next_call hint:
-            backlog_view(selector="...", navigate="4.0", head=4000)
-            backlog_view(selector="...", navigate="4.0", head=4000, skip_tokens=4000)
-
-    Progressive disclosure pattern (legacy, still supported):
-        Step 1 — call with summary=True (default) to get sections_index and metadata.
-        Step 2 — load only the sections needed:
-            backlog_view(selector="...", summary=False, section="Fact-Check")
-            backlog_view(selector="...", summary=False, section="0,1,3")
-            backlog_view(selector="...", summary=False, section="/acceptance|plan/")
+    To page through large content: navigate=<ordinal>, head=4000, then repeat with
+    skip_tokens set from the returned next_call hint until truncated=False.
 
     Returns:
-        When map=True: dict with map_text (ordinal structure, <2,000 tokens), selector,
+        When map=True: dict with map_text (ordinal structure), selector,
         total_sections, total_est_tokens, over_budget flag, and struck_ordinals (every
         struck/retracted ordinal in the map).
         When navigate=<ordinal> (no head): dict with ordinal, title, content,
@@ -2327,7 +2281,7 @@ async def backlog_list_followups(
         Field(
             description=(
                 "Logical ID of the originating plan or task (e.g. 'P1', 'P1/T3'). "
-                "Returns all backlog items whose followup_to matches this value."
+                "Returns backlog items whose followup_to matches this value, excluding skipped items."
             )
         ),
     ],
@@ -2355,7 +2309,12 @@ async def backlog_list_followups(
     )
 )
 async def backlog_close(
-    selector: Annotated[str, Field(description="Item selector: GitHub issue URL, #N, bare number, or title substring")],
+    selector: Annotated[
+        str,
+        Field(
+            description="Item selector: GitHub issue URL, #N, bare number, title substring, or beads nanoid (e.g. bd-a3f8)"
+        ),
+    ],
     reason: Annotated[
         str,
         Field(
@@ -2366,12 +2325,10 @@ async def backlog_close(
         str, Field(description="Related item reference: #N, URL, or title of the item this duplicates/is superseded by")
     ] = "",
     comment: Annotated[str, Field(description="Additional context about why this item is being closed")] = "",
-    cleanup: Annotated[
-        bool, Field(description="Remove local file after close; index link becomes GitHub issue URL")
-    ] = False,
+    cleanup: Annotated[bool, Field(description="Reserved; currently has no effect")] = False,
     force: Annotated[bool, Field(description="Close even if open PRs reference the issue")] = False,
 ) -> dict:
-    """Dismiss a backlog item without completing it and close its GitHub issue.
+    """Dismiss a backlog item without completing it and close it on the configured backend.
 
     Use for items that are duplicates, out of scope, superseded, wontfix,
     or permanently blocked. For completed work, use backlog_resolve instead.
@@ -2415,14 +2372,14 @@ async def backlog_resolve(
     notes: Annotated[str | None, Field(description="Problems found, surprises, or other comments")] = None,
     follow_ups: Annotated[str | None, Field(description="Created follow-up tickets (comma-separated refs)")] = None,
     findings: Annotated[str | None, Field(description="Retrospective learnings from this work")] = None,
-    cleanup: Annotated[
-        bool, Field(description="Remove local file after resolve; index link becomes GitHub issue URL")
-    ] = False,
+    cleanup: Annotated[bool, Field(description="Reserved; currently has no effect")] = False,
     force: Annotated[bool, Field(description="Resolve even if open PRs reference the issue")] = False,
 ) -> dict:
-    """Mark a backlog item as DONE (completed) and close its GitHub issue.
+    """Mark a backlog item as DONE (completed) and close it on the configured backend.
 
-    Creates a structured completion record as an audit/retrospective trail.
+    plan/method/notes/follow_ups/findings become a structured completion comment
+    on the GitHub backend; other backends forward only summary (as the close
+    reason) or discard these fields — they are not persisted to local item state.
     Only summary is required — for trivial items a one-liner suffices.
     For dismissals (duplicate, out of scope, etc.), use backlog_close instead.
 
@@ -2465,13 +2422,7 @@ async def backlog_update(
     plan: Annotated[str | None, Field(description="Path to a plan file to attach to the item")] = None,
     status: Annotated[
         str | None,
-        Field(
-            description=(
-                "Set item status (e.g. 'in-progress') — the only supported way to change an "
-                "item's status labels. Updates GitHub issue labels when applicable, as a side "
-                "effect of this transition."
-            )
-        ),
+        Field(description="Set item status (e.g. 'in-progress'). Updates the backend's status labels when applicable."),
     ] = None,
     section: Annotated[
         str | None, Field(description="Section name for groomed content update (use with content parameter)")
@@ -2512,19 +2463,13 @@ async def backlog_update(
         Field(
             description="Mark the linked work item as verified. "
             "Signals that /complete-implementation quality gates have passed. "
-            "Auto-creates the label if absent. No-op when item has no issue number."
+            "May be a no-op depending on the active backend — check the returned messages."
         ),
     ] = False,
 ) -> dict:
     """Update a backlog item: attach a plan, set status, or write groomed content.
 
-    For groomed content, provide section + content for section updates.
-    Use entry_id to replace a specific entry, or replace_section=True to
-    strike all entries and append new content. Groomed content is synced
-    to the linked work item when the item has one.
-
-    Use verified=True after /complete-implementation quality gates pass to
-    mark the linked work item as verified.
+    Groomed content is synced to the linked work item when the item has one.
 
     Returns:
         Dict with updated item title, applied changes, and output
@@ -2619,19 +2564,14 @@ async def backlog_groom(
         Field(
             description=(
                 "When True, advance item status to groomed after content is written: set local frontmatter "
-                "status to 'groomed', remove status:needs-grooming label (idempotent), and add status:groomed "
-                "label (created if absent). Default False preserves existing behavior."
+                "status to 'groomed' and update the backend's status labels. No effect on backends without "
+                "a groomed lifecycle state — check the returned messages."
             )
         ),
     ] = False,
 ) -> dict:
     """Write groomed content through the configured backend and sync its linked GitHub issue.
 
-    Provide section + content for section updates. Use entry_id to replace
-    a specific entry, or replace_section=True to strike all entries and
-    append new content. Set append=True to add content after existing section
-    text without entry-block wrapping. Use sections for atomic multi-section
-    writes in a single call — mutually exclusive with section/content/etc.
     When the item has a GitHub issue, the groomed content is synced there
     automatically.
 
@@ -2687,9 +2627,6 @@ async def backlog_normalize(
 ) -> dict:
     """Normalize all work items through the configured backend.
 
-    This is a one-off maintenance operation. Use dry_run=true to preview
-    what would change.
-
     Returns:
         Dict with count of normalized files and output messages/warnings.
         On error, dict contains an error key.
@@ -2700,7 +2637,7 @@ async def backlog_normalize(
         result = await asyncio.to_thread(operations.normalize_items, dry_run=dry_run, output=out)
         for w in out.warnings:
             await ctx.warning(w)
-        updated = result.get("updated", 0)
+        updated = result.get("normalized", 0)
         suffix = " (dry-run)" if dry_run else ""
         await ctx.info(f"Normalized {updated} file(s){suffix}")
         return {**result, **out.to_dict()}
@@ -2727,15 +2664,13 @@ async def backlog_pull(
     ] = False,
     diff: Annotated[bool, Field(description="Include entry-level diff output showing local vs remote changes")] = False,
 ) -> dict:
-    """Reconcile linked issue content through the configured sync backend.
+    """Reconcile linked issue content.
 
-    When selector is provided, pulls a single issue by #N, bare number,
-    GitHub URL, or title substring. When omitted, pulls all issues.
+    Only backends that support reconciliation act on this (currently GitHub) —
+    on other backends this is a no-op; check the returned messages.
 
     Auto-migrates P0/P1 items lacking GitHub Issues by creating them.
-    Merges by section using entry-aware merge (keeps longer entries,
-    preserves strikes). Use dry_run=true to preview changes.
-    Use diff=true to include entry-level diff output.
+    Merges by section using entry-aware merge (keeps longer entries, preserves strikes).
 
     Returns:
         Dict with count of pulled items (bulk) or file_path (single) and
@@ -2783,10 +2718,9 @@ async def backlog_create_sam_task(
 ) -> dict:
     """Create a GitHub sub-issue for a SAM task under a parent story issue.
 
-    Use to bootstrap GitHub visibility for a task when starting a new feature plan.
-
     Returns:
-        Dict with issue_number, title, url, and output messages. On error, returns error key.
+        Dict with issue_number, title, url (always empty), and output messages.
+        On error, returns error key.
     """
     out = Output()
     try:
@@ -2946,15 +2880,14 @@ async def artifact_register(
     artifact_id already exists it is updated in-place (status, agent, timestamp).
     If only the type matches but the artifact_id differs, a new row is added.
 
-    Content is written under the selected backend's logical artifact-content
-    reference before its revision-safe manifest entry is registered.
-
     Returns:
         Dict with registered (bool), artifact_count (int), action (str),
         content_stored (bool), and output messages/warnings.
 
-    Raises:
-        BacklogError: The selected backend could not store the artifact or its manifest.
+    A dict with an ``error`` key is returned for a ``BacklogError``. A
+    ``ContentUnavailableError`` or ``ContentConflictError`` (the backend could
+    not store the artifact or its manifest) is not caught here and surfaces as
+    a tool call error, not a dict.
     """
     out = Output()
     try:
@@ -2999,8 +2932,7 @@ async def artifact_list(
 ) -> dict:
     """Return all artifacts registered for a backlog item.
 
-    Optionally filter by artifact type. Returns an empty list when no
-    manifest section exists yet — this is not an error.
+    Returns an empty list when no manifest section exists yet — this is not an error.
 
     Returns:
         Dict with artifacts (list of dicts), count (int), and output
@@ -3008,7 +2940,9 @@ async def artifact_list(
 
     Raises:
         ValueError: ``artifact_type`` is not an ``ArtifactType`` member.
-        BacklogError: The selected backend could not resolve the manifest.
+        ContentUnavailableError: The selected backend could not resolve the
+            manifest. Not caught here — surfaces as a tool call error, not
+            the documented error dict.
     """
     out = Output()
     try:
@@ -3055,9 +2989,7 @@ async def artifact_get(
     """Return metadata for artifacts registered on a backlog item under one type.
 
     Omitting ``artifact_id`` returns every entry of the type (e.g. multiple
-    codebase-analysis files). Supplying it returns the single addressed entry, matching
-    ``dh_core.operations.artifact_get`` and the ``artifact get --artifact-id`` CLI option,
-    so both surfaces can address an artifact the same way.
+    codebase-analysis files). Supplying it returns the single addressed entry.
 
     Returns:
         Dict with artifacts (list of dicts), count (int), and output
@@ -3067,7 +2999,9 @@ async def artifact_get(
 
     Raises:
         ValueError: ``artifact_type`` is not an ``ArtifactType`` member.
-        BacklogError: The selected backend could not resolve the manifest.
+        ContentUnavailableError: The selected backend could not resolve the
+            manifest. Not caught here — surfaces as a tool call error, not
+            the documented error dict.
     """
     out = Output()
     try:
@@ -3120,9 +3054,7 @@ async def artifact_read(
     logical identifier. This layer does not access local artifact files.
 
     Omitting ``artifact_id`` returns the most recently registered entry of the type.
-    Supplying it addresses one specific entry, matching
-    ``dh_core.operations.artifact_read`` and the ``artifact read --artifact-id`` CLI
-    option, so both surfaces can address an artifact the same way.
+    Supplying it addresses one specific entry.
 
     Returns:
         Dict with type (str), path (str), content (str), status (str), and
@@ -3132,7 +3064,9 @@ async def artifact_read(
 
     Raises:
         ValueError: ``artifact_type`` is not an ``ArtifactType`` member.
-        BacklogError: The selected backend could not resolve the manifest.
+        ContentUnavailableError: The selected backend could not resolve the
+            manifest. Not caught here — surfaces as a tool call error, not
+            the documented error dict.
     """
     out = Output()
     try:
@@ -3177,15 +3111,13 @@ async def artifact_read(
     )
 )
 async def backlog_get_ready_sam_tasks(
-    parent_issue_number: Annotated[int, Field(description="Parent story issue number (GitHub issue integer)")],
+    parent_issue_number: Annotated[int, Field(description="Parent story issue number (native reference)")],
 ) -> dict:
-    """Return SAM tasks ready for execution from GitHub sub-issues.
+    """Return SAM tasks whose status is not-started and all dependencies are terminal.
 
-    Fetches sub-issues, resolves dependency graph locally, returns tasks whose
-    status is not-started and all dependencies are terminal.
-    Output shape matches implementation_manager.py ready-tasks JSON:
-    feature, ready_tasks, count. Each ready_task includes id, name, agent, skills, issue_number.
-    Falls back to local cache if GitHub is unavailable.
+    Returns:
+        Dict with feature (slug), ready_tasks (list), count. Each ready_task
+        contains id, name, agent, skills, issue_number.
     """
     out = Output()
     try:
@@ -3250,13 +3182,11 @@ async def backlog_strike_entry(
     )
 )
 async def backlog_list_labels(limit: Annotated[int, Field(description="Maximum labels to return")] = 100) -> dict:
-    """List repository labels (read-only).
+    """List repository labels. Requires a backend with label support — errors otherwise.
 
-    Returns all labels defined on the repository, up to ``limit``.
-    This tool is read-only. Status labels change as a side effect of
-    ``backlog_update``, ``backlog_groom``, ``backlog_resolve``, or
-    ``backlog_close`` changing an item's status — there is no separate
-    label-mutation tool to call directly.
+    Returns all labels defined on the repository, up to ``limit``. There is no
+    separate label-mutation tool; labels change as a side effect of ``backlog_update``,
+    ``backlog_groom``, ``backlog_resolve``, or ``backlog_close`` changing an item's status.
 
     Returns:
         Dict with ``labels`` (list of dicts with ``name``, ``color``, ``description``),
@@ -3289,7 +3219,7 @@ async def backlog_list_merged_prs(
     ] = None,
     limit: Annotated[int, Field(description="Maximum number of PRs to return")] = 20,
 ) -> dict:
-    """List merged pull requests, optionally filtered by a search query.
+    """List merged pull requests. Requires a backend with PR support — errors otherwise.
 
     Only PRs that were actually merged (not just closed) are returned.
     Use ``search`` to filter by issue reference (e.g. ``'#42'``) or any
@@ -3319,7 +3249,8 @@ async def backlog_list_milestones(
 ) -> dict:
     """List repository milestones filtered by state.
 
-    Returns milestones with their issue counts and optional due dates.
+    Requires a backend with milestone support — errors otherwise. Returns
+    milestones with their issue counts and optional due dates.
 
     Returns:
         Dict with ``milestones`` (list of dicts with ``number``, ``title``,
@@ -3343,7 +3274,8 @@ async def backlog_list_milestones(
 async def backlog_get_soonest_milestone() -> dict:
     """Return the open milestone with the earliest due date.
 
-    Milestones without a due date are excluded. If all open milestones
+    Requires a backend with milestone support — errors otherwise. Milestones
+    without a due date are excluded. If all open milestones
     lack a due date, the first one by GitHub's default ordering is returned
     with a warning.
 
@@ -3376,6 +3308,8 @@ async def backlog_create_milestone(
     ] = None,
 ) -> dict:
     """Create a new milestone on the repository.
+
+    Requires a backend with milestone support — errors otherwise.
 
     Returns:
         Dict with ``milestone`` containing ``number``, ``title``, ``state``,
@@ -3432,8 +3366,10 @@ async def backlog_comment_issue(
     """Add a comment to a GitHub issue.
 
     Returns:
-        Dict with issue_number, comment_id, comment_url, and output messages/warnings.
-        On error, dict contains an error key.
+        Dict with issue_number, comment_id (a GraphQL node ID — not usable as
+        backlog_read_comment's comment_id, which requires a REST integer ID),
+        comment_url (always empty), and output messages/warnings. On error,
+        dict contains an error key.
     """
     out = Output()
     try:
@@ -3480,7 +3416,11 @@ async def backlog_read_comment(
     comment_id: Annotated[
         int,
         Field(
-            description="REST comment database ID (integer). Use the GitHub REST API or issue comment list to obtain this ID."
+            description=(
+                "REST comment database ID (integer) — obtain it from the GitHub REST API. Not "
+                "the value backlog_list_comments/backlog_comment_issue return; those are GraphQL "
+                "node IDs and will not work here."
+            )
         ),
     ],
 ) -> dict:
@@ -3594,8 +3534,8 @@ def _try_register_dispatch_plan_artifact(item_id: ItemId, artifact_id: str, cont
 async def dispatch_read(milestone_number: Annotated[int, Field(description="GitHub milestone number")]) -> dict:
     """Read a dispatch plan for the given milestone.
 
-    Loads and returns the full plan as a dict. Returns an error dict if
-    the plan file does not exist or fails YAML/schema validation.
+    Returns an error dict if no plan is stored for this milestone or it
+    fails schema validation.
 
     Returns:
         Dict with ``milestone_number`` and ``plan`` (full plan
@@ -3653,9 +3593,10 @@ async def dispatch_stale_check(
 ) -> dict:
     """Check whether a dispatch plan is stale relative to the current milestone.
 
-    Fetches open issues assigned to the milestone from GitHub, compares
-    their issue numbers against those in the plan, and returns a stale/fresh
-    indicator with added/removed issue lists.
+    Requires a backend with milestone support — errors otherwise. Fetches the
+    milestone's issues (open and closed), compares their issue
+    numbers against those in the plan, and returns a stale/fresh indicator
+    with added/removed issue lists.
 
     Returns:
         Dict with ``is_stale`` (bool), ``added_issues`` (list[int]),
@@ -3704,8 +3645,8 @@ async def dispatch_create_plan(
         bool,
         Field(
             description=(
-                "Allow overwriting an existing plan file. When False (default), returns an error "
-                "if plan/milestone-{N}-dispatch.yaml already exists."
+                "Allow overwriting an existing stored plan. When False (default), returns an "
+                "error if a plan for this milestone already exists."
             )
         ),
     ] = False,
@@ -3728,22 +3669,12 @@ async def dispatch_create_plan(
         ),
     ] = None,
 ) -> dict:
-    """Create or overwrite a dispatch plan YAML file for a milestone.
+    """Create or overwrite a stored dispatch plan for a milestone.
 
-    Accepts a typed ``DispatchPlan`` model, writes it atomically to
-    ``plan/milestone-{N}-dispatch.yaml``, and optionally validates structural
-    integrity after writing.
-
-    Args:
-        milestone_number: GitHub milestone number.
-        plan: The dispatch plan for this milestone. ``plan.milestone.number``
-            must match ``milestone_number``.
-        overwrite: When ``False`` (default) returns an error if the plan file
-            already exists.
-        validate: When ``True`` (default) runs ``validate_plan_integrity`` after
-            writing and includes the result in the response.
-        issue: Optional GitHub issue number.  When provided, auto-registers the
-            plan file as a ``dispatch-plan`` artifact (best-effort).
+    Accepts a typed ``DispatchPlan`` model, stores it atomically through the
+    configured content backend, and optionally validates structural integrity
+    after writing. On the GitHub backend, writing a genuinely new plan (not
+    byte-identical to what's stored) is unsupported and returns an error.
 
     Returns:
         Success dict with ``milestone_number``, ``wave_count``,
@@ -3808,9 +3739,9 @@ async def dispatch_create_plan(
         "wave_count": wave_count,
         "item_count": item_count,
         "is_valid": is_valid,
+        **out.to_dict(),
         "errors": val_errors,
         "warnings": val_warnings,
-        **out.to_dict(),
     }
 
 
@@ -3942,12 +3873,15 @@ async def dispatch_wave_start(
         and ``messages``/``warnings``. Returns ``error`` if the wave already
         exists or if an item entry is malformed.
     """
-    item_records = [
-        _DispatchItemRecord(
-            milestone=milestone, wave_num=wave_num, issue=int(str(item["issue"])), title=str(item.get("title", ""))
-        )
-        for item in items
-    ]
+    try:
+        item_records = [
+            _DispatchItemRecord(
+                milestone=milestone, wave_num=wave_num, issue=int(str(item["issue"])), title=str(item.get("title", ""))
+            )
+            for item in items
+        ]
+    except (KeyError, ValueError) as exc:
+        return {"error": f"Malformed item entry: {exc}", "milestone": milestone, "wave_num": wave_num}
     try:
         wave: _DispatchWaveRecord = await asyncio.to_thread(
             _dispatch_state_manager().create_wave, milestone, wave_num, item_records
@@ -3993,7 +3927,8 @@ async def dispatch_item_status(
 
     Returns:
         Dict with ``milestone``, ``issue``, ``wave_num``, ``status``,
-        ``messages``/``warnings``. Returns ``error`` key if item not found.
+        ``messages``/``warnings``. Returns ``error`` key if item not found
+        or ``status`` is not one of complete/failed/skipped.
     """
     mgr = _dispatch_state_manager()
 
@@ -4053,13 +3988,16 @@ async def dispatch_wave_status(
 ) -> dict:
     """Query the current status of a dispatch wave.
 
-    Returns item-level detail grouped by status, with elapsed time and
-    progress counts. Checks PIDs for in-progress items and marks dead
-    ones as failed before returning.
+    Returns items as a flat list (in issue order) plus per-status counts and
+    elapsed time. Before querying, checks PIDs for ALL in-progress items across
+    every milestone/wave and marks dead ones as failed — this can mutate waves
+    other than the one requested; only stale items in the requested wave are
+    reported in the returned warnings.
 
     Returns:
         Dict with :class:`~backlog_core.models.DispatchWaveSummary` fields,
-        or ``error`` if wave not found.
+        or ``error`` if wave not found. accumulated_usage is currently always
+        zero (not yet wired up).
     """
     mgr = _dispatch_state_manager()
     warnings: list[str] = []
@@ -4092,9 +4030,7 @@ async def dispatch_wave_status(
             end = _datetime.fromisoformat(wave.completed_at) if wave.completed_at else _datetime.now(UTC)
             elapsed = (end - start).total_seconds()
 
-    # Usage accumulation is deferred to item completion time (dispatch_item_status)
-    # and stored in wave/item records. Reading JSONL on every wave query is a
-    # hot-path bloat issue; accumulated_usage is returned from stored dispatch state.
+    # TODO: not yet wired to stored dispatch state — always zero. See docstring.
     accumulated_usage = {
         "input_tokens": 0,
         "output_tokens": 0,

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1,8 +1,9 @@
 """FastMCP 3.x server exposing all backlog operations as MCP tools.
 
 Exists to guarantee what raw file or API access cannot:
-1. Correct, durable, audit-preserving backlog state across whichever backend is
-   configured, under concurrent writers.
+1. Correct, audit-preserving backlog state across whichever backend is
+   configured, under concurrent writers — durable for every backend except
+   the in-memory one, an intentionally non-durable test double.
 2. A structured, resource-bounded interface for the calling agent — safety
    annotations, typed errors, token-budget-aware pagination — in place of
    CLI/stderr parsing or unbounded reads.

--- a/plugins/development-harness/tests/test_backlog_core_server.py
+++ b/plugins/development-harness/tests/test_backlog_core_server.py
@@ -2015,7 +2015,7 @@ async def test_backlog_groom_ctx_warning_surfaces_output_warnings():
 
 async def test_backlog_normalize_ctx_info_start_message():
     """backlog_normalize emits ctx.info with start message before operation."""
-    op_result = {"updated": 3}
+    op_result = {"normalized": 3}
     with (
         patch("dh_core.operations.normalize_items", return_value=op_result),
         patch("fastmcp.server.context.Context.log", new_callable=AsyncMock) as mock_log,
@@ -2028,7 +2028,7 @@ async def test_backlog_normalize_ctx_info_start_message():
 
 async def test_backlog_normalize_ctx_info_start_message_dry_run():
     """backlog_normalize emits ctx.info with '(dry-run)' suffix when dry_run=True."""
-    op_result = {"updated": 0}
+    op_result = {"normalized": 0}
     with (
         patch("dh_core.operations.normalize_items", return_value=op_result),
         patch("fastmcp.server.context.Context.log", new_callable=AsyncMock) as mock_log,
@@ -2041,7 +2041,7 @@ async def test_backlog_normalize_ctx_info_start_message_dry_run():
 
 async def test_backlog_normalize_ctx_info_completion_message():
     """backlog_normalize emits ctx.info with 'Normalized N file(s)' after operation."""
-    op_result = {"updated": 7}
+    op_result = {"normalized": 7}
     with (
         patch("dh_core.operations.normalize_items", return_value=op_result),
         patch("fastmcp.server.context.Context.log", new_callable=AsyncMock) as mock_log,
@@ -2054,7 +2054,7 @@ async def test_backlog_normalize_ctx_info_completion_message():
 
 async def test_backlog_normalize_ctx_info_completion_message_dry_run():
     """backlog_normalize completion message includes '(dry-run)' suffix."""
-    op_result = {"updated": 2}
+    op_result = {"normalized": 2}
     with (
         patch("dh_core.operations.normalize_items", return_value=op_result),
         patch("fastmcp.server.context.Context.log", new_callable=AsyncMock) as mock_log,

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -567,6 +567,38 @@ def test_transaction_prefers_json_when_both_legacy_and_new_files_exist(tmp_path:
     assert store._legacy_state_path.with_name("cache.yaml.superseded").exists()
 
 
+def test_transaction_merges_queue_entries_from_a_legacy_file_recreated_by_older_code(tmp_path: Path) -> None:
+    # Given: cache.json already exists (a newer version migrated once), but an
+    # older plugin copy unaware of the rename later ran and wrote its own new
+    # offline mutation into a fresh cache.yaml -- the concurrent-mixed-version
+    # scenario named in _migrate_legacy_state_file's ponytail note
+    store = _CacheStateStore(tmp_path)
+    current_state = _populated_cache_state()
+    _write_new_json(store._state_path, current_state)
+
+    older_ref = _reference("#9")
+    older_write = ContentWrite(reference=older_ref, content="queued by older code", expected_revision="rev-1")
+    older_pending = PendingMutation(idempotency_key=_content_mutation_key(older_write), write=older_write)
+    older_item = BacklogItem(title="Queued by older code")
+    older_work_item = _PendingWorkItemMutation(
+        idempotency_key=_work_item_mutation_key("#9", older_item), key="#9", item=older_item
+    )
+    legacy_state = _CacheState(pending=[older_pending], pending_work_items=[older_work_item])
+    _write_legacy_yaml(store._legacy_state_path, legacy_state)
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: the older code's queued writes survive, merged into cache.json's
+    # existing queue -- not silently discarded when cache.yaml is superseded
+    loaded = store.load()
+    assert older_pending in loaded.pending
+    assert older_work_item in loaded.pending_work_items
+    assert all(entry in loaded.pending for entry in current_state.pending)
+    assert not store._legacy_state_path.exists()
+    assert store._legacy_state_path.with_name("cache.yaml.superseded").exists()
+
+
 def test_migration_leaves_lock_and_snapshot_items_untouched(tmp_path: Path) -> None:
     # Given: a legacy cache.yaml alongside the lock file and a per-item snapshot
     state = _populated_cache_state()
@@ -681,8 +713,44 @@ def test_load_salvages_valid_entries_when_one_pending_work_item_is_malformed(tmp
     # When: the store loads it
     loaded = store.load()
 
-    # Then: the malformed entry is dropped, the valid one survives, nothing raises
+    # Then: the malformed entry is removed from pending_work_items (it never
+    # became a valid model), the valid one survives, nothing raises -- and the
+    # malformed entry's raw payload is preserved in corrupt_queue_entries
+    # rather than silently lost (see the version-skew test below for why:
+    # "missing a required field" is exactly what schema evolution looks like)
     assert loaded.pending_work_items == [good_entry]
+    assert len(loaded.corrupt_queue_entries) == 1
+    preserved = loaded.corrupt_queue_entries[0]
+    assert preserved.field == "pending_work_items"
+    assert preserved.raw == {"idempotency_key": "whatever", "key": "#2"}
+
+
+def test_load_preserves_raw_payload_when_a_newer_version_adds_a_required_field(tmp_path: Path) -> None:
+    # Given: a pending entry written by a newer plugin version whose schema
+    # gained a required field this version's PendingMutation doesn't have --
+    # the strongest real justification for per-entry salvage in the first
+    # place. Missing-required-field is indistinguishable at validation time
+    # from any other malformed entry, so this exercises the same code path
+    # as a hand-edit -- the point is that it's preserved either way.
+    store = _CacheStateStore(tmp_path)
+    raw = json.loads(_CacheState().model_dump_json())
+    raw["pending"] = [
+        {
+            "idempotency_key": "whatever-the-newer-version-computed",
+            "write": {"reference": {"kind": "plan", "namespace": "", "artifact_type": "", "name": "P1.yaml"}},
+            "a_required_field_from_a_future_version": "unknown to this reader",
+        }
+    ]
+    store._state_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    # When: this (older) version loads it
+    loaded = store.load()
+
+    # Then: not silently lost -- the raw entry survives for manual recovery
+    assert loaded.pending == []
+    assert len(loaded.corrupt_queue_entries) == 1
+    assert loaded.corrupt_queue_entries[0].field == "pending"
+    assert loaded.corrupt_queue_entries[0].raw == raw["pending"][0]
 
 
 def test_load_dead_letters_pending_entry_with_mismatched_idempotency_key(tmp_path: Path) -> None:

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -869,6 +869,46 @@ def test_load_dead_letters_pending_entry_from_version_skew_not_just_hand_edits(t
     assert loaded.rejected[0].write.content == "from a newer version"
 
 
+def test_load_preserves_a_stored_rejected_entry_that_fails_schema_validation(tmp_path: Path) -> None:
+    # Given: a stored rejected entry (already the terminal recovery record for
+    # a prior key mismatch) that itself fails schema validation on this load
+    # -- e.g. its nested ContentWrite gained a required field on a later
+    # version. Routed through _salvage_list before this fix, it would have
+    # been silently dropped -- losing the only remaining copy of what it held.
+    good_state = _populated_cache_state()
+    raw = json.loads(good_state.model_dump_json())
+    raw["rejected"] = [{"idempotency_key": "whatever", "write": {"reference": {}}}]  # missing "reason", malformed ref
+    store = _CacheStateStore(tmp_path)
+    store._state_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    # When: the store loads it
+    loaded = store.load()
+
+    # Then: not silently lost -- preserved as a corrupt_queue_entries record
+    assert loaded.rejected == []
+    corrupt = [entry for entry in loaded.corrupt_queue_entries if entry.field == "rejected"]
+    assert len(corrupt) == 1
+    assert corrupt[0].raw == raw["rejected"][0]
+
+
+def test_load_preserves_a_malformed_non_list_queue_field_as_a_single_corrupt_entry(tmp_path: Path) -> None:
+    # Given: pending_work_items itself is not a list at all (e.g. corrupted to
+    # a bare string) -- a coarser failure than one bad entry within the list
+    store = _CacheStateStore(tmp_path)
+    raw = json.loads(_CacheState().model_dump_json())
+    raw["pending_work_items"] = "not-a-list-at-all"
+    store._state_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    # When: the store loads it
+    loaded = store.load()
+
+    # Then: the whole raw value is preserved, not silently discarded
+    assert loaded.pending_work_items == []
+    corrupt = [entry for entry in loaded.corrupt_queue_entries if entry.field == "pending_work_items"]
+    assert len(corrupt) == 1
+    assert corrupt[0].raw == "not-a-list-at-all"
+
+
 def test_load_does_not_key_check_rejected_entries(tmp_path: Path) -> None:
     # Given: a rejected entry with a stale key from before its mutation was
     # queue_write-superseded -- rejected entries are inert inspection records,

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from threading import Barrier, Thread
 from unittest.mock import MagicMock
 
-import pydantic
 import pytest
 from backlog_core import file_cache
 from backlog_core.file_cache import CacheCheckpoint, FileCache, ReplayAcknowledgement, _ProviderSnapshotCheckpoint
@@ -16,11 +15,14 @@ from backlog_core.file_cache_state import (
     PendingMutation,
     _CacheState,
     _CacheStateStore,
+    _content_mutation_key,
     _PendingWorkItemMutation,
     _RejectedMutation,
+    _work_item_mutation_key,
 )
 from backlog_core.models import (
     BacklogItem,
+    CacheStateCorruptError,
     ContentKind,
     ContentRecord,
     ContentRef,
@@ -432,23 +434,23 @@ def test_get_content_surfaces_the_rejection_reason_for_a_rejected_reference(tmp_
 
 
 def _populated_cache_state() -> _CacheState:
-    # A realistic mix of the nested models actually persisted to cache.yaml.
+    # A realistic mix of the nested models actually persisted to cache.json.
+    # pending/pending_work_items keys are derived through the real formula
+    # (not hardcoded) so they pass the idempotency-key self-consistency check
+    # on load -- a hardcoded fake key would be dead-lettered as a hand-edit.
     artifact_ref = _reference("#1")
     plan_ref = ContentRef(kind=ContentKind.PLAN, name="P12.yaml")
+    pending_write = ContentWrite(reference=artifact_ref, content="updated", expected_revision="rev-1")
+    work_item = BacklogItem(title="Offline edit")
     return _CacheState(
         records=[
             _record(artifact_ref, "artifact body"),
             ContentRecord(reference=plan_ref, owner_reference="", content="plan body", revision="rev-2", stale=True),
         ],
         checkpoints=[CacheCheckpoint(reference=artifact_ref, revision="rev-1", fingerprint="fp-1")],
-        pending=[
-            PendingMutation(
-                idempotency_key="key-1",
-                write=ContentWrite(reference=artifact_ref, content="updated", expected_revision="rev-1"),
-            )
-        ],
+        pending=[PendingMutation(idempotency_key=_content_mutation_key(pending_write), write=pending_write)],
         pending_work_items=[
-            _PendingWorkItemMutation(idempotency_key="key-2", key="#1", item=BacklogItem(title="Offline edit"))
+            _PendingWorkItemMutation(idempotency_key=_work_item_mutation_key("#1", work_item), key="#1", item=work_item)
         ],
         snapshot_checkpoint=_ProviderSnapshotCheckpoint(watermark="2026-08-12T01:00:00Z"),
     )
@@ -466,20 +468,22 @@ def _write_new_json(path: Path, state: _CacheState) -> None:
 
 
 def test_load_reads_legacy_yaml_cache_file_with_full_fidelity(tmp_path: Path) -> None:
-    # Given: a cache.yaml written the way every process writes it today
+    # Given: a cache.yaml written the way every process wrote it before the
+    # cache.json rename -- the legacy path, not the (now cache.json) accessor
     state = _populated_cache_state()
     store = _CacheStateStore(tmp_path)
-    _write_legacy_yaml(store._state_path, state)
+    _write_legacy_yaml(store._legacy_state_path, state)
 
-    # When: the store loads it
+    # When: the store loads it (read-only -- no migration, no write)
     loaded = store.load()
 
     # Then: every record, checkpoint, pending mutation, and snapshot survives intact
     assert loaded == state
+    assert not store._state_path.exists()
 
 
 def test_load_reads_new_json_cache_file_with_full_fidelity(tmp_path: Path) -> None:
-    # Given: a cache.yaml written by a process that already has the JSON-codec fix
+    # Given: a cache.json written by the store's own save path
     state = _populated_cache_state()
     store = _CacheStateStore(tmp_path)
     _write_new_json(store._state_path, state)
@@ -491,20 +495,118 @@ def test_load_reads_new_json_cache_file_with_full_fidelity(tmp_path: Path) -> No
     assert loaded == state
 
 
-def test_yaml_safe_load_already_parses_json_written_cache_files(tmp_path: Path) -> None:
-    # Given: a cache.yaml written by a process running the new JSON-codec fix
+def test_load_performs_no_writes(tmp_path: Path) -> None:
+    # Given: a legacy-only root -- regression guard for the deadlock fix: load()
+    # must never migrate or write, only transaction() may (see file_cache_state.py
+    # _migrate_legacy_state_file's docstring for why doing it in load() deadlocks)
     state = _populated_cache_state()
-    path = tmp_path / "cache.yaml"
-    _write_new_json(path, state)
+    store = _CacheStateStore(tmp_path)
+    _write_legacy_yaml(store._legacy_state_path, state)
+    before = sorted(p.name for p in tmp_path.iterdir())
 
-    # When: an old-code process reads it using only its current YAML-safe-load logic
-    yaml = YAML(typ="safe")
-    with path.open(encoding="utf-8") as stream:
-        loaded = _CacheState.model_validate(yaml.load(stream))
+    # When: the store loads it
+    store.load()
 
-    # Then: it round-trips correctly, because JSON is valid YAML -- this is the
-    # backward-compatibility property the migration depends on
-    assert loaded == state
+    # Then: the directory is untouched -- no cache.json, no cache.lock
+    assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+
+def test_transaction_migrates_legacy_yaml_to_json(tmp_path: Path) -> None:
+    # Given: a genuine legacy YAML cache.yaml (not JSON wearing the extension)
+    state = _populated_cache_state()
+    store = _CacheStateStore(tmp_path)
+    _write_legacy_yaml(store._legacy_state_path, state)
+
+    # When: a transaction runs (the only path that migrates)
+    result = store.transaction(lambda s: (s, None))
+
+    # Then: cache.json exists with identical content, cache.yaml is gone (superseded,
+    # not deleted), and the transaction's own read saw the migrated state
+    assert result is None
+    assert store._state_path.exists()
+    assert not store._legacy_state_path.exists()
+    assert store._legacy_state_path.with_name("cache.yaml.superseded").exists()
+    assert store.load() == state
+
+
+def test_transaction_renames_already_json_legacy_file_without_rewriting(tmp_path: Path) -> None:
+    # Given: a cache.yaml that's already JSON (written by code after the format
+    # fix but before the rename) -- the json.loads-succeeds discriminator path
+    state = _populated_cache_state()
+    store = _CacheStateStore(tmp_path)
+    _write_new_json(store._legacy_state_path, state)
+    original_bytes = store._legacy_state_path.read_bytes()
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: renamed byte-for-byte, no ".superseded" leftover (nothing to supersede
+    # -- the rename consumed the only copy), no rewrite occurred
+    assert store._state_path.read_bytes() == original_bytes
+    assert not store._legacy_state_path.exists()
+    assert not store._legacy_state_path.with_name("cache.yaml.superseded").exists()
+
+
+def test_transaction_prefers_json_when_both_legacy_and_new_files_exist(tmp_path: Path) -> None:
+    # Given: both cache.json and a stale cache.yaml present (e.g. post-downgrade-
+    # then-upgrade)
+    current_state = _populated_cache_state()
+    store = _CacheStateStore(tmp_path)
+    _write_new_json(store._state_path, current_state)
+    stale_state = _CacheState()
+    _write_legacy_yaml(store._legacy_state_path, stale_state)
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: cache.json (the real current state) wins; the stale cache.yaml is
+    # superseded, not destroyed
+    assert store.load() == current_state
+    assert not store._legacy_state_path.exists()
+    assert store._legacy_state_path.with_name("cache.yaml.superseded").exists()
+
+
+def test_migration_leaves_lock_and_snapshot_items_untouched(tmp_path: Path) -> None:
+    # Given: a legacy cache.yaml alongside the lock file and a per-item snapshot
+    state = _populated_cache_state()
+    store = _CacheStateStore(tmp_path)
+    _write_legacy_yaml(store._legacy_state_path, state)
+    (tmp_path / "cache.lock").touch()
+    items_dir = tmp_path / "items"
+    items_dir.mkdir()
+    (items_dir / "issues" / "12.yaml").parent.mkdir(parents=True)
+    (items_dir / "issues" / "12.yaml").write_text("title: kept\n", encoding="utf-8")
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: the lock file is never renamed (it's what gives old and new plugin
+    # copies mutual exclusion) and per-item snapshots are untouched
+    assert (tmp_path / "cache.lock").exists()
+    assert (items_dir / "issues" / "12.yaml").read_text(encoding="utf-8") == "title: kept\n"
+
+
+def test_migration_is_serialized_across_threads(tmp_path: Path) -> None:
+    # Given: a legacy cache.yaml and several threads racing to be the one that migrates it
+    state = _populated_cache_state()
+    store = _CacheStateStore(tmp_path)
+    _write_legacy_yaml(store._legacy_state_path, state)
+    start = Barrier(5)
+
+    def run() -> None:
+        start.wait()
+        store.transaction(lambda s: (s, None))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(run) for _ in range(4)]
+        start.wait()
+        for future in futures:
+            future.result()
+
+    # Then: exactly one migration happened -- no data lost, no leftover legacy file
+    assert store.load() == state
+    assert not store._legacy_state_path.exists()
+    assert store._legacy_state_path.with_name("cache.yaml.superseded").exists()
 
 
 def test_save_writes_content_parseable_as_plain_json(tmp_path: Path) -> None:
@@ -513,10 +615,11 @@ def test_save_writes_content_parseable_as_plain_json(tmp_path: Path) -> None:
     store = _CacheStateStore(tmp_path)
     store._save(state)
 
-    # When: the raw bytes on disk are parsed as plain JSON (not YAML)
+    # Then: the state file is actually named cache.json now (the direct
+    # regression guard for the rename -- nothing else in this suite asserts
+    # the filename), and its raw bytes parse as plain JSON, not YAML
+    assert store._state_path.name == "cache.json"
     raw_text = store._state_path.read_text(encoding="utf-8")
-
-    # Then: json.loads succeeds directly, proving the on-disk format is JSON
     json.loads(raw_text)
 
 
@@ -534,7 +637,7 @@ def test_empty_state_round_trips_through_save_and_load(tmp_path: Path) -> None:
 
 
 def test_load_returns_empty_state_when_file_is_missing(tmp_path: Path) -> None:
-    # Given: a cache root with no cache.yaml written yet
+    # Given: a cache root with neither cache.json nor cache.yaml written yet
     store = _CacheStateStore(tmp_path)
 
     # When: the store loads it
@@ -544,14 +647,83 @@ def test_load_returns_empty_state_when_file_is_missing(tmp_path: Path) -> None:
     assert loaded == _CacheState()
 
 
-def test_load_raises_instead_of_silently_returning_empty_state_for_corrupt_file(tmp_path: Path) -> None:
-    # Given: a cache.yaml that exists but is neither valid JSON nor a valid _CacheState
+def test_load_raises_typed_error_for_file_that_is_neither_json_nor_yaml(tmp_path: Path) -> None:
+    # Given: a cache.json that parses as neither JSON nor YAML
+    store = _CacheStateStore(tmp_path)
+    store._state_path.write_text("{[", encoding="utf-8")
+
+    # When/Then: loading raises the typed error, not a raw ruamel.yaml.YAMLError
+    with pytest.raises(CacheStateCorruptError):
+        store.load()
+
+
+def test_load_raises_typed_error_for_file_that_parses_to_a_non_mapping(tmp_path: Path) -> None:
+    # Given: a cache.json that's valid YAML (a plain scalar) but not a mapping
     store = _CacheStateStore(tmp_path)
     store._state_path.write_text("just a garbage string, not a mapping", encoding="utf-8")
 
     # When/Then: loading raises rather than silently discarding the on-disk state
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(CacheStateCorruptError):
         store.load()
+
+
+def test_load_salvages_valid_entries_when_one_pending_work_item_is_malformed(tmp_path: Path) -> None:
+    # Given: a state dict with one schema-valid pending_work_items entry and one
+    # that's missing a required field
+    state = _populated_cache_state()
+    good_entry = state.pending_work_items[0]
+    raw = json.loads(state.model_dump_json())
+    raw["pending_work_items"].append({"idempotency_key": "whatever", "key": "#2"})  # missing "item"
+    store = _CacheStateStore(tmp_path)
+    store._state_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    # When: the store loads it
+    loaded = store.load()
+
+    # Then: the malformed entry is dropped, the valid one survives, nothing raises
+    assert loaded.pending_work_items == [good_entry]
+
+
+def test_load_dead_letters_pending_entry_with_mismatched_idempotency_key(tmp_path: Path) -> None:
+    # Given: a state dict with one legitimate pending_work_items entry and one
+    # that's schema-valid but whose idempotency_key doesn't match its own
+    # content -- the shape of the hand-edit incident this check exists for
+    state = _populated_cache_state()
+    good_entry = state.pending_work_items[0]
+    forged_item = BacklogItem(title="Hand-edited entry")
+    raw = json.loads(state.model_dump_json())
+    raw["pending_work_items"].append({
+        "idempotency_key": "not-the-real-hash",
+        "key": "#2",
+        "item": json.loads(forged_item.model_dump_json()),
+    })
+    store = _CacheStateStore(tmp_path)
+    store._state_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    # When: the store loads it
+    loaded = store.load()
+
+    # Then: the forged entry is dropped, the legitimate one survives
+    assert loaded.pending_work_items == [good_entry]
+
+
+def test_load_does_not_key_check_rejected_entries(tmp_path: Path) -> None:
+    # Given: a rejected entry with a stale key from before its mutation was
+    # queue_write-superseded -- rejected entries are inert inspection records,
+    # never replayed, so they're exempt from the self-consistency check
+    reference = _reference("#1")
+    write = ContentWrite(reference=reference, content="rejected", expected_revision="rev-1")
+    state = _CacheState(
+        rejected=[_RejectedMutation(idempotency_key="stale-key", write=write, reason="revision no longer matches")]
+    )
+    store = _CacheStateStore(tmp_path)
+    store._save(state)
+
+    # When: the store loads it
+    loaded = store.load()
+
+    # Then: the rejected entry survives despite the mismatched key
+    assert loaded == state
 
 
 def test_file_cache_serializes_process_writers(tmp_path: Path) -> None:

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -659,6 +659,66 @@ def test_pending_mutations_sees_a_legacy_file_recreated_by_older_code_without_a_
     assert not cache_store._legacy_state_path.exists()
 
 
+def test_load_after_migration_migrates_and_reads_under_one_lock_acquisition(tmp_path: Path) -> None:
+    # Given: a legacy-only root -- direct test of the combined method
+    # FileCache._load_state() now uses instead of two separate calls
+    # (ensure_migrated() then load()), which left a race window between them
+    state = _populated_cache_state()
+    store = _CacheStateStore(tmp_path)
+    _write_legacy_yaml(store._legacy_state_path, state)
+
+    # When: load_after_migration runs
+    loaded = store.load_after_migration()
+
+    # Then: migration happened and the returned state already reflects it --
+    # a single call, not migrate-then-a-separate-read
+    assert loaded == state
+    assert store._state_path.exists()
+    assert not store._legacy_state_path.exists()
+
+
+def test_unparsable_legacy_file_gets_a_unique_backup_not_the_shared_superseded_name(tmp_path: Path) -> None:
+    # Given: cache.json exists, and cache.yaml is neither valid JSON nor YAML
+    # -- can't be read to merge its queued writes, unlike the other
+    # both-files-present tests above
+    store = _CacheStateStore(tmp_path)
+    current_state = _populated_cache_state()
+    _write_new_json(store._state_path, current_state)
+    store._legacy_state_path.write_text("{[", encoding="utf-8")
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: preserved under a unique name, not the fixed .superseded target
+    assert not store._legacy_state_path.exists()
+    assert not store._legacy_state_path.with_name("cache.yaml.superseded").exists()
+    backups = list(tmp_path.glob("cache.yaml.corrupt.*"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == "{["
+
+
+def test_a_second_unparsable_legacy_file_does_not_overwrite_the_first_backup(tmp_path: Path) -> None:
+    # Given: one unparsable legacy file already migrated (backed up) once
+    store = _CacheStateStore(tmp_path)
+    current_state = _populated_cache_state()
+    _write_new_json(store._state_path, current_state)
+    store._legacy_state_path.write_text("{[ first corrupt file", encoding="utf-8")
+    store.transaction(lambda s: (s, None))
+    first_backups = list(tmp_path.glob("cache.yaml.corrupt.*"))
+    assert len(first_backups) == 1
+
+    # When: an older process recreates cache.yaml, itself unparsable, and a
+    # second transaction migrates it
+    store._legacy_state_path.write_text("{[ second corrupt file", encoding="utf-8")
+    store.transaction(lambda s: (s, None))
+
+    # Then: both backups survive -- the second didn't overwrite the first
+    backups = {path: path.read_text(encoding="utf-8") for path in tmp_path.glob("cache.yaml.corrupt.*")}
+    assert len(backups) == 2
+    assert "{[ first corrupt file" in backups.values()
+    assert "{[ second corrupt file" in backups.values()
+
+
 def test_migration_leaves_lock_and_snapshot_items_untouched(tmp_path: Path) -> None:
     # Given: a legacy cache.yaml alongside the lock file and a per-item snapshot
     state = _populated_cache_state()

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -17,8 +17,10 @@ from backlog_core.file_cache_state import (
     _CacheState,
     _CacheStateStore,
     _content_mutation_key,
+    _CorruptQueueEntry,
     _PendingWorkItemMutation,
     _RejectedMutation,
+    _RejectedWorkItemMutation,
     _work_item_mutation_key,
 )
 from backlog_core.models import (
@@ -597,6 +599,64 @@ def test_transaction_merges_queue_entries_from_a_legacy_file_recreated_by_older_
     assert all(entry in loaded.pending for entry in current_state.pending)
     assert not store._legacy_state_path.exists()
     assert store._legacy_state_path.with_name("cache.yaml.superseded").exists()
+
+
+def test_transaction_merges_dead_lettered_entries_from_a_recreated_legacy_file(tmp_path: Path) -> None:
+    # Given: cache.json exists, and a legacy cache.yaml recreated by older
+    # code holds not just a new pending write but also entries that the
+    # legacy file's own load-time checks (_verify_queue_keys/_salvage) would
+    # dead-letter -- a key mismatch, a schema failure. Superseding the file
+    # unread would silently strand these in an inert renamed backup that a
+    # second occurrence of this scenario could later overwrite.
+    store = _CacheStateStore(tmp_path)
+    current_state = _populated_cache_state()
+    _write_new_json(store._state_path, current_state)
+
+    write = ContentWrite(reference=_reference("#9"), content="rejected on the legacy side", expected_revision="rev-1")
+    legacy_rejected = _RejectedMutation(idempotency_key="stale-key-1", write=write, reason="revision no longer matches")
+    legacy_item = BacklogItem(title="Rejected on the legacy side")
+    legacy_rejected_work_item = _RejectedWorkItemMutation(
+        idempotency_key="stale-key-2", key="#9", item=legacy_item, reason="idempotency_key does not match its content"
+    )
+    legacy_corrupt = _CorruptQueueEntry(field="pending", raw={"idempotency_key": "x"}, reason="missing 'write'")
+    legacy_state = _CacheState(
+        rejected=[legacy_rejected],
+        rejected_work_items=[legacy_rejected_work_item],
+        corrupt_queue_entries=[legacy_corrupt],
+    )
+    _write_legacy_yaml(store._legacy_state_path, legacy_state)
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: all three dead-letter collections survive, merged into cache.json
+    loaded = store.load()
+    assert legacy_rejected in loaded.rejected
+    assert legacy_rejected_work_item in loaded.rejected_work_items
+    assert legacy_corrupt in loaded.corrupt_queue_entries
+    assert all(entry in loaded.rejected for entry in current_state.rejected)
+
+
+def test_pending_mutations_sees_a_legacy_file_recreated_by_older_code_without_a_prior_write(tmp_path: Path) -> None:
+    # Given: cache.json exists, and a legacy cache.yaml recreated by older
+    # code holds a new offline write -- but no write of our own has happened
+    # yet to trigger transaction()'s migration as a side effect
+    cache_store = _CacheStateStore(tmp_path)
+    current_state = _populated_cache_state()
+    _write_new_json(cache_store._state_path, current_state)
+    older_write = ContentWrite(reference=_reference("#9"), content="queued by older code", expected_revision="rev-1")
+    older_pending = PendingMutation(idempotency_key=_content_mutation_key(older_write), write=older_write)
+    _write_legacy_yaml(cache_store._legacy_state_path, _CacheState(pending=[older_pending]))
+
+    # When: a plain read accessor is called first -- the shape of what
+    # replay_pending()/reconcile() do before ever writing anything
+    cache = FileCache(tmp_path)
+    pending = cache.pending_mutations()
+
+    # Then: the legacy entry is visible immediately, not only after some
+    # unrelated write happens to trigger transaction()'s migration
+    assert older_pending in pending
+    assert not cache_store._legacy_state_path.exists()
 
 
 def test_migration_leaves_lock_and_snapshot_items_untouched(tmp_path: Path) -> None:

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -601,6 +601,60 @@ def test_transaction_merges_queue_entries_from_a_legacy_file_recreated_by_older_
     assert store._legacy_state_path.with_name("cache.yaml.superseded").exists()
 
 
+def test_transaction_merge_keeps_one_pending_entry_per_reference_on_collision(tmp_path: Path) -> None:
+    # Given: cache.json already has a pending write for a reference, and a
+    # legacy file recreated by older code has a *different* write for that
+    # *same* reference (different content -> different idempotency_key, so
+    # a merge-by-key-only approach would keep both, breaking queue_write()'s
+    # one-entry-per-reference invariant)
+    store = _CacheStateStore(tmp_path)
+    current_state = _populated_cache_state()
+    _write_new_json(store._state_path, current_state)
+    colliding_reference = current_state.pending[0].write.reference
+
+    legacy_write = ContentWrite(
+        reference=colliding_reference, content="a different write for the same reference", expected_revision="rev-1"
+    )
+    legacy_pending = PendingMutation(idempotency_key=_content_mutation_key(legacy_write), write=legacy_write)
+    _write_legacy_yaml(store._legacy_state_path, _CacheState(pending=[legacy_pending]))
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: still exactly one pending entry for that reference -- current's,
+    # not both -- and the superseded legacy entry is dead-lettered, not
+    # silently dropped
+    loaded = store.load()
+    matching = [entry for entry in loaded.pending if entry.write.reference == colliding_reference]
+    assert matching == [current_state.pending[0]]
+    assert any(entry.idempotency_key == legacy_pending.idempotency_key for entry in loaded.rejected)
+
+
+def test_transaction_merge_keeps_one_pending_work_item_per_key_on_collision(tmp_path: Path) -> None:
+    # Given: the same collision scenario as above, for pending_work_items --
+    # a legacy entry for a key cache.json already has queued, with different
+    # content (so a different idempotency_key)
+    store = _CacheStateStore(tmp_path)
+    current_state = _populated_cache_state()
+    _write_new_json(store._state_path, current_state)
+    colliding_key = current_state.pending_work_items[0].key
+
+    legacy_item = BacklogItem(title="A different item for the same key")
+    legacy_work_item = _PendingWorkItemMutation(
+        idempotency_key=_work_item_mutation_key(colliding_key, legacy_item), key=colliding_key, item=legacy_item
+    )
+    _write_legacy_yaml(store._legacy_state_path, _CacheState(pending_work_items=[legacy_work_item]))
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: still exactly one pending_work_items entry for that key
+    loaded = store.load()
+    matching = [entry for entry in loaded.pending_work_items if entry.key == colliding_key]
+    assert matching == [current_state.pending_work_items[0]]
+    assert any(entry.idempotency_key == legacy_work_item.idempotency_key for entry in loaded.rejected_work_items)
+
+
 def test_transaction_merges_dead_lettered_entries_from_a_recreated_legacy_file(tmp_path: Path) -> None:
     # Given: cache.json exists, and a legacy cache.yaml recreated by older
     # code holds not just a new pending write but also entries that the

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import get_context
@@ -703,8 +704,41 @@ def test_load_dead_letters_pending_entry_with_mismatched_idempotency_key(tmp_pat
     # When: the store loads it
     loaded = store.load()
 
-    # Then: the forged entry is dropped, the legitimate one survives
+    # Then: the forged entry is dead-lettered (not deleted, not replayed), the
+    # legitimate one survives untouched
     assert loaded.pending_work_items == [good_entry]
+    assert len(loaded.rejected_work_items) == 1
+    dead_lettered = loaded.rejected_work_items[0]
+    assert dead_lettered.idempotency_key == "not-the-real-hash"
+    assert dead_lettered.key == "#2"
+    assert dead_lettered.reason == "idempotency_key does not match its content"
+
+
+def test_load_dead_letters_pending_entry_from_version_skew_not_just_hand_edits(tmp_path: Path) -> None:
+    # Given: a pending entry whose key was computed by a NEWER plugin version
+    # that included a field this version's ContentWrite model doesn't know
+    # about -- pydantic's default extra="ignore" silently drops that field on
+    # load, so re-deriving the key from the (now-lossy) parsed model produces
+    # a different hash than the writer's, even though the entry is legitimate
+    reference = _reference("#1")
+    write = ContentWrite(reference=reference, content="from a newer version", expected_revision="rev-1")
+    raw_write = json.loads(write.model_dump_json())
+    raw_write["field_added_by_a_future_version"] = "unknown to this reader"
+    payload = json.dumps(raw_write, sort_keys=True, separators=(",", ":"))
+    key_from_newer_version = hashlib.sha256(payload.encode()).hexdigest()
+    raw_state = json.loads(_CacheState().model_dump_json())
+    raw_state["pending"] = [{"idempotency_key": key_from_newer_version, "write": raw_write}]
+    store = _CacheStateStore(tmp_path)
+    store._state_path.write_text(json.dumps(raw_state), encoding="utf-8")
+
+    # When: this (older) version loads it
+    loaded = store.load()
+
+    # Then: not silently lost -- dead-lettered for inspection, not deleted
+    assert loaded.pending == []
+    assert len(loaded.rejected) == 1
+    assert loaded.rejected[0].idempotency_key == key_from_newer_version
+    assert loaded.rejected[0].write.content == "from a newer version"
 
 
 def test_load_does_not_key_check_rejected_entries(tmp_path: Path) -> None:

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -655,6 +655,34 @@ def test_transaction_merge_keeps_one_pending_work_item_per_key_on_collision(tmp_
     assert any(entry.idempotency_key == legacy_work_item.idempotency_key for entry in loaded.rejected_work_items)
 
 
+def test_transaction_merge_lets_a_terminal_entry_win_over_a_still_pending_copy(tmp_path: Path) -> None:
+    # Given: cache.json still has an entry queued in pending, but a legacy
+    # file recreated by older code already classified that exact entry
+    # (same idempotency_key) as rejected -- e.g. it replayed and got a
+    # permanent conflict before this process ever saw cache.yaml. The two
+    # per-field merges (pending-vs-pending, rejected-vs-rejected) don't
+    # cross-check against each other, so without the final cleanup pass the
+    # merged state would hold the same key in both pending and rejected.
+    store = _CacheStateStore(tmp_path)
+    current_state = _populated_cache_state()
+    _write_new_json(store._state_path, current_state)
+    shared_key = current_state.pending[0].idempotency_key
+
+    legacy_rejected = _RejectedMutation(
+        idempotency_key=shared_key, write=current_state.pending[0].write, reason="conflicted during legacy replay"
+    )
+    _write_legacy_yaml(store._legacy_state_path, _CacheState(rejected=[legacy_rejected]))
+
+    # When: a transaction runs
+    store.transaction(lambda s: (s, None))
+
+    # Then: the terminal classification wins -- the key is in rejected, not
+    # also still sitting in pending waiting to be replayed again
+    loaded = store.load()
+    assert shared_key not in {entry.idempotency_key for entry in loaded.pending}
+    assert shared_key in {entry.idempotency_key for entry in loaded.rejected}
+
+
 def test_transaction_merges_dead_lettered_entries_from_a_recreated_legacy_file(tmp_path: Path) -> None:
     # Given: cache.json exists, and a legacy cache.yaml recreated by older
     # code holds not just a new pending write but also entries that the

--- a/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
+++ b/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
@@ -8,6 +8,7 @@ from backlog_core.backends import github_work_items
 from backlog_core.backends._github_work_item_versions import root_revision
 from backlog_core.backends.github_backend import GitHubBackend, _GitHubPlanPersistence
 from backlog_core.file_cache import FileCache, _ProviderSnapshotCheckpoint
+from backlog_core.file_cache_state import _CacheState, _RejectedWorkItemMutation
 from backlog_core.models import (
     BacklogError,
     BacklogItem,
@@ -43,6 +44,35 @@ def test_github_reconcile_initial_establishes_durable_snapshot_checkpoint(tmp_pa
     assert FileCache(tmp_path)._get_snapshot_checkpoint() == _ProviderSnapshotCheckpoint(
         watermark="2026-08-12T01:00:00Z"
     )
+
+
+def test_github_reconcile_result_counts_dead_lettered_work_item_rejections(tmp_path: Path) -> None:
+    # Given: a cache with one dead-lettered work-item mutation (e.g. from a
+    # key/content mismatch caught on load -- see _verify_queue_keys) and no
+    # content-side rejections
+    cache = FileCache(tmp_path)
+    forged_item = BacklogItem(title="Forged entry")
+    cache._state._save(
+        _CacheState(
+            rejected_work_items=[
+                _RejectedWorkItemMutation(
+                    idempotency_key="stale-key", key="#1", item=forged_item, reason="test fixture"
+                )
+            ]
+        )
+    )
+    backend = GitHubBackend(cache=cache)
+    backend._fetch_snapshot = MagicMock(
+        return_value=ProviderSnapshot(items=[], sync_started_at="2026-08-12T01:00:00Z", pages_fetched=1)
+    )
+
+    # When: reconcile runs
+    result = backend.reconcile(ReconcileRequest(scope=ReconcileScope.INITIAL))
+
+    # Then: the work-item rejection is counted, not just the content-side one
+    # (reconcile() previously summed only cache.rejected_mutations(), missing
+    # _rejected_work_item_mutations() entirely)
+    assert result.rejected_mutations == 1
 
 
 def test_github_reconcile_empty_incremental_normalizes_to_initial(tmp_path: Path) -> None:

--- a/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
+++ b/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
@@ -8,7 +8,7 @@ from backlog_core.backends import github_work_items
 from backlog_core.backends._github_work_item_versions import root_revision
 from backlog_core.backends.github_backend import GitHubBackend, _GitHubPlanPersistence
 from backlog_core.file_cache import FileCache, _ProviderSnapshotCheckpoint
-from backlog_core.file_cache_state import _CacheState, _RejectedWorkItemMutation
+from backlog_core.file_cache_state import _CacheState, _CorruptQueueEntry, _RejectedWorkItemMutation
 from backlog_core.models import (
     BacklogError,
     BacklogItem,
@@ -72,6 +72,30 @@ def test_github_reconcile_result_counts_dead_lettered_work_item_rejections(tmp_p
     # Then: the work-item rejection is counted, not just the content-side one
     # (reconcile() previously summed only cache.rejected_mutations(), missing
     # _rejected_work_item_mutations() entirely)
+    assert result.rejected_mutations == 1
+
+
+def test_github_reconcile_result_counts_corrupt_queue_entries_as_rejected(tmp_path: Path) -> None:
+    # Given: a cache with one schema-invalid entry dead-lettered into
+    # corrupt_queue_entries (e.g. from schema evolution -- see
+    # _CacheStateStore._salvage_queue_list) and no other rejections
+    cache = FileCache(tmp_path)
+    cache._state._save(
+        _CacheState(
+            corrupt_queue_entries=[
+                _CorruptQueueEntry(field="pending", raw={"whatever": "shape"}, reason="test fixture")
+            ]
+        )
+    )
+    backend = GitHubBackend(cache=cache)
+    backend._fetch_snapshot = MagicMock(
+        return_value=ProviderSnapshot(items=[], sync_started_at="2026-08-12T01:00:00Z", pages_fetched=1)
+    )
+
+    # When: reconcile runs
+    result = backend.reconcile(ReconcileRequest(scope=ReconcileScope.INITIAL))
+
+    # Then: it's counted -- previously invisible in both pending and rejected
     assert result.rejected_mutations == 1
 
 


### PR DESCRIPTION
## Summary
- Multi-agent audit of every `backlog_core/server.py` MCP tool docstring against its actual implementation, correcting ~25 false or backend-specific-stated-as-general claims (fabricated dispatch YAML path, inverted section-filter behavior, a nonexistent "2,000 token" cap, an incompatible comment-ID format, a systemic pattern of GitHub-only tools describing themselves as backend-agnostic) plus removable restated filler.
- Three real code bugs fixed along the way: `backlog_normalize`'s progress log read the wrong result-dict key, `dispatch_create_plan`'s return dict silently clobbered real validation errors via dict-spread ordering, `dispatch_wave_start` raised an uncaught exception instead of its documented error dict for malformed input.
- Renames the GitHub backend's private durability cache state file from `cache.yaml` to `cache.json` (it's held pure JSON since a past migration; the misleading extension is plausibly what led an agent on an unrelated project to hand-edit it directly, bypassing the store's own locking and validation). Adds a locked, self-healing migration, a typed corruption error, per-entry dead-lettering for malformed cache entries, and an idempotency-key self-consistency check that directly closes the incident that motivated this change. Reviewed independently by an adversarial-solution-design pass, which caught a deadlock in the original migration design before implementation.
- Filed follow-up scope on existing issue #2287 rather than a new duplicate item: the `isinstance(backend, GitHubExtras)` capability gate used at 17+ call sites is structurally satisfied by `SQLiteBackend`/`InMemoryBackend` (their stub methods exist, just raise `NotImplementedError`), so it doesn't actually catch 2 of the 4 backends today — a real bug beyond the docstring wording, tracked separately.

## Test plan
- [x] `tests_backlog/test_file_cache.py` — 34/34 (new migration, dead-letter, and key-consistency tests included)
- [x] `tests/test_server_descriptions.py` + `tests/test_backlog_core_server.py` — 212/212
- [x] Broader integration suite (`tests_backlog/`, `tests/test_github_content_safety.py`, `tests/test_github_content_migration.py`, `tests/test_github_contents.py`) — 634/634
- [x] Full plugin suite — 5,530+ passed, baseline held (one unrelated `test_network_guard.py` subprocess-timeout flake confirmed pre-existing/environmental, not touched by this change)
- [x] `ruff check` / `ty check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWiYwQtC42K2ELfu3WzXt2