### PR TITLE
fix(backlog): surface dead-letter mutation counts on the main sync path

### DIFF
--- a/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
+++ b/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
@@ -11,7 +11,7 @@ legacy `cache.yaml` (real YAML, or JSON still wearing the old extension) is
 migrated to `cache.json` inside `transaction()`, under the lock; `load()` stays
 read-only and never migrates (doing it there self-deadlocks — see
 `_migrate_legacy_state_file`'s docstring). `FileCache._load_state()` also calls
-`_CacheStateStore.ensure_migrated()` first, so every read accessor
+`_CacheStateStore.load_after_migration()` first, so every read accessor
 (`pending_mutations`, `get_content`, reconciliation's `load_records`, ...) sees
 migrated state immediately, not only after some unrelated `transaction()`
 happens to run. Both files present (e.g. an older plugin copy recreating
@@ -53,12 +53,21 @@ resolve it correctly.
 Schema-invalid entries (fails `model_validate`, not just a key mismatch) are
 handled the same way, one level further: `pending`/`pending_work_items`/
 `rejected`/`rejected_work_items` are all routed through
-`_salvage_queue_list`, which preserves the raw, unvalidated payload in
-`corrupt_queue_entries` (a `raw: Any` field — never itself fails validation,
-so it's the terminal fallback with nothing further to preserve it from) rather
-than dropping the entry. `reconcile()`'s `rejected_mutations` count includes
-`corrupt_queue_entries` alongside both rejected buckets, so a dead-lettered
-entry is never invisible in sync output.
+`_salvage_field(..., preserve=True)` (merged with the non-queue-field
+`preserve=False` path into one function; see the `_salvage` docstring),
+which preserves the raw, unvalidated payload in `corrupt_queue_entries` (a
+`raw: Any` field — never itself fails validation, so it's the terminal
+fallback with nothing further to preserve it from) rather than dropping the
+entry. `reconcile()`'s `rejected_mutations` count includes
+`corrupt_queue_entries` alongside both rejected buckets
+(`github_work_items.py:529-541`). That count now reaches a user on both
+paths: `_reconcile_groomed_item` (`operations.py:1170-1174`, per-item
+grooming) and `refresh_local_cache_from_github` (`operations.py:1676-1685`,
+the main sync path — dropped both mutation counts before this fix), and
+`sync_status()`/`sync_now()` (`server.py`) report the same two counts as of
+the last completed background sync via `SyncState.pending_mutations`/
+`.rejected_mutations` (`sync_state.py`, populated in
+`sync_engine._run_single_sync`).
 
 Latent (tamper-only) bug, still present, unrelated to the above: `acknowledge_replay`
 does `remaining = [e for e in state.pending if e.idempotency_key not in acknowledged_keys]`

--- a/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
+++ b/.claude/agent-memory/python-engineering-adversarial-solution-design/backlog_core_file_cache_state.md
@@ -60,14 +60,12 @@ which preserves the raw, unvalidated payload in `corrupt_queue_entries` (a
 fallback with nothing further to preserve it from) rather than dropping the
 entry. `reconcile()`'s `rejected_mutations` count includes
 `corrupt_queue_entries` alongside both rejected buckets
-(`github_work_items.py:529-541`). That count now reaches a user on both
-paths: `_reconcile_groomed_item` (`operations.py:1170-1174`, per-item
-grooming) and `refresh_local_cache_from_github` (`operations.py:1676-1685`,
-the main sync path — dropped both mutation counts before this fix), and
-`sync_status()`/`sync_now()` (`server.py`) report the same two counts as of
-the last completed background sync via `SyncState.pending_mutations`/
-`.rejected_mutations` (`sync_state.py`, populated in
-`sync_engine._run_single_sync`).
+(`github_work_items.py`). That count reaches a user on every sync path:
+`_reconcile_groomed_item` (per-item grooming) and
+`refresh_local_cache_from_github` (the main sync path) both print it, and
+`sync_status()`/`sync_now()` report the same two counts as of the last
+completed background sync via `SyncState.pending_mutations`/
+`.rejected_mutations`, populated in `sync_engine._run_single_sync`.
 
 Latent (tamper-only) bug, still present, unrelated to the above: `acknowledge_replay`
 does `remaining = [e for e in state.pending if e.idempotency_key not in acknowledged_keys]`

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.6",
+  "version": "11.0.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/github_work_items.py
+++ b/plugins/development-harness/backlog_core/backends/github_work_items.py
@@ -531,9 +531,9 @@ class _GitHubReconciliation:
                 "pending_mutations": len(self._cache.pending_mutations())
                 + len(self._cache._pending_work_item_mutations()),
                 # Schema-invalid entries dead-lettered into corrupt_queue_entries
-                # (see _CacheStateStore._salvage_queue_list) count as rejected
-                # too: like a key mismatch, they're terminal and need manual
-                # recovery, not silently invisible zero pending/zero rejected.
+                # (see _CacheStateStore._salvage_field with preserve=True) count
+                # as rejected too: like a key mismatch, they're terminal and need
+                # manual recovery, not silently invisible zero pending/zero rejected.
                 "rejected_mutations": len(self._cache.rejected_mutations())
                 + len(self._cache._rejected_work_item_mutations())
                 + len(self._cache._corrupt_queue_entries()),

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -284,8 +284,9 @@ class FileCache:
     def _corrupt_queue_entries(self) -> list[_CorruptQueueEntry]:
         """Return pending/pending_work_items entries that failed schema validation on load.
 
-        See :meth:`_CacheStateStore._salvage_queue_list` -- stored as raw
-        payloads for manual recovery, since they never became typed models.
+        See :meth:`_CacheStateStore._salvage_field` (``preserve=True``) --
+        stored as raw payloads for manual recovery, since they never became
+        typed models.
         """
         return list(self._load_state().corrupt_queue_entries)
 

--- a/plugins/development-harness/backlog_core/file_cache_state.py
+++ b/plugins/development-harness/backlog_core/file_cache_state.py
@@ -531,15 +531,16 @@ class _CacheStateStore:
         per-entry salvage cannot help when the document itself doesn't parse.
 
         records/checkpoints are different from the other four fields: those
-        are pure cache, safely dropped and logged (:meth:`_salvage_list`).
-        pending/pending_work_items/rejected/rejected_work_items are all
-        precious -- a schema-invalid entry there is more likely a legitimate
-        write this version can't parse yet (schema evolution) than genuine
-        corruption, including in the two terminal dead-letter buckets
-        themselves (a stored ``rejected``/``rejected_work_items`` entry is
-        the only recovery record for whatever it holds; losing it too on a
-        later load would be worse than the mismatch that put it there).
-        :meth:`_salvage_queue_list` preserves each one's raw payload in
+        are pure cache, safely dropped and logged (:meth:`_salvage_field`
+        with ``preserve=False``). pending/pending_work_items/rejected/
+        rejected_work_items are all precious -- a schema-invalid entry there
+        is more likely a legitimate write this version can't parse yet
+        (schema evolution) than genuine corruption, including in the two
+        terminal dead-letter buckets themselves (a stored ``rejected``/
+        ``rejected_work_items`` entry is the only recovery record for
+        whatever it holds; losing it too on a later load would be worse
+        than the mismatch that put it there). :meth:`_salvage_field` with
+        ``preserve=True`` preserves each one's raw payload in
         ``corrupt_queue_entries`` instead of dropping it. That field is the
         terminal fallback and isn't routed through the same path itself:
         its ``raw: Any`` member can't fail model validation, so there's
@@ -551,15 +552,15 @@ class _CacheStateStore:
             entries in the four precious fields are preserved in
             ``corrupt_queue_entries``.
         """
-        # Runtime shape is guaranteed by _salvage_list's/_salvage_queue_list's own
+        # Runtime shape is guaranteed by _salvage_field's own
         # model.model_validate() calls; the casts below narrow the result back
         # for the type checker, which can't express that generically without an
         # overload per field. Driven by a loop rather than one named pair of
         # locals per field, to stay under ruff's too-many-locals limit.
-        records = cast("list[ContentRecord]", self._salvage_list(raw, "records", ContentRecord, path))
-        checkpoints = cast("list[CacheCheckpoint]", self._salvage_list(raw, "checkpoints", CacheCheckpoint, path))
+        records = cast("list[ContentRecord]", self._salvage_field(raw, "records", ContentRecord, path)[0])
+        checkpoints = cast("list[CacheCheckpoint]", self._salvage_field(raw, "checkpoints", CacheCheckpoint, path)[0])
         corrupt = cast(
-            "list[_CorruptQueueEntry]", self._salvage_list(raw, "corrupt_queue_entries", _CorruptQueueEntry, path)
+            "list[_CorruptQueueEntry]", self._salvage_field(raw, "corrupt_queue_entries", _CorruptQueueEntry, path)[0]
         )
         survivors: dict[str, list[BaseModel]] = {}
         for field_name, model in (
@@ -568,7 +569,7 @@ class _CacheStateStore:
             ("rejected", _RejectedMutation),
             ("rejected_work_items", _RejectedWorkItemMutation),
         ):
-            entries, bad = self._salvage_queue_list(raw, field_name, model, path)
+            entries, bad = self._salvage_field(raw, field_name, model, path, preserve=True)
             survivors[field_name] = entries
             corrupt.extend(bad)
         # Idempotency-key self-consistency is checked once, uniformly, in
@@ -587,61 +588,56 @@ class _CacheStateStore:
         )
 
     @staticmethod
-    def _salvage_list(raw: dict[str, object], field_name: str, model: type[BaseModel], path: Path) -> list[BaseModel]:
-        """Validate each entry of one non-queue field independently, dropping failures.
-
-        Not used for pending/pending_work_items -- see :meth:`_salvage_queue_list`.
-
-        Returns:
-            The entries that validated; malformed ones are logged and dropped.
-        """
-        value = raw.get(field_name, [])
-        if not isinstance(value, list):
-            _log.warning("Cache state %s: %r is not a list (%r) -- dropping all entries", path, field_name, value)
-            return []
-        survivors: list[BaseModel] = []
-        for entry in value:
-            try:
-                survivors.append(model.model_validate(entry))
-            except pydantic.ValidationError as exc:
-                _log.warning("Cache state %s: dropping malformed %s entry: %s", path, field_name, exc)
-        return survivors
-
-    @staticmethod
-    def _salvage_queue_list(
-        raw: dict[str, object], field_name: str, model: type[BaseModel], path: Path
+    def _salvage_field(
+        raw: dict[str, object], field_name: str, model: type[BaseModel], path: Path, *, preserve: bool = False
     ) -> tuple[list[BaseModel], list[_CorruptQueueEntry]]:
-        """Validate each entry of a precious field, preserving failures instead of dropping them.
+        """Validate each entry of one field independently, per ``preserve``'s failure policy.
 
-        Used for pending/pending_work_items/rejected/rejected_work_items --
-        every field where losing an entry outright would discard something
-        no longer recoverable elsewhere.
+        ``preserve=False`` (records/checkpoints/corrupt_queue_entries -- pure
+        cache, safe to drop): a malformed entry is logged at warning level and
+        dropped; the second return element is always empty.
+
+        ``preserve=True`` (pending/pending_work_items/rejected/
+        rejected_work_items -- precious, losing one outright would discard
+        something no longer recoverable elsewhere): a malformed entry is
+        logged at error level and dead-lettered into a :class:`_CorruptQueueEntry`
+        instead of being dropped.
 
         Returns:
-            The entries that validated, and a :class:`_CorruptQueueEntry` for
-            each one that didn't -- or, if ``field_name`` itself isn't a
-            list, a single entry preserving the whole raw value, rather than
-            silently discarding the entire field.
+            The entries that validated, and (``preserve=True`` only) a
+            :class:`_CorruptQueueEntry` for each one that didn't -- or, if
+            ``field_name`` itself isn't a list, a single such entry
+            preserving the whole raw value rather than silently discarding
+            the entire field. Always ``[]`` when ``preserve=False``.
         """
         value = raw.get(field_name, [])
         if not isinstance(value, list):
-            _log.error(
-                "Cache state %s: %r is not a list (%r) -- preserving as a single corrupt entry", path, field_name, value
-            )
-            return [], [_CorruptQueueEntry(field=field_name, raw=value, reason="value is not a list")]
+            if preserve:
+                _log.error(
+                    "Cache state %s: %r is not a list (%r) -- preserving as a single corrupt entry",
+                    path,
+                    field_name,
+                    value,
+                )
+                return [], [_CorruptQueueEntry(field=field_name, raw=value, reason="value is not a list")]
+            _log.warning("Cache state %s: %r is not a list (%r) -- dropping all entries", path, field_name, value)
+            return [], []
         survivors: list[BaseModel] = []
         corrupt: list[_CorruptQueueEntry] = []
         for entry in value:
             try:
                 survivors.append(model.model_validate(entry))
             except pydantic.ValidationError as exc:
-                _log.error(
-                    "Cache state %s: dead-lettering malformed %s entry (raw payload preserved): %s",
-                    path,
-                    field_name,
-                    exc,
-                )
-                corrupt.append(_CorruptQueueEntry(field=field_name, raw=entry, reason=str(exc)))
+                if preserve:
+                    _log.error(
+                        "Cache state %s: dead-lettering malformed %s entry (raw payload preserved): %s",
+                        path,
+                        field_name,
+                        exc,
+                    )
+                    corrupt.append(_CorruptQueueEntry(field=field_name, raw=entry, reason=str(exc)))
+                else:
+                    _log.warning("Cache state %s: dropping malformed %s entry: %s", path, field_name, exc)
         return survivors, corrupt
 
     @staticmethod

--- a/plugins/development-harness/backlog_core/jsonl_utils.py
+++ b/plugins/development-harness/backlog_core/jsonl_utils.py
@@ -4,7 +4,36 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _iter_json_lines(jsonl_path: Path) -> Iterator[dict[str, Any]]:
+    """Yield each well-formed JSON object in a JSONL file.
+
+    Skips blank lines and lines that fail to parse as JSON. Handles a
+    missing or unreadable file by yielding nothing.
+
+    Args:
+        jsonl_path: Path to the .jsonl file.
+
+    Yields:
+        Each line's parsed JSON object, in file order.
+    """
+    try:
+        with jsonl_path.open(encoding="utf-8") as f:
+            for line in f:
+                text = line.strip()
+                if not text:
+                    continue
+                try:
+                    yield json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        return
 
 
 def parse_jsonl_events(jsonl_path: Path | str, event_type: str | None = None) -> list[dict[str, Any]]:
@@ -19,31 +48,9 @@ def parse_jsonl_events(jsonl_path: Path | str, event_type: str | None = None) ->
     Returns:
         List of parsed event dicts. Empty list if file doesn't exist or is unreadable.
     """
-    jsonl_path = Path(jsonl_path)
-    events: list[dict[str, Any]] = []
-
-    if not jsonl_path.exists():
-        return events
-
-    try:
-        with jsonl_path.open(encoding="utf-8") as f:
-            for line in f:
-                text = line.strip()
-                if not text:
-                    continue
-
-                try:
-                    event = json.loads(text)
-                except json.JSONDecodeError:
-                    continue
-
-                if event_type is None or event.get("type") == event_type:
-                    events.append(event)
-
-    except OSError:
-        pass
-
-    return events
+    return [
+        event for event in _iter_json_lines(Path(jsonl_path)) if event_type is None or event.get("type") == event_type
+    ]
 
 
 def find_first_event(jsonl_path: Path | str, event_type: str, subtype: str | None = None) -> dict[str, Any] | None:
@@ -57,27 +64,11 @@ def find_first_event(jsonl_path: Path | str, event_type: str, subtype: str | Non
     Returns:
         The first matching event dict, or None if not found or file is unreadable.
     """
-    jsonl_path = Path(jsonl_path)
-
-    if not jsonl_path.exists():
-        return None
-
-    try:
-        with jsonl_path.open(encoding="utf-8") as f:
-            for line in f:
-                text = line.strip()
-                if not text:
-                    continue
-
-                try:
-                    event = json.loads(text)
-                except json.JSONDecodeError:
-                    continue
-
-                if event.get("type") == event_type and (subtype is None or event.get("subtype") == subtype):
-                    return event
-
-    except OSError:
-        pass
-
-    return None
+    return next(
+        (
+            event
+            for event in _iter_json_lines(Path(jsonl_path))
+            if event.get("type") == event_type and (subtype is None or event.get("subtype") == subtype)
+        ),
+        None,
+    )

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1656,14 +1656,16 @@ def refresh_local_cache_from_github(
             reconciled. Receives ``(items_done, items_total)``.
 
     Returns:
-        Dict with count of refreshed (open) issues and count of reconciled
-        (closed) issues.
+        Dict with count of refreshed (open) issues, count of reconciled
+        (closed) issues, and the offline queue's pending/rejected mutation
+        counts (see ``_reconcile_groomed_item`` for the same counts on the
+        per-item grooming path).
     """
     out = output or Output()
     backend = get_config().backend
     if not isinstance(backend, SyncProvider):
         out.info("Active backend does not support reconciliation.")
-        return {"refreshed": 0, "reconciled": 0, **out.to_dict()}
+        return {"refreshed": 0, "reconciled": 0, "pending_mutations": 0, "rejected_mutations": 0, **out.to_dict()}
     scope = ReconcileScope.INITIAL if full_refresh else ReconcileScope.INCREMENTAL
     references = (
         []
@@ -1675,12 +1677,15 @@ def refresh_local_cache_from_github(
         progress_callback(result.fetched_items, result.fetched_items)
     out.info(
         f"Reconciled {result.fetched_items} provider item(s): {result.local_updates} local updates, "
-        f"{result.provider_patches} patches, {result.no_ops} no-ops, {result.failures} failures."
+        f"{result.provider_patches} patches, {result.no_ops} no-ops, {result.failures} failures, "
+        f"{result.pending_mutations} pending mutation(s), {result.rejected_mutations} rejected mutation(s)."
     )
     return {
         "refreshed": result.local_updates,
         "reconciled": result.deleted_provider_items,
         "failures": result.failures,
+        "pending_mutations": result.pending_mutations,
+        "rejected_mutations": result.rejected_mutations,
         **out.to_dict(),
     }
 

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1155,6 +1155,11 @@ async def sync_status() -> dict[str, object]:
             percent (int | None): Completion percentage 0-100; None when total unknown.
             last_error (str): Error message from last failed sync, or empty string.
             offline_reason (str): Why server entered offline mode, or empty string.
+            pending_mutations (int): Offline-queue depth as of the last completed
+                sync. Not a live read; updates only when a sync finishes.
+            rejected_mutations (int): Dead-lettered mutation count (key
+                mismatches plus schema-invalid entries) as of the last
+                completed sync. Same not-live caveat as pending_mutations.
     """
     return get_sync_state().to_dict()
 

--- a/plugins/development-harness/backlog_core/sync_engine.py
+++ b/plugins/development-harness/backlog_core/sync_engine.py
@@ -33,7 +33,7 @@ from .models import BacklogError
 from .sync_state import SyncErrorKind, SyncState, SyncStatus, classify_sync_error
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
 __all__ = ["_startup_sync_loop"]
 
@@ -89,13 +89,30 @@ def _make_progress_callback(state: SyncState) -> Callable[[int, int | None], Non
     return _callback
 
 
+def _count(result: Mapping[str, int | list[str]], key: str) -> int:
+    """Narrow one ``refresh_local_cache_from_github`` result field to an int.
+
+    Args:
+        result: The dict returned by ``refresh_local_cache_from_github``.
+        key: The field to read.
+
+    Returns:
+        The field's int value, or 0 if absent or not an int.
+    """
+    value = result.get(key, 0)
+    return value if isinstance(value, int) else 0
+
+
 async def _run_single_sync(state: SyncState, full_refresh: bool = False) -> None:
     """Execute one sync pass by calling ``refresh_local_cache_from_github`` in a thread.
 
     Updates ``state.items_done`` and ``state.items_total`` via progress callback
-    as pages arrive.  On success, sets ``state.status = IDLE`` and records
-    ``state.last_success_at``.  On error, raises the original exception for
-    the caller to classify and handle.
+    as pages arrive.  On success, sets ``state.status = IDLE``, records
+    ``state.last_success_at``, and copies the offline queue's pending/rejected
+    mutation counts onto ``state`` so ``sync_status()`` can report them.  On
+    error, raises the original exception for the caller to classify and
+    handle -- ``state.pending_mutations``/``rejected_mutations`` are left at
+    their last known values in that case, not zeroed.
 
     Args:
         state: Process-singleton SyncState — written by progress callback.
@@ -106,7 +123,7 @@ async def _run_single_sync(state: SyncState, full_refresh: bool = False) -> None
             re-raised for the caller to classify.
     """
     callback = _make_progress_callback(state)
-    await asyncio.to_thread(
+    result = await asyncio.to_thread(
         operations.refresh_local_cache_from_github, full_refresh=full_refresh, progress_callback=callback
     )
     # The progress callback marshals mutations via loop.call_soon_threadsafe.
@@ -118,6 +135,8 @@ async def _run_single_sync(state: SyncState, full_refresh: bool = False) -> None
     state.last_success_at = now
     state.last_error = ""
     state.retry_count = 0
+    state.pending_mutations = _count(result, "pending_mutations")
+    state.rejected_mutations = _count(result, "rejected_mutations")
     _log.info("Background sync completed successfully.")
 
 

--- a/plugins/development-harness/backlog_core/sync_state.py
+++ b/plugins/development-harness/backlog_core/sync_state.py
@@ -186,6 +186,8 @@ class SyncState:
             "retry_count": self.retry_count,
             "offline_reason": self.offline_reason,
             "percent": self.percent,
+            "pending_mutations": self.pending_mutations,
+            "rejected_mutations": self.rejected_mutations,
         }
 
 

--- a/plugins/development-harness/backlog_core/sync_state.py
+++ b/plugins/development-harness/backlog_core/sync_state.py
@@ -104,6 +104,9 @@ class SyncState:
         last_success_at: UTC timestamp of the last *successful* sync.
         retry_count: Consecutive failed attempts in the current cycle.
         offline_reason: Human-readable explanation for OFFLINE state entry.
+        pending_mutations: Offline-queue depth as of the last completed sync.
+        rejected_mutations: Dead-lettered mutation count as of the last
+            completed sync (key mismatches plus schema-invalid entries).
         lock: asyncio.Lock serialising sync workers.  Named without underscore
             so sync_engine can access it without triggering SLF001.
     """
@@ -117,6 +120,8 @@ class SyncState:
     last_success_at: datetime | None = None
     retry_count: int = 0
     offline_reason: str = ""
+    pending_mutations: int = 0
+    rejected_mutations: int = 0
     lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
 
     @property

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -1015,8 +1015,9 @@ def test_load_preserves_a_stored_rejected_entry_that_fails_schema_validation(tmp
     # Given: a stored rejected entry (already the terminal recovery record for
     # a prior key mismatch) that itself fails schema validation on this load
     # -- e.g. its nested ContentWrite gained a required field on a later
-    # version. Routed through _salvage_list before this fix, it would have
-    # been silently dropped -- losing the only remaining copy of what it held.
+    # version. Routed through _salvage_field(preserve=False) before this fix,
+    # it would have been silently dropped -- losing the only remaining copy
+    # of what it held.
     good_state = _populated_cache_state()
     raw = json.loads(good_state.model_dump_json())
     raw["rejected"] = [{"idempotency_key": "whatever", "write": {"reference": {}}}]  # missing "reason", malformed ref

--- a/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
+++ b/plugins/development-harness/tests_backlog/test_github_reconcile_checkpoint.py
@@ -78,7 +78,7 @@ def test_github_reconcile_result_counts_dead_lettered_work_item_rejections(tmp_p
 def test_github_reconcile_result_counts_corrupt_queue_entries_as_rejected(tmp_path: Path) -> None:
     # Given: a cache with one schema-invalid entry dead-lettered into
     # corrupt_queue_entries (e.g. from schema evolution -- see
-    # _CacheStateStore._salvage_queue_list) and no other rejections
+    # _CacheStateStore._salvage_field with preserve=True) and no other rejections
     cache = FileCache(tmp_path)
     cache._state._save(
         _CacheState(

--- a/plugins/development-harness/tests_backlog/test_jsonl_utils.py
+++ b/plugins/development-harness/tests_backlog/test_jsonl_utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from backlog_core.jsonl_utils import find_first_event, parse_jsonl_events
+
+
+def test_parse_jsonl_events_skips_malformed_and_blank_lines(tmp_path: Path) -> None:
+    # Given: a file with a malformed line and a blank line between two good ones
+    jsonl_path = tmp_path / "transcript.jsonl"
+    jsonl_path.write_text('{"type": "a", "n": 1}\nnot json\n\n{"type": "b", "n": 2}\n', encoding="utf-8")
+
+    # When: parsing without a type filter
+    events = parse_jsonl_events(jsonl_path)
+
+    # Then: only the two well-formed events survive, in file order
+    assert events == [{"type": "a", "n": 1}, {"type": "b", "n": 2}]
+
+
+def test_parse_jsonl_events_filters_by_type(tmp_path: Path) -> None:
+    jsonl_path = tmp_path / "transcript.jsonl"
+    jsonl_path.write_text('{"type": "a"}\n{"type": "b"}\n{"type": "a"}\n', encoding="utf-8")
+
+    events = parse_jsonl_events(jsonl_path, event_type="a")
+
+    assert events == [{"type": "a"}, {"type": "a"}]
+
+
+def test_parse_jsonl_events_returns_empty_for_missing_file(tmp_path: Path) -> None:
+    assert parse_jsonl_events(tmp_path / "missing.jsonl") == []
+
+
+def test_find_first_event_matches_type_and_subtype(tmp_path: Path) -> None:
+    jsonl_path = tmp_path / "transcript.jsonl"
+    jsonl_path.write_text('{"type": "a", "subtype": "x"}\n{"type": "a", "subtype": "y"}\n', encoding="utf-8")
+
+    assert find_first_event(jsonl_path, "a", subtype="y") == {"type": "a", "subtype": "y"}
+    assert find_first_event(jsonl_path, "a") == {"type": "a", "subtype": "x"}
+    assert find_first_event(jsonl_path, "missing") is None
+
+
+def test_find_first_event_returns_none_for_missing_file(tmp_path: Path) -> None:
+    assert find_first_event(tmp_path / "missing.jsonl", "a") is None

--- a/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
+++ b/plugins/development-harness/tests_backlog/test_reconciliation_wrapper.py
@@ -9,6 +9,7 @@ from backlog_core.backend_types import BacklogConfig
 from backlog_core.backends.github_backend import GitHubBackend
 from backlog_core.backends.memory_backend import InMemoryBackend
 from backlog_core.file_cache import FileCache
+from backlog_core.file_cache_state import _CacheState, _CorruptQueueEntry
 from backlog_core.models import (
     BackendUnavailableError,
     BacklogItem,
@@ -79,6 +80,43 @@ def test_refresh_wrapper_maps_label_and_progress(
     assert progress == expected_progress
     assert result["refreshed"] == 2
     assert result["reconciled"] == 1
+
+
+def test_refresh_wrapper_surfaces_a_dead_lettered_entry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given: a cache with one schema-invalid entry already dead-lettered into
+    # corrupt_queue_entries (e.g. from schema evolution -- see
+    # _CacheStateStore._salvage_field with preserve=True), and no other rejections.
+    # Before this fix, refresh_local_cache_from_github() computed this count via
+    # reconcile() but dropped it from both its message and its return dict.
+    cache = FileCache(tmp_path / "github-cache")
+    cache._root.mkdir(parents=True, exist_ok=True)
+    cache._state._save(
+        _CacheState(
+            corrupt_queue_entries=[
+                _CorruptQueueEntry(field="pending", raw={"whatever": "shape"}, reason="test fixture")
+            ]
+        )
+    )
+    backend = GitHubBackend(cache=cache)
+    monkeypatch.setattr(
+        backend,
+        "_fetch_snapshot",
+        lambda request: ProviderSnapshot(items=[], sync_started_at="2026-08-12T01:00:00Z", pages_fetched=1),
+    )
+    monkeypatch.setattr(
+        _models, "_config", _models.BacklogConfig(repo_root=tmp_path, backlog_dir=tmp_path / "backlog", default_repo="")
+    )
+    set_config(BacklogConfig(backend=backend))
+
+    # When: the main sync path runs (not the per-item grooming path)
+    result = refresh_local_cache_from_github(full_refresh=True)
+
+    # Then: the dead-lettered entry is counted and named in the sync message
+    assert result["rejected_mutations"] == 1
+    assert result["pending_mutations"] == 0
+    messages = result["messages"]
+    assert isinstance(messages, list)
+    assert any("1 rejected mutation(s)" in msg for msg in messages)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- `refresh_local_cache_from_github` and `sync_status()`/`sync_now()` now surface `pending_mutations`/`rejected_mutations` — previously only `_reconcile_groomed_item` (per-item grooming) showed these counts, so a dead-lettered cache entry needed manual recovery with no visibility that one existed.
- Merges `_salvage_list`/`_salvage_queue_list` into one `_salvage_field(preserve=...)` in `file_cache_state.py`.
- Dedupes `jsonl_utils.py`'s two identical JSONL-parse loops into one `_iter_json_lines` generator.
- Fixes stale `ensure_migrated()`/`_salvage_queue_list` references in code comments and the `backlog_core_file_cache_state.md` agent-memory doc.

Slice D of backlog #2287. Does not change dead-letter policy — visibility only. No edits to `backend_types.py` or anything under `backlog_core/backends/` except a one-line comment-name fix caused by the rename above (cleared with the session owning that directory).

## Test plan
- [x] New test: `test_reconciliation_wrapper.py::test_refresh_wrapper_surfaces_a_dead_lettered_entry` — builds a real `FileCache` with a dead-lettered `corrupt_queue_entries` entry, runs it through `GitHubBackend.reconcile()` via `refresh_local_cache_from_github()`, asserts the count and message text (fails on `main`, passes here).
- [x] New `test_jsonl_utils.py` (previously zero coverage on that module).
- [x] `uv run pytest plugins/development-harness/tests_backlog/ -q --no-cov` — 596/596 pass.
- [x] `ruff check` / `ty check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e5K78ukiffNgWBdmY9yYr