### PR TITLE
feat(backlog): make milestones backend-agnostic (#2287 slice C)

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.7",
+  "version": "11.0.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -544,7 +544,7 @@ grooming, plan, task, artifact-manifest, and artifact-content operations. The fo
 families are available:
 
 - `github` (default) — GitHub Issues via GraphQL + PyGithub REST. Requires `GITHUB_TOKEN`.
-- `sqlite` — local 5-table SQLite schema, WAL mode. No external credentials.
+- `sqlite` — local 7-table SQLite schema, WAL mode. No external credentials.
 - `memory` — in-memory native test double. No persistence, YAML, or `FileCache`.
 - `beads` — routes to `bd` CLI via lazy subprocess wrapper. Auto-detected when `.beads/dh-backend` marker file exists at project root (explicit opt-in required). `bd` binary validated on first use; raises `BdNotInstalledError` on failure with no silent fallback.
 

--- a/plugins/development-harness/AGENTS.md
+++ b/plugins/development-harness/AGENTS.md
@@ -544,7 +544,7 @@ grooming, plan, task, artifact-manifest, and artifact-content operations. The fo
 families are available:
 
 - `github` (default) — GitHub Issues via GraphQL + PyGithub REST. Requires `GITHUB_TOKEN`.
-- `sqlite` — local 6-table SQLite schema, WAL mode. No external credentials.
+- `sqlite` — local 5-table SQLite schema, WAL mode. No external credentials.
 - `memory` — in-memory native test double. No persistence, YAML, or `FileCache`.
 - `beads` — routes to `bd` CLI via lazy subprocess wrapper. Auto-detected when `.beads/dh-backend` marker file exists at project root (explicit opt-in required). `bd` binary validated on first use; raises `BdNotInstalledError` on failure with no silent fallback.
 

--- a/plugins/development-harness/backlog_core/_capability_gates.py
+++ b/plugins/development-harness/backlog_core/_capability_gates.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from .backend_types import BranchBackend, GitHubExtras, WorkItemBackend
 from .models import UnsupportedBackendCapabilityError
 
-__all__ = ["require_branch_support", "require_github_extras"]
+__all__ = ["require_branch_support", "require_github_extras", "require_milestone_support"]
 
 
 def require_github_extras(backend: WorkItemBackend, operation: str) -> GitHubExtras:
@@ -79,4 +79,27 @@ def require_branch_support(backend: WorkItemBackend, operation: str) -> BranchBa
         raise UnsupportedBackendCapabilityError("branches", type(backend).__name__, operation)
     if not isinstance(backend, BranchBackend):
         raise UnsupportedBackendCapabilityError("branches", type(backend).__name__, operation, protocol_mismatch=True)
+    return backend
+
+
+def require_milestone_support(backend: WorkItemBackend, operation: str) -> WorkItemBackend:
+    """Return ``backend``, or raise if it does not support milestones.
+
+    Unlike ``require_github_extras``/``require_branch_support``, the milestone
+    methods live directly on ``WorkItemBackend`` rather than a separate
+    optional Protocol, so no ``isinstance`` structural check is needed here
+    — the flag alone is authoritative.
+
+    Args:
+        backend: The active backend instance to check (see require_github_extras's Args for why this is a parameter rather than fetched internally).
+        operation: See require_github_extras.
+
+    Returns:
+        The same backend instance.
+
+    Raises:
+        UnsupportedBackendCapabilityError: If ``backend.supports_milestones`` is falsy.
+    """
+    if not getattr(backend, "supports_milestones", False):
+        raise UnsupportedBackendCapabilityError("milestones", type(backend).__name__, operation)
     return backend

--- a/plugins/development-harness/backlog_core/backend_protocol.py
+++ b/plugins/development-harness/backlog_core/backend_protocol.py
@@ -27,7 +27,7 @@ from backlog_core.backends.github_backend import GitHubBackend
 from backlog_core.backends.memory_backend import InMemoryBackend
 from backlog_core.backends.sqlite_backend import SQLiteBackend
 
-from ._capability_gates import require_branch_support, require_github_extras
+from ._capability_gates import require_branch_support, require_github_extras, require_milestone_support
 from .backend_types import (
     AssigneeNode,
     BacklogConfig,
@@ -81,6 +81,7 @@ __all__ = [
     "get_config",
     "require_branch_support",
     "require_github_extras",
+    "require_milestone_support",
     "reset_config",
     "set_config",
 ]

--- a/plugins/development-harness/backlog_core/backend_types.py
+++ b/plugins/development-harness/backlog_core/backend_types.py
@@ -145,7 +145,7 @@ class WorkItemBackend(Protocol):
       ``WorkItemBackend`` and every backend must define them (raising
       ``NotImplementedError`` and setting the flag ``False`` is the
       documented escape hatch for a backend whose native ID type cannot
-      satisfy the ``int`` signature below — see ``BeadsBackend``'s ADR-002).
+      satisfy the ``int`` signature below — see ``BeadsBackend``'s ADR-003).
     """
 
     supports_batch_status_fetch: bool

--- a/plugins/development-harness/backlog_core/backend_types.py
+++ b/plugins/development-harness/backlog_core/backend_types.py
@@ -40,7 +40,12 @@ class LabelNode(TypedDict):
 
 
 class MilestoneNode(TypedDict):
-    """Milestone node nested inside an IssueNode."""
+    """Milestone node nested inside an IssueNode.
+
+    ``state`` is a backend-neutral open/closed flag, not a GitHub-only value
+    set — every backend collapses its own milestone lifecycle onto these two
+    values at the backend boundary.
+    """
 
     id: str
     number: int
@@ -132,6 +137,15 @@ class WorkItemBackend(Protocol):
     - ``issue_id_type`` — integer vs string issue IDs.
     - ``supports_branches`` — whether ``BranchBackend`` is implemented.
     - ``supports_github_extras`` — whether ``GitHubExtras`` is implemented; gate via ``require_github_extras()`` (see ``GitHubExtras``'s docstring for why ``isinstance`` alone is insufficient).
+    - ``supports_milestones`` — whether the milestone create/list/assign
+      methods below are genuinely implemented; gate via
+      ``require_milestone_support()`` in ``_capability_gates.py``. Unlike
+      ``supports_branches``/``supports_github_extras`` this is not a
+      separate optional Protocol — the methods live directly on
+      ``WorkItemBackend`` and every backend must define them (raising
+      ``NotImplementedError`` and setting the flag ``False`` is the
+      documented escape hatch for a backend whose native ID type cannot
+      satisfy the ``int`` signature below — see ``BeadsBackend``'s ADR-002).
     """
 
     supports_batch_status_fetch: bool
@@ -139,6 +153,7 @@ class WorkItemBackend(Protocol):
     issue_id_type: Literal["integer", "string"]
     supports_branches: bool
     supports_github_extras: bool
+    supports_milestones: bool
 
     def list_work_items(self) -> list[BacklogItem]: ...
     def get_work_item(self, reference: str) -> BacklogItem: ...
@@ -199,6 +214,13 @@ class WorkItemBackend(Protocol):
     def section_heading(self) -> dict[str, str]: ...
     def render_groomed_section(self, groomed: GroomedData) -> str: ...
     def section_display_title(self, key: str, groomed_date: str = "") -> str: ...
+
+    # Milestones (generic — gate via require_milestone_support())
+    def list_milestones(self, states: list[str] | None = None, repo: str = "") -> list[MilestoneFullNode]: ...
+    def create_milestone(
+        self, title: str, description: str = "", due_on: datetime | None = None, repo: str = ""
+    ) -> MilestoneFullNode: ...
+    def assign_item_to_milestone(self, issue_number: int, milestone_number: int, repo: str = "") -> None: ...
 
 
 @runtime_checkable

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -268,8 +268,8 @@ _ADR_003_NOTE = (
     "list_milestones/create_milestone/assign_item_to_milestone use int issue/milestone numbers "
     "(MilestoneFullNode.number: int) but beads milestones are issues with string nanoid IDs "
     "(bd create --type milestone). Use list_beads_milestones/create_beads_milestone/"
-    "assign_beads_item_to_milestone for beads-native milestone support instead. See ADR-002 — "
-    "the same int-vs-string-ID mismatch, applied to milestones."
+    "assign_beads_item_to_milestone for beads-native milestone support instead. See ADR-003 — "
+    "the same int-vs-string-ID mismatch ADR-002 describes for issues, applied to milestones."
 )
 
 _ADR_002_BATCH_NOTE = (

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -264,12 +264,16 @@ _ADR_002_NOTE = (
     "Use fetch_open_issues_by_title_str() for beads-native title lookup. See ADR-002."
 )
 
+# ADR-003: the same int-vs-string-ID mismatch ADR-002 describes for issues,
+# applied to milestones — MilestoneFullNode.number is int, beads milestone
+# IDs are string nanoids. Design-time rationale only; kept out of the raised
+# message text below, which callers receive at runtime and only need told
+# what to call instead, not why the Protocol method can't be implemented.
 _ADR_003_NOTE = (
     "list_milestones/create_milestone/assign_item_to_milestone use int issue/milestone numbers "
     "(MilestoneFullNode.number: int) but beads milestones are issues with string nanoid IDs "
     "(bd create --type milestone). Use list_beads_milestones/create_beads_milestone/"
-    "assign_beads_item_to_milestone for beads-native milestone support instead. See ADR-003 — "
-    "the same int-vs-string-ID mismatch ADR-002 describes for issues, applied to milestones."
+    "assign_beads_item_to_milestone for beads-native milestone support instead."
 )
 
 _ADR_002_BATCH_NOTE = (

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -844,7 +844,7 @@ class BeadsBackend:
             GitHub/SQLite/Memory milestones, so a future beads-native dispatch
             path can reuse the shape without translation.
         """
-        raw = self._runner.run_json(["list", "--status", "all", "--limit", "0"])
+        raw = self._runner.run_json(["list", "--all", "--limit", "0"])
         issues = parse_issue_list(raw)
         milestones = [i for i in issues if i.type == BeadsIssueType.MILESTONE]
         if states:

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -829,7 +829,7 @@ class BeadsBackend:
         """List beads issues of type ``milestone``, with member counts via ``parent``.
 
         Beads-native equivalent of :meth:`list_milestones`. A single
-        ``bd list --status all`` call fetches every issue once; milestone
+        ``bd list --all`` call fetches every issue once; milestone
         member counts are computed client-side by grouping on each issue's
         ``parent`` field rather than issuing one ``bd children`` call per
         milestone.

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -61,6 +61,7 @@ from backlog_core.backends.bd_runner import (
     JsonValue,
 )
 from backlog_core.backends.beads_models import (
+    BeadsIssueRaw,
     BeadsIssueType,
     BeadsStatus,
     parse_issue,
@@ -246,6 +247,11 @@ def _normalize_due_at(due_at: str | None) -> str | None:
         parsed = datetime.fromisoformat(due_at)
     except ValueError:
         return None
+    if parsed.tzinfo is None:
+        # A date-only or offset-less value has no timezone to convert from;
+        # treat it as already UTC rather than silently reinterpreting it
+        # through the host process's local timezone.
+        parsed = parsed.replace(tzinfo=UTC)
     return parsed.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
@@ -840,9 +846,13 @@ class BeadsBackend:
         if states:
             state_set = {s.upper() for s in states}
             milestones = [m for m in milestones if _collapse_beads_status(m.status) in state_set]
+        children_by_parent: dict[str, list[BeadsIssueRaw]] = {}
+        for i in issues:
+            if i.parent is not None:
+                children_by_parent.setdefault(i.parent, []).append(i)
         result: list[dict[str, object]] = []
         for m in milestones:
-            children = [i for i in issues if i.parent == m.id]
+            children = children_by_parent.get(m.id, [])
             open_count = sum(1 for c in children if _collapse_beads_status(c.status) == "OPEN")
             closed_count = sum(1 for c in children if _collapse_beads_status(c.status) == "CLOSED")
             result.append({
@@ -873,9 +883,6 @@ class BeadsBackend:
             Beads nanoid string of the created milestone, or ``None`` when
             ``bd`` is unavailable or creation fails.
         """
-        from backlog_core.models import Output  # ruff: ignore[import-outside-top-level]
-
-        out = Output()
         argv = ["create", title, "--type", BeadsIssueType.MILESTONE]
         if description:
             argv.extend(["--description", description])
@@ -888,11 +895,9 @@ class BeadsBackend:
             parsed = parse_issue(raw)
         except (BdNotInstalledError, BdInvocationError, BdJsonDecodeError) as exc:
             _log.debug("create_beads_milestone: bd invocation failed: %s", exc)
-            out.warn(f"  WARNING: bd create --type milestone failed: {exc}")
             return None
         except ValidationError as exc:
             _log.debug("create_beads_milestone: bd create output validation failed: %s", exc)
-            out.warn(f"  WARNING: bd create output did not match expected schema: {exc}")
             return None
         else:
             return parsed.id or None

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -45,6 +45,7 @@ import logging
 import os
 import uuid
 from collections.abc import Iterator, Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, Final, Literal, Protocol
@@ -89,7 +90,7 @@ from backlog_core.models import (
 if TYPE_CHECKING:
     from github.Repository import Repository
 
-    from backlog_core.backend_types import IssueNode, MilestoneNode
+    from backlog_core.backend_types import IssueNode, MilestoneFullNode, MilestoneNode
     from backlog_core.models import Output
 
 __all__ = ["BeadsBackend"]
@@ -217,6 +218,37 @@ def _beads_status_for_item_status(status: str) -> str:
     return _LOGICAL_STATUS_TO_BEADS.get(status.casefold(), status)
 
 
+def _collapse_beads_status(status: BeadsStatus) -> Literal["OPEN", "CLOSED"]:
+    """Collapse beads' seven-value status enum onto the backend-neutral open/closed pair.
+
+    Returns:
+        ``"CLOSED"`` for :attr:`BeadsStatus.CLOSED`, ``"OPEN"`` for every
+        other beads status (``open``, ``in_progress``, ``blocked``,
+        ``hooked``, ``deferred``, ``pinned``).
+    """
+    return "CLOSED" if status == BeadsStatus.CLOSED else "OPEN"
+
+
+def _normalize_due_at(due_at: str | None) -> str | None:
+    """Normalize a beads ``due_at`` timestamp to a UTC ``Z``-suffixed string.
+
+    ``bd create --json`` and ``bd list --json`` return this field with
+    different UTC offset shapes for the same underlying value (e.g.
+    ``+10:00`` vs ``Z``); normalizing here keeps callers offset-agnostic.
+
+    Returns:
+        ISO-8601 string with a ``Z`` suffix, or ``None`` when ``due_at`` is
+        absent or unparsable.
+    """
+    if not due_at:
+        return None
+    try:
+        parsed = datetime.fromisoformat(due_at)
+    except ValueError:
+        return None
+    return parsed.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 _ADR_001_NOTE = (
     "BeadsBackend does not implement GitHub-specific operations. See ADR-001 in the project architecture documentation."
 )
@@ -224,6 +256,14 @@ _ADR_001_NOTE = (
 _ADR_002_NOTE = (
     "fetch_open_issues_by_title returns dict[str, int] but beads issue IDs are strings. "
     "Use fetch_open_issues_by_title_str() for beads-native title lookup. See ADR-002."
+)
+
+_ADR_003_NOTE = (
+    "list_milestones/create_milestone/assign_item_to_milestone use int issue/milestone numbers "
+    "(MilestoneFullNode.number: int) but beads milestones are issues with string nanoid IDs "
+    "(bd create --type milestone). Use list_beads_milestones/create_beads_milestone/"
+    "assign_beads_item_to_milestone for beads-native milestone support instead. See ADR-002 — "
+    "the same int-vs-string-ID mismatch, applied to milestones."
 )
 
 _ADR_002_BATCH_NOTE = (
@@ -254,6 +294,13 @@ class BeadsBackend:
       ``GitHubExtras`` methods (see ``backend_types.py`` for the protocol);
       this is the one backend the old ``isinstance``-only gate actually
       caught correctly.
+    - ``supports_milestones = False`` — the generic ``list_milestones``/
+      ``create_milestone``/``assign_item_to_milestone`` methods use ``int``
+      issue/milestone numbers, which beads' string nanoid IDs cannot satisfy
+      (see ADR-003). Beads-native milestone support is real, just reached
+      through the beads-native shadow methods
+      (:meth:`list_beads_milestones`, :meth:`create_beads_milestone`,
+      :meth:`assign_beads_item_to_milestone`) instead of the generic gate.
 
     Parameters
     ----------
@@ -269,6 +316,7 @@ class BeadsBackend:
     issue_id_type: Literal["integer", "string"] = "string"
     supports_branches: bool = False
     supports_github_extras: bool = False
+    supports_milestones: bool = False
 
     def __init__(self, runner: _BdRunnerLike | None = None) -> None:
         """Store the runner; do not touch the filesystem or spawn processes."""
@@ -698,7 +746,7 @@ class BeadsBackend:
             return False
 
         result.status = str(parsed.status)
-        result.state = "closed" if parsed.status == BeadsStatus.CLOSED else "open"
+        result.state = _collapse_beads_status(parsed.status).lower()
         result.source = "beads"
         result.issue = parsed.id
         if parsed.title:
@@ -739,6 +787,124 @@ class BeadsBackend:
             assignees=assignees,
             labels=labels,
         )
+
+    # ------------------------------------------------------------------
+    # Milestones
+    # ------------------------------------------------------------------
+
+    def list_milestones(self, states: list[str] | None = None, repo: str = "") -> list[MilestoneFullNode]:
+        """Raise NotImplementedError — beads milestone IDs are strings; see ADR-003.
+
+        Use :meth:`list_beads_milestones` for beads-native milestone listing.
+        """
+        raise NotImplementedError(_ADR_003_NOTE)
+
+    def create_milestone(
+        self, title: str, description: str = "", due_on: datetime | None = None, repo: str = ""
+    ) -> MilestoneFullNode:
+        """Raise NotImplementedError — beads milestone IDs are strings; see ADR-003.
+
+        Use :meth:`create_beads_milestone` for beads-native milestone creation.
+        """
+        raise NotImplementedError(_ADR_003_NOTE)
+
+    def assign_item_to_milestone(self, issue_number: int, milestone_number: int, repo: str = "") -> None:
+        """Raise NotImplementedError — beads milestone IDs are strings; see ADR-003.
+
+        Use :meth:`assign_beads_item_to_milestone` for beads-native assignment.
+        """
+        raise NotImplementedError(_ADR_003_NOTE)
+
+    def list_beads_milestones(self, states: list[str] | None = None) -> list[dict[str, object]]:
+        """List beads issues of type ``milestone``, with member counts via ``parent``.
+
+        Beads-native equivalent of :meth:`list_milestones`. A single
+        ``bd list --status all`` call fetches every issue once; milestone
+        member counts are computed client-side by grouping on each issue's
+        ``parent`` field rather than issuing one ``bd children`` call per
+        milestone.
+
+        Args:
+            states: Optional state filter (``"OPEN"``/``"CLOSED"``, case-insensitive).
+
+        Returns:
+            List of dicts with ``number`` (beads nanoid), ``title``, ``state``,
+            ``description``, ``due_on`` (UTC ``Z``-normalized), ``open_issues``,
+            ``closed_issues`` — the same field names ``operations.py`` uses for
+            GitHub/SQLite/Memory milestones, so a future beads-native dispatch
+            path can reuse the shape without translation.
+        """
+        raw = self._runner.run_json(["list", "--status", "all", "--limit", "0"])
+        issues = parse_issue_list(raw)
+        milestones = [i for i in issues if i.type == BeadsIssueType.MILESTONE]
+        if states:
+            state_set = {s.upper() for s in states}
+            milestones = [m for m in milestones if _collapse_beads_status(m.status) in state_set]
+        result: list[dict[str, object]] = []
+        for m in milestones:
+            children = [i for i in issues if i.parent == m.id]
+            open_count = sum(1 for c in children if _collapse_beads_status(c.status) == "OPEN")
+            closed_count = sum(1 for c in children if _collapse_beads_status(c.status) == "CLOSED")
+            result.append({
+                "number": m.id,
+                "title": m.title,
+                "state": _collapse_beads_status(m.status).lower(),
+                "description": m.description or "",
+                "due_on": _normalize_due_at(m.due_at),
+                "open_issues": open_count,
+                "closed_issues": closed_count,
+            })
+        return result
+
+    def create_beads_milestone(
+        self, title: str, description: str = "", due_on: str | None = None, parent: str | None = None
+    ) -> str | None:
+        """Create a beads milestone issue via ``bd create --type milestone``.
+
+        Args:
+            title: Milestone title.
+            description: Optional milestone description.
+            due_on: Optional due date, any format ``bd create --due`` accepts
+                (e.g. ``"2026-06-30"``).
+            parent: Optional parent-child parent ID, set at creation time via
+                ``bd create --parent`` instead of a separate ``bd link`` call.
+
+        Returns:
+            Beads nanoid string of the created milestone, or ``None`` when
+            ``bd`` is unavailable or creation fails.
+        """
+        from backlog_core.models import Output  # ruff: ignore[import-outside-top-level]
+
+        out = Output()
+        argv = ["create", title, "--type", BeadsIssueType.MILESTONE]
+        if description:
+            argv.extend(["--description", description])
+        if due_on:
+            argv.extend(["--due", due_on])
+        if parent:
+            argv.extend(["--parent", parent])
+        try:
+            raw = self._runner.run_json(argv)
+            parsed = parse_issue(raw)
+        except (BdNotInstalledError, BdInvocationError, BdJsonDecodeError) as exc:
+            _log.debug("create_beads_milestone: bd invocation failed: %s", exc)
+            out.warn(f"  WARNING: bd create --type milestone failed: {exc}")
+            return None
+        except ValidationError as exc:
+            _log.debug("create_beads_milestone: bd create output validation failed: %s", exc)
+            out.warn(f"  WARNING: bd create output did not match expected schema: {exc}")
+            return None
+        else:
+            return parsed.id or None
+
+    def assign_beads_item_to_milestone(self, issue_id: str, milestone_id: str) -> None:
+        """Assign a beads issue to a milestone via ``bd link --type parent-child``.
+
+        Args:
+            issue_id: Beads nanoid of the item being assigned (the child).
+            milestone_id: Beads nanoid of the milestone (the parent).
+        """
+        self._runner.run_text(["link", issue_id, milestone_id, "--type", "parent-child"])
 
     # ------------------------------------------------------------------
     # Status mutations

--- a/plugins/development-harness/backlog_core/backends/beads_models.py
+++ b/plugins/development-harness/backlog_core/backends/beads_models.py
@@ -159,6 +159,14 @@ class BeadsIssueRaw(BaseModel):
         created_at: ISO-8601 creation timestamp, may be absent.
         updated_at: ISO-8601 last-update timestamp, may be absent.
         closed_at: ISO-8601 closure timestamp, absent when issue is open.
+        parent: Beads nanoid of this issue's parent-child parent, if any.
+            Emitted by the CLI as a first-class ``"parent"`` scalar on both
+            ``bd create --parent`` and ``bd link --type parent-child``
+            output; used as the milestone-membership signal (Slice C).
+        due_at: ISO-8601 due date/time, may be absent.  ``bd create --json``
+            and ``bd list --json`` return this field with different UTC
+            offset shapes for the same value — callers normalize to a ``Z``
+            suffix at the backend boundary, not here.
     """
 
     model_config = ConfigDict(strict=True, extra="ignore")
@@ -176,6 +184,8 @@ class BeadsIssueRaw(BaseModel):
     created_at: str | None = None
     updated_at: str | None = None
     closed_at: str | None = None
+    parent: str | None = None
+    due_at: str | None = None
 
 
 class BeadsDependencyRaw(BaseModel):

--- a/plugins/development-harness/backlog_core/backends/github_backend.py
+++ b/plugins/development-harness/backlog_core/backends/github_backend.py
@@ -29,9 +29,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal
 
 import dh_paths as _dh_paths
+from github import GithubObject
 
 from backlog_core import gh_client, github_branches, github_sync, rendering as _rendering
 from backlog_core.artifact_provider import ArtifactBackend, GitHubGistArtifactProvider
+from backlog_core.backend_types import MilestoneFullNode
 from backlog_core.backends.github_content_migration import (
     _GitHubContentCache,
     _GitHubContentMigration,
@@ -67,7 +69,7 @@ if TYPE_CHECKING:
 
     from github.Repository import Repository
 
-    from backlog_core.backend_types import IssueCommentNode, IssueNode, MilestoneFullNode
+    from backlog_core.backend_types import IssueCommentNode, IssueNode
     from backlog_core.file_cache_state import _PendingWorkItemMutation
     from backlog_core.models import (
         BackendStatus,
@@ -112,6 +114,7 @@ class GitHubBackend:
     issue_id_type: Literal["integer", "string"] = "integer"
     supports_branches: bool = True
     supports_github_extras: bool = True
+    supports_milestones: bool = True
 
     def __init__(
         self,
@@ -670,6 +673,48 @@ class GitHubBackend:
             Tuple of (mutation_string, variables_dict).
         """
         return gh_client._projects_v2_create_mutation(owner_id, title)
+
+    def list_milestones(self, states: list[str] | None = None, repo: str = "") -> list[MilestoneFullNode]:
+        """List milestones via the GraphQL milestone query.
+
+        Returns:
+            List of MilestoneFullNode TypedDicts.
+        """
+        repository = self.get_github(repo)
+        owner, repo_name = repository.full_name.split("/", 1)
+        return self._fetch_milestones_graphql(repository, owner, repo_name, states)
+
+    def create_milestone(
+        self, title: str, description: str = "", due_on: datetime | None = None, repo: str = ""
+    ) -> MilestoneFullNode:
+        """Create a milestone via PyGithub's REST create_milestone call.
+
+        Returns:
+            MilestoneFullNode describing the created milestone.
+        """
+        repository = self.get_github(repo)
+        ms = repository.create_milestone(
+            title=title,
+            state="open",
+            description=description or GithubObject.NotSet,
+            due_on=due_on if due_on is not None else GithubObject.NotSet,
+        )
+        return MilestoneFullNode(
+            id=str(getattr(ms, "node_id", f"github-milestone-{ms.number}")),
+            number=ms.number,
+            title=ms.title,
+            state=str(ms.state).upper(),
+            description=ms.description or "",
+            dueOn=ms.due_on.strftime("%Y-%m-%dT%H:%M:%SZ") if ms.due_on else None,
+            openIssueCount=ms.open_issues,
+            closedIssueCount=ms.closed_issues,
+        )
+
+    def assign_item_to_milestone(self, issue_number: int, milestone_number: int, repo: str = "") -> None:
+        """Assign a GitHub issue to a milestone via PyGithub's issue.edit call."""
+        repository = self.get_github(repo)
+        milestone_obj = repository.get_milestone(milestone_number)
+        repository.get_issue(issue_number).edit(milestone=milestone_obj)
 
     # ------------------------------------------------------------------
     # Task issues

--- a/plugins/development-harness/backlog_core/backends/memory_backend.py
+++ b/plugins/development-harness/backlog_core/backends/memory_backend.py
@@ -546,25 +546,24 @@ class InMemoryBackend:
         self, repo: Repository, owner: str, repo_name: str, states: list[str] | None = None
     ) -> list[MilestoneFullNode]:
         """Return stored milestones (with issue counts recomputed live), optionally filtered by state."""
-        milestones: list[MilestoneFullNode] = []
-        for m in self._milestones.values():
-            open_count = sum(
-                1
-                for issue in self._issues.values()
-                if issue["milestone"] is not None
-                and issue["milestone"]["number"] == m["number"]
-                and issue["state"] == "OPEN"
+        open_counts: dict[int, int] = {}
+        closed_counts: dict[int, int] = {}
+        for issue in self._issues.values():
+            milestone = issue["milestone"]
+            if milestone is None:
+                continue
+            counts = open_counts if issue["state"] == "OPEN" else closed_counts
+            counts[milestone["number"]] = counts.get(milestone["number"], 0) + 1
+        milestones: list[MilestoneFullNode] = [
+            MilestoneFullNode(
+                **{
+                    **m,
+                    "openIssueCount": open_counts.get(m["number"], 0),
+                    "closedIssueCount": closed_counts.get(m["number"], 0),
+                }
             )
-            closed_count = sum(
-                1
-                for issue in self._issues.values()
-                if issue["milestone"] is not None
-                and issue["milestone"]["number"] == m["number"]
-                and issue["state"] == "CLOSED"
-            )
-            milestones.append(
-                MilestoneFullNode(**{**m, "openIssueCount": open_count, "closedIssueCount": closed_count})
-            )
+            for m in self._milestones.values()
+        ]
         if states:
             state_set = {s.upper() for s in states}
             milestones = [m for m in milestones if str(m["state"]).upper() in state_set]

--- a/plugins/development-harness/backlog_core/backends/memory_backend.py
+++ b/plugins/development-harness/backlog_core/backends/memory_backend.py
@@ -555,22 +555,21 @@ class InMemoryBackend:
             counts = open_counts if issue["state"] == "OPEN" else closed_counts
             counts[milestone["number"]] = counts.get(milestone["number"], 0) + 1
         milestones: list[MilestoneFullNode] = [
-            MilestoneFullNode(
-                **{
-                    **m,
-                    "openIssueCount": open_counts.get(m["number"], 0),
-                    "closedIssueCount": closed_counts.get(m["number"], 0),
-                }
-            )
+            MilestoneFullNode(**{
+                **m,
+                "openIssueCount": open_counts.get(m["number"], 0),
+                "closedIssueCount": closed_counts.get(m["number"], 0),
+            })
             for m in self._milestones.values()
         ]
         if states:
             state_set = {s.upper() for s in states}
             milestones = [m for m in milestones if str(m["state"]).upper() in state_set]
+        milestones.sort(key=lambda m: (m["dueOn"] is None, m["dueOn"], m["number"]))
         return milestones
 
     def list_milestones(self, states: list[str] | None = None, repo: str = "") -> list[MilestoneFullNode]:
-        """Return stored milestones, optionally filtered by state.
+        """Return stored milestones, ordered by due date then number, optionally filtered by state.
 
         Args:
             states: Optional list of state filters (e.g. ``["OPEN", "CLOSED"]``).

--- a/plugins/development-harness/backlog_core/backends/memory_backend.py
+++ b/plugins/development-harness/backlog_core/backends/memory_backend.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from threading import RLock
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -112,6 +112,7 @@ class InMemoryBackend:
     issue_id_type: Literal["integer", "string"] = "integer"
     supports_branches: bool = True
     supports_github_extras: bool = False
+    supports_milestones: bool = True
 
     def __init__(self) -> None:
         """Initialise empty in-memory storage for all backend state."""
@@ -544,12 +545,98 @@ class InMemoryBackend:
     def _fetch_milestones_graphql(
         self, repo: Repository, owner: str, repo_name: str, states: list[str] | None = None
     ) -> list[MilestoneFullNode]:
-        """Return stored milestones, optionally filtered by state."""
-        milestones = list(self._milestones.values())
+        """Return stored milestones (with issue counts recomputed live), optionally filtered by state."""
+        milestones: list[MilestoneFullNode] = []
+        for m in self._milestones.values():
+            open_count = sum(
+                1
+                for issue in self._issues.values()
+                if issue["milestone"] is not None
+                and issue["milestone"]["number"] == m["number"]
+                and issue["state"] == "OPEN"
+            )
+            closed_count = sum(
+                1
+                for issue in self._issues.values()
+                if issue["milestone"] is not None
+                and issue["milestone"]["number"] == m["number"]
+                and issue["state"] == "CLOSED"
+            )
+            milestones.append(
+                MilestoneFullNode(**{**m, "openIssueCount": open_count, "closedIssueCount": closed_count})
+            )
         if states:
-            state_set = set(states)
-            milestones = [m for m in milestones if m["state"] in state_set]
+            state_set = {s.upper() for s in states}
+            milestones = [m for m in milestones if str(m["state"]).upper() in state_set]
         return milestones
+
+    def list_milestones(self, states: list[str] | None = None, repo: str = "") -> list[MilestoneFullNode]:
+        """Return stored milestones, optionally filtered by state.
+
+        Args:
+            states: Optional list of state filters (e.g. ``["OPEN", "CLOSED"]``).
+            repo: Ignored — InMemoryBackend has no GitHub connection.
+
+        Returns:
+            List of ``MilestoneFullNode`` TypedDicts.
+        """
+        return self._fetch_milestones_graphql(cast("Repository", None), "", "", states)
+
+    def create_milestone(
+        self, title: str, description: str = "", due_on: datetime | None = None, repo: str = ""
+    ) -> MilestoneFullNode:
+        """Create and store a milestone.
+
+        Args:
+            title: Milestone title.
+            description: Optional milestone description.
+            due_on: Optional due date.
+            repo: Ignored — InMemoryBackend has no GitHub connection.
+
+        Returns:
+            MilestoneFullNode describing the created milestone.
+        """
+        number = self._next_milestone_number
+        self._next_milestone_number += 1
+        node = MilestoneFullNode(
+            id=f"memory-milestone-{number}",
+            number=number,
+            title=title,
+            state="OPEN",
+            description=description or "",
+            dueOn=due_on.strftime("%Y-%m-%dT%H:%M:%SZ") if due_on is not None else None,
+            openIssueCount=0,
+            closedIssueCount=0,
+        )
+        self._milestones[number] = node
+        return node
+
+    def assign_item_to_milestone(self, issue_number: int, milestone_number: int, repo: str = "") -> None:
+        """Set an issue's embedded milestone reference.
+
+        Args:
+            issue_number: Issue to assign.
+            milestone_number: Milestone to assign it to.
+            repo: Ignored — InMemoryBackend has no GitHub connection.
+
+        Raises:
+            KeyError: When ``issue_number`` or ``milestone_number`` is unknown.
+        """
+        issue = self._issues.get(issue_number)
+        if issue is None:
+            msg = f"InMemoryBackend: issue #{issue_number} not found"
+            raise KeyError(msg)
+        milestone = self._milestones.get(milestone_number)
+        if milestone is None:
+            msg = f"InMemoryBackend: milestone #{milestone_number} not found"
+            raise KeyError(msg)
+        issue["milestone"] = MilestoneNode(
+            id=milestone["id"],
+            number=milestone["number"],
+            title=milestone["title"],
+            dueOn=milestone["dueOn"],
+            state=cast('Literal["OPEN", "CLOSED"]', milestone["state"]),
+        )
 
     def _projects_v2_list_query(self, owner: str, limit: int = 20) -> tuple[str, dict[str, object]]:
         """Return stub query/variables — no ProjectsV2 in in-memory backend."""

--- a/plugins/development-harness/backlog_core/backends/memory_backend.py
+++ b/plugins/development-harness/backlog_core/backends/memory_backend.py
@@ -596,13 +596,18 @@ class InMemoryBackend:
         """
         number = self._next_milestone_number
         self._next_milestone_number += 1
+        due_on_str = None
+        if due_on is not None:
+            if due_on.tzinfo is None:
+                due_on = due_on.replace(tzinfo=UTC)
+            due_on_str = due_on.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         node = MilestoneFullNode(
             id=f"memory-milestone-{number}",
             number=number,
             title=title,
             state="OPEN",
             description=description or "",
-            dueOn=due_on.strftime("%Y-%m-%dT%H:%M:%SZ") if due_on is not None else None,
+            dueOn=due_on_str,
             openIssueCount=0,
             closedIssueCount=0,
         )

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -196,7 +196,31 @@ class SQLiteBackend:
         self._conn.row_factory = sqlite3.Row
         self._content_lock = RLock()
         self._conn.executescript(_SCHEMA_SQL)
+        self._migrate_schema()
         self._conn.commit()
+
+    def _migrate_schema(self) -> None:
+        """Add columns introduced after a durable database's original schema.
+
+        ``CREATE TABLE IF NOT EXISTS`` is a no-op on a table that already
+        exists, so a pre-existing durable ``items`` table never gains new
+        columns on its own. Backfills from the legacy ``item_milestones``
+        join table when present, then drops it.
+        """
+        columns = {row["name"] for row in self._conn.execute("PRAGMA table_info(items)").fetchall()}
+        if "milestone_number" not in columns:
+            self._conn.execute("ALTER TABLE items ADD COLUMN milestone_number INTEGER REFERENCES milestones(number)")
+        legacy_table = self._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'item_milestones'"
+        ).fetchone()
+        if legacy_table is not None:
+            self._conn.execute(
+                "UPDATE items SET milestone_number = ("
+                "  SELECT milestone_number FROM item_milestones"
+                "  WHERE item_milestones.issue_number = items.issue_number LIMIT 1"
+                ") WHERE issue_number IN (SELECT issue_number FROM item_milestones)"
+            )
+            self._conn.execute("DROP TABLE item_milestones")
 
     @_serialized_connection_operation
     def list_work_items(self) -> list[BacklogItem]:
@@ -1086,7 +1110,20 @@ class SQLiteBackend:
             issue_number: Item to assign.
             milestone_number: Milestone to assign it to.
             repo: Ignored — SQLite has no GitHub connection.
+
+        Raises:
+            KeyError: When ``issue_number`` or ``milestone_number`` is unknown.
+                SQLite foreign keys are never enforced (``PRAGMA foreign_keys``
+                defaults off), so an unchecked ``UPDATE`` would silently accept
+                a nonexistent milestone or update zero rows for an unknown
+                issue.
         """
+        if self._conn.execute("SELECT 1 FROM items WHERE issue_number = ?", (issue_number,)).fetchone() is None:
+            msg = f"SQLiteBackend: issue #{issue_number} not found"
+            raise KeyError(msg)
+        if self._conn.execute("SELECT 1 FROM milestones WHERE number = ?", (milestone_number,)).fetchone() is None:
+            msg = f"SQLiteBackend: milestone #{milestone_number} not found"
+            raise KeyError(msg)
         self._conn.execute(
             "UPDATE items SET milestone_number = ? WHERE issue_number = ?", (milestone_number, issue_number)
         )

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -1119,7 +1119,11 @@ class SQLiteBackend:
             MilestoneFullNode describing the created milestone.
         """
         number = self._next_milestone_number()
-        due_on_str = due_on.strftime("%Y-%m-%dT%H:%M:%SZ") if due_on is not None else None
+        due_on_str = None
+        if due_on is not None:
+            if due_on.tzinfo is None:
+                due_on = due_on.replace(tzinfo=UTC)
+            due_on_str = due_on.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         self._conn.execute(
             "INSERT INTO milestones (number, title, due_on, description, state, created_at) "
             "VALUES (?, ?, ?, ?, 'open', ?)",

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -3,7 +3,7 @@
 Stores all backlog state in a local SQLite database file.  No PyGithub
 dependency — uses only ``sqlite3`` from the standard library.
 
-Schema (5 tables):
+Schema (7 tables):
     items            — maps directly to BacklogItem fields; each item carries
                        a nullable ``milestone_number`` FK (one milestone per
                        item, matching GitHub's model)
@@ -11,6 +11,8 @@ Schema (5 tables):
     milestones       — backend-neutral milestone/deadline-bucket concept
     comments         — maps to GitHub issue comments
     projects         — maps to GitHub Projects V2
+    content_records  — logical plan/artifact content (``ContentProvider``)
+    work_item_records — opaque native work-item store (``put_work_item``)
 
 Branch operations are not supported; all five branch methods raise
 ``RuntimeError``.  The body column stores sections as JSON.
@@ -378,6 +380,17 @@ class SQLiteBackend:
         row = self._conn.execute("SELECT COALESCE(MAX(number), 0) + 1 FROM projects").fetchone()
         return int(row[0])
 
+    def _milestones_by_number_for(self, rows: list[sqlite3.Row]) -> dict[int, sqlite3.Row]:
+        """Pre-fetch milestones for a batch of ``items`` rows, or skip the query entirely.
+
+        Returns:
+            Empty dict, with no query run, when no row in ``rows`` references
+            a milestone. Otherwise every ``milestones`` row keyed by number.
+        """
+        if not any(r["milestone_number"] is not None for r in rows):
+            return {}
+        return {int(r["number"]): r for r in self._conn.execute("SELECT * FROM milestones").fetchall()}
+
     def _row_to_issue_node(
         self,
         row: sqlite3.Row,
@@ -561,7 +574,7 @@ class SQLiteBackend:
                 "SELECT * FROM items WHERE status = ? ORDER BY issue_number LIMIT ?", (db_status, first)
             ).fetchall()
 
-        milestones_by_number = {int(r["number"]): r for r in self._conn.execute("SELECT * FROM milestones").fetchall()}
+        milestones_by_number = self._milestones_by_number_for(rows)
         nodes = [self._row_to_issue_node(r, milestones_by_number=milestones_by_number) for r in rows]
 
         if labels:
@@ -1249,7 +1262,7 @@ class SQLiteBackend:
             All stored issue nodes.
         """
         rows = self._conn.execute("SELECT * FROM items ORDER BY issue_number").fetchall()
-        milestones_by_number = {int(r["number"]): r for r in self._conn.execute("SELECT * FROM milestones").fetchall()}
+        milestones_by_number = self._milestones_by_number_for(rows)
         return [self._row_to_issue_node(r, milestones_by_number=milestones_by_number) for r in rows]
 
     @_serialized_connection_operation

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from backlog_core.models import Output, SamTask
 
 from backlog_core import rendering as _rendering
-from backlog_core.backend_types import IssueCommentNode, IssueNode, LabelNode, MilestoneFullNode
+from backlog_core.backend_types import IssueCommentNode, IssueNode, LabelNode, MilestoneFullNode, MilestoneNode
 from backlog_core.models import (
     BackendAvailability,
     BackendStatus,
@@ -391,6 +391,18 @@ class SQLiteBackend:
             tags = [r["tag"] for r in tag_rows]
         label_nodes: list[LabelNode] = [LabelNode(id=f"label-{t}", name=t) for t in tags]
         state = "OPEN" if str(row["status"]).lower() == "open" else "CLOSED"
+        milestone: MilestoneNode | None = None
+        milestone_number = row["milestone_number"]
+        if milestone_number is not None:
+            ms_row = self._conn.execute("SELECT * FROM milestones WHERE number = ?", (milestone_number,)).fetchone()
+            if ms_row is not None:
+                milestone = MilestoneNode(
+                    id=f"sqlite-milestone-{milestone_number}",
+                    number=int(milestone_number),
+                    title=ms_row["title"],
+                    dueOn=ms_row["due_on"],
+                    state=cast('Literal["OPEN", "CLOSED"]', str(ms_row["state"]).upper()),
+                )
         return IssueNode(
             id=f"sqlite-issue-{number}",
             number=number,
@@ -400,7 +412,7 @@ class SQLiteBackend:
             createdAt=row["created_at"],
             updatedAt=row["updated_at"],
             labels=label_nodes,
-            milestone=None,
+            milestone=milestone,
             assignees=[],
         )
 

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -3,11 +3,12 @@
 Stores all backlog state in a local SQLite database file.  No PyGithub
 dependency — uses only ``sqlite3`` from the standard library.
 
-Schema (6 tables):
-    items            — maps directly to BacklogItem fields
+Schema (5 tables):
+    items            — maps directly to BacklogItem fields; each item carries
+                       a nullable ``milestone_number`` FK (one milestone per
+                       item, matching GitHub's model)
     item_tags        — replaces GitHub label system
-    milestones       — maps to GitHub milestones
-    item_milestones  — item-to-milestone association
+    milestones       — backend-neutral milestone/deadline-bucket concept
     comments         — maps to GitHub issue comments
     projects         — maps to GitHub Projects V2
 
@@ -34,7 +35,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from functools import wraps
 from threading import RLock
-from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypeVar, cast
 
 if TYPE_CHECKING:
     from github.Repository import Repository
@@ -70,22 +71,6 @@ __all__ = ["SQLiteBackend"]
 
 # DDL executed once at startup — CREATE TABLE IF NOT EXISTS is idempotent.
 _SCHEMA_SQL = """\
-CREATE TABLE IF NOT EXISTS items (
-    issue_number   INTEGER PRIMARY KEY,
-    title          TEXT NOT NULL,
-    status         TEXT NOT NULL DEFAULT 'open',
-    body           TEXT,
-    created_at     TEXT NOT NULL,
-    updated_at     TEXT NOT NULL,
-    closed_at      TEXT
-);
-
-CREATE TABLE IF NOT EXISTS item_tags (
-    issue_number   INTEGER NOT NULL REFERENCES items(issue_number),
-    tag            TEXT NOT NULL,
-    UNIQUE(issue_number, tag)
-);
-
 CREATE TABLE IF NOT EXISTS milestones (
     number         INTEGER PRIMARY KEY,
     title          TEXT NOT NULL,
@@ -95,10 +80,21 @@ CREATE TABLE IF NOT EXISTS milestones (
     created_at     TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS item_milestones (
-    issue_number      INTEGER NOT NULL REFERENCES items(issue_number),
-    milestone_number  INTEGER NOT NULL REFERENCES milestones(number),
-    PRIMARY KEY (issue_number, milestone_number)
+CREATE TABLE IF NOT EXISTS items (
+    issue_number      INTEGER PRIMARY KEY,
+    title             TEXT NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'open',
+    body              TEXT,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL,
+    closed_at         TEXT,
+    milestone_number  INTEGER REFERENCES milestones(number)
+);
+
+CREATE TABLE IF NOT EXISTS item_tags (
+    issue_number   INTEGER NOT NULL REFERENCES items(issue_number),
+    tag            TEXT NOT NULL,
+    UNIQUE(issue_number, tag)
 );
 
 CREATE TABLE IF NOT EXISTS comments (
@@ -187,6 +183,7 @@ class SQLiteBackend:
     issue_id_type: Literal["integer", "string"] = "integer"
     supports_branches: bool = False
     supports_github_extras: bool = False
+    supports_milestones: bool = True
 
     def __init__(self, db_path: str = ":memory:") -> None:
         """Initialise the SQLite database and create tables if absent.
@@ -394,18 +391,12 @@ class SQLiteBackend:
         number = int(row["number"])
         open_count = int(
             self._conn.execute(
-                "SELECT COUNT(*) FROM item_milestones im "
-                "JOIN items i ON im.issue_number = i.issue_number "
-                "WHERE im.milestone_number = ? AND i.status = 'open'",
-                (number,),
+                "SELECT COUNT(*) FROM items WHERE milestone_number = ? AND status = 'open'", (number,)
             ).fetchone()[0]
         )
         closed_count = int(
             self._conn.execute(
-                "SELECT COUNT(*) FROM item_milestones im "
-                "JOIN items i ON im.issue_number = i.issue_number "
-                "WHERE im.milestone_number = ? AND i.status != 'open'",
-                (number,),
+                "SELECT COUNT(*) FROM items WHERE milestone_number = ? AND status != 'open'", (number,)
             ).fetchone()[0]
         )
         state = str(row["state"]).upper()
@@ -521,7 +512,7 @@ class SQLiteBackend:
             milestone_numbers = {
                 int(r["issue_number"])
                 for r in self._conn.execute(
-                    "SELECT issue_number FROM item_milestones WHERE milestone_number = ?", (milestone_number,)
+                    "SELECT issue_number FROM items WHERE milestone_number = ?", (milestone_number,)
                 ).fetchall()
             }
             nodes = [n for n in nodes if n["number"] in milestone_numbers]
@@ -1043,11 +1034,63 @@ class SQLiteBackend:
         Returns:
             List of ``MilestoneFullNode`` TypedDicts.
         """
-        rows = self._conn.execute("SELECT * FROM milestones").fetchall()
+        rows = self._conn.execute("SELECT * FROM milestones ORDER BY due_on IS NULL, due_on, number").fetchall()
         if states:
             state_set = {s.lower() for s in states}
             rows = [r for r in rows if str(r["state"]).lower() in state_set]
         return [self._row_to_milestone_full(r) for r in rows]
+
+    def list_milestones(self, states: list[str] | None = None, repo: str = "") -> list[MilestoneFullNode]:
+        """Return stored milestones, ordered by due date then number.
+
+        Args:
+            states: Optional list of state filters (e.g. ``["OPEN", "CLOSED"]``).
+            repo: Ignored — SQLite has no GitHub connection.
+
+        Returns:
+            List of ``MilestoneFullNode`` TypedDicts.
+        """
+        return self._fetch_milestones_graphql(cast("Repository", None), "", "", states)
+
+    @_serialized_connection_operation
+    def create_milestone(
+        self, title: str, description: str = "", due_on: datetime | None = None, repo: str = ""
+    ) -> MilestoneFullNode:
+        """Insert a new milestone row and return it as a MilestoneFullNode.
+
+        Args:
+            title: Milestone title.
+            description: Optional milestone description.
+            due_on: Optional due date.
+            repo: Ignored — SQLite has no GitHub connection.
+
+        Returns:
+            MilestoneFullNode describing the created milestone.
+        """
+        number = self._next_milestone_number()
+        due_on_str = due_on.strftime("%Y-%m-%dT%H:%M:%SZ") if due_on is not None else None
+        self._conn.execute(
+            "INSERT INTO milestones (number, title, due_on, description, state, created_at) "
+            "VALUES (?, ?, ?, ?, 'open', ?)",
+            (number, title, due_on_str, description or "", _now()),
+        )
+        self._conn.commit()
+        row = self._conn.execute("SELECT * FROM milestones WHERE number = ?", (number,)).fetchone()
+        return self._row_to_milestone_full(row)
+
+    @_serialized_connection_operation
+    def assign_item_to_milestone(self, issue_number: int, milestone_number: int, repo: str = "") -> None:
+        """Set an item's ``milestone_number`` FK.
+
+        Args:
+            issue_number: Item to assign.
+            milestone_number: Milestone to assign it to.
+            repo: Ignored — SQLite has no GitHub connection.
+        """
+        self._conn.execute(
+            "UPDATE items SET milestone_number = ? WHERE issue_number = ?", (milestone_number, issue_number)
+        )
+        self._conn.commit()
 
     def _projects_v2_list_query(self, owner: str, limit: int = 20) -> tuple[str, dict[str, object]]:
         """Return stub query/variables — SQLite has no GraphQL layer.

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -224,7 +224,8 @@ class SQLiteBackend:
                 "  SELECT milestone_number FROM item_milestones"
                 "  WHERE item_milestones.issue_number = items.issue_number"
                 "  ORDER BY milestone_number LIMIT 1"
-                ") WHERE issue_number IN (SELECT issue_number FROM item_milestones)"
+                ") WHERE milestone_number IS NULL"
+                "  AND issue_number IN (SELECT issue_number FROM item_milestones)"
             )
             self._conn.execute("DROP TABLE item_milestones")
 

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -1144,6 +1144,9 @@ class SQLiteBackend:
         )
         self._conn.commit()
         row = self._conn.execute("SELECT * FROM milestones WHERE number = ?", (number,)).fetchone()
+        if row is None:
+            msg = f"SQLiteBackend: milestone #{number} not found immediately after insert"
+            raise RuntimeError(msg)
         return self._row_to_milestone_full(row)
 
     @_serialized_connection_operation

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -375,12 +375,21 @@ class SQLiteBackend:
         row = self._conn.execute("SELECT COALESCE(MAX(number), 0) + 1 FROM projects").fetchone()
         return int(row[0])
 
-    def _row_to_issue_node(self, row: sqlite3.Row, tags: list[str] | None = None) -> IssueNode:
+    def _row_to_issue_node(
+        self,
+        row: sqlite3.Row,
+        tags: list[str] | None = None,
+        milestones_by_number: dict[int, sqlite3.Row] | None = None,
+    ) -> IssueNode:
         """Convert a database row from ``items`` to an ``IssueNode``.
 
         Args:
             row: Row from the ``items`` table.
             tags: Pre-fetched tag list for this issue, or ``None`` to fetch now.
+            milestones_by_number: Pre-fetched ``milestones`` rows keyed by
+                ``number``, or ``None`` to fetch this row's milestone
+                individually. Callers converting many rows at once should
+                pass this to avoid one extra query per row.
 
         Returns:
             ``IssueNode`` TypedDict populated from the row.
@@ -394,7 +403,11 @@ class SQLiteBackend:
         milestone: MilestoneNode | None = None
         milestone_number = row["milestone_number"]
         if milestone_number is not None:
-            ms_row = self._conn.execute("SELECT * FROM milestones WHERE number = ?", (milestone_number,)).fetchone()
+            ms_row = (
+                milestones_by_number.get(int(milestone_number))
+                if milestones_by_number is not None
+                else self._conn.execute("SELECT * FROM milestones WHERE number = ?", (milestone_number,)).fetchone()
+            )
             if ms_row is not None:
                 milestone = MilestoneNode(
                     id=f"sqlite-milestone-{milestone_number}",
@@ -539,7 +552,8 @@ class SQLiteBackend:
             "SELECT * FROM items WHERE status = ? ORDER BY issue_number LIMIT ?", (db_status, first)
         ).fetchall()
 
-        nodes = [self._row_to_issue_node(r) for r in rows]
+        milestones_by_number = {int(r["number"]): r for r in self._conn.execute("SELECT * FROM milestones").fetchall()}
+        nodes = [self._row_to_issue_node(r, milestones_by_number=milestones_by_number) for r in rows]
 
         if labels:
             label_set = set(labels)
@@ -1231,7 +1245,8 @@ class SQLiteBackend:
             All stored issue nodes.
         """
         rows = self._conn.execute("SELECT * FROM items ORDER BY issue_number").fetchall()
-        return [self._row_to_issue_node(r) for r in rows]
+        milestones_by_number = {int(r["number"]): r for r in self._conn.execute("SELECT * FROM milestones").fetchall()}
+        return [self._row_to_issue_node(r, milestones_by_number=milestones_by_number) for r in rows]
 
     @_serialized_connection_operation
     def update_task_status(

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -217,7 +217,8 @@ class SQLiteBackend:
             self._conn.execute(
                 "UPDATE items SET milestone_number = ("
                 "  SELECT milestone_number FROM item_milestones"
-                "  WHERE item_milestones.issue_number = items.issue_number LIMIT 1"
+                "  WHERE item_milestones.issue_number = items.issue_number"
+                "  ORDER BY milestone_number LIMIT 1"
                 ") WHERE issue_number IN (SELECT issue_number FROM item_milestones)"
             )
             self._conn.execute("DROP TABLE item_milestones")

--- a/plugins/development-harness/backlog_core/backends/sqlite_backend.py
+++ b/plugins/development-harness/backlog_core/backends/sqlite_backend.py
@@ -210,6 +210,9 @@ class SQLiteBackend:
         columns = {row["name"] for row in self._conn.execute("PRAGMA table_info(items)").fetchall()}
         if "milestone_number" not in columns:
             self._conn.execute("ALTER TABLE items ADD COLUMN milestone_number INTEGER REFERENCES milestones(number)")
+        # Runs after the column above is guaranteed present, so this is safe on
+        # both a fresh database and a durable one migrated by this method.
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_items_milestone_number ON items(milestone_number)")
         legacy_table = self._conn.execute(
             "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'item_milestones'"
         ).fetchone()
@@ -548,9 +551,15 @@ class SQLiteBackend:
             List of ``IssueNode`` TypedDicts.
         """
         db_status = "open" if state.upper() == "OPEN" else "closed"
-        rows = self._conn.execute(
-            "SELECT * FROM items WHERE status = ? ORDER BY issue_number LIMIT ?", (db_status, first)
-        ).fetchall()
+        if milestone_number is not None:
+            rows = self._conn.execute(
+                "SELECT * FROM items WHERE status = ? AND milestone_number = ? ORDER BY issue_number LIMIT ?",
+                (db_status, milestone_number, first),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM items WHERE status = ? ORDER BY issue_number LIMIT ?", (db_status, first)
+            ).fetchall()
 
         milestones_by_number = {int(r["number"]): r for r in self._conn.execute("SELECT * FROM milestones").fetchall()}
         nodes = [self._row_to_issue_node(r, milestones_by_number=milestones_by_number) for r in rows]
@@ -558,15 +567,6 @@ class SQLiteBackend:
         if labels:
             label_set = set(labels)
             nodes = [n for n in nodes if any(lbl["name"] in label_set for lbl in n["labels"])]
-
-        if milestone_number is not None:
-            milestone_numbers = {
-                int(r["issue_number"])
-                for r in self._conn.execute(
-                    "SELECT issue_number FROM items WHERE milestone_number = ?", (milestone_number,)
-                ).fetchall()
-            }
-            nodes = [n for n in nodes if n["number"] in milestone_numbers]
 
         return nodes
 

--- a/plugins/development-harness/backlog_core/models.py
+++ b/plugins/development-harness/backlog_core/models.py
@@ -817,7 +817,9 @@ class MilestoneInfo(BaseModel):
     ``milestone_due_on``, ``milestone_state``) that previously appeared
     separately on :class:`BacklogItemMetadata` and :class:`IssueLocalFields`.
 
-    ``state`` is constrained to the two values GitHub's GraphQL API returns.
+    ``state`` is a backend-neutral open/closed flag: every backend collapses
+    its own milestone lifecycle (or, for beads, its native issue-status set)
+    onto these two values at the backend boundary.
     """
 
     title: str = ""

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -16,8 +16,8 @@ from typing import Any, Final, NotRequired, TypeGuard
 
 from dispatch_schema.core.constants import MIN_CONFLICT_GROUP_SIZE
 from dispatch_schema.core.models import ConflictGroup
-from github import GithubException, GithubObject
-from github.Repository import Repository  # GithubObject used only by create_milestone (ADR-004)
+from github import GithubException
+from github.Repository import Repository
 from ruamel.yaml.error import YAMLError
 from sam_schema.core.backends.content import parse_plan_content
 from sam_schema.core.dependencies import SUCCESSFUL_STATUSES as _SAM_CORE_SUCCESSFUL_STATUSES
@@ -25,7 +25,7 @@ from sam_schema.core.models import Plan
 from typing_extensions import TypedDict
 
 from . import models as _models
-from ._capability_gates import require_github_extras
+from ._capability_gates import require_github_extras, require_milestone_support
 from .backend_protocol import get_config
 from .backend_types import ContentProvider, IssueCommentNode, IssueNode, MilestoneFullNode, SyncProvider
 from .entry_blocks import _render_entry_raw, find_entry_spans, parse_entries, resolve_all_entry_ids, resolve_entry_id
@@ -4460,13 +4460,31 @@ def list_merged_prs(
 # ---------------------------------------------------------------------------
 
 
+def _milestone_dict(ms: MilestoneFullNode) -> dict[str, object]:
+    """Shape a ``MilestoneFullNode`` into the dict returned by the milestone operations.
+
+    Returns:
+        Dict with ``number``, ``title``, ``state``, ``description``,
+        ``due_on``, ``open_issues``, ``closed_issues``.
+    """
+    return {
+        "number": ms["number"],
+        "title": ms["title"],
+        "state": ms["state"].lower(),
+        "description": ms["description"] or "",
+        "due_on": ms["dueOn"],
+        "open_issues": ms["openIssueCount"],
+        "closed_issues": ms["closedIssueCount"],
+    }
+
+
 def list_milestones(
     repo: str = "", state: str = "open", output: Output | None = None
 ) -> dict[str, list[dict[str, object]] | int | list[str]]:
-    """Return repository milestones filtered by state.
+    """Return backend milestones filtered by state.
 
     Args:
-        repo: Repository slug (``owner/name``). Defaults to ``DEFAULT_REPO``.
+        repo: Repository slug (``owner/name``). Ignored by non-GitHub backends.
         state: Filter by milestone state: ``"open"``, ``"closed"``, or ``"all"``.
             Defaults to ``"open"``.
         output: Optional Output collector.
@@ -4477,7 +4495,7 @@ def list_milestones(
         ``closed_issues``), ``count`` (int), and output messages/warnings.
 
     Raises:
-        GitHubUnavailableError: If GITHUB_TOKEN is not set or GitHub is unreachable.
+        UnsupportedBackendCapabilityError: If the active backend does not support milestones.
         ValidationError: If ``state`` is not one of ``open``, ``closed``, ``all``.
     """
     out = output or Output()
@@ -4485,22 +4503,10 @@ def list_milestones(
     if state not in valid_states:
         msg = f"state must be one of {sorted(valid_states)!r}, got {state!r}"
         raise ValidationError(msg)
-    repository = get_github(repo)
-    owner, repo_name = repository.full_name.split("/", 1)
+    backend = require_milestone_support(get_config().backend, "list_milestones")
     state_map = {"open": ["OPEN"], "closed": ["CLOSED"], "all": ["OPEN", "CLOSED"]}
-    ms_nodes = _fetch_milestones_graphql(repository, owner, repo_name, states=state_map[state])
-    milestones: list[dict[str, object]] = [
-        {
-            "number": ms["number"],
-            "title": ms["title"],
-            "state": ms["state"].lower(),
-            "description": ms["description"] or "",
-            "due_on": ms["dueOn"],
-            "open_issues": ms["openIssueCount"],
-            "closed_issues": ms["closedIssueCount"],
-        }
-        for ms in ms_nodes
-    ]
+    ms_nodes = backend.list_milestones(states=state_map[state], repo=repo)
+    milestones = [_milestone_dict(ms) for ms in ms_nodes]
     return {"milestones": milestones, "count": len(milestones), **out.to_dict()}
 
 
@@ -4508,11 +4514,11 @@ def get_soonest_milestone(repo: str = "", output: Output | None = None) -> dict[
     """Return the open milestone with the earliest due date.
 
     Milestones without a due date are excluded from consideration.
-    If all open milestones lack a due date, the first one by GitHub's
+    If all open milestones lack a due date, the first one by the backend's
     default ordering is returned with a warning.
 
     Args:
-        repo: Repository slug (``owner/name``). Defaults to ``DEFAULT_REPO``.
+        repo: Repository slug (``owner/name``). Ignored by non-GitHub backends.
         output: Optional Output collector.
 
     Returns:
@@ -4522,12 +4528,11 @@ def get_soonest_milestone(repo: str = "", output: Output | None = None) -> dict[
         ``milestone`` is ``None`` when no open milestones exist.
 
     Raises:
-        GitHubUnavailableError: If GITHUB_TOKEN is not set or GitHub is unreachable.
+        UnsupportedBackendCapabilityError: If the active backend does not support milestones.
     """
     out = output or Output()
-    repository = get_github(repo)
-    owner, repo_name = repository.full_name.split("/", 1)
-    all_open = _fetch_milestones_graphql(repository, owner, repo_name, states=["OPEN"])
+    backend = require_milestone_support(get_config().backend, "get_soonest_milestone")
+    all_open = backend.list_milestones(states=["OPEN"], repo=repo)
     if not all_open:
         return {"milestone": None, **out.to_dict()}
 
@@ -4538,32 +4543,21 @@ def get_soonest_milestone(repo: str = "", output: Output | None = None) -> dict[
         out.warn("No open milestones have a due date; returning first by default ordering")
         soonest = all_open[0]
 
-    return {
-        "milestone": {
-            "number": soonest["number"],
-            "title": soonest["title"],
-            "state": soonest["state"].lower(),
-            "description": soonest["description"] or "",
-            "due_on": soonest["dueOn"],
-            "open_issues": soonest["openIssueCount"],
-            "closed_issues": soonest["closedIssueCount"],
-        },
-        **out.to_dict(),
-    }
+    return {"milestone": _milestone_dict(soonest), **out.to_dict()}
 
 
 def create_milestone(
     repo: str = "", title: str = "", description: str = "", due_on: str | None = None, output: Output | None = None
 ) -> dict[str, object]:
-    """Create a new milestone on the repository.
+    """Create a new milestone on the active backend.
 
     Args:
-        repo: Repository slug (``owner/name``). Defaults to ``DEFAULT_REPO``.
+        repo: Repository slug (``owner/name``). Ignored by non-GitHub backends.
         title: Milestone title. Must be non-empty.
         description: Optional milestone description.
         due_on: Optional due date as ISO 8601 string (e.g. ``"2026-06-30"`` or
             ``"2026-06-30T00:00:00Z"``). Parsed to a ``datetime`` before
-            passing to PyGithub.
+            dispatch.
         output: Optional Output collector.
 
     Returns:
@@ -4572,7 +4566,7 @@ def create_milestone(
         and output messages/warnings.
 
     Raises:
-        GitHubUnavailableError: If GITHUB_TOKEN is not set or GitHub is unreachable.
+        UnsupportedBackendCapabilityError: If the active backend does not support milestones.
         ValidationError: If ``title`` is empty or ``due_on`` cannot be parsed.
     """
     out = output or Output()
@@ -4592,26 +4586,10 @@ def create_milestone(
             msg = f"due_on must be ISO 8601 (e.g. '2026-06-30' or '2026-06-30T00:00:00Z'), got {due_on!r}"
             raise ValidationError(msg)
 
-    repository = get_github(repo)
-    ms = repository.create_milestone(
-        title=title.strip(),
-        state="open",
-        description=description or GithubObject.NotSet,
-        due_on=due_on_dt if due_on_dt is not None else GithubObject.NotSet,
-    )
-    out.info(f"Created milestone #{ms.number}: {ms.title}")
-    return {
-        "milestone": {
-            "number": ms.number,
-            "title": ms.title,
-            "state": ms.state,
-            "description": ms.description or "",
-            "due_on": ms.due_on.strftime("%Y-%m-%dT%H:%M:%SZ") if ms.due_on else None,
-            "open_issues": ms.open_issues,
-            "closed_issues": ms.closed_issues,
-        },
-        **out.to_dict(),
-    }
+    backend = require_milestone_support(get_config().backend, "create_milestone")
+    ms = backend.create_milestone(title=title.strip(), description=description, due_on=due_on_dt, repo=repo)
+    out.info(f"Created milestone #{ms['number']}: {ms['title']}")
+    return {"milestone": _milestone_dict(ms), **out.to_dict()}
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -4582,15 +4582,12 @@ def create_milestone(
 
     due_on_dt: datetime | None = None
     if due_on is not None:
-        for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"):
-            try:
-                due_on_dt = datetime.strptime(due_on, fmt).replace(tzinfo=UTC)
-                break
-            except ValueError:
-                continue
-        else:
+        try:
+            due_on_dt = datetime.fromisoformat(due_on)
+        except ValueError:
             msg = f"due_on must be ISO 8601 (e.g. '2026-06-30' or '2026-06-30T00:00:00Z'), got {due_on!r}"
-            raise ValidationError(msg)
+            raise ValidationError(msg) from None
+        due_on_dt = due_on_dt.replace(tzinfo=UTC) if due_on_dt.tzinfo is None else due_on_dt.astimezone(UTC)
 
     backend = require_milestone_support(get_config().backend, "create_milestone")
     ms = backend.create_milestone(title=title.strip(), description=description, due_on=due_on_dt, repo=repo)

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -4497,6 +4497,8 @@ def list_milestones(
     Raises:
         UnsupportedBackendCapabilityError: If the active backend does not support milestones.
         ValidationError: If ``state`` is not one of ``open``, ``closed``, ``all``.
+        GitHubUnavailableError: On the GitHub backend, if GITHUB_TOKEN is not
+            set or GitHub is unreachable.
     """
     out = output or Output()
     valid_states = {"open", "closed", "all"}
@@ -4529,6 +4531,8 @@ def get_soonest_milestone(repo: str = "", output: Output | None = None) -> dict[
 
     Raises:
         UnsupportedBackendCapabilityError: If the active backend does not support milestones.
+        GitHubUnavailableError: On the GitHub backend, if GITHUB_TOKEN is not
+            set or GitHub is unreachable.
     """
     out = output or Output()
     backend = require_milestone_support(get_config().backend, "get_soonest_milestone")
@@ -4568,6 +4572,8 @@ def create_milestone(
     Raises:
         UnsupportedBackendCapabilityError: If the active backend does not support milestones.
         ValidationError: If ``title`` is empty or ``due_on`` cannot be parsed.
+        GitHubUnavailableError: On the GitHub backend, if GITHUB_TOKEN is not
+            set or GitHub is unreachable.
     """
     out = output or Output()
     if not title.strip():

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -3285,8 +3285,8 @@ async def backlog_get_soonest_milestone() -> dict:
 
     Requires a backend with milestone support — errors otherwise. Milestones
     without a due date are excluded. If all open milestones
-    lack a due date, the first one by GitHub's default ordering is returned
-    with a warning.
+    lack a due date, the first one by the backend's default ordering is
+    returned with a warning.
 
     Returns:
         Dict with ``milestone`` (dict or None) containing ``number``, ``title``,

--- a/plugins/development-harness/docs/backend-providers.md
+++ b/plugins/development-harness/docs/backend-providers.md
@@ -115,7 +115,7 @@ the accepted state.
 
 ### Capability flags
 
-`WorkItemBackend` declares four class-level capability flags every backend
+`WorkItemBackend` declares five class-level capability flags every backend
 sets. Callers read a flag before invoking the operation it gates, rather than
 probing behavior or catching a stub's exception:
 
@@ -125,6 +125,7 @@ probing behavior or catching a stub's exception:
 | `supports_branches` | Backend can satisfy `BranchBackend` — integration branch create/merge/delete. | `True` | `False` | `True` | `False` |
 | `supports_batch_status_fetch` | Backend implements a real batched status fetch. | `True` | `True` | `True` | `False` |
 | `supports_batch_issue_update` | Backend implements a real batched GraphQL update. | `True` | `False` | `False` | `False` |
+| `supports_milestones` | Backend implements real `list_milestones`/`create_milestone`/`assign_item_to_milestone` (`require_milestone_support()`, `backlog_core/_capability_gates.py`). Beads has no int-keyed milestone concept (ADR-003) — use its beads-native shadow methods (`list_beads_milestones` etc.) instead. | `True` | `True` | `True` | `False` |
 
 **Flag-first gating rule:** `GitHubExtras` and `BranchBackend` are both
 `runtime_checkable` Protocols. `isinstance(backend, SomeProtocol)` checks

--- a/plugins/development-harness/docs/backend-providers.md
+++ b/plugins/development-harness/docs/backend-providers.md
@@ -80,6 +80,11 @@ support reconciliation and recovery but do not create a second backlog. Beads,
 SQLite, and memory backends read and write their own native state directly and
 do not use YAML or a provider cache.
 
+Known gap: `add_item` on `sqlite`/`memory` does not insert a normally-created
+item into that backend's native issue table — it is stored only through
+`put_work_item`, so a backend-native operation keyed on `issue_number`
+(milestone assignment included) cannot find it yet. Tracked as #3365.
+
 <provider_contract>
 
 ## Provider behavior
@@ -140,6 +145,26 @@ also set the matching flag `True` — declaring the flag without satisfying the
 Protocol raises `UnsupportedBackendCapabilityError` with `protocol_mismatch=True`
 (a backend bug), and satisfying the Protocol without setting the flag is
 treated as unsupported (the flag getter defaults `False`).
+
+### Milestones
+
+Milestone assignment is one-per-item on every backend: `sqlite`'s
+`items.milestone_number` is a nullable FK, and beads' own `parent` field is a
+scalar, so an item belongs to at most one milestone. Opening a durable
+`sqlite` database created before this contract existed self-migrates on
+connect — adds `milestone_number`, backfills it from the deprecated
+`item_milestones` join table (lowest milestone number wins when an item had
+more than one legacy link), then drops that table. `sqlite`/`memory` order
+`list_milestones` by `due_on` then `number`; neither has a priority-ordering
+concept.
+
+`beads` sets `supports_milestones = False` (ADR-003 — its milestone IDs are
+string nanoids, `MilestoneFullNode.number` is `int`). Use its beads-native
+shadow methods instead of the generic Protocol methods:
+`list_beads_milestones`/`create_beads_milestone`/`assign_beads_item_to_milestone`,
+backed by `bd create --type milestone [--due] [--parent]` and
+`bd link --type parent-child` (`bd`'s `--all` flag, not `--status all`, is
+what includes closed issues).
 
 ### GitHub contract
 

--- a/plugins/development-harness/tests/test_github_extras_capability_gate.py
+++ b/plugins/development-harness/tests/test_github_extras_capability_gate.py
@@ -41,26 +41,59 @@ def sqlite_backend() -> Iterator[SQLiteBackend]:
     backend._conn.close()
 
 
-def test_list_milestones_under_sqlite_backend_raises_typed_capability_error(sqlite_backend: SQLiteBackend) -> None:
-    """list_milestones() under SQLiteBackend raises UnsupportedBackendCapabilityError.
+def test_list_milestones_under_sqlite_backend_no_longer_requires_github_extras(sqlite_backend: SQLiteBackend) -> None:
+    """list_milestones() under SQLiteBackend no longer routes through get_github().
 
-    Tests: the GitHubExtras capability gate (require_github_extras)
-    How: Configure SQLiteBackend (supports_github_extras=False) as the active
-        backend, then call list_milestones() — which calls get_github() first —
-        and assert the typed error's structured fields.
-    Why: This is the exact bug reported in backlog #2287: SQLite structurally
-        satisfies GitHubExtras via isinstance, so the old gate let it reach a
-        bare RuntimeError instead of a typed, caller-recognisable error. This
-        test fails on pre-fix code with RuntimeError instead of
-        UnsupportedBackendCapabilityError.
+    Tests: slice C's milestone capability gate (require_milestone_support)
+        supersedes the old GitHubExtras-only routing for milestones.
+    How: Configure SQLiteBackend (supports_github_extras=False, but
+        supports_milestones=True as of slice C) as the active backend, then
+        call list_milestones() — it must succeed (empty list), not raise.
+    Why: Before slice C, list_milestones() called get_github() unconditionally,
+        so every non-GitHub backend raised UnsupportedBackendCapabilityError
+        for the "github_extras" capability regardless of whether it could
+        genuinely support milestones. Slice C gives SQLite (and Memory) a
+        real milestone implementation, gated on the new "milestones"
+        capability instead — this test fails if that routing regresses back
+        to the GitHubExtras gate.
     """
-    # Act / Assert
-    with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
-        operations.list_milestones()
+    # Act
+    result = operations.list_milestones()
 
-    assert exc_info.value.backend == "SQLiteBackend"
-    assert exc_info.value.capability == "github_extras"
-    assert exc_info.value.operation == "get_github"
+    # Assert
+    assert result["milestones"] == []
+    assert result["count"] == 0
+
+
+def test_list_milestones_under_beads_backend_raises_typed_milestones_capability_error() -> None:
+    """list_milestones() under BeadsBackend raises UnsupportedBackendCapabilityError for "milestones".
+
+    Tests: require_milestone_support() gates on supports_milestones, not
+        supports_github_extras.
+    How: Configure a BeadsBackend (supports_milestones=False — beads
+        milestone IDs are strings, see ADR-003 in beads_backend.py) as the
+        active backend, then call list_milestones() and assert the typed
+        error's structured fields name the "milestones" capability.
+    Why: BeadsBackend is the one backend that genuinely cannot satisfy the
+        int-typed generic milestone Protocol methods; this proves it still
+        fails loudly with a typed, caller-recognisable error rather than a
+        bare NotImplementedError leaking out of operations.py.
+    """
+    from unittest.mock import MagicMock
+
+    from backlog_core.backends.beads_backend import BeadsBackend
+
+    backend = BeadsBackend(runner=MagicMock())
+    set_config(BacklogConfig(backend=backend))
+    try:
+        with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+            operations.list_milestones()
+    finally:
+        reset_config()
+
+    assert exc_info.value.backend == "BeadsBackend"
+    assert exc_info.value.capability == "milestones"
+    assert exc_info.value.operation == "list_milestones"
 
 
 def test_list_issues_under_sqlite_backend_raises_typed_capability_error_not_wrapped(

--- a/plugins/development-harness/tests/test_github_tools_milestones.py
+++ b/plugins/development-harness/tests/test_github_tools_milestones.py
@@ -14,7 +14,6 @@ No @pytest.mark.asyncio decorators — asyncio_mode = "auto" is set globally.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import cast
 from unittest.mock import MagicMock, patch
 
@@ -30,29 +29,7 @@ from tests.helpers import call_mcp_tool
 # Shared helpers
 # ---------------------------------------------------------------------------
 
-_DUE_ON = datetime(2026, 6, 30, 0, 0, 0, tzinfo=UTC)
 _DUE_ON_STR = "2026-06-30T00:00:00Z"
-
-
-def _make_milestone(
-    number: int = 1,
-    title: str = "v1.0",
-    state: str = "open",
-    description: str = "",
-    due_on: datetime | None = _DUE_ON,
-    open_issues: int = 3,
-    closed_issues: int = 7,
-) -> MagicMock:
-    """Build a MagicMock mimicking a PyGithub Milestone object."""
-    ms = MagicMock()
-    ms.number = number
-    ms.title = title
-    ms.state = state
-    ms.description = description
-    ms.due_on = due_on
-    ms.open_issues = open_issues
-    ms.closed_issues = closed_issues
-    return ms
 
 
 async def _call(tool_name: str, params: dict | None = None) -> dict:
@@ -305,19 +282,13 @@ def test_get_soonest_milestone_falls_back_to_first_when_no_due_dates(monkeypatch
 # ---------------------------------------------------------------------------
 
 
-def test_create_milestone_returns_milestone_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_milestone_returns_milestone_fields() -> None:
     """create_milestone returns a milestone dict with all expected fields.
 
     Tests: create_milestone return shape
-    How: Mock create_milestone on repo; verify returned dict keys.
+    How: Create through the real (in-memory) backend dispatch; verify returned dict keys.
     Why: Callers need the milestone number immediately after creation.
     """
-    # Arrange
-    mock_ms = _make_milestone(number=5, title="v3.0")
-    mock_repo = MagicMock()
-    mock_repo.create_milestone.return_value = mock_ms
-    monkeypatch.setattr("backlog_core.operations.get_github", lambda repo=None: mock_repo)
-
     from backlog_core.operations import create_milestone
 
     # Act
@@ -326,22 +297,19 @@ def test_create_milestone_returns_milestone_fields(monkeypatch: pytest.MonkeyPat
     # Assert
     ms = cast("dict[str, object]", result["milestone"])
     assert ms is not None
-    assert ms["number"] == 5
+    assert ms["number"] is not None
     assert ms["title"] == "v3.0"
     assert "state" in ms
     assert "due_on" in ms
 
 
-def test_create_milestone_empty_title_raises_validation_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_milestone_empty_title_raises_validation_error() -> None:
     """create_milestone raises ValidationError when title is empty or whitespace.
 
     Tests: create_milestone title validation
     How: Pass empty title string; expect ValidationError.
     Why: An empty milestone title is invalid and would confuse consumers.
     """
-    # Arrange
-    monkeypatch.setattr("backlog_core.operations.get_github", lambda repo=None: MagicMock())
-
     from backlog_core.operations import create_milestone
 
     # Act / Assert
@@ -349,39 +317,30 @@ def test_create_milestone_empty_title_raises_validation_error(monkeypatch: pytes
         create_milestone(title="")
 
 
-def test_create_milestone_parses_date_string(monkeypatch: pytest.MonkeyPatch) -> None:
-    """create_milestone parses ISO 8601 date string and passes datetime to PyGithub.
+def test_create_milestone_formats_due_on_as_utc_z_string() -> None:
+    """create_milestone parses an ISO 8601 date string and normalizes due_on to UTC Z.
 
     Tests: create_milestone due_on date parsing
-    How: Capture kwargs passed to create_milestone on mock repo; verify due_on is datetime.
-    Why: PyGithub expects a datetime object, not a string.
+    How: Create with a bare-date due_on; verify the returned due_on is UTC-Z-normalized.
+    Why: Consumers must see one consistent due_on shape regardless of backend.
     """
-    # Arrange
-    mock_ms = _make_milestone(number=1, title="v1.0", due_on=datetime(2026, 6, 30, tzinfo=UTC))
-    mock_repo = MagicMock()
-    mock_repo.create_milestone.return_value = mock_ms
-    monkeypatch.setattr("backlog_core.operations.get_github", lambda repo=None: mock_repo)
-
     from backlog_core.operations import create_milestone
 
     # Act
-    create_milestone(title="v1.0", due_on="2026-06-30")
+    result = create_milestone(title="v1.0", due_on="2026-06-30")
 
     # Assert
-    call_kwargs = mock_repo.create_milestone.call_args.kwargs
-    assert isinstance(call_kwargs.get("due_on"), datetime)
+    ms = cast("dict[str, object]", result["milestone"])
+    assert ms["due_on"] == _DUE_ON_STR
 
 
-def test_create_milestone_invalid_date_raises_validation_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_milestone_invalid_date_raises_validation_error() -> None:
     """create_milestone raises ValidationError when due_on cannot be parsed.
 
     Tests: create_milestone due_on parse failure
     How: Pass nonsensical date string; verify ValidationError is raised.
     Why: Silent date parsing failure would create milestones with wrong due dates.
     """
-    # Arrange
-    monkeypatch.setattr("backlog_core.operations.get_github", lambda repo=None: MagicMock())
-
     from backlog_core.operations import create_milestone
 
     # Act / Assert

--- a/plugins/development-harness/tests/test_milestone_parity.py
+++ b/plugins/development-harness/tests/test_milestone_parity.py
@@ -90,6 +90,22 @@ def _force_milestone_closed(backend: WorkItemBackend, number: int) -> None:
         milestone_obj.edit(title=milestone_obj.title, state="closed")
 
 
+def _repo_for_create_issue(backend: WorkItemBackend) -> GithubRepository:
+    """Return the repository argument to pass to ``create_issue_for_item``.
+
+    Memory/SQLite document this argument as ignored, so the shared mock is
+    fine there. GitHubBackend genuinely uses it (``gh_client.create_issue_for_item``
+    reads ``repo.full_name``), so it needs the real configured repository —
+    passing ``_MOCK_REPO`` there raises before ever reaching milestone
+    assignment, silently skipping the GitHub leg of the decisive test below.
+    """
+    if isinstance(backend, (InMemoryBackend, SQLiteBackend)):
+        return _MOCK_REPO
+    from backlog_core.backends.github_backend import GitHubBackend
+
+    return cast("GitHubBackend", backend).get_github()
+
+
 # ---------------------------------------------------------------------------
 # 1. Shape parity
 # ---------------------------------------------------------------------------
@@ -164,7 +180,17 @@ def test_soonest_milestone_returns_earliest_due_date(backend: WorkItemBackend) -
 
 
 def test_soonest_milestone_none_on_fresh_backend(backend: WorkItemBackend) -> None:
-    """A fresh backend with no milestones returns {"milestone": None}, no exception."""
+    """A fresh backend with no milestones returns {"milestone": None}, no exception.
+
+    GitHub is excluded: Memory/SQLite get a brand-new backend instance per
+    test, but the GitHub leg targets a real persistent repository whose
+    milestone state carries over across test runs and earlier tests in this
+    file — "fresh" isn't guaranteed there without live cleanup this slice
+    doesn't add.
+    """
+    if not isinstance(backend, (InMemoryBackend, SQLiteBackend)):
+        pytest.skip("GitHub backend milestone state is not guaranteed fresh across runs")
+
     result = operations.get_soonest_milestone()
 
     assert result["milestone"] is None
@@ -233,8 +259,9 @@ def test_membership_counts_after_assign_and_close(backend: WorkItemBackend) -> N
     ms_number = cast("int", ms["number"])
     item_a = _make_item("Item A")
     item_b = _make_item("Item B")
-    num_a = backend.create_issue_for_item(_MOCK_REPO, item_a)
-    num_b = backend.create_issue_for_item(_MOCK_REPO, item_b)
+    repo = _repo_for_create_issue(backend)
+    num_a = backend.create_issue_for_item(repo, item_a)
+    num_b = backend.create_issue_for_item(repo, item_b)
     assert num_a is not None
     assert num_b is not None
 

--- a/plugins/development-harness/tests/test_milestone_parity.py
+++ b/plugins/development-harness/tests/test_milestone_parity.py
@@ -143,7 +143,7 @@ def test_write_read_round_trip(backend: WorkItemBackend) -> None:
 
 
 def test_state_filter_excludes_closed_includes_all(backend: WorkItemBackend) -> None:
-    """state='closed' excludes an open milestone; state='all' includes both regardless of case."""
+    """state='closed' excludes an open milestone; state='all' includes both."""
     open_ms = cast("dict[str, object]", operations.create_milestone(title="open one")["milestone"])
     closed_ms = cast("dict[str, object]", operations.create_milestone(title="closed one")["milestone"])
     _force_milestone_closed(backend, cast("int", closed_ms["number"]))

--- a/plugins/development-harness/tests/test_milestone_parity.py
+++ b/plugins/development-harness/tests/test_milestone_parity.py
@@ -90,6 +90,19 @@ def _force_milestone_closed(backend: WorkItemBackend, number: int) -> None:
         milestone_obj.edit(title=milestone_obj.title, state="closed")
 
 
+def _skip_github_shared_state(backend: WorkItemBackend) -> None:
+    """Skip on GitHub: assertions here assume a pristine milestone set.
+
+    Memory/SQLite get a brand-new backend instance per test. The GitHub leg
+    targets one real, persistent, possibly non-empty repository with no
+    cleanup between test runs — an exact-match or no-earlier-milestone
+    assumption cannot hold there without live remote cleanup this slice
+    doesn't add.
+    """
+    if not isinstance(backend, (InMemoryBackend, SQLiteBackend)):
+        pytest.skip("GitHub backend milestone state is not guaranteed pristine across runs")
+
+
 def _repo_for_create_issue(backend: WorkItemBackend) -> GithubRepository:
     """Return the repository argument to pass to ``create_issue_for_item``.
 
@@ -144,6 +157,7 @@ def test_write_read_round_trip(backend: WorkItemBackend) -> None:
 
 def test_state_filter_excludes_closed_includes_all(backend: WorkItemBackend) -> None:
     """state='closed' excludes an open milestone; state='all' includes both."""
+    _skip_github_shared_state(backend)
     open_ms = cast("dict[str, object]", operations.create_milestone(title="open one")["milestone"])
     closed_ms = cast("dict[str, object]", operations.create_milestone(title="closed one")["milestone"])
     _force_milestone_closed(backend, cast("int", closed_ms["number"]))
@@ -165,6 +179,7 @@ def test_state_filter_excludes_closed_includes_all(backend: WorkItemBackend) -> 
 
 def test_soonest_milestone_returns_earliest_due_date(backend: WorkItemBackend) -> None:
     """get_soonest_milestone returns the milestone due earliest, everywhere."""
+    _skip_github_shared_state(backend)
     operations.create_milestone(title="mid", due_on="2026-06-30")
     operations.create_milestone(title="early", due_on="2026-01-31")
 
@@ -180,16 +195,8 @@ def test_soonest_milestone_returns_earliest_due_date(backend: WorkItemBackend) -
 
 
 def test_soonest_milestone_none_on_fresh_backend(backend: WorkItemBackend) -> None:
-    """A fresh backend with no milestones returns {"milestone": None}, no exception.
-
-    GitHub is excluded: Memory/SQLite get a brand-new backend instance per
-    test, but the GitHub leg targets a real persistent repository whose
-    milestone state carries over across test runs and earlier tests in this
-    file — "fresh" isn't guaranteed there without live cleanup this slice
-    doesn't add.
-    """
-    if not isinstance(backend, (InMemoryBackend, SQLiteBackend)):
-        pytest.skip("GitHub backend milestone state is not guaranteed fresh across runs")
+    """A fresh backend with no milestones returns {"milestone": None}, no exception."""
+    _skip_github_shared_state(backend)
 
     result = operations.get_soonest_milestone()
 
@@ -203,6 +210,7 @@ def test_soonest_milestone_none_on_fresh_backend(backend: WorkItemBackend) -> No
 
 def test_soonest_milestone_without_due_date_warns_not_raises(backend: WorkItemBackend) -> None:
     """When no open milestone has a due date, a warning is emitted instead of an exception."""
+    _skip_github_shared_state(backend)
     operations.create_milestone(title="undated")
 
     result = operations.get_soonest_milestone()

--- a/plugins/development-harness/tests/test_milestone_parity.py
+++ b/plugins/development-harness/tests/test_milestone_parity.py
@@ -1,0 +1,248 @@
+"""Cross-backend parity tests for milestone operations (backlog #2287, Slice C).
+
+Before this slice, ``operations.list_milestones``/``get_soonest_milestone``/
+``create_milestone`` called ``get_github()`` unconditionally, so every
+non-GitHub backend failed the capability gate before ever reaching a real
+milestone implementation. SQLite shipped a milestone read path over a table
+that nothing ever wrote to. These tests drive the ``operations.py`` entry
+points (not backend internals directly) against Memory and SQLite to prove
+the capability-gated dispatch this slice adds actually reaches working
+per-backend milestone create/list/assign implementations.
+
+Memory and SQLite legs run unmarked, in the default test suite — neither
+needs network access. The GitHub leg is gated behind the same
+``BACKLOG_CROSS_BACKEND_GITHUB`` env var used by ``test_cross_backend.py``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+from backlog_core import operations
+from backlog_core.backend_protocol import reset_config, set_config
+from backlog_core.backend_types import BacklogConfig, WorkItemBackend
+from backlog_core.backends.memory_backend import InMemoryBackend
+from backlog_core.backends.sqlite_backend import SQLiteBackend
+from backlog_core.models import BacklogItem, BacklogItemMetadata, UnsupportedBackendCapabilityError, ValidationError
+from github.Repository import Repository as GithubRepository
+
+_MOCK_REPO: GithubRepository = MagicMock(spec=GithubRepository)
+
+_GITHUB_MARKER = pytest.mark.skipif(
+    not os.environ.get("BACKLOG_CROSS_BACKEND_GITHUB"),
+    reason="Set BACKLOG_CROSS_BACKEND_GITHUB=1 to run GitHub backend tests",
+)
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("memory", id="InMemoryBackend"),
+        pytest.param("sqlite", id="SQLiteBackend"),
+        pytest.param("github", id="GitHubBackend", marks=_GITHUB_MARKER),
+    ]
+)
+def backend(request: pytest.FixtureRequest) -> Iterator[WorkItemBackend]:
+    """Parametrized fixture installing one backend as the active operations.py config."""
+    name: str = request.param
+    if name == "memory":
+        impl: WorkItemBackend = InMemoryBackend()
+    elif name == "sqlite":
+        impl = SQLiteBackend(":memory:")
+    else:
+        from backlog_core.backends.github_backend import GitHubBackend
+
+        impl = GitHubBackend()
+    set_config(BacklogConfig(backend=impl))
+    yield impl
+    reset_config()
+    if isinstance(impl, SQLiteBackend):
+        impl._conn.close()
+
+
+def _make_item(title: str) -> BacklogItem:
+    return BacklogItem(
+        title=title,
+        description="",
+        metadata=BacklogItemMetadata(
+            source="test", added="2026-01-01", priority="P1", item_type="Feature", status="open"
+        ),
+    )
+
+
+def _force_milestone_closed(backend: WorkItemBackend, number: int) -> None:
+    """Directly close a milestone at the backend layer (no generic close-milestone op exists)."""
+    if isinstance(backend, InMemoryBackend):
+        backend._milestones[number]["state"] = "CLOSED"
+    elif isinstance(backend, SQLiteBackend):
+        backend._conn.execute("UPDATE milestones SET state = 'closed' WHERE number = ?", (number,))
+        backend._conn.commit()
+    else:
+        from backlog_core.backends.github_backend import GitHubBackend
+
+        repository = cast("GitHubBackend", backend).get_github()
+        milestone_obj = repository.get_milestone(number)
+        milestone_obj.edit(title=milestone_obj.title, state="closed")
+
+
+# ---------------------------------------------------------------------------
+# 1. Shape parity
+# ---------------------------------------------------------------------------
+
+
+def test_create_milestone_shape_parity(backend: WorkItemBackend) -> None:
+    """create_milestone returns an identical key set on every backend, with a non-None identifier."""
+    result = operations.create_milestone(title="v1.0")
+    ms = cast("dict[str, object]", result["milestone"])
+    assert set(ms) == {"number", "title", "state", "description", "due_on", "open_issues", "closed_issues"}
+    assert ms["number"] is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. Write -> read round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_write_read_round_trip(backend: WorkItemBackend) -> None:
+    """A created milestone is readable via list_milestones with matching fields, due_on normalized to UTC Z."""
+    created = cast(
+        "dict[str, object]",
+        operations.create_milestone(title="v1.0", description="desc", due_on="2026-06-30")["milestone"],
+    )
+    listed = cast("list[dict[str, object]]", operations.list_milestones(state="open")["milestones"])
+    match = next(m for m in listed if m["number"] == created["number"])
+    assert match["title"] == "v1.0"
+    assert match["description"] == "desc"
+    assert match["due_on"] == "2026-06-30T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# 3. State filter
+# ---------------------------------------------------------------------------
+
+
+def test_state_filter_excludes_closed_includes_all(backend: WorkItemBackend) -> None:
+    """state='closed' excludes an open milestone; state='all' includes both regardless of case."""
+    open_ms = cast("dict[str, object]", operations.create_milestone(title="open one")["milestone"])
+    closed_ms = cast("dict[str, object]", operations.create_milestone(title="closed one")["milestone"])
+    _force_milestone_closed(backend, cast("int", closed_ms["number"]))
+
+    closed_listed = cast("list[dict[str, object]]", operations.list_milestones(state="closed")["milestones"])
+    all_listed = cast("list[dict[str, object]]", operations.list_milestones(state="all")["milestones"])
+    closed_numbers = {m["number"] for m in closed_listed}
+    all_numbers = {m["number"] for m in all_listed}
+
+    assert closed_numbers == {closed_ms["number"]}
+    assert open_ms["number"] not in closed_numbers
+    assert {open_ms["number"], closed_ms["number"]} <= all_numbers
+
+
+# ---------------------------------------------------------------------------
+# 4. Ordering
+# ---------------------------------------------------------------------------
+
+
+def test_soonest_milestone_returns_earliest_due_date(backend: WorkItemBackend) -> None:
+    """get_soonest_milestone returns the milestone due earliest, everywhere."""
+    operations.create_milestone(title="mid", due_on="2026-06-30")
+    operations.create_milestone(title="early", due_on="2026-01-31")
+
+    result = operations.get_soonest_milestone()
+    milestone = cast("dict[str, object]", result["milestone"])
+
+    assert milestone["title"] == "early"
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty state
+# ---------------------------------------------------------------------------
+
+
+def test_soonest_milestone_none_on_fresh_backend(backend: WorkItemBackend) -> None:
+    """A fresh backend with no milestones returns {"milestone": None}, no exception."""
+    result = operations.get_soonest_milestone()
+
+    assert result["milestone"] is None
+
+
+# ---------------------------------------------------------------------------
+# 6. No-due-date
+# ---------------------------------------------------------------------------
+
+
+def test_soonest_milestone_without_due_date_warns_not_raises(backend: WorkItemBackend) -> None:
+    """When no open milestone has a due date, a warning is emitted instead of an exception."""
+    operations.create_milestone(title="undated")
+
+    result = operations.get_soonest_milestone()
+
+    assert result["milestone"] is not None
+    assert len(cast("list[str]", result.get("warnings", []))) > 0
+
+
+# ---------------------------------------------------------------------------
+# 7. Error parity — validation stays above backend dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_create_milestone_empty_title_raises_validation_error_before_dispatch(backend: WorkItemBackend) -> None:
+    """create_milestone(title="") raises ValidationError on every backend, before any backend dispatch."""
+    with pytest.raises(ValidationError, match="title must be non-empty"):
+        operations.create_milestone(title="")
+
+
+# ---------------------------------------------------------------------------
+# 8. Capability parity
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_backend_raises_typed_capability_error() -> None:
+    """A backend with supports_milestones=False raises UnsupportedBackendCapabilityError with populated fields."""
+    from backlog_core.backends.beads_backend import BeadsBackend
+
+    beads = BeadsBackend(runner=MagicMock())
+    set_config(BacklogConfig(backend=beads))
+    try:
+        with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
+            operations.list_milestones()
+    finally:
+        reset_config()
+
+    assert exc_info.value.capability == "milestones"
+    assert exc_info.value.backend == "BeadsBackend"
+    assert exc_info.value.operation == "list_milestones"
+
+
+# ---------------------------------------------------------------------------
+# 9. Membership counts — the decisive assertion
+# ---------------------------------------------------------------------------
+
+
+def test_membership_counts_after_assign_and_close(backend: WorkItemBackend) -> None:
+    """Create a milestone, assign 2 items, close 1 -> open_issues == 1, closed_issues == 1 everywhere.
+
+    Proves the SQLite milestone_number FK path and the Memory dynamic-count
+    path actually work, rather than shipping green against an empty table.
+    """
+    ms = cast("dict[str, object]", operations.create_milestone(title="Sprint 1")["milestone"])
+    ms_number = cast("int", ms["number"])
+    item_a = _make_item("Item A")
+    item_b = _make_item("Item B")
+    num_a = backend.create_issue_for_item(_MOCK_REPO, item_a)
+    num_b = backend.create_issue_for_item(_MOCK_REPO, item_b)
+    assert num_a is not None
+    assert num_b is not None
+
+    backend.assign_item_to_milestone(num_a, ms_number)
+    backend.assign_item_to_milestone(num_b, ms_number)
+    backend.close_github_issue(str(num_a), "done")
+
+    listed = cast("list[dict[str, object]]", operations.list_milestones(state="all")["milestones"])
+    match = next(m for m in listed if m["number"] == ms_number)
+    assert match["open_issues"] == 1
+    assert match["closed_issues"] == 1


### PR DESCRIPTION
## Summary
- Routes `list_milestones`/`get_soonest_milestone`/`create_milestone` (`operations.py`) through a new `supports_milestones` capability flag and `require_milestone_support()` gate, instead of an unconditional `get_github()` call.
- Adds real `create_milestone`/`list_milestones`/`assign_item_to_milestone` implementations to the GitHub, SQLite, and Memory backends. SQLite/Memory's milestone tables previously had **no writer at all** — this was a read path over data that could never be populated.
- SQLite: drops the never-populated `item_milestones` join table for a nullable `milestone_number` FK on `items` (one milestone per item — matches GitHub's model and beads' own scalar `parent` field). Orders by `due_on`/`number`, not a priority column GitHub can't express.
- Beads: adds beads-native shadow methods (`list_beads_milestones`/`create_beads_milestone`/`assign_beads_item_to_milestone`) using `bd create --type milestone` and `bd link --type parent-child`, per ADR-003 (beads milestone IDs are strings and can't satisfy the int-keyed `MilestoneFullNode` contract the generic Protocol methods use, so those raise `NotImplementedError` with `supports_milestones = False`).
- `MilestoneInfo`/`MilestoneNode` docstrings restated as backend-neutral (value set unchanged — still `Literal["OPEN", "CLOSED"]`); beads' 7-state `BeadsStatus` collapses to OPEN/CLOSED at the backend boundary via the existing collapse pattern.
- Fixes a latent state-filter case mismatch in the Memory backend.
- Out of scope, by design: #2287's fifth acceptance criterion (a cross-agent milestone-grooming mechanism) — that's a separate multi-week design project, not part of this refactor.

## Test plan
- [x] New `tests/test_milestone_parity.py` — 9 parity assertions × {Memory, SQLite, GitHub-gated} backends, including the decisive case: create a milestone, assign 2 items, close 1, assert `open_issues`/`closed_issues` match on every backend. Written and run failing before any backend implementation existed.
- [x] `uv run pytest plugins/development-harness/tests/ plugins/development-harness/tests_backlog/ -q` → 3645 passed, 49 skipped, 5 xfailed, 0 failed (independently re-run, not just trusting the implementer's report).
- [x] `uv run ty check` on all touched files — clean (independently re-run).
- [x] `uv run ruff check` on all touched files — clean (independently re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj76ZCampHU14169cwyaoh