### PR TITLE
fix(backlog): gate GitHubExtras on a capability flag, not structural isinstance

### DIFF
--- a/plugins/development-harness/backlog_core/_branch_delegates.py
+++ b/plugins/development-harness/backlog_core/_branch_delegates.py
@@ -1,7 +1,9 @@
 """Branch operation delegates — thin wrappers routing through the active BacklogBackend.
 
-Gate on the active backend's ``supports_branches`` capability flag (T-P6-PROTOCOL)
-so unsupported backends report it cleanly instead of relying on the
+Gate on the active backend's ``supports_branches`` capability flag
+(T-P6-PROTOCOL) via the shared ``require_branch_support`` helper in
+``_capability_gates.py``, so unsupported backends raise a typed
+``UnsupportedBackendCapabilityError`` instead of relying on the
 ``RuntimeError`` stubs in ``SQLiteBackend`` / ``InMemoryBackend``.
 """
 
@@ -9,8 +11,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ._capability_gates import require_branch_support
 from .backend_protocol import get_config
-from .backend_types import BranchBackend
 
 if TYPE_CHECKING:
     from .models import BranchInfo, MergeResult, Output
@@ -22,25 +24,6 @@ __all__ = [
     "list_integration_branches",
     "merge_integration_branch",
 ]
-
-
-def _require_branch_support() -> BranchBackend:
-    """Return the active backend as a BranchBackend, or raise if unsupported.
-
-    Raises:
-        RuntimeError: If the active backend does not support branch operations.
-    """
-    backend = get_config().backend
-    if not getattr(backend, "supports_branches", False):
-        msg = (
-            f"{type(backend).__name__}: branch operations not supported "
-            f"(supports_branches=False). Use the GitHub backend for branch ops."
-        )
-        raise RuntimeError(msg)
-    if not isinstance(backend, BranchBackend):
-        msg = f"{type(backend).__name__}: does not implement BranchBackend protocol."
-        raise TypeError(msg)
-    return backend
 
 
 def create_integration_branch(
@@ -59,9 +42,9 @@ def create_integration_branch(
         BranchInfo describing the created branch.
 
     Raises:
-        RuntimeError: If the active backend does not support branch operations.
+        UnsupportedBackendCapabilityError: If the active backend does not support branch operations.
     """
-    backend = _require_branch_support()
+    backend = require_branch_support(get_config().backend, "create_integration_branch")
     return backend.create_integration_branch(milestone_number, slug, base_branch=base_branch, repo=repo, output=output)
 
 
@@ -79,9 +62,9 @@ def get_integration_branch_status(
         BranchInfo, or None if the branch does not exist.
 
     Raises:
-        RuntimeError: If the active backend does not support branch operations.
+        UnsupportedBackendCapabilityError: If the active backend does not support branch operations.
     """
-    backend = _require_branch_support()
+    backend = require_branch_support(get_config().backend, "get_integration_branch_status")
     return backend.get_integration_branch_status(branch_name, repo=repo, output=output)
 
 
@@ -101,9 +84,9 @@ def merge_integration_branch(
         MergeResult with merge outcome.
 
     Raises:
-        RuntimeError: If the active backend does not support branch operations.
+        UnsupportedBackendCapabilityError: If the active backend does not support branch operations.
     """
-    backend = _require_branch_support()
+    backend = require_branch_support(get_config().backend, "merge_integration_branch")
     return backend.merge_integration_branch(head_branch, base_branch, commit_message, repo=repo, output=output)
 
 
@@ -119,9 +102,9 @@ def delete_integration_branch(branch_name: str, *, repo: str = "", output: Outpu
         True if the branch was deleted, False if it did not exist.
 
     Raises:
-        RuntimeError: If the active backend does not support branch operations.
+        UnsupportedBackendCapabilityError: If the active backend does not support branch operations.
     """
-    backend = _require_branch_support()
+    backend = require_branch_support(get_config().backend, "delete_integration_branch")
     return backend.delete_integration_branch(branch_name, repo=repo, output=output)
 
 
@@ -136,7 +119,7 @@ def list_integration_branches(*, repo: str = "", output: Output | None = None) -
         List of BranchInfo for all integration branches.
 
     Raises:
-        RuntimeError: If the active backend does not support branch operations.
+        UnsupportedBackendCapabilityError: If the active backend does not support branch operations.
     """
-    backend = _require_branch_support()
+    backend = require_branch_support(get_config().backend, "list_integration_branches")
     return backend.list_integration_branches(repo=repo, output=output)

--- a/plugins/development-harness/backlog_core/_capability_gates.py
+++ b/plugins/development-harness/backlog_core/_capability_gates.py
@@ -44,9 +44,7 @@ def require_github_extras(backend: WorkItemBackend, operation: str) -> GitHubExt
             is falsy, or the backend does not structurally satisfy
             ``GitHubExtras`` despite declaring the flag.
     """
-    if not getattr(backend, "supports_github_extras", False):
-        raise UnsupportedBackendCapabilityError("github_extras", type(backend).__name__, operation)
-    if not isinstance(backend, GitHubExtras):
+    if not getattr(backend, "supports_github_extras", False) or not isinstance(backend, GitHubExtras):
         raise UnsupportedBackendCapabilityError("github_extras", type(backend).__name__, operation)
     return backend
 
@@ -70,8 +68,6 @@ def require_branch_support(backend: WorkItemBackend, operation: str) -> BranchBa
             is falsy, or the backend does not structurally satisfy
             ``BranchBackend`` despite declaring the flag.
     """
-    if not getattr(backend, "supports_branches", False):
-        raise UnsupportedBackendCapabilityError("branches", type(backend).__name__, operation)
-    if not isinstance(backend, BranchBackend):
+    if not getattr(backend, "supports_branches", False) or not isinstance(backend, BranchBackend):
         raise UnsupportedBackendCapabilityError("branches", type(backend).__name__, operation)
     return backend

--- a/plugins/development-harness/backlog_core/_capability_gates.py
+++ b/plugins/development-harness/backlog_core/_capability_gates.py
@@ -1,0 +1,77 @@
+"""Shared capability gates for optional backend protocol subsets.
+
+``GitHubExtras`` and ``BranchBackend`` are both ``runtime_checkable``
+Protocols, which means ``isinstance(backend, SomeProtocol)`` checks method
+*names* only — a backend can satisfy a Protocol structurally (by
+implementing every method, even as a local simulation) without actually
+having the underlying capability. ``SQLiteBackend`` and ``InMemoryBackend``
+both implement every ``GitHubExtras`` method, but neither can return a real
+``Repository``, so ``isinstance`` alone lets them through the gate.
+
+The functions here gate on the backend's explicit capability flag first —
+``supports_github_extras`` / ``supports_branches`` — and use ``isinstance``
+only as a secondary structural assertion once the flag confirms the
+capability is genuinely present. Both raise the same typed
+``UnsupportedBackendCapabilityError`` (rather than a bare ``RuntimeError``
+or ``TypeError``) so every capability gap in the ``BacklogError`` tree looks
+identical to callers.
+"""
+
+from __future__ import annotations
+
+from .backend_types import BranchBackend, GitHubExtras, WorkItemBackend
+from .models import UnsupportedBackendCapabilityError
+
+__all__ = ["require_branch_support", "require_github_extras"]
+
+
+def require_github_extras(backend: WorkItemBackend, operation: str) -> GitHubExtras:
+    """Return ``backend`` narrowed to ``GitHubExtras``, or raise if unsupported.
+
+    Args:
+        backend: The active backend instance to check. Passed in by the
+            caller (rather than fetched here) so callers keep patching
+            ``get_config()`` directly in tests, and so static type checkers
+            narrow the return value at the call site.
+        operation: Name of the operation the caller is attempting, recorded
+            on the raised error for a specific remediation message.
+
+    Returns:
+        The same backend instance, statically narrowed to ``GitHubExtras``.
+
+    Raises:
+        UnsupportedBackendCapabilityError: If ``backend.supports_github_extras``
+            is falsy, or the backend does not structurally satisfy
+            ``GitHubExtras`` despite declaring the flag.
+    """
+    if not getattr(backend, "supports_github_extras", False):
+        raise UnsupportedBackendCapabilityError("github_extras", type(backend).__name__, operation)
+    if not isinstance(backend, GitHubExtras):
+        raise UnsupportedBackendCapabilityError("github_extras", type(backend).__name__, operation)
+    return backend
+
+
+def require_branch_support(backend: WorkItemBackend, operation: str) -> BranchBackend:
+    """Return ``backend`` narrowed to ``BranchBackend``, or raise if unsupported.
+
+    Args:
+        backend: The active backend instance to check. Passed in by the
+            caller (rather than fetched here) so callers keep patching
+            ``get_config()`` directly in tests, and so static type checkers
+            narrow the return value at the call site.
+        operation: Name of the operation the caller is attempting, recorded
+            on the raised error for a specific remediation message.
+
+    Returns:
+        The same backend instance, statically narrowed to ``BranchBackend``.
+
+    Raises:
+        UnsupportedBackendCapabilityError: If ``backend.supports_branches``
+            is falsy, or the backend does not structurally satisfy
+            ``BranchBackend`` despite declaring the flag.
+    """
+    if not getattr(backend, "supports_branches", False):
+        raise UnsupportedBackendCapabilityError("branches", type(backend).__name__, operation)
+    if not isinstance(backend, BranchBackend):
+        raise UnsupportedBackendCapabilityError("branches", type(backend).__name__, operation)
+    return backend

--- a/plugins/development-harness/backlog_core/_capability_gates.py
+++ b/plugins/development-harness/backlog_core/_capability_gates.py
@@ -62,12 +62,8 @@ def require_branch_support(backend: WorkItemBackend, operation: str) -> BranchBa
     """Return ``backend`` narrowed to ``BranchBackend``, or raise if unsupported.
 
     Args:
-        backend: The active backend instance to check. Passed in by the
-            caller (rather than fetched here) so callers keep patching
-            ``get_config()`` directly in tests, and so static type checkers
-            narrow the return value at the call site.
-        operation: Name of the operation the caller is attempting, recorded
-            on the raised error for a specific remediation message.
+        backend: The active backend instance to check (see require_github_extras's Args for why this is a parameter rather than fetched internally).
+        operation: See require_github_extras.
 
     Returns:
         The same backend instance, statically narrowed to ``BranchBackend``.

--- a/plugins/development-harness/backlog_core/_capability_gates.py
+++ b/plugins/development-harness/backlog_core/_capability_gates.py
@@ -11,10 +11,13 @@ both implement every ``GitHubExtras`` method, but neither can return a real
 The functions here gate on the backend's explicit capability flag first —
 ``supports_github_extras`` / ``supports_branches`` — and use ``isinstance``
 only as a secondary structural assertion once the flag confirms the
-capability is genuinely present. Both raise the same typed
+capability is genuinely present. Both failure modes raise the same typed
 ``UnsupportedBackendCapabilityError`` (rather than a bare ``RuntimeError``
-or ``TypeError``) so every capability gap in the ``BacklogError`` tree looks
-identical to callers.
+or ``TypeError``), staying inside the ``BacklogError`` tree — but a
+flag-``False`` backend and a flag-``True``-yet-protocol-mismatched backend
+are different situations (the latter is a backend bug, not a genuinely
+unsupported capability), so the error's ``protocol_mismatch`` flag and
+message distinguish them.
 """
 
 from __future__ import annotations
@@ -41,11 +44,17 @@ def require_github_extras(backend: WorkItemBackend, operation: str) -> GitHubExt
 
     Raises:
         UnsupportedBackendCapabilityError: If ``backend.supports_github_extras``
-            is falsy, or the backend does not structurally satisfy
-            ``GitHubExtras`` despite declaring the flag.
+            is falsy (capability genuinely unsupported), or the backend does
+            not structurally satisfy ``GitHubExtras`` despite declaring the
+            flag (``protocol_mismatch=True`` — a backend bug, not an
+            unsupported capability).
     """
-    if not getattr(backend, "supports_github_extras", False) or not isinstance(backend, GitHubExtras):
+    if not getattr(backend, "supports_github_extras", False):
         raise UnsupportedBackendCapabilityError("github_extras", type(backend).__name__, operation)
+    if not isinstance(backend, GitHubExtras):
+        raise UnsupportedBackendCapabilityError(
+            "github_extras", type(backend).__name__, operation, protocol_mismatch=True
+        )
     return backend
 
 
@@ -65,9 +74,13 @@ def require_branch_support(backend: WorkItemBackend, operation: str) -> BranchBa
 
     Raises:
         UnsupportedBackendCapabilityError: If ``backend.supports_branches``
-            is falsy, or the backend does not structurally satisfy
-            ``BranchBackend`` despite declaring the flag.
+            is falsy (capability genuinely unsupported), or the backend does
+            not structurally satisfy ``BranchBackend`` despite declaring the
+            flag (``protocol_mismatch=True`` — a backend bug, not an
+            unsupported capability).
     """
-    if not getattr(backend, "supports_branches", False) or not isinstance(backend, BranchBackend):
+    if not getattr(backend, "supports_branches", False):
         raise UnsupportedBackendCapabilityError("branches", type(backend).__name__, operation)
+    if not isinstance(backend, BranchBackend):
+        raise UnsupportedBackendCapabilityError("branches", type(backend).__name__, operation, protocol_mismatch=True)
     return backend

--- a/plugins/development-harness/backlog_core/backend_protocol.py
+++ b/plugins/development-harness/backlog_core/backend_protocol.py
@@ -27,6 +27,7 @@ from backlog_core.backends.github_backend import GitHubBackend
 from backlog_core.backends.memory_backend import InMemoryBackend
 from backlog_core.backends.sqlite_backend import SQLiteBackend
 
+from ._capability_gates import require_branch_support, require_github_extras
 from .backend_types import (
     AssigneeNode,
     BacklogConfig,
@@ -78,6 +79,8 @@ __all__ = [
     "WorkItemBackend",
     "create_backend",
     "get_config",
+    "require_branch_support",
+    "require_github_extras",
     "reset_config",
     "set_config",
 ]

--- a/plugins/development-harness/backlog_core/backend_types.py
+++ b/plugins/development-harness/backlog_core/backend_types.py
@@ -344,9 +344,12 @@ class BranchBackend(Protocol):
 
     Backends that do not support Git branch operations set
     ``supports_branches = False`` and are NOT required to implement this
-    protocol.  Callers branch on ``supports_branches`` (or
-    ``isinstance(backend, BranchBackend)``) before invoking these methods;
-    they must not rely on catching :exc:`RuntimeError` from a stub.
+    protocol. ``BranchBackend`` is ``runtime_checkable``, which means
+    ``isinstance(backend, BranchBackend)`` checks attribute names only, so
+    callers MUST gate on the ``supports_branches`` flag first — via
+    ``require_branch_support()`` in ``_capability_gates.py`` — and must not
+    rely on catching :exc:`RuntimeError` from a stub; the gate raises
+    ``UnsupportedBackendCapabilityError`` instead.
     """
 
     def create_integration_branch(

--- a/plugins/development-harness/backlog_core/backend_types.py
+++ b/plugins/development-harness/backlog_core/backend_types.py
@@ -131,15 +131,7 @@ class WorkItemBackend(Protocol):
     - ``supports_batch_issue_update`` — batch GraphQL update implemented.
     - ``issue_id_type`` — integer vs string issue IDs.
     - ``supports_branches`` — whether ``BranchBackend`` is implemented.
-    - ``supports_github_extras`` — whether ``GitHubExtras`` is implemented.
-      Gate on this flag first (via ``require_github_extras`` in
-      ``_capability_gates.py``), and treat ``isinstance(backend,
-      GitHubExtras)`` only as a secondary structural assertion:
-      ``GitHubExtras`` is ``runtime_checkable``, which checks attribute
-      names only, so a backend that structurally implements every method as
-      a local simulation still satisfies ``isinstance`` while this flag is
-      ``False`` because the simulation has no real GitHub connection behind
-      it.
+    - ``supports_github_extras`` — whether ``GitHubExtras`` is implemented; gate via ``require_github_extras()`` (see ``GitHubExtras``'s docstring for why ``isinstance`` alone is insufficient).
     """
 
     supports_batch_status_fetch: bool

--- a/plugins/development-harness/backlog_core/backend_types.py
+++ b/plugins/development-harness/backlog_core/backend_types.py
@@ -131,12 +131,22 @@ class WorkItemBackend(Protocol):
     - ``supports_batch_issue_update`` — batch GraphQL update implemented.
     - ``issue_id_type`` — integer vs string issue IDs.
     - ``supports_branches`` — whether ``BranchBackend`` is implemented.
+    - ``supports_github_extras`` — whether ``GitHubExtras`` is implemented.
+      Gate on this flag first (via ``require_github_extras`` in
+      ``_capability_gates.py``), and treat ``isinstance(backend,
+      GitHubExtras)`` only as a secondary structural assertion:
+      ``GitHubExtras`` is ``runtime_checkable``, which checks attribute
+      names only, so a backend that structurally implements every method as
+      a local simulation still satisfies ``isinstance`` while this flag is
+      ``False`` because the simulation has no real GitHub connection behind
+      it.
     """
 
     supports_batch_status_fetch: bool
     supports_batch_issue_update: bool
     issue_id_type: Literal["integer", "string"]
     supports_branches: bool
+    supports_github_extras: bool
 
     def list_work_items(self) -> list[BacklogItem]: ...
     def get_work_item(self, reference: str) -> BacklogItem: ...
@@ -220,10 +230,19 @@ class GitHubExtras(Protocol):
     """GitHub-specific surface only ``GitHubBackend`` implements.
 
     Backends that are not GitHub-backed are NOT required to implement this
-    protocol; they set the capability flags to ``False`` / raise
-    ``NotImplementedError`` only if a caller bypasses the capability check.
-    Callers gate on ``isinstance(backend, GitHubExtras)`` (or the relevant
-    capability flag) before invoking these.
+    protocol. ``GitHubExtras`` is ``runtime_checkable``, which means
+    ``isinstance(backend, GitHubExtras)`` checks attribute *names* only —
+    ``SQLiteBackend`` and ``InMemoryBackend`` implement all of these methods
+    as local simulations and therefore satisfy ``isinstance`` structurally,
+    even though neither can return a real ``Repository``.
+
+    Callers MUST gate on the ``supports_github_extras`` capability flag
+    first — via ``require_github_extras()`` in ``_capability_gates.py`` —
+    and treat ``isinstance(backend, GitHubExtras)`` only as a secondary
+    assertion after that flag check passes. Gating on ``isinstance`` alone
+    is a defect: it lets non-GitHub backends pass the gate and reach a
+    bare ``RuntimeError`` stub instead of a typed
+    ``UnsupportedBackendCapabilityError``.
     """
 
     # Repository access (GitHub-only)

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -247,6 +247,10 @@ class BeadsBackend:
       title is used as the selector.
     - ``supports_branches = False`` — beads does not manage git branches;
       callers must check this flag before invoking ``BranchBackend`` methods.
+    - ``supports_github_extras = False`` — beads implements none of the
+      ``GitHubExtras`` methods (see ``backend_types.py`` for the protocol);
+      this is the one backend the old ``isinstance``-only gate actually
+      caught correctly.
 
     Parameters
     ----------
@@ -261,6 +265,7 @@ class BeadsBackend:
     supports_batch_issue_update: bool = False
     issue_id_type: Literal["integer", "string"] = "string"
     supports_branches: bool = False
+    supports_github_extras: bool = False
 
     def __init__(self, runner: _BdRunnerLike | None = None) -> None:
         """Store the runner; do not touch the filesystem or spawn processes."""

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -6,8 +6,11 @@ Routes all supported backlog operations to the ``bd`` (beads) CLI via
 BeadsBackend implements :class:`~backlog_core.backend_types.WorkItemBackend`
 only — it does not implement :class:`~backlog_core.backend_types.GitHubExtras`
 or :class:`~backlog_core.backend_types.BranchBackend`.  Callers gate
-GitHub-specific operations on ``isinstance(backend, GitHubExtras)`` and branch
-operations on the ``supports_branches`` capability flag.
+GitHub-specific operations on the ``supports_github_extras`` capability flag
+(via ``require_github_extras()`` in ``_capability_gates.py``) and branch
+operations on the ``supports_branches`` flag (via ``require_branch_support()``)
+— ``isinstance`` alone is not sufficient, since both protocols are
+``runtime_checkable`` and check attribute names only.
 
 ADR-001: GitHub-specific operations (GraphQL, integration branches, task
 issues, milestone/project management) are not implemented for beads and have

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -102,12 +102,16 @@ class GitHubBackend:
       is implemented via aliased GraphQL mutations.
     - ``issue_id_type = "integer"`` — GitHub Issues are identified by integer
       issue numbers.
+    - ``supports_github_extras = True`` — this is the only backend that
+      implements ``GitHubExtras`` for real, backed by a live GitHub
+      connection.
     """
 
     supports_batch_status_fetch: bool = True
     supports_batch_issue_update: bool = True
     issue_id_type: Literal["integer", "string"] = "integer"
     supports_branches: bool = True
+    supports_github_extras: bool = True
 
     def __init__(
         self,

--- a/plugins/development-harness/backlog_core/backends/memory_backend.py
+++ b/plugins/development-harness/backlog_core/backends/memory_backend.py
@@ -104,12 +104,17 @@ class InMemoryBackend:
     - ``supports_branches = True`` — in-memory branch CRUD is fully
       implemented (create/get/list/delete/merge) for test-double coverage
       of the ``BranchBackend`` protocol.
+    - ``supports_github_extras = False`` — this backend implements the
+      ``GitHubExtras`` methods as local simulations for internal delegation,
+      but ``get_github()`` cannot return a real ``Repository``, so the
+      capability is absent regardless of which methods exist.
     """
 
     supports_batch_status_fetch: bool = True
     supports_batch_issue_update: bool = False
     issue_id_type: Literal["integer", "string"] = "integer"
     supports_branches: bool = True
+    supports_github_extras: bool = False
 
     def __init__(self) -> None:
         """Initialise empty in-memory storage for all backend state."""

--- a/plugins/development-harness/backlog_core/backends/memory_backend.py
+++ b/plugins/development-harness/backlog_core/backends/memory_backend.py
@@ -104,10 +104,7 @@ class InMemoryBackend:
     - ``supports_branches = True`` — in-memory branch CRUD is fully
       implemented (create/get/list/delete/merge) for test-double coverage
       of the ``BranchBackend`` protocol.
-    - ``supports_github_extras = False`` — this backend implements the
-      ``GitHubExtras`` methods as local simulations for internal delegation,
-      but ``get_github()`` cannot return a real ``Repository``, so the
-      capability is absent regardless of which methods exist.
+    - ``supports_github_extras = False`` — same reason as ``SQLiteBackend``: methods are local simulations, ``get_github()`` can't return a real ``Repository``.
     """
 
     supports_batch_status_fetch: bool = True

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -172,6 +172,10 @@ class SQLiteBackend:
     - ``supports_batch_issue_update = False`` — no real GraphQL layer; batch
       mutations are not available.
     - ``issue_id_type = "integer"`` — items are keyed by integer issue number.
+    - ``supports_github_extras = False`` — this backend implements the
+      ``GitHubExtras`` methods as local simulations for internal delegation,
+      but ``get_github()`` cannot return a real ``Repository``, so the
+      capability is absent regardless of which methods exist.
 
     Args:
         db_path: Path to the SQLite database file, or ``:memory:`` for an
@@ -182,6 +186,7 @@ class SQLiteBackend:
     supports_batch_issue_update: bool = False
     issue_id_type: Literal["integer", "string"] = "integer"
     supports_branches: bool = False
+    supports_github_extras: bool = False
 
     def __init__(self, db_path: str = ":memory:") -> None:
         """Initialise the SQLite database and create tables if absent.

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -639,7 +639,7 @@ class UnsupportedBackendCapabilityError(BacklogError):
         Args:
             capability: Name of the missing capability flag (e.g. "github_extras").
             backend: ``type(backend).__name__`` of the active backend.
-            operation: Name of the operation the caller attempted.
+            operation: Name of the operation the caller attempted, echoed into the raised error's message.
             protocol_mismatch: True when the backend declared the capability flag
                 ``True`` but does not structurally satisfy the corresponding
                 ``runtime_checkable`` Protocol — a backend implementation bug, not

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -613,6 +613,33 @@ class GitHubUnavailableError(BackendUnavailableError):
     """Raised when GITHUB_TOKEN is missing or the GitHub API is unreachable."""
 
 
+class UnsupportedBackendCapabilityError(BacklogError):
+    """Raised when the active backend does not implement an optional capability.
+
+    Pick this class for any ``BacklogError``-tree call site (``operations.py``,
+    the ~30 ``except BacklogError`` handlers in ``server.py``). Pick
+    ``ContentProviderError``'s sibling ``UnsupportedCapabilityError`` (below)
+    for ``ContentProvider``-tree call sites instead — the two trees are
+    deliberately not unified. Carries structured fields (rather than prose
+    only) so callers can render a specific remediation.
+    """
+
+    def __init__(self, capability: str, backend: str, operation: str) -> None:
+        """Initialize with the missing capability, backend name, and attempted operation.
+
+        Args:
+            capability: Name of the missing capability flag (e.g. "github_extras").
+            backend: ``type(backend).__name__`` of the active backend.
+            operation: Name of the operation the caller attempted.
+        """
+        self.capability = capability
+        self.backend = backend
+        self.operation = operation
+        super().__init__(
+            f"{backend}: {operation} requires the {capability} capability, which this backend does not support."
+        )
+
+
 class ValidationError(BacklogError):
     """Raised on input validation failure."""
 

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -624,20 +624,33 @@ class UnsupportedBackendCapabilityError(BacklogError):
     only) so callers can render a specific remediation.
     """
 
-    def __init__(self, capability: str, backend: str, operation: str) -> None:
+    def __init__(self, capability: str, backend: str, operation: str, *, protocol_mismatch: bool = False) -> None:
         """Initialize with the missing capability, backend name, and attempted operation.
 
         Args:
             capability: Name of the missing capability flag (e.g. "github_extras").
             backend: ``type(backend).__name__`` of the active backend.
             operation: Name of the operation the caller attempted.
+            protocol_mismatch: True when the backend declared the capability flag
+                ``True`` but does not structurally satisfy the corresponding
+                ``runtime_checkable`` Protocol — a backend implementation bug, not
+                a genuinely unsupported capability. Produces a message that says
+                so, rather than the misleading "does not support" wording that
+                fits only the flag-``False`` case.
         """
         self.capability = capability
         self.backend = backend
         self.operation = operation
-        super().__init__(
-            f"{backend}: {operation} requires the {capability} capability, which this backend does not support."
-        )
+        self.protocol_mismatch = protocol_mismatch
+        if protocol_mismatch:
+            msg = (
+                f"{backend}: {operation} — backend declares supports_{capability}=True but does not "
+                f"structurally implement the {capability} protocol. This is a backend bug, not an "
+                "unsupported capability."
+            )
+        else:
+            msg = f"{backend}: {operation} requires the {capability} capability, which this backend does not support."
+        super().__init__(msg)
 
     def to_response(self, milestone_number: int) -> dict[str, str | int]:
         """Build the dispatch-tool error payload for this capability gap.

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -613,6 +613,15 @@ class GitHubUnavailableError(BackendUnavailableError):
     """Raised when GITHUB_TOKEN is missing or the GitHub API is unreachable."""
 
 
+# Maps a capability flag name to the runtime_checkable Protocol it gates, for use in
+# UnsupportedBackendCapabilityError's protocol_mismatch message — "github_extras" alone
+# doesn't tell a reader which Protocol class the backend failed to satisfy.
+_CAPABILITY_PROTOCOL_NAMES: dict[str, str] = {
+    "github_extras": "GitHubExtras",
+    "branches": "BranchBackend",
+}
+
+
 class UnsupportedBackendCapabilityError(BacklogError):
     """Raised when the active backend does not implement an optional capability.
 
@@ -643,9 +652,10 @@ class UnsupportedBackendCapabilityError(BacklogError):
         self.operation = operation
         self.protocol_mismatch = protocol_mismatch
         if protocol_mismatch:
+            protocol_name = _CAPABILITY_PROTOCOL_NAMES.get(capability, capability)
             msg = (
                 f"{backend}: {operation} — backend declares supports_{capability}=True but does not "
-                f"structurally implement the {capability} protocol. This is a backend bug, not an "
+                f"structurally implement the {protocol_name} protocol. This is a backend bug, not an "
                 "unsupported capability."
             )
         else:

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -639,6 +639,24 @@ class UnsupportedBackendCapabilityError(BacklogError):
             f"{backend}: {operation} requires the {capability} capability, which this backend does not support."
         )
 
+    def to_response(self, milestone_number: int) -> dict[str, str | int]:
+        """Build the dispatch-tool error payload for this capability gap.
+
+        Shared by ``dispatch_stale_check``/``dispatch_conflicts`` in both
+        ``server.py`` and ``dh_core/operations.py`` so the four call sites
+        don't each hand-build the same dict.
+
+        Returns:
+            Dict with ``error``, ``unsupported_capability``, ``backend``, and
+            ``milestone_number`` fields for the caller to return directly.
+        """
+        return {
+            "error": str(self),
+            "unsupported_capability": self.capability,
+            "backend": self.backend,
+            "milestone_number": milestone_number,
+        }
+
 
 class ValidationError(BacklogError):
     """Raised on input validation failure."""

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -616,10 +616,7 @@ class GitHubUnavailableError(BackendUnavailableError):
 # Maps a capability flag name to the runtime_checkable Protocol it gates, for use in
 # UnsupportedBackendCapabilityError's protocol_mismatch message — "github_extras" alone
 # doesn't tell a reader which Protocol class the backend failed to satisfy.
-_CAPABILITY_PROTOCOL_NAMES: dict[str, str] = {
-    "github_extras": "GitHubExtras",
-    "branches": "BranchBackend",
-}
+_CAPABILITY_PROTOCOL_NAMES: dict[str, str] = {"github_extras": "GitHubExtras", "branches": "BranchBackend"}
 
 
 class UnsupportedBackendCapabilityError(BacklogError):

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -25,8 +25,9 @@ from sam_schema.core.models import Plan
 from typing_extensions import TypedDict
 
 from . import models as _models
+from ._capability_gates import require_github_extras
 from .backend_protocol import get_config
-from .backend_types import ContentProvider, GitHubExtras, IssueCommentNode, IssueNode, MilestoneFullNode, SyncProvider
+from .backend_types import ContentProvider, IssueCommentNode, IssueNode, MilestoneFullNode, SyncProvider
 from .entry_blocks import _render_entry_raw, find_entry_spans, parse_entries, resolve_all_entry_ids, resolve_entry_id
 from .models import (
     ITEM_TYPE_ALIASES,
@@ -127,9 +128,7 @@ def get_github(repo: str = "", timeout: int = 15) -> Repository:
         Authenticated Repository object.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("get_github requires a GitHub-backed backend")
-    return backend.get_github(repo, timeout)
+    return require_github_extras(backend, "get_github").get_github(repo, timeout)
 
 
 def try_get_github(repo: str = "") -> Repository | None:
@@ -178,9 +177,7 @@ def sync_issues_graphql(
         List of IssueNode objects matching the query.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("sync_issues_graphql requires a GitHub-backed backend")
-    return backend.sync_issues_graphql(
+    return require_github_extras(backend, "sync_issues_graphql").sync_issues_graphql(
         repo,
         owner,
         repo_name,
@@ -305,9 +302,9 @@ def create_task_issue(
         IssueNode for the created child issue, or None on failure.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("create_task_issue requires a GitHub-backed backend")
-    return backend.create_task_issue(repo, parent_issue_number, task, description, acceptance_criteria, labels, output)
+    return require_github_extras(backend, "create_task_issue").create_task_issue(
+        repo, parent_issue_number, task, description, acceptance_criteria, labels, output
+    )
 
 
 def get_task_issues(repo: Repository, parent_issue_number: int, output: Output | None = None) -> list[IssueNode]:
@@ -317,9 +314,7 @@ def get_task_issues(repo: Repository, parent_issue_number: int, output: Output |
         List of IssueNode objects for child task issues.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("get_task_issues requires a GitHub-backed backend")
-    return backend.get_task_issues(repo, parent_issue_number, output)
+    return require_github_extras(backend, "get_task_issues").get_task_issues(repo, parent_issue_number, output)
 
 
 def update_task_status(repo: Repository, issue_number: int, new_status: str, output: Output | None = None) -> bool:
@@ -329,9 +324,9 @@ def update_task_status(repo: Repository, issue_number: int, new_status: str, out
         True if the status was updated, False otherwise.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("update_task_status requires a GitHub-backed backend")
-    return backend.update_task_status(repo, issue_number, new_status, output)
+    return require_github_extras(backend, "update_task_status").update_task_status(
+        repo, issue_number, new_status, output
+    )
 
 
 def _fetch_issue_graphql(repo: Repository, owner: str, repo_name: str, issue_number: int) -> IssueNode:
@@ -341,9 +336,9 @@ def _fetch_issue_graphql(repo: Repository, owner: str, repo_name: str, issue_num
         IssueNode for the requested issue.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_fetch_issue_graphql requires a GitHub-backed backend")
-    return backend._fetch_issue_graphql(repo, owner, repo_name, issue_number)
+    return require_github_extras(backend, "_fetch_issue_graphql")._fetch_issue_graphql(
+        repo, owner, repo_name, issue_number
+    )
 
 
 def _update_issue_graphql(
@@ -358,9 +353,7 @@ def _update_issue_graphql(
 ) -> None:
     """Update an issue's mutable fields via the active backend."""
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_update_issue_graphql requires a GitHub-backed backend")
-    backend._update_issue_graphql(
+    require_github_extras(backend, "_update_issue_graphql")._update_issue_graphql(
         repo, issue_node_id, state=state, body=body, title=title, label_ids=label_ids, milestone_id=milestone_id
     )
 
@@ -373,9 +366,7 @@ def _update_issues_graphql_batch(repo: Repository, updates: list[tuple[str, str]
     = False`` raise :exc:`NotImplementedError`.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_update_issues_graphql_batch requires a GitHub-backed backend")
-    backend._update_issues_graphql_batch(repo, updates)
+    require_github_extras(backend, "_update_issues_graphql_batch")._update_issues_graphql_batch(repo, updates)
 
 
 def _add_comment_graphql(repo: Repository, issue_node_id: str, body: str) -> str:
@@ -385,9 +376,7 @@ def _add_comment_graphql(repo: Repository, issue_node_id: str, body: str) -> str
         GraphQL node ID of the newly created comment.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_add_comment_graphql requires a GitHub-backed backend")
-    return backend._add_comment_graphql(repo, issue_node_id, body)
+    return require_github_extras(backend, "_add_comment_graphql")._add_comment_graphql(repo, issue_node_id, body)
 
 
 def _fetch_issue_comments_graphql(
@@ -399,9 +388,9 @@ def _fetch_issue_comments_graphql(
         List of IssueCommentNode objects for the issue.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_fetch_issue_comments_graphql requires a GitHub-backed backend")
-    return backend._fetch_issue_comments_graphql(repo, owner, repo_name, issue_number)
+    return require_github_extras(backend, "_fetch_issue_comments_graphql")._fetch_issue_comments_graphql(
+        repo, owner, repo_name, issue_number
+    )
 
 
 def _fetch_comment_by_id_graphql(repo: Repository, comment_node_id: str) -> IssueCommentNode:
@@ -411,9 +400,9 @@ def _fetch_comment_by_id_graphql(repo: Repository, comment_node_id: str) -> Issu
         IssueCommentNode for the requested comment.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_fetch_comment_by_id_graphql requires a GitHub-backed backend")
-    return backend._fetch_comment_by_id_graphql(repo, comment_node_id)
+    return require_github_extras(backend, "_fetch_comment_by_id_graphql")._fetch_comment_by_id_graphql(
+        repo, comment_node_id
+    )
 
 
 def _fetch_milestones_graphql(
@@ -425,9 +414,9 @@ def _fetch_milestones_graphql(
         List of MilestoneFullNode objects.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_fetch_milestones_graphql requires a GitHub-backed backend")
-    return backend._fetch_milestones_graphql(repo, owner, repo_name, states)
+    return require_github_extras(backend, "_fetch_milestones_graphql")._fetch_milestones_graphql(
+        repo, owner, repo_name, states
+    )
 
 
 def _graphql_request(repo: Repository, query: str, variables: dict[str, object] | None = None) -> dict[str, Any]:
@@ -437,9 +426,7 @@ def _graphql_request(repo: Repository, query: str, variables: dict[str, object] 
         Parsed JSON response dict from the GraphQL endpoint.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_graphql_request requires a GitHub-backed backend")
-    return backend._graphql_request(repo, query, variables)
+    return require_github_extras(backend, "_graphql_request")._graphql_request(repo, query, variables)
 
 
 def _projects_v2_list_query(owner: str, limit: int = 20) -> tuple[str, dict[str, object]]:
@@ -449,9 +436,7 @@ def _projects_v2_list_query(owner: str, limit: int = 20) -> tuple[str, dict[str,
         Tuple of (query_string, variables_dict).
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_projects_v2_list_query requires a GitHub-backed backend")
-    return backend._projects_v2_list_query(owner, limit)
+    return require_github_extras(backend, "_projects_v2_list_query")._projects_v2_list_query(owner, limit)
 
 
 def _projects_v2_create_mutation(owner_id: str, title: str) -> tuple[str, dict[str, object]]:
@@ -461,9 +446,7 @@ def _projects_v2_create_mutation(owner_id: str, title: str) -> tuple[str, dict[s
         Tuple of (mutation_string, variables_dict).
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        raise BacklogError("_projects_v2_create_mutation requires a GitHub-backed backend")
-    return backend._projects_v2_create_mutation(owner_id, title)
+    return require_github_extras(backend, "_projects_v2_create_mutation")._projects_v2_create_mutation(owner_id, title)
 
 
 # github_sync delegates — original alias names preserved for test patchability

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -57,6 +57,7 @@ from .models import (
     Section,
     SectionEntryDict,
     SectionEntryMetadata,
+    UnsupportedBackendCapabilityError,
     ValidationError,
     ViewItemResult,
     parse_issue_number,
@@ -4723,6 +4724,8 @@ def list_issues(
         milestone_number = _resolve_milestone_number(gh_repo, milestone, out)
         label_names = _resolve_label_names(labels)
         issue_list = _collect_issues(gh_repo, state, label_names, milestone_number, limit)
+    except UnsupportedBackendCapabilityError:
+        raise
     except (GithubException, BacklogError) as e:
         msg = f"GitHub API error fetching issues: {e}"
         raise BacklogError(msg) from e
@@ -4762,6 +4765,8 @@ def comment_issue(
         issue_node = _fetch_issue_graphql(gh_repo, owner, repo_name, issue_number)
         comment_node_id = _add_comment_graphql(gh_repo, issue_node["id"], body)
         out.info(f"  Comment added to issue #{issue_number}")
+    except UnsupportedBackendCapabilityError:
+        raise
     except (GithubException, BacklogError) as e:
         msg = f"GitHub API error adding comment: {e}"
         raise BacklogError(msg) from e
@@ -4803,6 +4808,8 @@ def list_comments(
         gh_repo = get_github(repo)
         owner, repo_name = gh_repo.full_name.split("/", 1)
         all_comments = _fetch_issue_comments_graphql(gh_repo, owner, repo_name, issue_number)
+    except UnsupportedBackendCapabilityError:
+        raise
     except (GithubException, BacklogError) as e:
         msg = f"GitHub API error fetching comments: {e}"
         raise BacklogError(msg) from e
@@ -4878,6 +4885,8 @@ def read_comment(
         pygithub_comment = pygithub_issue.get_comment(comment_id)
         node_id: str = str(pygithub_comment.node_id)
         comment = _fetch_comment_by_id_graphql(gh_repo, node_id)
+    except UnsupportedBackendCapabilityError:
+        raise
     except (GithubException, BacklogError) as e:
         msg = f"GitHub API error reading comment: {e}"
         raise BacklogError(msg) from e

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -3628,12 +3628,7 @@ async def dispatch_stale_check(
     try:
         current_numbers = await asyncio.to_thread(_fetch_milestone_issue_numbers)
     except UnsupportedBackendCapabilityError as exc:
-        return {
-            "error": str(exc),
-            "unsupported_capability": exc.capability,
-            "backend": exc.backend,
-            "milestone_number": milestone_number,
-        }
+        return exc.to_response(milestone_number)
     except GitHubUnavailableError as exc:
         return {"error": str(exc), "milestone_number": milestone_number}
     except (BacklogError, _GithubException) as exc:
@@ -3800,12 +3795,7 @@ async def dispatch_conflicts(
     try:
         items = await asyncio.to_thread(_fetch_items_with_impact_radius)
     except UnsupportedBackendCapabilityError as exc:
-        return {
-            "error": str(exc),
-            "unsupported_capability": exc.capability,
-            "backend": exc.backend,
-            "milestone_number": milestone_number,
-        }
+        return exc.to_response(milestone_number)
     except GitHubUnavailableError as exc:
         return {"error": str(exc), "milestone_number": milestone_number}
     except (BacklogError, _GithubException) as exc:

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -40,6 +40,7 @@ from pydantic import Field
 from ruamel.yaml import YAML as _YAML
 
 from . import models as _models, sync_engine as _sync_engine
+from ._capability_gates import require_github_extras
 from .artifact_manifest_store import (
     artifact_content_reference,
     load_manifest as _load_manifest_record,
@@ -47,7 +48,7 @@ from .artifact_manifest_store import (
 )
 from .artifact_registry import ArtifactRegistry
 from .backend_protocol import get_config as _get_config
-from .backend_types import ContentProvider, GitHubExtras, IssueNode as _IssueNode, SyncProvider
+from .backend_types import ContentProvider, IssueNode as _IssueNode, SyncProvider
 from .disclosure_handler import BacklogViewDisclosureHandler, DisclosureRequest, DisclosureRequestParser
 from .disclosure_types import DisclosureMode, DisclosureParamError, OrdinalNotFoundError
 from .dispatch_state import DispatchStateManager as _DispatchStateManager
@@ -73,6 +74,7 @@ from .models import (
     GitHubUnavailableError,
     Output,
     RegisterResult,
+    UnsupportedBackendCapabilityError,
     UnsupportedCapabilityError,
     init as _init_models,
 )
@@ -3612,20 +3614,26 @@ async def dispatch_stale_check(
 
     def _fetch_milestone_issue_numbers() -> list[int]:
         backend = _get_config().backend
-        if not isinstance(backend, GitHubExtras):
-            raise BacklogError("dispatch_stale_check requires a GitHub-backed backend")
-        gh_repo = backend.get_github(repo)
+        github_backend = require_github_extras(backend, "get_github")
+        gh_repo = github_backend.get_github(repo)
         owner, repo_name = gh_repo.full_name.split("/", 1)
-        open_issues = backend.sync_issues_graphql(
+        open_issues = github_backend.sync_issues_graphql(
             gh_repo, owner, repo_name, state="OPEN", milestone_number=milestone_number
         )
-        closed_issues = backend.sync_issues_graphql(
+        closed_issues = github_backend.sync_issues_graphql(
             gh_repo, owner, repo_name, state="CLOSED", milestone_number=milestone_number
         )
         return [issue["number"] for issue in open_issues + closed_issues]
 
     try:
         current_numbers = await asyncio.to_thread(_fetch_milestone_issue_numbers)
+    except UnsupportedBackendCapabilityError as exc:
+        return {
+            "error": str(exc),
+            "unsupported_capability": exc.capability,
+            "backend": exc.backend,
+            "milestone_number": milestone_number,
+        }
     except GitHubUnavailableError as exc:
         return {"error": str(exc), "milestone_number": milestone_number}
     except (BacklogError, _GithubException) as exc:
@@ -3774,11 +3782,10 @@ async def dispatch_conflicts(
 
     def _fetch_items_with_impact_radius() -> list[_ImpactRadiusItem]:
         backend = _get_config().backend
-        if not isinstance(backend, GitHubExtras):
-            raise BacklogError("dispatch_conflicts requires a GitHub-backed backend")
-        gh_repo = backend.get_github(repo)
+        github_backend = require_github_extras(backend, "get_github")
+        gh_repo = github_backend.get_github(repo)
         owner, repo_name = gh_repo.full_name.split("/", 1)
-        issue_nodes: list[_IssueNode] = backend.sync_issues_graphql(
+        issue_nodes: list[_IssueNode] = github_backend.sync_issues_graphql(
             gh_repo, owner, repo_name, state="OPEN", milestone_number=milestone_number
         )
         items: list[_ImpactRadiusItem] = []
@@ -3792,6 +3799,13 @@ async def dispatch_conflicts(
 
     try:
         items = await asyncio.to_thread(_fetch_items_with_impact_radius)
+    except UnsupportedBackendCapabilityError as exc:
+        return {
+            "error": str(exc),
+            "unsupported_capability": exc.capability,
+            "backend": exc.backend,
+            "milestone_number": milestone_number,
+        }
     except GitHubUnavailableError as exc:
         return {"error": str(exc), "milestone_number": milestone_number}
     except (BacklogError, _GithubException) as exc:

--- a/plugins/development-harness/backlog_core/sync_engine.py
+++ b/plugins/development-harness/backlog_core/sync_engine.py
@@ -175,7 +175,9 @@ async def _attempt_sync(state: SyncState, attempt: int, full_refresh: bool) -> b
             # raise (the set classify_sync_error handles — BacklogError covers its
             # BackendUnavailableError subclass; ContentProviderError is a separate
             # exception tree, not a BacklogError subclass, so it needs its own entry
-            # here or classify_sync_error's NON_RETRYABLE branch for it is unreachable).
+            # here or classify_sync_error never runs on it at all). classify_sync_error
+            # then decides RETRYABLE vs NON_RETRYABLE per exception, inspecting a
+            # ContentProviderError's wrapped cause for a transient GithubException.
             # Any other exception is a programming bug and propagates to the task
             # done-callback (_log_sync_task_exc), which logs it — never silently masked
             # as OFFLINE.

--- a/plugins/development-harness/backlog_core/sync_engine.py
+++ b/plugins/development-harness/backlog_core/sync_engine.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Protocol
 from github import GithubException
 
 from . import operations
-from .models import BacklogError
+from .models import BacklogError, ContentProviderError
 from .sync_state import SyncErrorKind, SyncState, SyncStatus, classify_sync_error
 
 if TYPE_CHECKING:
@@ -170,12 +170,15 @@ async def _attempt_sync(state: SyncState, attempt: int, full_refresh: bool) -> b
             state.status = SyncStatus.IDLE
             _log.info("Background sync cancelled during attempt %d.", attempt + 1)
             raise
-        except (BacklogError, GithubException, OSError, ValueError) as exc:
+        except (BacklogError, ContentProviderError, GithubException, OSError, ValueError) as exc:
             # Catch the exception types refresh_local_cache_from_github is documented to
             # raise (the set classify_sync_error handles — BacklogError covers its
-            # BackendUnavailableError subclass).  Any other
-            # exception is a programming bug and propagates to the task done-callback
-            # (_log_sync_task_exc), which logs it — never silently masked as OFFLINE.
+            # BackendUnavailableError subclass; ContentProviderError is a separate
+            # exception tree, not a BacklogError subclass, so it needs its own entry
+            # here or classify_sync_error's NON_RETRYABLE branch for it is unreachable).
+            # Any other exception is a programming bug and propagates to the task
+            # done-callback (_log_sync_task_exc), which logs it — never silently masked
+            # as OFFLINE.
             state.completed_at = datetime.now(UTC)
             kind = classify_sync_error(exc)
             error_msg = str(exc)

--- a/plugins/development-harness/backlog_core/sync_state.py
+++ b/plugins/development-harness/backlog_core/sync_state.py
@@ -248,6 +248,32 @@ def _classify_github_exception(exc: GithubException) -> SyncErrorKind:
     return SyncErrorKind.UNKNOWN
 
 
+def _classify_content_provider_error(exc: ContentProviderError) -> SyncErrorKind:
+    """Classify a ContentProviderError by inspecting its wrapped cause, if any.
+
+    A ContentProviderError is not always structural: ``_GitHubContentsStore.get_many()``
+    wraps *any* ``GithubException`` it sees — including a transient 503 or a
+    rate-limited 429 — in ``ContentUnavailableError`` via ``raise ... from exc``.
+    Blanket-classifying every ContentProviderError as non-retryable would send a
+    merely-overloaded GitHub API straight to OFFLINE instead of the bounded retry
+    policy transient failures are supposed to get.
+
+    Args:
+        exc: A ContentProviderError, possibly wrapping a GithubException as its
+            ``__cause__``.
+
+    Returns:
+        The wrapped GithubException's own classification when one is present
+        (delegates to ``_classify_github_exception``); otherwise
+        ``NON_RETRYABLE`` — the error is genuinely structural (a capability
+        gap, a not-found, a revision conflict), and retrying won't fix it.
+    """
+    cause = exc.__cause__
+    if isinstance(cause, GithubException):
+        return _classify_github_exception(cause)
+    return SyncErrorKind.NON_RETRYABLE
+
+
 def classify_sync_error(exc: BaseException) -> SyncErrorKind:
     """Classify a sync exception as retryable or non-retryable.
 
@@ -256,8 +282,11 @@ def classify_sync_error(exc: BaseException) -> SyncErrorKind:
     - ``BackendUnavailableError`` (includes ``GitHubUnavailableError``) — NON_RETRYABLE.
     - ``UnsupportedBackendCapabilityError`` (backend lacks an optional capability;
       retrying will not change what the backend supports) — NON_RETRYABLE.
-    - ``ContentProviderError`` (logical content capability failure; unrelated
-      exception tree from ``BacklogError``, so needs its own branch) — NON_RETRYABLE.
+    - ``ContentProviderError`` (unrelated exception tree from ``BacklogError``, so
+      needs its own branch) — delegates to ``_classify_content_provider_error``,
+      which inspects ``__cause__``: a wrapped ``GithubException`` (e.g. a transient
+      503 from ``get_many()``) gets that exception's own classification; otherwise
+      NON_RETRYABLE (a genuine capability gap, not-found, or conflict).
     - ``BacklogError`` (generic backend/GraphQL fetch failure) — RETRYABLE.
     - ``GithubException`` with status 401 or 404 — NON_RETRYABLE.
     - ``GithubException`` with status 403 and no ``Retry-After`` header — NON_RETRYABLE.
@@ -281,20 +310,23 @@ def classify_sync_error(exc: BaseException) -> SyncErrorKind:
     Returns:
         ``SyncErrorKind`` indicating whether the sync should retry.
     """
-    if isinstance(exc, (BackendUnavailableError, UnsupportedBackendCapabilityError, ContentProviderError)):
-        # Structural, not transient: a capability gap or content-provider failure
-        # won't resolve by retrying. ContentProviderError is an unrelated exception
-        # tree from BacklogError (see models.py) — needs its own branch or it falls
-        # through to UNKNOWN.
+    if isinstance(exc, (BackendUnavailableError, UnsupportedBackendCapabilityError)):
+        # Structural, not transient: a capability gap won't resolve by retrying.
         return SyncErrorKind.NON_RETRYABLE
-    if isinstance(exc, BacklogError):
-        # Generic backend/GraphQL failure (e.g. from sync_issues_graphql) — transient.
-        # Checked after BackendUnavailableError/UnsupportedBackendCapabilityError
-        # (structural non-retryable cases) so those stay non-retryable.
-        return SyncErrorKind.RETRYABLE
+    if isinstance(exc, ContentProviderError):
+        # Unrelated exception tree from BacklogError (see models.py) — needs its own
+        # branch or it falls through to UNKNOWN. Not always structural: see
+        # _classify_content_provider_error's docstring.
+        return _classify_content_provider_error(exc)
     if isinstance(exc, GithubException):
         return _classify_github_exception(exc)
-    if isinstance(exc, RETRYABLE_TRANSIENT_EXCEPTIONS):
+    if isinstance(exc, (BacklogError, *RETRYABLE_TRANSIENT_EXCEPTIONS)):
+        # Generic BacklogError (e.g. from sync_issues_graphql) and the transient
+        # network exceptions both mean "worth retrying" — merged into one branch to
+        # stay under ruff's too-many-return-statements limit. Checked after the
+        # structural non-retryable cases above so those stay non-retryable, and
+        # after GithubException so a raw GithubException still gets status-code
+        # classification rather than a blanket RETRYABLE.
         return SyncErrorKind.RETRYABLE
     if isinstance(exc, (OSError, ValueError)):
         return SyncErrorKind.NON_RETRYABLE

--- a/plugins/development-harness/backlog_core/sync_state.py
+++ b/plugins/development-harness/backlog_core/sync_state.py
@@ -248,8 +248,40 @@ def _classify_github_exception(exc: GithubException) -> SyncErrorKind:
     return SyncErrorKind.UNKNOWN
 
 
+_MAX_CAUSE_CHAIN_DEPTH = 5
+
+
+def _find_wrapped_github_exception(exc: BaseException) -> GithubException | None:
+    """Walk ``exc``'s ``__cause__`` chain looking for a wrapped GithubException.
+
+    A content-provider error can wrap through more than one layer before
+    reaching the original GithubException. E.g. ``gh_client._graphql_request()``
+    wraps a GithubException in ``BacklogError``, and
+    ``_fetch_blobs_graphql()`` then wraps that ``BacklogError`` in
+    ``ContentUnavailableError`` — the GithubException sits two ``__cause__``
+    links down, not one.
+
+    Args:
+        exc: The outermost exception to search from.
+
+    Returns:
+        The first GithubException found while walking ``__cause__``, or
+        ``None`` if none is present within ``_MAX_CAUSE_CHAIN_DEPTH`` links
+        (bounded so a pathological or accidentally-cyclic chain can't loop
+        forever — real exception chains here are 1-2 links deep).
+    """
+    cause: BaseException | None = exc.__cause__
+    for _ in range(_MAX_CAUSE_CHAIN_DEPTH):
+        if cause is None:
+            return None
+        if isinstance(cause, GithubException):
+            return cause
+        cause = cause.__cause__
+    return None
+
+
 def _classify_content_provider_error(exc: ContentProviderError) -> SyncErrorKind:
-    """Classify a ContentProviderError by inspecting its wrapped cause, if any.
+    """Classify a ContentProviderError by inspecting its wrapped cause chain, if any.
 
     A ContentProviderError is not always structural: ``_GitHubContentsStore.get_many()``
     wraps *any* ``GithubException`` it sees — including a transient 503 or a
@@ -259,18 +291,20 @@ def _classify_content_provider_error(exc: ContentProviderError) -> SyncErrorKind
     policy transient failures are supposed to get.
 
     Args:
-        exc: A ContentProviderError, possibly wrapping a GithubException as its
-            ``__cause__``.
+        exc: A ContentProviderError, possibly wrapping a GithubException
+            somewhere in its ``__cause__`` chain (see
+            ``_find_wrapped_github_exception``).
 
     Returns:
         The wrapped GithubException's own classification when one is present
-        (delegates to ``_classify_github_exception``); otherwise
-        ``NON_RETRYABLE`` — the error is genuinely structural (a capability
-        gap, a not-found, a revision conflict), and retrying won't fix it.
+        anywhere in the chain (delegates to ``_classify_github_exception``);
+        otherwise ``NON_RETRYABLE`` — the error is genuinely structural (a
+        capability gap, a not-found, a revision conflict), and retrying
+        won't fix it.
     """
-    cause = exc.__cause__
-    if isinstance(cause, GithubException):
-        return _classify_github_exception(cause)
+    github_cause = _find_wrapped_github_exception(exc)
+    if github_cause is not None:
+        return _classify_github_exception(github_cause)
     return SyncErrorKind.NON_RETRYABLE
 
 

--- a/plugins/development-harness/backlog_core/sync_state.py
+++ b/plugins/development-harness/backlog_core/sync_state.py
@@ -24,7 +24,7 @@ from enum import StrEnum
 import requests
 from github import GithubException
 
-from .models import BackendUnavailableError, BacklogError
+from .models import BackendUnavailableError, BacklogError, ContentProviderError, UnsupportedBackendCapabilityError
 
 # Transient-network exceptions that are also OSError subclasses, so they must be
 # checked before the generic OSError branch: asyncio.TimeoutError (Python 3.11+
@@ -254,6 +254,10 @@ def classify_sync_error(exc: BaseException) -> SyncErrorKind:
     Classification table (from design doc section 5.1):
 
     - ``BackendUnavailableError`` (includes ``GitHubUnavailableError``) — NON_RETRYABLE.
+    - ``UnsupportedBackendCapabilityError`` (backend lacks an optional capability;
+      retrying will not change what the backend supports) — NON_RETRYABLE.
+    - ``ContentProviderError`` (logical content capability failure; unrelated
+      exception tree from ``BacklogError``, so needs its own branch) — NON_RETRYABLE.
     - ``BacklogError`` (generic backend/GraphQL fetch failure) — RETRYABLE.
     - ``GithubException`` with status 401 or 404 — NON_RETRYABLE.
     - ``GithubException`` with status 403 and no ``Retry-After`` header — NON_RETRYABLE.
@@ -277,11 +281,16 @@ def classify_sync_error(exc: BaseException) -> SyncErrorKind:
     Returns:
         ``SyncErrorKind`` indicating whether the sync should retry.
     """
-    if isinstance(exc, BackendUnavailableError):
+    if isinstance(exc, (BackendUnavailableError, UnsupportedBackendCapabilityError, ContentProviderError)):
+        # Structural, not transient: a capability gap or content-provider failure
+        # won't resolve by retrying. ContentProviderError is an unrelated exception
+        # tree from BacklogError (see models.py) — needs its own branch or it falls
+        # through to UNKNOWN.
         return SyncErrorKind.NON_RETRYABLE
     if isinstance(exc, BacklogError):
         # Generic backend/GraphQL failure (e.g. from sync_issues_graphql) — transient.
-        # Checked after BackendUnavailableError (its subclass) so auth/config stays non-retryable.
+        # Checked after BackendUnavailableError/UnsupportedBackendCapabilityError
+        # (structural non-retryable cases) so those stay non-retryable.
         return SyncErrorKind.RETRYABLE
     if isinstance(exc, GithubException):
         return _classify_github_exception(exc)

--- a/plugins/development-harness/dh_core/operations.py
+++ b/plugins/development-harness/dh_core/operations.py
@@ -43,8 +43,8 @@ from backlog_core.artifact_manifest_store import (
     publish_artifact,
 )
 from backlog_core.artifact_registry import ArtifactRegistry
-from backlog_core.backend_protocol import get_config
-from backlog_core.backend_types import ContentProvider, GitHubExtras
+from backlog_core.backend_protocol import get_config, require_github_extras
+from backlog_core.backend_types import ContentProvider
 from backlog_core.dispatch_state import DispatchStateManager
 from backlog_core.models import (
     ArtifactContent,
@@ -64,6 +64,7 @@ from backlog_core.models import (
     DispatchWaveSummary,
     GitHubUnavailableError,
     Output,
+    UnsupportedBackendCapabilityError,
     UnsupportedCapabilityError,
     get_repo_root,
 )
@@ -1241,18 +1242,24 @@ def dispatch_stale_check(milestone_number: int, repo: str = "") -> dict[str, Any
         return {"error": str(exc), "milestone_number": milestone_number}
 
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        return {"error": "dispatch_stale_check requires a GitHub-backed backend", "milestone_number": milestone_number}
     try:
-        gh_repo = backend.get_github(repo)
+        github_backend = require_github_extras(backend, "get_github")
+        gh_repo = github_backend.get_github(repo)
         owner, repo_name = gh_repo.full_name.split("/", 1)
-        open_issues = backend.sync_issues_graphql(
+        open_issues = github_backend.sync_issues_graphql(
             gh_repo, owner, repo_name, state="OPEN", milestone_number=milestone_number
         )
-        closed_issues = backend.sync_issues_graphql(
+        closed_issues = github_backend.sync_issues_graphql(
             gh_repo, owner, repo_name, state="CLOSED", milestone_number=milestone_number
         )
         current_numbers = [issue["number"] for issue in open_issues + closed_issues]
+    except UnsupportedBackendCapabilityError as exc:
+        return {
+            "error": str(exc),
+            "unsupported_capability": exc.capability,
+            "backend": exc.backend,
+            "milestone_number": milestone_number,
+        }
     except GitHubUnavailableError as exc:
         return {"error": str(exc), "milestone_number": milestone_number}
     except (BacklogError, GithubException) as exc:
@@ -1354,14 +1361,20 @@ def dispatch_conflicts(milestone_number: int, repo: str = "") -> dict[str, Any]:
         or ``error`` on failure.
     """
     backend = get_config().backend
-    if not isinstance(backend, GitHubExtras):
-        return {"error": "dispatch_conflicts requires a GitHub-backed backend", "milestone_number": milestone_number}
     try:
-        gh_repo = backend.get_github(repo)
+        github_backend = require_github_extras(backend, "get_github")
+        gh_repo = github_backend.get_github(repo)
         owner, repo_name = gh_repo.full_name.split("/", 1)
-        issue_nodes = backend.sync_issues_graphql(
+        issue_nodes = github_backend.sync_issues_graphql(
             gh_repo, owner, repo_name, state="OPEN", milestone_number=milestone_number
         )
+    except UnsupportedBackendCapabilityError as exc:
+        return {
+            "error": str(exc),
+            "unsupported_capability": exc.capability,
+            "backend": exc.backend,
+            "milestone_number": milestone_number,
+        }
     except GitHubUnavailableError as exc:
         return {"error": str(exc), "milestone_number": milestone_number}
     except (BacklogError, GithubException) as exc:

--- a/plugins/development-harness/dh_core/operations.py
+++ b/plugins/development-harness/dh_core/operations.py
@@ -1254,12 +1254,7 @@ def dispatch_stale_check(milestone_number: int, repo: str = "") -> dict[str, Any
         )
         current_numbers = [issue["number"] for issue in open_issues + closed_issues]
     except UnsupportedBackendCapabilityError as exc:
-        return {
-            "error": str(exc),
-            "unsupported_capability": exc.capability,
-            "backend": exc.backend,
-            "milestone_number": milestone_number,
-        }
+        return exc.to_response(milestone_number)
     except GitHubUnavailableError as exc:
         return {"error": str(exc), "milestone_number": milestone_number}
     except (BacklogError, GithubException) as exc:
@@ -1369,12 +1364,7 @@ def dispatch_conflicts(milestone_number: int, repo: str = "") -> dict[str, Any]:
             gh_repo, owner, repo_name, state="OPEN", milestone_number=milestone_number
         )
     except UnsupportedBackendCapabilityError as exc:
-        return {
-            "error": str(exc),
-            "unsupported_capability": exc.capability,
-            "backend": exc.backend,
-            "milestone_number": milestone_number,
-        }
+        return exc.to_response(milestone_number)
     except GitHubUnavailableError as exc:
         return {"error": str(exc), "milestone_number": milestone_number}
     except (BacklogError, GithubException) as exc:

--- a/plugins/development-harness/docs/backend-providers.md
+++ b/plugins/development-harness/docs/backend-providers.md
@@ -113,6 +113,33 @@ The same rule applies to remote work-item reconciliation: provider snapshots
 and local item files are private cache records, while the remote provider owns
 the accepted state.
 
+### Capability flags
+
+`WorkItemBackend` declares four class-level capability flags every backend
+sets. Callers read a flag before invoking the operation it gates, rather than
+probing behavior or catching a stub's exception:
+
+| Flag | Meaning | `github` | `sqlite` | `memory` | `beads` |
+|---|---|---|---|---|---|
+| `supports_github_extras` | Backend can satisfy `GitHubExtras` — `get_github()` returns a real `Repository`, GraphQL issue/comment/milestone/project operations work. | `True` | `False` | `False` | `False` |
+| `supports_branches` | Backend can satisfy `BranchBackend` — integration branch create/merge/delete. | `True` | `False` | `True` | `False` |
+| `supports_batch_status_fetch` | Backend implements a real batched status fetch. | `True` | `True` | `True` | `False` |
+| `supports_batch_issue_update` | Backend implements a real batched GraphQL update. | `True` | `False` | `False` | `False` |
+
+**Flag-first gating rule:** `GitHubExtras` and `BranchBackend` are both
+`runtime_checkable` Protocols. `isinstance(backend, SomeProtocol)` checks
+method *names* only — a backend can satisfy a Protocol structurally, by
+implementing every method (even as a local simulation, as `sqlite` and
+`memory` do for `GitHubExtras`), without having the underlying capability.
+Gate on the flag first via `require_github_extras()` /
+`require_branch_support()` (`backlog_core/_capability_gates.py`), which use
+`isinstance` only as a secondary assertion once the flag confirms the
+capability is genuinely present. A backend adding one of these protocols must
+also set the matching flag `True` — declaring the flag without satisfying the
+Protocol raises `UnsupportedBackendCapabilityError` with `protocol_mismatch=True`
+(a backend bug), and satisfying the Protocol without setting the flag is
+treated as unsupported (the flag getter defaults `False`).
+
 ### GitHub contract
 
 GitHub stores plans, artifact manifests, artifact content, and dispatch plans as

--- a/plugins/development-harness/tests/conftest.py
+++ b/plugins/development-harness/tests/conftest.py
@@ -48,6 +48,24 @@ if TYPE_CHECKING:
 
 
 class ProviderMemoryBackend(InMemoryBackend):
+    """Default per-test backend: an InMemoryBackend that also simulates GitHub.
+
+    Dozens of operation-layer tests across ``tests/test_github_tools_*.py``
+    patch only ``operations.get_github`` and then exercise the real
+    ``GitHubExtras`` delegate methods (``sync_issues_graphql``,
+    ``_fetch_milestones_graphql``, ``_projects_v2_list_query``, ...) that
+    ``InMemoryBackend`` implements as local simulations. Those tests are
+    deliberately simulating a GitHub-shaped backend, so ``supports_github_extras``
+    is ``True`` here even though the base ``InMemoryBackend`` declares it
+    ``False`` (see ``backends/memory_backend.py`` — a plain in-memory backend
+    cannot return a real ``Repository``). Setting it centrally here, rather
+    than in every individual test fixture, is the honest fix for the whole
+    class of tests that use this double via the autouse ``_isolated_backend``
+    fixture below.
+    """
+
+    supports_github_extras: bool = True
+
     def __init__(self) -> None:
         super().__init__()
         self.reconcile_requests: list[ReconcileRequest] = []

--- a/plugins/development-harness/tests/test_github_extras_capability_gate.py
+++ b/plugins/development-harness/tests/test_github_extras_capability_gate.py
@@ -15,15 +15,33 @@ typed, structured ``UnsupportedBackendCapabilityError`` instead.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 from backlog_core import operations
-from backlog_core.backend_protocol import set_config
+from backlog_core.backend_protocol import reset_config, set_config
 from backlog_core.backend_types import BacklogConfig
 from backlog_core.backends.sqlite_backend import SQLiteBackend
 from backlog_core.models import UnsupportedBackendCapabilityError
 
 
-def test_list_milestones_under_sqlite_backend_raises_typed_capability_error() -> None:
+@pytest.fixture
+def sqlite_backend() -> Iterator[SQLiteBackend]:
+    """Configure an in-memory SQLiteBackend as the active backend, then tear it down.
+
+    Closes the backend's sqlite3.Connection and resets the config singleton on
+    teardown — a bare `SQLiteBackend()` with no cleanup leaves its connection
+    open, which fails this repo's strict warning-as-error validation policy
+    (AGENTS.md #18) with a ResourceWarning/PytestUnraisableExceptionWarning.
+    """
+    backend = SQLiteBackend()
+    set_config(BacklogConfig(backend=backend))
+    yield backend
+    reset_config()
+    backend._conn.close()
+
+
+def test_list_milestones_under_sqlite_backend_raises_typed_capability_error(sqlite_backend: SQLiteBackend) -> None:
     """list_milestones() under SQLiteBackend raises UnsupportedBackendCapabilityError.
 
     Tests: the GitHubExtras capability gate (require_github_extras)
@@ -36,9 +54,6 @@ def test_list_milestones_under_sqlite_backend_raises_typed_capability_error() ->
         test fails on pre-fix code with RuntimeError instead of
         UnsupportedBackendCapabilityError.
     """
-    # Arrange
-    set_config(BacklogConfig(backend=SQLiteBackend()))
-
     # Act / Assert
     with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
         operations.list_milestones()
@@ -48,7 +63,9 @@ def test_list_milestones_under_sqlite_backend_raises_typed_capability_error() ->
     assert exc_info.value.operation == "get_github"
 
 
-def test_list_issues_under_sqlite_backend_raises_typed_capability_error_not_wrapped() -> None:
+def test_list_issues_under_sqlite_backend_raises_typed_capability_error_not_wrapped(
+    sqlite_backend: SQLiteBackend,
+) -> None:
     """list_issues() under SQLiteBackend raises UnsupportedBackendCapabilityError, not a generic BacklogError.
 
     Tests: list_issues()'s ``except (GithubException, BacklogError)`` handler
@@ -65,9 +82,6 @@ def test_list_issues_under_sqlite_backend_raises_typed_capability_error_not_wrap
         ``except UnsupportedBackendCapabilityError: raise`` guard preceding
         that generic handler.
     """
-    # Arrange
-    set_config(BacklogConfig(backend=SQLiteBackend()))
-
     # Act / Assert
     with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
         operations.list_issues()

--- a/plugins/development-harness/tests/test_github_extras_capability_gate.py
+++ b/plugins/development-harness/tests/test_github_extras_capability_gate.py
@@ -46,3 +46,32 @@ def test_list_milestones_under_sqlite_backend_raises_typed_capability_error() ->
     assert exc_info.value.backend == "SQLiteBackend"
     assert exc_info.value.capability == "github_extras"
     assert exc_info.value.operation == "get_github"
+
+
+def test_list_issues_under_sqlite_backend_raises_typed_capability_error_not_wrapped() -> None:
+    """list_issues() under SQLiteBackend raises UnsupportedBackendCapabilityError, not a generic BacklogError.
+
+    Tests: list_issues()'s ``except (GithubException, BacklogError)`` handler
+        does not re-wrap UnsupportedBackendCapabilityError.
+    How: Configure SQLiteBackend as the active backend, call list_issues(),
+        and assert the raised exception is still UnsupportedBackendCapabilityError
+        with its structured fields intact.
+    Why: A Codex review on PR #3360 found that list_issues(), comment_issue(),
+        list_comments(), and read_comment() each catch
+        ``(GithubException, BacklogError)`` around their internal
+        ``get_github()`` call and re-raise a generic ``BacklogError`` labeled
+        "GitHub API error: ...", discarding the capability/backend/operation
+        fields. This test fails (wrong exception type, and .capability raises
+        AttributeError) without the ``except UnsupportedBackendCapabilityError:
+        raise`` guard preceding that generic handler.
+    """
+    # Arrange
+    set_config(BacklogConfig(backend=SQLiteBackend()))
+
+    # Act / Assert
+    with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+        operations.list_issues()
+
+    assert exc_info.value.backend == "SQLiteBackend"
+    assert exc_info.value.capability == "github_extras"
+    assert "GitHub API error" not in str(exc_info.value)

--- a/plugins/development-harness/tests/test_github_extras_capability_gate.py
+++ b/plugins/development-harness/tests/test_github_extras_capability_gate.py
@@ -1,0 +1,48 @@
+"""Regression test for the ``GitHubExtras`` capability gate (backlog #2287, slice 1).
+
+Before this fix, ``operations.py`` gated every ``GitHubExtras``-only operation with
+a bare ``isinstance(backend, GitHubExtras)`` check. ``GitHubExtras`` is a
+``runtime_checkable`` Protocol, so that ``isinstance`` check verifies attribute
+*names* only. ``SQLiteBackend`` and ``InMemoryBackend`` implement every
+``GitHubExtras`` method as a local simulation, so both satisfied the check and
+reached ``SQLiteBackend.get_github()``'s bare ``RuntimeError`` stub instead of a
+caller-recognisable error.
+
+This test proves the fix: ``require_github_extras()`` gates on the
+``supports_github_extras`` flag first, so a flag-``False`` backend now raises the
+typed, structured ``UnsupportedBackendCapabilityError`` instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from backlog_core import operations
+from backlog_core.backend_protocol import set_config
+from backlog_core.backend_types import BacklogConfig
+from backlog_core.backends.sqlite_backend import SQLiteBackend
+from backlog_core.models import UnsupportedBackendCapabilityError
+
+
+def test_list_milestones_under_sqlite_backend_raises_typed_capability_error() -> None:
+    """list_milestones() under SQLiteBackend raises UnsupportedBackendCapabilityError.
+
+    Tests: the GitHubExtras capability gate (require_github_extras)
+    How: Configure SQLiteBackend (supports_github_extras=False) as the active
+        backend, then call list_milestones() — which calls get_github() first —
+        and assert the typed error's structured fields.
+    Why: This is the exact bug reported in backlog #2287: SQLite structurally
+        satisfies GitHubExtras via isinstance, so the old gate let it reach a
+        bare RuntimeError instead of a typed, caller-recognisable error. This
+        test fails on pre-fix code with RuntimeError instead of
+        UnsupportedBackendCapabilityError.
+    """
+    # Arrange
+    set_config(BacklogConfig(backend=SQLiteBackend()))
+
+    # Act / Assert
+    with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+        operations.list_milestones()
+
+    assert exc_info.value.backend == "SQLiteBackend"
+    assert exc_info.value.capability == "github_extras"
+    assert exc_info.value.operation == "get_github"

--- a/plugins/development-harness/tests/test_github_extras_capability_gate.py
+++ b/plugins/development-harness/tests/test_github_extras_capability_gate.py
@@ -56,14 +56,14 @@ def test_list_issues_under_sqlite_backend_raises_typed_capability_error_not_wrap
     How: Configure SQLiteBackend as the active backend, call list_issues(),
         and assert the raised exception is still UnsupportedBackendCapabilityError
         with its structured fields intact.
-    Why: A Codex review on PR #3360 found that list_issues(), comment_issue(),
-        list_comments(), and read_comment() each catch
-        ``(GithubException, BacklogError)`` around their internal
+    Why: list_issues(), comment_issue(), list_comments(), and read_comment()
+        each catch ``(GithubException, BacklogError)`` around their internal
         ``get_github()`` call and re-raise a generic ``BacklogError`` labeled
         "GitHub API error: ...", discarding the capability/backend/operation
-        fields. This test fails (wrong exception type, and .capability raises
-        AttributeError) without the ``except UnsupportedBackendCapabilityError:
-        raise`` guard preceding that generic handler.
+        fields. This test fails (wrong exception type, and ``.capability``
+        raises ``AttributeError``) without the
+        ``except UnsupportedBackendCapabilityError: raise`` guard preceding
+        that generic handler.
     """
     # Arrange
     set_config(BacklogConfig(backend=SQLiteBackend()))

--- a/plugins/development-harness/tests/test_github_tools_issues.py
+++ b/plugins/development-harness/tests/test_github_tools_issues.py
@@ -33,6 +33,11 @@ def configured_github_backend(monkeypatch: pytest.MonkeyPatch) -> tuple[InMemory
     assert isinstance(backend, InMemoryBackend)
     repository = MagicMock(full_name="owner/repo")
     monkeypatch.setattr(backend, "get_github", lambda repo="", timeout=15: repository)
+    # InMemoryBackend declares supports_github_extras=False (it cannot return a real
+    # Repository), so require_github_extras() would reject it despite implementing
+    # every GitHubExtras method. This fixture deliberately simulates a GitHub-shaped
+    # backend, so flip the flag to make that simulation honest.
+    monkeypatch.setattr(backend, "supports_github_extras", True)
     return backend, repository
 
 

--- a/plugins/development-harness/tests/test_sync_state_classify.py
+++ b/plugins/development-harness/tests/test_sync_state_classify.py
@@ -1,0 +1,65 @@
+"""Regression tests for classify_sync_error's ContentProviderError handling.
+
+A Codex review on PR #3360 found that a prior fix in this same PR — adding
+ContentProviderError to classify_sync_error's NON_RETRYABLE branch — was too
+broad: ``_GitHubContentsStore.get_many()`` wraps *any* ``GithubException``,
+including a transient 503 or a rate-limited 429, in ``ContentUnavailableError``
+via ``raise ... from exc``. Blanket-classifying every ContentProviderError as
+non-retryable sends a merely-overloaded GitHub API straight to OFFLINE instead
+of the bounded retry policy transient failures are supposed to get.
+"""
+
+from __future__ import annotations
+
+import pytest
+from backlog_core.models import ContentConflictError, ContentUnavailableError, UnsupportedCapabilityError
+from backlog_core.sync_state import SyncErrorKind, classify_sync_error
+from github import GithubException
+
+
+def _raise_content_unavailable_from(cause: GithubException) -> None:
+    """Raise ContentUnavailableError chained to cause, mirroring get_many()'s own shape."""
+    raise ContentUnavailableError(f"GitHub content discovery failed: {cause.status}") from cause
+
+
+def test_content_unavailable_wrapping_a_503_is_retryable() -> None:
+    """A ContentUnavailableError wrapping a transient 503 GithubException retries.
+
+    Tests: classify_sync_error's ContentProviderError branch inspects __cause__.
+    How: Build a ContentUnavailableError the way get_many() actually raises one
+        — via `raise ContentUnavailableError(...) from exc` — with exc a 503
+        GithubException, and classify it.
+    Why: This fails (returns NON_RETRYABLE) without the __cause__ inspection —
+        that was exactly the bug Codex flagged: a transient GitHub server error
+        would send the sync straight to OFFLINE instead of retrying.
+    """
+    cause = GithubException(503, {"message": "Service Unavailable"}, {})
+    with pytest.raises(ContentUnavailableError) as exc_info:
+        _raise_content_unavailable_from(cause)
+
+    assert classify_sync_error(exc_info.value) == SyncErrorKind.RETRYABLE
+
+
+def test_content_unavailable_wrapping_a_404_is_non_retryable() -> None:
+    """A ContentUnavailableError wrapping a 404 stays non-retryable.
+
+    Tests: the __cause__ inspection still classifies a permanent GitHub error
+        as NON_RETRYABLE, not blanket RETRYABLE.
+    """
+    cause = GithubException(404, {"message": "Not Found"}, {})
+    with pytest.raises(ContentUnavailableError) as exc_info:
+        _raise_content_unavailable_from(cause)
+
+    assert classify_sync_error(exc_info.value) == SyncErrorKind.NON_RETRYABLE
+
+
+def test_content_provider_error_without_a_github_cause_is_non_retryable() -> None:
+    """A structural ContentProviderError (no wrapped GithubException) stays non-retryable.
+
+    Tests: UnsupportedCapabilityError and ContentConflictError, raised with no
+        `from exc` chain, are genuinely structural — retrying can't fix a
+        missing capability or a stale revision — so they still classify as
+        NON_RETRYABLE, same as before this fix.
+    """
+    assert classify_sync_error(UnsupportedCapabilityError("provider-private")) == SyncErrorKind.NON_RETRYABLE
+    assert classify_sync_error(ContentConflictError("revision mismatch")) == SyncErrorKind.NON_RETRYABLE

--- a/plugins/development-harness/tests/test_sync_state_classify.py
+++ b/plugins/development-harness/tests/test_sync_state_classify.py
@@ -7,12 +7,19 @@ including a transient 503 or a rate-limited 429, in ``ContentUnavailableError``
 via ``raise ... from exc``. Blanket-classifying every ContentProviderError as
 non-retryable sends a merely-overloaded GitHub API straight to OFFLINE instead
 of the bounded retry policy transient failures are supposed to get.
+
+A follow-up Codex review found the single-level ``__cause__`` inspection this
+fix first shipped with was itself incomplete: ``_fetch_blobs_graphql()``
+double-wraps — ``gh_client._graphql_request()`` wraps the GithubException in
+``BacklogError`` first, then ``_fetch_blobs_graphql()`` wraps that
+``BacklogError`` in ``ContentUnavailableError`` — so the GithubException sits
+two ``__cause__`` links down, not one.
 """
 
 from __future__ import annotations
 
 import pytest
-from backlog_core.models import ContentConflictError, ContentUnavailableError, UnsupportedCapabilityError
+from backlog_core.models import BacklogError, ContentConflictError, ContentUnavailableError, UnsupportedCapabilityError
 from backlog_core.sync_state import SyncErrorKind, classify_sync_error
 from github import GithubException
 
@@ -20,6 +27,22 @@ from github import GithubException
 def _raise_content_unavailable_from(cause: GithubException) -> None:
     """Raise ContentUnavailableError chained to cause, mirroring get_many()'s own shape."""
     raise ContentUnavailableError(f"GitHub content discovery failed: {cause.status}") from cause
+
+
+def _raise_double_wrapped_content_unavailable_from(github_exc: GithubException) -> None:
+    """Raise ContentUnavailableError wrapping a BacklogError wrapping github_exc.
+
+    Mirrors _fetch_blobs_graphql()'s actual double-wrap shape: gh_client._graphql_request()
+    wraps GithubException in BacklogError, then _fetch_blobs_graphql() wraps that
+    BacklogError in ContentUnavailableError.
+    """
+    try:
+        try:
+            raise github_exc
+        except GithubException as exc:
+            raise BacklogError(f"GraphQL request failed: {exc}") from exc
+    except BacklogError as exc:
+        raise ContentUnavailableError(f"GitHub content discovery failed: {exc}") from exc
 
 
 def test_content_unavailable_wrapping_a_503_is_retryable() -> None:
@@ -51,6 +74,25 @@ def test_content_unavailable_wrapping_a_404_is_non_retryable() -> None:
         _raise_content_unavailable_from(cause)
 
     assert classify_sync_error(exc_info.value) == SyncErrorKind.NON_RETRYABLE
+
+
+def test_double_wrapped_content_unavailable_from_a_503_is_retryable() -> None:
+    """A ContentUnavailableError wrapping a BacklogError wrapping a 503 GithubException retries.
+
+    Tests: classify_sync_error's ContentProviderError branch walks the full
+        __cause__ chain, not just one level.
+    How: Build the exact double-wrap shape _fetch_blobs_graphql() produces
+        and classify it.
+    Why: This fails (returns NON_RETRYABLE) with only a single-level
+        __cause__ check — that was the follow-up bug Codex flagged: a
+        transient 503 hitting the blob-fetch path would still send the sync
+        straight to OFFLINE.
+    """
+    github_exc = GithubException(503, {"message": "Service Unavailable"}, {})
+    with pytest.raises(ContentUnavailableError) as exc_info:
+        _raise_double_wrapped_content_unavailable_from(github_exc)
+
+    assert classify_sync_error(exc_info.value) == SyncErrorKind.RETRYABLE
 
 
 def test_content_provider_error_without_a_github_cause_is_non_retryable() -> None:

--- a/plugins/development-harness/tests/test_sync_state_classify.py
+++ b/plugins/development-harness/tests/test_sync_state_classify.py
@@ -1,19 +1,20 @@
 """Regression tests for classify_sync_error's ContentProviderError handling.
 
-A Codex review on PR #3360 found that a prior fix in this same PR — adding
-ContentProviderError to classify_sync_error's NON_RETRYABLE branch — was too
-broad: ``_GitHubContentsStore.get_many()`` wraps *any* ``GithubException``,
-including a transient 503 or a rate-limited 429, in ``ContentUnavailableError``
-via ``raise ... from exc``. Blanket-classifying every ContentProviderError as
-non-retryable sends a merely-overloaded GitHub API straight to OFFLINE instead
-of the bounded retry policy transient failures are supposed to get.
+ContentProviderError is a separate exception tree from BacklogError (see
+models.py), so classify_sync_error needs its own branch for it — and that
+branch is not always NON_RETRYABLE. ``_GitHubContentsStore.get_many()`` wraps
+*any* ``GithubException`` it sees, including a transient 503 or a
+rate-limited 429, in ``ContentUnavailableError`` via ``raise ... from exc``.
+Blanket-classifying every ContentProviderError as non-retryable would send a
+merely-overloaded GitHub API straight to OFFLINE instead of the bounded retry
+policy transient failures are supposed to get.
 
-A follow-up Codex review found the single-level ``__cause__`` inspection this
-fix first shipped with was itself incomplete: ``_fetch_blobs_graphql()``
-double-wraps — ``gh_client._graphql_request()`` wraps the GithubException in
-``BacklogError`` first, then ``_fetch_blobs_graphql()`` wraps that
-``BacklogError`` in ``ContentUnavailableError`` — so the GithubException sits
-two ``__cause__`` links down, not one.
+The ``__cause__`` inspection must walk the full chain, not stop at one level:
+``_fetch_blobs_graphql()`` double-wraps — ``gh_client._graphql_request()``
+wraps the GithubException in ``BacklogError`` first, then
+``_fetch_blobs_graphql()`` wraps that ``BacklogError`` in
+``ContentUnavailableError`` — so the GithubException sits two ``__cause__``
+links down, not one.
 """
 
 from __future__ import annotations

--- a/plugins/development-harness/tests/test_sync_state_classify.py
+++ b/plugins/development-harness/tests/test_sync_state_classify.py
@@ -30,12 +30,7 @@ def _raise_content_unavailable_from(cause: GithubException) -> None:
 
 
 def _raise_double_wrapped_content_unavailable_from(github_exc: GithubException) -> None:
-    """Raise ContentUnavailableError wrapping a BacklogError wrapping github_exc.
-
-    Mirrors _fetch_blobs_graphql()'s actual double-wrap shape: gh_client._graphql_request()
-    wraps GithubException in BacklogError, then _fetch_blobs_graphql() wraps that
-    BacklogError in ContentUnavailableError.
-    """
+    """Mirrors _fetch_blobs_graphql()'s actual double-wrap shape (see module docstring)."""
     try:
         try:
             raise github_exc

--- a/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
+++ b/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
@@ -240,11 +240,7 @@ class TestGitHubExtrasCapabilityContract:
 
         Contract: When ``supports_github_extras`` is ``False``,
         ``require_github_extras(backend, ...)`` MUST raise
-        ``UnsupportedBackendCapabilityError``. This is the regression target
-        for backlog #2287: before the fix, ``SQLiteBackend`` and
-        ``InMemoryBackend`` structurally satisfied the old
-        ``isinstance(backend, GitHubExtras)`` gate and reached a bare
-        ``RuntimeError`` stub instead.
+        ``UnsupportedBackendCapabilityError``.
         """
         backend = create_backend(name)
 

--- a/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
+++ b/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
@@ -305,3 +305,7 @@ class TestGitHubExtrasCapabilityContract:
 
         assert exc_info.value.protocol_mismatch is True
         assert "backend bug" in str(exc_info.value)
+        assert "GitHubExtras" in str(exc_info.value), (
+            "message should name the actual Protocol class, not just the opaque "
+            "capability flag string 'github_extras' — raised in code review on PR #3360"
+        )

--- a/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
+++ b/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
@@ -35,7 +35,8 @@ from typing import TYPE_CHECKING
 
 import backlog_core.backend_protocol as _bp
 import pytest
-from backlog_core.backend_protocol import create_backend, require_github_extras
+from backlog_core.backend_protocol import create_backend, require_branch_support, require_github_extras
+from backlog_core.backends.sqlite_backend import SQLiteBackend
 from backlog_core.models import UnsupportedBackendCapabilityError
 
 if TYPE_CHECKING:
@@ -215,6 +216,18 @@ class TestBacklogBackendCapabilityContract:
 # ---------------------------------------------------------------------------
 
 
+def _close_if_sqlite(backend: object) -> None:
+    """Close backend's sqlite3.Connection if it's a SQLiteBackend.
+
+    ``create_backend("sqlite")`` leaves its connection open with no
+    lifecycle owner; a bare instance with no cleanup fails this repo's
+    strict warning-as-error validation policy (AGENTS.md #18) with a
+    ResourceWarning/PytestUnraisableExceptionWarning.
+    """
+    if isinstance(backend, SQLiteBackend):
+        backend._conn.close()
+
+
 @pytest.mark.unit
 class TestGitHubExtrasCapabilityContract:
     """Parametrized contract suite for the ``supports_github_extras`` flag.
@@ -243,15 +256,17 @@ class TestGitHubExtrasCapabilityContract:
         ``UnsupportedBackendCapabilityError``.
         """
         backend = create_backend(name)
-
-        if not backend.supports_github_extras:
-            with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
-                require_github_extras(backend, "get_github")
-            assert exc_info.value.capability == "github_extras"
-            assert exc_info.value.backend == type(backend).__name__
-            assert exc_info.value.protocol_mismatch is False, (
-                "a flag-False backend is a genuinely unsupported capability, not a protocol mismatch"
-            )
+        try:
+            if not backend.supports_github_extras:
+                with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+                    require_github_extras(backend, "get_github")
+                assert exc_info.value.capability == "github_extras"
+                assert exc_info.value.backend == type(backend).__name__
+                assert exc_info.value.protocol_mismatch is False, (
+                    "a flag-False backend is a genuinely unsupported capability, not a protocol mismatch"
+                )
+        finally:
+            _close_if_sqlite(backend)
 
     @pytest.mark.parametrize("name", list(_bp._VALID_BACKENDS))
     def test_true_flag_does_not_raise_unsupported_capability(self, name: str) -> None:
@@ -265,17 +280,19 @@ class TestGitHubExtrasCapabilityContract:
         ``GitHubBackend``.
         """
         backend = create_backend(name)
-
-        if backend.supports_github_extras:
-            try:
-                narrowed = require_github_extras(backend, "get_github")
-            except UnsupportedBackendCapabilityError as exc:
-                pytest.fail(
-                    f"{type(backend).__name__}.supports_github_extras is True but "
-                    f"require_github_extras() raised UnsupportedBackendCapabilityError: {exc}"
-                )
-            else:
-                assert narrowed is backend
+        try:
+            if backend.supports_github_extras:
+                try:
+                    narrowed = require_github_extras(backend, "get_github")
+                except UnsupportedBackendCapabilityError as exc:
+                    pytest.fail(
+                        f"{type(backend).__name__}.supports_github_extras is True but "
+                        f"require_github_extras() raised UnsupportedBackendCapabilityError: {exc}"
+                    )
+                else:
+                    assert narrowed is backend
+        finally:
+            _close_if_sqlite(backend)
 
     def test_protocol_mismatch_flag_distinguishes_backend_bug_from_unsupported(self) -> None:
         """A True flag paired with a non-conforming backend raises protocol_mismatch=True.
@@ -303,4 +320,91 @@ class TestGitHubExtrasCapabilityContract:
         assert "GitHubExtras" in str(exc_info.value), (
             "message should name the actual Protocol class, not just the opaque "
             "capability flag string 'github_extras'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestBranchSupportCapabilityContract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBranchSupportCapabilityContract:
+    """Parametrized contract suite for the ``supports_branches`` flag.
+
+    Mirrors ``TestGitHubExtrasCapabilityContract`` above, for
+    ``require_branch_support`` instead of ``require_github_extras``.
+    ``test_branch_backend.py`` skips every backend where ``supports_branches``
+    is ``False``, so it never exercises this gate's failure path — this class
+    fills that gap: the flag-False raise, the flag-True non-raise, and the
+    ``protocol_mismatch`` path, all of which changed behavior when
+    ``require_branch_support`` replaced ``_branch_delegates.py``'s ad-hoc
+    ``RuntimeError``/``TypeError`` (backlog #2287, slice 1).
+    """
+
+    @pytest.mark.parametrize("name", list(_bp._VALID_BACKENDS))
+    def test_false_flag_raises_unsupported_capability(self, name: str) -> None:
+        """Backends declaring ``supports_branches == False`` MUST raise.
+
+        Contract: When ``supports_branches`` is ``False``,
+        ``require_branch_support(backend, ...)`` MUST raise
+        ``UnsupportedBackendCapabilityError``.
+        """
+        backend = create_backend(name)
+        try:
+            if not backend.supports_branches:
+                with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+                    require_branch_support(backend, "create_integration_branch")
+                assert exc_info.value.capability == "branches"
+                assert exc_info.value.backend == type(backend).__name__
+                assert exc_info.value.protocol_mismatch is False, (
+                    "a flag-False backend is a genuinely unsupported capability, not a protocol mismatch"
+                )
+        finally:
+            _close_if_sqlite(backend)
+
+    @pytest.mark.parametrize("name", list(_bp._VALID_BACKENDS))
+    def test_true_flag_does_not_raise_unsupported_capability(self, name: str) -> None:
+        """Backends declaring ``supports_branches == True`` MUST NOT raise it.
+
+        Contract: When ``supports_branches`` is ``True``,
+        ``require_branch_support(backend, ...)`` must not raise
+        ``UnsupportedBackendCapabilityError`` and must return the backend
+        unchanged.
+        """
+        backend = create_backend(name)
+        try:
+            if backend.supports_branches:
+                try:
+                    narrowed = require_branch_support(backend, "create_integration_branch")
+                except UnsupportedBackendCapabilityError as exc:
+                    pytest.fail(
+                        f"{type(backend).__name__}.supports_branches is True but "
+                        f"require_branch_support() raised UnsupportedBackendCapabilityError: {exc}"
+                    )
+                else:
+                    assert narrowed is backend
+        finally:
+            _close_if_sqlite(backend)
+
+    def test_protocol_mismatch_flag_distinguishes_backend_bug_from_unsupported(self) -> None:
+        """A True flag paired with a non-conforming backend raises protocol_mismatch=True.
+
+        Contract: no backend in ``_bp._VALID_BACKENDS`` currently exhibits this
+        inconsistency, so this test builds a minimal stub that lies about its
+        own capability — ``supports_branches = True`` but none of the
+        ``BranchBackend`` methods implemented — to exercise the ``isinstance``
+        branch directly.
+        """
+
+        class _LyingBackend:
+            supports_branches = True
+
+        with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+            require_branch_support(_LyingBackend(), "create_integration_branch")  # type: ignore[arg-type]
+
+        assert exc_info.value.protocol_mismatch is True
+        assert "backend bug" in str(exc_info.value)
+        assert "BranchBackend" in str(exc_info.value), (
+            "message should name the actual Protocol class, not just the opaque capability flag string 'branches'"
         )

--- a/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
+++ b/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
@@ -35,7 +35,8 @@ from typing import TYPE_CHECKING
 
 import backlog_core.backend_protocol as _bp
 import pytest
-from backlog_core.backend_protocol import create_backend
+from backlog_core.backend_protocol import create_backend, require_github_extras
+from backlog_core.models import UnsupportedBackendCapabilityError
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -207,3 +208,72 @@ class TestBacklogBackendCapabilityContract:
             + ("did NOT raise" if flag is False else "raised")
             + " NotImplementedError — flag and behaviour are inconsistent"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestGitHubExtrasCapabilityContract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGitHubExtrasCapabilityContract:
+    """Parametrized contract suite for the ``supports_github_extras`` flag.
+
+    Mirrors ``TestBacklogBackendCapabilityContract``'s Contract 1/Contract 2
+    pair above, for the ``GitHubExtras`` capability gate
+    (``require_github_extras``, re-exported from ``backend_protocol.py``)
+    instead of ``supports_batch_status_fetch``. Every backend in
+    ``_bp._VALID_BACKENDS`` is enrolled automatically.
+
+    Unlike ``supports_batch_status_fetch``, the ``GitHubExtras`` gate is not
+    self-checked inside the backend's own ``get_github()`` — it is enforced by
+    the caller-side ``require_github_extras()`` helper (this is precisely the
+    defect backlog #2287 reports: ``isinstance(backend, GitHubExtras)`` alone
+    lets a structurally-compliant backend reach its own bare ``RuntimeError``
+    stub). These tests therefore exercise ``require_github_extras()`` rather
+    than the backend method directly.
+    """
+
+    @pytest.mark.parametrize("name", list(_bp._VALID_BACKENDS))
+    def test_false_flag_raises_unsupported_capability(self, name: str) -> None:
+        """Backends declaring ``supports_github_extras == False`` MUST raise.
+
+        Contract: When ``supports_github_extras`` is ``False``,
+        ``require_github_extras(backend, ...)`` MUST raise
+        ``UnsupportedBackendCapabilityError``. This is the regression target
+        for backlog #2287: before the fix, ``SQLiteBackend`` and
+        ``InMemoryBackend`` structurally satisfied the old
+        ``isinstance(backend, GitHubExtras)`` gate and reached a bare
+        ``RuntimeError`` stub instead.
+        """
+        backend = create_backend(name)
+
+        if not backend.supports_github_extras:
+            with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+                require_github_extras(backend, "get_github")
+            assert exc_info.value.capability == "github_extras"
+            assert exc_info.value.backend == type(backend).__name__
+
+    @pytest.mark.parametrize("name", list(_bp._VALID_BACKENDS))
+    def test_true_flag_does_not_raise_unsupported_capability(self, name: str) -> None:
+        """Backends declaring ``supports_github_extras == True`` MUST NOT raise it.
+
+        Contract: When ``supports_github_extras`` is ``True``,
+        ``require_github_extras(backend, ...)`` must not raise
+        ``UnsupportedBackendCapabilityError`` and must return the backend
+        unchanged. The gate is checked without calling ``get_github()`` itself,
+        so no network or credential dependency is required even for
+        ``GitHubBackend``.
+        """
+        backend = create_backend(name)
+
+        if backend.supports_github_extras:
+            try:
+                narrowed = require_github_extras(backend, "get_github")
+            except UnsupportedBackendCapabilityError as exc:
+                pytest.fail(
+                    f"{type(backend).__name__}.supports_github_extras is True but "
+                    f"require_github_extras() raised UnsupportedBackendCapabilityError: {exc}"
+                )
+            else:
+                assert narrowed is backend

--- a/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
+++ b/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
@@ -253,6 +253,9 @@ class TestGitHubExtrasCapabilityContract:
                 require_github_extras(backend, "get_github")
             assert exc_info.value.capability == "github_extras"
             assert exc_info.value.backend == type(backend).__name__
+            assert exc_info.value.protocol_mismatch is False, (
+                "a flag-False backend is a genuinely unsupported capability, not a protocol mismatch"
+            )
 
     @pytest.mark.parametrize("name", list(_bp._VALID_BACKENDS))
     def test_true_flag_does_not_raise_unsupported_capability(self, name: str) -> None:
@@ -277,3 +280,28 @@ class TestGitHubExtrasCapabilityContract:
                 )
             else:
                 assert narrowed is backend
+
+    def test_protocol_mismatch_flag_distinguishes_backend_bug_from_unsupported(self) -> None:
+        """A True flag paired with a non-conforming backend raises protocol_mismatch=True.
+
+        Contract: no backend in ``_bp._VALID_BACKENDS`` currently exhibits this
+        inconsistency (each one's flag matches its actual method set), so this
+        test builds a minimal stub that lies about its own capability —
+        ``supports_github_extras = True`` but none of the ``GitHubExtras``
+        methods implemented — to exercise the ``isinstance`` branch directly.
+
+        Why: a flag-``False`` backend is a normal, expected "this capability
+        isn't offered" outcome; a flag-``True`` backend that fails the
+        ``isinstance`` check is a backend implementation bug (the flag lied).
+        Conflating the two in one message misleads whoever reads it — this
+        was raised in code review on PR #3360.
+        """
+
+        class _LyingBackend:
+            supports_github_extras = True
+
+        with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+            require_github_extras(_LyingBackend(), "get_github")  # type: ignore[arg-type]
+
+        assert exc_info.value.protocol_mismatch is True
+        assert "backend bug" in str(exc_info.value)

--- a/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
+++ b/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
@@ -289,8 +289,7 @@ class TestGitHubExtrasCapabilityContract:
         Why: a flag-``False`` backend is a normal, expected "this capability
         isn't offered" outcome; a flag-``True`` backend that fails the
         ``isinstance`` check is a backend implementation bug (the flag lied).
-        Conflating the two in one message misleads whoever reads it — this
-        was raised in code review on PR #3360.
+        Conflating the two in one message misleads whoever reads it.
         """
 
         class _LyingBackend:
@@ -303,5 +302,5 @@ class TestGitHubExtrasCapabilityContract:
         assert "backend bug" in str(exc_info.value)
         assert "GitHubExtras" in str(exc_info.value), (
             "message should name the actual Protocol class, not just the opaque "
-            "capability flag string 'github_extras' — raised in code review on PR #3360"
+            "capability flag string 'github_extras'"
         )

--- a/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
+++ b/plugins/development-harness/tests_backlog/test_backlog_backend_capability_contract.py
@@ -313,13 +313,12 @@ class TestGitHubExtrasCapabilityContract:
             supports_github_extras = True
 
         with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
-            require_github_extras(_LyingBackend(), "get_github")  # type: ignore[arg-type]
+            require_github_extras(_LyingBackend(), "get_github")  # ty: ignore[invalid-argument-type]
 
         assert exc_info.value.protocol_mismatch is True
         assert "backend bug" in str(exc_info.value)
         assert "GitHubExtras" in str(exc_info.value), (
-            "message should name the actual Protocol class, not just the opaque "
-            "capability flag string 'github_extras'"
+            "message should name the actual Protocol class, not just the opaque capability flag string 'github_extras'"
         )
 
 
@@ -401,7 +400,7 @@ class TestBranchSupportCapabilityContract:
             supports_branches = True
 
         with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
-            require_branch_support(_LyingBackend(), "create_integration_branch")  # type: ignore[arg-type]
+            require_branch_support(_LyingBackend(), "create_integration_branch")  # ty: ignore[invalid-argument-type]
 
         assert exc_info.value.protocol_mismatch is True
         assert "backend bug" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- `isinstance(backend, GitHubExtras)` checks method names only; `SQLiteBackend` and `InMemoryBackend` pass it structurally (they implement every `GitHubExtras` method as a local simulation) even though neither can return a real GitHub `Repository`. 19 gate sites let non-GitHub backends fall through and hit a bare `RuntimeError`/`TypeError`/mislabeled `BacklogError` instead of a typed, catchable error.
- Adds `supports_github_extras` (flag-first, `isinstance` second — mirrors the existing `supports_branches` pattern), a shared `require_github_extras()`/`require_branch_support()` pair in `_capability_gates.py`, and `UnsupportedBackendCapabilityError(BacklogError)` with structured `capability`/`backend`/`operation` fields.
- Replaces all 19 gate sites (15 in `operations.py`, 2 in `server.py`, 2 in `dh_core/operations.py`) and fixes a mislabel bug where `server.py` relabeled any `BacklogError` as `"GitHub API error"` even for a capability gap.
- Root-caused a test dependency: `tests/conftest.py`'s shared `ProviderMemoryBackend` needed `supports_github_extras = True` — three test files (not just the two originally suspected) depended on it implicitly.

This is slice 1 of backlog #2287. Three follow-up slices (dialect cleanup, milestone backend dispatch, dead-letter visibility) are running in parallel worktrees; slice D (dead-letter visibility) is already up as PR #3359.

## Test plan
- [x] `uv run pytest plugins/development-harness/tests/ -q` — 3008 passed, 41 skipped, 5 xfailed
- [x] `uv run pytest plugins/development-harness/tests_backlog/ -q` — 598 passed
- [x] New regression test proves `operations.list_milestones()` under `SQLiteBackend` raises `UnsupportedBackendCapabilityError`, not a bare `RuntimeError` — confirmed it fails on pre-change code via `git stash`
- [x] `ruff check` clean on all changed/new files
- [x] Behavioral: `dispatch_stale_check` under a SQLite backend returns `unsupported_capability`/`backend` fields, not `"GitHub API error"`
- [x] Live smoke against the real GitHub backend (`get_github()`/`list_milestones()`) — no regression on the GitHub path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5uhpwjRxNJMWBBboLgntv