### PR TITLE
fix(backlog): wire up assign_item_to_milestone across the public API

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.10",
+  "version": "11.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.10",
+  "version": "10.0.11",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.10",
+  "version": "7.0.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/backends/beads_backend.py
+++ b/plugins/development-harness/backlog_core/backends/beads_backend.py
@@ -915,7 +915,13 @@ class BeadsBackend:
 
         Returns:
             Beads nanoid string of the created milestone, or ``None`` when
-            ``bd`` is unavailable or creation fails.
+            ``bd`` returned a record without an id.
+
+        Raises:
+            BdNotInstalledError: When ``bd`` is not on ``PATH``.
+            BdInvocationError: When ``bd create`` exits non-zero.
+            BdJsonDecodeError: When ``bd`` stdout is not valid JSON.
+            ValidationError: When the JSON response does not match the expected schema.
         """
         argv = ["create", title, "--type", BeadsIssueType.MILESTONE]
         if description:
@@ -924,17 +930,7 @@ class BeadsBackend:
             argv.extend(["--due", due_on])
         if parent:
             argv.extend(["--parent", parent])
-        try:
-            raw = self._runner.run_json(argv)
-            parsed = parse_issue(raw)
-        except (BdNotInstalledError, BdInvocationError, BdJsonDecodeError) as exc:
-            _log.debug("create_beads_milestone: bd invocation failed: %s", exc)
-            return None
-        except ValidationError as exc:
-            _log.debug("create_beads_milestone: bd create output validation failed: %s", exc)
-            return None
-        else:
-            return parsed.id or None
+        return parse_issue(self._runner.run_json(argv)).id or None
 
     def assign_beads_item_to_milestone(self, issue_id: str, milestone_id: str) -> None:
         """Assign a beads issue to a milestone via ``bd link --type parent-child``.

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -4643,7 +4643,8 @@ def assign_item_to_milestone(
 
     Raises:
         UnsupportedBackendCapabilityError: If the active backend does not support milestones.
-        BacklogError: If ``issue_number`` or ``milestone_number`` is unknown to the backend.
+        BacklogError: If ``issue_number`` or ``milestone_number`` is unknown to the
+            backend, or on other GitHub API failures.
         GitHubUnavailableError: On the GitHub backend, if GITHUB_TOKEN is not
             set or GitHub is unreachable.
     """
@@ -4653,6 +4654,9 @@ def assign_item_to_milestone(
         backend.assign_item_to_milestone(issue_number, milestone_number, repo=repo)
     except KeyError as e:
         raise BacklogError(str(e.args[0])) from e
+    except GithubException as e:
+        msg = f"GitHub API error assigning issue to milestone: {e}"
+        raise BacklogError(msg) from e
     out.info(f"Assigned issue #{issue_number} to milestone #{milestone_number}")
     return {"issue_number": issue_number, "milestone_number": milestone_number, **out.to_dict()}
 

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -4626,6 +4626,37 @@ def create_milestone(
     return {"milestone": _milestone_dict(ms), **out.to_dict()}
 
 
+def assign_item_to_milestone(
+    issue_number: int, milestone_number: int, repo: str = "", output: Output | None = None
+) -> dict[str, object]:
+    """Assign a backlog item to a milestone on the active backend.
+
+    Args:
+        issue_number: Issue number to assign.
+        milestone_number: Milestone number to assign the issue to.
+        repo: Repository slug (``owner/name``). Ignored by non-GitHub backends.
+        output: Optional Output collector.
+
+    Returns:
+        Dict with ``issue_number``, ``milestone_number``, and output
+        messages/warnings.
+
+    Raises:
+        UnsupportedBackendCapabilityError: If the active backend does not support milestones.
+        BacklogError: If ``issue_number`` or ``milestone_number`` is unknown to the backend.
+        GitHubUnavailableError: On the GitHub backend, if GITHUB_TOKEN is not
+            set or GitHub is unreachable.
+    """
+    out = output or Output()
+    backend = require_milestone_support(get_config().backend, "assign_item_to_milestone")
+    try:
+        backend.assign_item_to_milestone(issue_number, milestone_number, repo=repo)
+    except KeyError as e:
+        raise BacklogError(str(e.args[0])) from e
+    out.info(f"Assigned issue #{issue_number} to milestone #{milestone_number}")
+    return {"issue_number": issue_number, "milestone_number": milestone_number, **out.to_dict()}
+
+
 # ---------------------------------------------------------------------------
 # Issues (ancillary listing + commenting)
 # ---------------------------------------------------------------------------

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -93,6 +93,7 @@ from .tool_responses import (
     ArtifactRegisterResponse,
     ArtifactsListResponse,
     BacklogAddResponse,
+    BacklogAssignItemToMilestoneResponse,
     BacklogCloseResponse,
     BacklogCommentIssueResponse,
     BacklogCreateMilestoneResponse,
@@ -3488,14 +3489,15 @@ async def backlog_create_milestone(
 async def backlog_assign_item_to_milestone(
     issue_number: Annotated[int, Field(description="Issue number to assign")],
     milestone_number: Annotated[int, Field(description="Milestone number to assign the issue to")],
-) -> dict:
+) -> BacklogAssignItemToMilestoneResponse:
     """Assign a backlog item to a milestone.
 
     Requires a backend with milestone support — errors otherwise.
 
     Returns:
-        Dict with ``issue_number``, ``milestone_number``, and output
-        messages/warnings. On error, dict contains an ``error`` key.
+        :class:`~backlog_core.tool_responses.BacklogAssignItemToMilestoneResponse`
+        with ``issue_number``, ``milestone_number``, and output
+        messages/warnings. On error, ``error`` is set.
     """
     out = Output()
     try:
@@ -3505,9 +3507,13 @@ async def backlog_assign_item_to_milestone(
             milestone_number=milestone_number,
             output=out,
         )
-        return {**result, **out.to_dict()}
     except BacklogError as e:
-        return {"error": str(e), **out.to_dict()}
+        return BacklogAssignItemToMilestoneResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
+            exclude_none=True
+        )
+    return BacklogAssignItemToMilestoneResponse.model_validate({**result, **out.to_dict()}).model_dump(
+        exclude_none=True
+    )
 
 
 @mcp.tool(

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -3478,6 +3478,40 @@ async def backlog_create_milestone(
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Assign Item To Milestone",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+)
+async def backlog_assign_item_to_milestone(
+    issue_number: Annotated[int, Field(description="Issue number to assign")],
+    milestone_number: Annotated[int, Field(description="Milestone number to assign the issue to")],
+) -> dict:
+    """Assign a backlog item to a milestone.
+
+    Requires a backend with milestone support — errors otherwise.
+
+    Returns:
+        Dict with ``issue_number``, ``milestone_number``, and output
+        messages/warnings. On error, dict contains an ``error`` key.
+    """
+    out = Output()
+    try:
+        result = await asyncio.to_thread(
+            operations.assign_item_to_milestone,
+            issue_number=issue_number,
+            milestone_number=milestone_number,
+            output=out,
+        )
+        return {**result, **out.to_dict()}
+    except BacklogError as e:
+        return {"error": str(e), **out.to_dict()}
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
         title="List Issues", readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True
     )
 )

--- a/plugins/development-harness/backlog_core/tool_responses.py
+++ b/plugins/development-harness/backlog_core/tool_responses.py
@@ -52,6 +52,7 @@ __all__ = [
     "ArtifactRegisterResponse",
     "ArtifactsListResponse",
     "BacklogAddResponse",
+    "BacklogAssignItemToMilestoneResponse",
     "BacklogCloseResponse",
     "BacklogCommentIssueResponse",
     "BacklogCreateMilestoneResponse",
@@ -224,6 +225,16 @@ class BacklogAddResponse(FallibleToolResponse):
 
     item_ref: str | None = None
     """Backend issue ref, or ``""`` when creation failed or was skipped."""
+
+
+class BacklogAssignItemToMilestoneResponse(FallibleToolResponse):
+    """Response for ``backlog_assign_item_to_milestone``."""
+
+    issue_number: int | None = None
+    """Issue number that was assigned. Absent only on the ``BacklogError`` arm."""
+
+    milestone_number: int | None = None
+    """Milestone number the issue was assigned to. Absent only on the ``BacklogError`` arm."""
 
 
 # operations.close_item has two distinct success shapes: an already-closed

--- a/plugins/development-harness/dh_core/operations.py
+++ b/plugins/development-harness/dh_core/operations.py
@@ -119,6 +119,7 @@ __all__ = [
     "artifact_read",
     # --- Artifact operations ---
     "artifact_register",
+    "assign_item_to_milestone",
     "batch_fetch_statuses",
     "check_open_prs_for_issue",
     "claim_task",
@@ -1124,6 +1125,7 @@ from backlog_core.operations import (
     apply_status_groomed,
     apply_status_in_progress,
     apply_status_verified,
+    assign_item_to_milestone,
     batch_fetch_statuses,
     check_open_prs_for_issue,
     close_github_issue,

--- a/plugins/development-harness/dh_core/operations.py
+++ b/plugins/development-harness/dh_core/operations.py
@@ -117,7 +117,6 @@ __all__ = [
     "artifact_get",
     "artifact_list",
     "artifact_read",
-    # --- Artifact operations ---
     "artifact_register",
     "assign_item_to_milestone",
     "batch_fetch_statuses",

--- a/plugins/development-harness/sam_schema/backlog.py
+++ b/plugins/development-harness/sam_schema/backlog.py
@@ -407,9 +407,12 @@ def assign_milestone(
 ) -> None:
     """Assign a backlog item to a milestone."""
     output = Output()
-    result = operations.assign_item_to_milestone(
-        issue_number=issue_number, milestone_number=milestone_number, repo=repo, output=output
-    )
+    try:
+        result = operations.assign_item_to_milestone(
+            issue_number=issue_number, milestone_number=milestone_number, repo=repo, output=output
+        )
+    except BacklogError as exc:
+        cli_output.exit_with_json_error({"error": str(exc)})
     _emit(result, output)
 
 

--- a/plugins/development-harness/sam_schema/backlog.py
+++ b/plugins/development-harness/sam_schema/backlog.py
@@ -399,6 +399,20 @@ def create_milestone(
     _emit(result, output)
 
 
+@app.command("assign-milestone")
+def assign_milestone(
+    issue_number: Annotated[int, typer.Option("--issue-number", help="Issue number to assign")],
+    milestone_number: Annotated[int, typer.Option("--milestone-number", help="Milestone number to assign to")],
+    repo: Annotated[str, typer.Option("--repo", help="Repository (owner/name)")] = "",
+) -> None:
+    """Assign a backlog item to a milestone."""
+    output = Output()
+    result = operations.assign_item_to_milestone(
+        issue_number=issue_number, milestone_number=milestone_number, repo=repo, output=output
+    )
+    _emit(result, output)
+
+
 @app.command("issues")
 def issues(
     repo: Annotated[str, typer.Option("--repo", help="Repository (owner/name)")] = "",

--- a/plugins/development-harness/skills/group-items-to-milestone/SKILL.md
+++ b/plugins/development-harness/skills/group-items-to-milestone/SKILL.md
@@ -80,7 +80,7 @@ Skip issue creation for P2/Ideas items — assign by milestone number only if th
 
 ### Step 5: Assign Existing Issues
 
-For selected items that already have issues but are not yet in this milestone, call `backlog_assign_item_to_milestone(issue_number={issue_number}, milestone_number={milestone_number})`.
+For selected items that already have issues but are not yet in this milestone, call `backlog_assign_item_to_milestone(issue_number={issue_number}, milestone_number={milestone_number})`. If the response contains an `error` key, the assignment did not happen — skip Steps 6-7 for that item and report the error instead.
 
 ### Step 6: Update Project V2 Status
 
@@ -111,5 +111,6 @@ Next step: /dh:groom-milestone {number}
 
 - Milestone not found: call `backlog_list_milestones(state="open")` and list available milestones, then stop.
 - Issue creation fails: log error per item, continue with remaining.
+- Milestone assignment fails (`backlog_assign_item_to_milestone` response has an `error` key): log error per item, skip Project V2 status update and success reporting for that item, continue with remaining.
 - No items match filter: report and show available sections.
 - Label not found: `github_project_setup.py issue create` handles label creation automatically via `_ensure_label()`.

--- a/plugins/development-harness/skills/group-items-to-milestone/SKILL.md
+++ b/plugins/development-harness/skills/group-items-to-milestone/SKILL.md
@@ -80,13 +80,7 @@ Skip issue creation for P2/Ideas items — assign by milestone number only if th
 
 ### Step 5: Assign Existing Issues
 
-For selected items that already have issues but are not yet in this milestone:
-
-```bash
-uv run .claude/skills/gh/scripts/github_project_setup.py issue set-milestone \
-  --issue {issue_number} \
-  --milestone {milestone_number}
-```
+For selected items that already have issues but are not yet in this milestone, call `backlog_assign_item_to_milestone(issue_number={issue_number}, milestone_number={milestone_number})`.
 
 ### Step 6: Update Project V2 Status
 

--- a/plugins/development-harness/tests/test_github_tools_milestones.py
+++ b/plugins/development-harness/tests/test_github_tools_milestones.py
@@ -1,9 +1,10 @@
 """Tests for backlog milestone MCP tools and operations.
 
-Covers three tools and operations:
+Covers four tools and operations:
 - list_milestones / backlog_list_milestones
 - get_soonest_milestone / backlog_get_soonest_milestone
 - create_milestone / backlog_create_milestone
+- assign_item_to_milestone / backlog_assign_item_to_milestone
 
 Tests are structured in two layers:
 - Operation layer: functions in operations.py, mocked at get_github boundary.
@@ -577,3 +578,45 @@ async def test_backlog_create_milestone_backlog_error_returns_error_key() -> Non
     # Assert
     assert "error" in result
     assert "Milestone title already used" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Server layer: backlog_assign_item_to_milestone tool
+# ---------------------------------------------------------------------------
+
+
+async def test_backlog_assign_item_to_milestone_success_returns_result() -> None:
+    """backlog_assign_item_to_milestone returns issue_number/milestone_number with no error key.
+
+    Tests: backlog_assign_item_to_milestone server tool success path
+    How: Patch assign_item_to_milestone with fake result; verify response shape.
+    Why: Verifies the tool is registered and wired to the operation.
+    """
+    # Arrange
+    fake_result = {"issue_number": 12, "milestone_number": 5, "messages": [], "warnings": []}
+
+    with patch("dh_core.operations.assign_item_to_milestone", return_value=fake_result):
+        # Act
+        result = await _call("backlog_assign_item_to_milestone", {"issue_number": 12, "milestone_number": 5})
+
+    # Assert
+    assert result["issue_number"] == 12
+    assert result["milestone_number"] == 5
+    assert "error" not in result
+
+
+async def test_backlog_assign_item_to_milestone_backlog_error_returns_error_key() -> None:
+    """backlog_assign_item_to_milestone returns dict with error key on BacklogError.
+
+    Tests: backlog_assign_item_to_milestone error handling
+    How: Raise BacklogError from patched operation; verify error key.
+    Why: Tool must not raise; MCP requires serialisable error response.
+    """
+    # Arrange
+    with patch("dh_core.operations.assign_item_to_milestone", side_effect=BacklogError("issue #999 not found")):
+        # Act
+        result = await _call("backlog_assign_item_to_milestone", {"issue_number": 999, "milestone_number": 5})
+
+    # Assert
+    assert "error" in result
+    assert "issue #999 not found" in result["error"]

--- a/plugins/development-harness/tests/test_milestone_parity.py
+++ b/plugins/development-harness/tests/test_milestone_parity.py
@@ -29,7 +29,13 @@ from backlog_core.backend_protocol import reset_config, set_config
 from backlog_core.backend_types import BacklogConfig, WorkItemBackend
 from backlog_core.backends.memory_backend import InMemoryBackend
 from backlog_core.backends.sqlite_backend import SQLiteBackend
-from backlog_core.models import BacklogItem, BacklogItemMetadata, UnsupportedBackendCapabilityError, ValidationError
+from backlog_core.models import (
+    BacklogError,
+    BacklogItem,
+    BacklogItemMetadata,
+    UnsupportedBackendCapabilityError,
+    ValidationError,
+)
 from github.Repository import Repository as GithubRepository
 
 _MOCK_REPO: GithubRepository = MagicMock(spec=GithubRepository)
@@ -235,7 +241,18 @@ def test_create_milestone_empty_title_raises_validation_error_before_dispatch(ba
 # ---------------------------------------------------------------------------
 
 
-def test_unsupported_backend_raises_typed_capability_error() -> None:
+@pytest.mark.parametrize(
+    ("op_name", "kwargs"),
+    [
+        pytest.param("list_milestones", {}, id="list_milestones"),
+        pytest.param("get_soonest_milestone", {}, id="get_soonest_milestone"),
+        pytest.param("create_milestone", {"title": "x"}, id="create_milestone"),
+        pytest.param(
+            "assign_item_to_milestone", {"issue_number": 1, "milestone_number": 1}, id="assign_item_to_milestone"
+        ),
+    ],
+)
+def test_unsupported_backend_raises_typed_capability_error(op_name: str, kwargs: dict[str, object]) -> None:
     """A backend with supports_milestones=False raises UnsupportedBackendCapabilityError with populated fields."""
     from backlog_core.backends.beads_backend import BeadsBackend
 
@@ -243,13 +260,13 @@ def test_unsupported_backend_raises_typed_capability_error() -> None:
     set_config(BacklogConfig(backend=beads))
     try:
         with pytest.raises(UnsupportedBackendCapabilityError) as exc_info:
-            operations.list_milestones()
+            getattr(operations, op_name)(**kwargs)
     finally:
         reset_config()
 
     assert exc_info.value.capability == "milestones"
     assert exc_info.value.backend == "BeadsBackend"
-    assert exc_info.value.operation == "list_milestones"
+    assert exc_info.value.operation == op_name
 
 
 # ---------------------------------------------------------------------------
@@ -273,11 +290,44 @@ def test_membership_counts_after_assign_and_close(backend: WorkItemBackend) -> N
     assert num_a is not None
     assert num_b is not None
 
-    backend.assign_item_to_milestone(num_a, ms_number)
-    backend.assign_item_to_milestone(num_b, ms_number)
+    operations.assign_item_to_milestone(issue_number=num_a, milestone_number=ms_number)
+    operations.assign_item_to_milestone(issue_number=num_b, milestone_number=ms_number)
     backend.close_github_issue(str(num_a), "done")
 
     listed = cast("list[dict[str, object]]", operations.list_milestones(state="all")["milestones"])
     match = next(m for m in listed if m["number"] == ms_number)
     assert match["open_issues"] == 1
     assert match["closed_issues"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 10. assign_item_to_milestone via operations
+# ---------------------------------------------------------------------------
+
+
+def test_assign_item_to_milestone_via_operations(backend: WorkItemBackend) -> None:
+    """operations.assign_item_to_milestone assigns an item, reflected in list_milestones open_issues."""
+    ms = cast("dict[str, object]", operations.create_milestone(title="Sprint 1")["milestone"])
+    ms_number = cast("int", ms["number"])
+    item = _make_item("Item A")
+    repo = _repo_for_create_issue(backend)
+    num = backend.create_issue_for_item(repo, item)
+    assert num is not None
+
+    operations.assign_item_to_milestone(issue_number=num, milestone_number=ms_number)
+
+    listed = cast("list[dict[str, object]]", operations.list_milestones(state="all")["milestones"])
+    match = next(m for m in listed if m["number"] == ms_number)
+    assert match["open_issues"] == 1
+
+
+def test_assign_unknown_issue_raises_backlog_error(backend: WorkItemBackend) -> None:
+    """operations.assign_item_to_milestone raises BacklogError (not KeyError) for an unknown issue."""
+    _skip_github_shared_state(backend)
+    ms = cast("dict[str, object]", operations.create_milestone(title="Sprint 1")["milestone"])
+    ms_number = cast("int", ms["number"])
+
+    with pytest.raises(BacklogError) as exc_info:
+        operations.assign_item_to_milestone(issue_number=999999, milestone_number=ms_number)
+
+    assert "not found" in str(exc_info.value)

--- a/plugins/development-harness/tests/test_milestone_parity.py
+++ b/plugins/development-harness/tests/test_milestone_parity.py
@@ -36,6 +36,7 @@ from backlog_core.models import (
     UnsupportedBackendCapabilityError,
     ValidationError,
 )
+from github import GithubException
 from github.Repository import Repository as GithubRepository
 
 _MOCK_REPO: GithubRepository = MagicMock(spec=GithubRepository)
@@ -331,3 +332,29 @@ def test_assign_unknown_issue_raises_backlog_error(backend: WorkItemBackend) -> 
         operations.assign_item_to_milestone(issue_number=999999, milestone_number=ms_number)
 
     assert "not found" in str(exc_info.value)
+
+
+def test_assign_item_to_milestone_normalizes_github_exception() -> None:
+    """A GithubException from the backend (e.g. GitHubBackend's unknown issue/milestone 404) is
+    normalized to BacklogError, not left to escape as a raw PyGithub exception.
+
+    KeyError-raising backends (Memory/SQLite) are covered by
+    test_assign_unknown_issue_raises_backlog_error above; GitHubBackend's
+    assign_item_to_milestone raises GithubException instead (PyGithub's
+    get_issue/get_milestone), which is a distinct code path in the
+    operations.py wrapper.
+    """
+
+    class _FakeGitHubLikeBackend:
+        supports_milestones = True
+
+        def assign_item_to_milestone(self, issue_number: int, milestone_number: int, repo: str = "") -> None:
+            raise GithubException(404, {"message": "Not Found"}, None)
+
+    set_config(BacklogConfig(backend=cast("WorkItemBackend", _FakeGitHubLikeBackend())))
+    try:
+        with pytest.raises(BacklogError) as exc_info:
+            operations.assign_item_to_milestone(issue_number=1, milestone_number=1)
+        assert "GitHub API error" in str(exc_info.value)
+    finally:
+        reset_config()


### PR DESCRIPTION
## Summary

Follow-up to #3364 (backend-agnostic milestones). `/code-review low --fix` on the merged PR surfaced that `assign_item_to_milestone` existed on every backend but had zero public API callers — no MCP tool, no `operations.py` wrapper, on any backend.

- `operations.assign_item_to_milestone`: new wrapper. Normalizes the SQLite/Memory backends' bare `KeyError` into `BacklogError` so it can't escape an MCP tool's `except BacklogError` handler (regression test: `test_assign_unknown_issue_raises_backlog_error`, verified to fail without the catch).
- `backlog_assign_item_to_milestone`: new MCP tool, matching the existing milestone tools' style.
- `BeadsBackend.create_beads_milestone`: stop swallowing `bd` invocation/validation errors into a silent `None` return — let them propagate, consistent with its sibling shadow methods (`list_beads_milestones`, `assign_beads_item_to_milestone`).
- `group-items-to-milestone` skill: Step 5 now calls the new tool instead of shelling out to the GitHub-only `github_project_setup.py issue set-milestone`.

Beads has no milestone entry point through the generic `WorkItemBackend` Protocol (string nanoid IDs, ADR-003) — intentionally out of scope here, tracked as #3372.

## Test plan

- [x] `uv run pytest plugins/development-harness/tests/ -q` — 3040 passed, 51 skipped, 5 xfailed
- [x] `uv run pytest plugins/development-harness/tests_backlog/ -q` — 614 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on all changed files — clean
- [x] `uv run ty check` on all changed files — clean
- [x] Verified `test_assign_unknown_issue_raises_backlog_error` actually fails without the `except KeyError` catch (removed it, confirmed 2 failures, restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj76ZCampHU14169cwyaoh