### PR TITLE
fix(receiving-pr-reviews): don't require a reply to Codex's boilerplate review

### DIFF
--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -131,15 +131,32 @@ _REACTION_ADAPTER: TypeAdapter[list[Reaction]] = TypeAdapter(list[Reaction])
 # starts with the same text (e.g. a public PR's `chatgpt-codex-connector-imposter`).
 _CODEX_REACTOR_LOGINS = frozenset({"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"})
 
-# Matches only the variable slot of Codex's own top-level review body when it found nothing to
-# say: fixed boilerplate text, then the reviewed commit's short sha, then nothing but whitespace
-# before Codex's own "About Codex in GitHub" `<details>` footer starts. Verified byte-for-byte
-# against this repo's own PR #3318/#3306 history (see `_is_codex_empty_review`): a review that
-# *does* carry findings keeps the identical header and footer but replaces this exact text with
-# the finding itself, so this regex does not match it.
+# Codex's own "About Codex in GitHub" `<details>` footer, present byte-for-byte on every Codex
+# review regardless of findings — confirmed against this repo's own PR #3318/#3306 history: a
+# review that *does* carry a finding keeps this exact footer, only the text ahead of it differs.
+_CODEX_EMPTY_REVIEW_FOOTER = (
+    "<details> <summary>\N{INFORMATION SOURCE}\N{VARIATION SELECTOR-16} About Codex in GitHub</summary>\n<br/>\n\n"
+    "[Your team has set up Codex to review pull requests in this repo]"
+    "(https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you\n"
+    "- Open a pull request for review\n"
+    "- Mark a draft as ready\n"
+    '- Comment "@codex review".\n\n'
+    "If Codex has suggestions, it will comment; otherwise it will react with \N{THUMBS UP SIGN}.\n\n\n\n\n"
+    'Codex can also answer questions or update the PR. Try commenting "@codex address that feedback".\n            \n'
+    "</details>"
+)
+
+# Matches Codex's own top-level review body only when it found nothing to say: the fixed header,
+# fixed boilerplate text, the reviewed commit's short sha, then the footer above — and nothing
+# else, in either direction. `_is_codex_empty_review` runs this as a `fullmatch` against the whole
+# (stripped) body rather than a `.search()`: a bare search only anchors the fixed pieces and would
+# still match a review that tucks a real finding somewhere the regex isn't looking, e.g. appended
+# after the footer's closing `</details>` tag — `fullmatch` requires the entire body to consist of
+# exactly this template, so any such addition breaks the match instead of being silently missed.
 _CODEX_EMPTY_REVIEW_BODY = re.compile(
+    r"### 💡 Codex Review\s*"
     r"Here are some automated review suggestions for this pull request\.\s*"
-    r"\*\*Reviewed commit:\*\*\s*`[0-9a-f]+`\s*(?=<details>)"
+    r"\*\*Reviewed commit:\*\*\s*`[0-9a-f]+`\s*" + re.escape(_CODEX_EMPTY_REVIEW_FOOTER)
 )
 
 
@@ -529,9 +546,11 @@ def _is_codex_empty_review(review: ReviewNode) -> bool:
 
     Codex posts a review with this same boilerplate body on every push regardless of what it
     finds — real findings, when present, arrive separately as inline thread comments already
-    tracked through `unresolved`/`resolve`, never in this top-level review's own body. Requiring
-    the reaction phrase in addition to the regex match on `_CODEX_EMPTY_REVIEW_BODY` guards against
-    matching some unrelated review whose body happens to contain a reviewed-commit line.
+    tracked through `unresolved`/`resolve`, never in this top-level review's own body. Matching
+    with `fullmatch` against the whole stripped body (not `.search()`) is what rejects a review
+    that tucks a real finding anywhere outside the template's own variable slot — including after
+    the fixed footer's closing `</details>` tag, where a `.search()` for the fixed pieces alone
+    would still match and silently miss the addition — see `_CODEX_EMPTY_REVIEW_BODY`.
 
     Args:
         review: A review whose body is non-empty (`reviews_with_body`).
@@ -544,8 +563,7 @@ def _is_codex_empty_review(review: ReviewNode) -> bool:
     return (
         review.author is not None
         and review.author.login.lower() in _CODEX_REACTOR_LOGINS
-        and "will react with 👍" in review.body
-        and _CODEX_EMPTY_REVIEW_BODY.search(review.body) is not None
+        and _CODEX_EMPTY_REVIEW_BODY.fullmatch(review.body.strip()) is not None
     )
 
 

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -131,6 +131,17 @@ _REACTION_ADAPTER: TypeAdapter[list[Reaction]] = TypeAdapter(list[Reaction])
 # starts with the same text (e.g. a public PR's `chatgpt-codex-connector-imposter`).
 _CODEX_REACTOR_LOGINS = frozenset({"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"})
 
+# Matches only the variable slot of Codex's own top-level review body when it found nothing to
+# say: fixed boilerplate text, then the reviewed commit's short sha, then nothing but whitespace
+# before Codex's own "About Codex in GitHub" `<details>` footer starts. Verified byte-for-byte
+# against this repo's own PR #3318/#3306 history (see `_is_codex_empty_review`): a review that
+# *does* carry findings keeps the identical header and footer but replaces this exact text with
+# the finding itself, so this regex does not match it.
+_CODEX_EMPTY_REVIEW_BODY = re.compile(
+    r"Here are some automated review suggestions for this pull request\.\s*"
+    r"\*\*Reviewed commit:\*\*\s*`[0-9a-f]+`\s*(?=<details>)"
+)
+
 
 def run_gh(args: list[str], *, timeout: float | None = None) -> str:
     """Run a `gh` command and return its captured stdout.
@@ -513,8 +524,39 @@ def _references_review(comment_body: str, review_url: str) -> bool:
     return re.search(re.escape(review_url) + r"(?!\d)", comment_body) is not None
 
 
+def _is_codex_empty_review(review: ReviewNode) -> bool:
+    """Whether `review` is Codex's fixed no-findings wrapper, carrying no feedback of its own.
+
+    Codex posts a review with this same boilerplate body on every push regardless of what it
+    finds — real findings, when present, arrive separately as inline thread comments already
+    tracked through `unresolved`/`resolve`, never in this top-level review's own body. Requiring
+    the reaction phrase in addition to the regex match on `_CODEX_EMPTY_REVIEW_BODY` guards against
+    matching some unrelated review whose body happens to contain a reviewed-commit line.
+
+    Args:
+        review: A review whose body is non-empty (`reviews_with_body`).
+
+    Returns:
+        `True` only when `review` is authored by the Codex bot (see `_CODEX_REACTOR_LOGINS`) and
+        its body is exactly the boilerplate no-findings template — not merely a review that
+        contains the template text somewhere alongside real findings.
+    """
+    return (
+        review.author is not None
+        and review.author.login.lower() in _CODEX_REACTOR_LOGINS
+        and "will react with 👍" in review.body
+        and _CODEX_EMPTY_REVIEW_BODY.search(review.body) is not None
+    )
+
+
 def _unresponded_reviews(reviews_with_body: list[ReviewNode], own_comments: list[IssueComment]) -> list[ReviewNode]:
     """Which of `reviews_with_body` this workflow has not yet explicitly responded to.
+
+    A Codex review whose entire body is its own fixed no-findings boilerplate (see
+    `_is_codex_empty_review`) is excluded up front — every push posts a fresh one regardless of
+    findings, and responding to it is pure busywork with no informational value. A Codex review
+    that carries real content beyond that template is not excluded and follows the same rule as
+    any other review below.
 
     A review counts as responded only when at least one of this workflow's own PR-level comments
     both quotes that review's own `url` (its canonical GitHub permalink, matched as a complete id —
@@ -542,6 +584,7 @@ def _unresponded_reviews(reviews_with_body: list[ReviewNode], own_comments: list
         review
         for review in reviews_with_body
         if review.submittedAt is not None
+        and not _is_codex_empty_review(review)
         and not any(
             _references_review(comment.body, review.url) and comment.created_at >= _review_effective_timestamp(review)
             for comment in own_comments
@@ -614,7 +657,10 @@ def build_fetch_result(
     own workflow sanctions) is not evidence it addressed that review's feedback, and a plain
     chronological cutover cannot tell the two apart. Comments from any other account are ignored
     for the same reason a comment without any reference is. A review with no `submittedAt` (not
-    yet actually submitted) is excluded rather than treated as always-unresponded.
+    yet actually submitted) is excluded rather than treated as always-unresponded. A Codex review
+    whose entire body is its own fixed no-findings boilerplate is excluded up front, before any of
+    the above — see `_is_codex_empty_review` — since every push posts a fresh one regardless of
+    findings and responding to it has no informational value.
 
     `codex_approved` is `True` when a "+1" reaction from exactly the Codex bot's known login (not
     merely one that starts with the same text — see `_CODEX_REACTOR_LOGINS`) exists on the PR

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -611,7 +611,7 @@ _CODEX_EMPTY_REVIEW_BODY = (
     "\n### 💡 Codex Review\n\n"
     "Here are some automated review suggestions for this pull request.\n\n"
     "**Reviewed commit:** `a4929550cb`\n    \n\n"
-    "<details> <summary>ℹ️ About Codex in GitHub</summary>\n<br/>\n\n"  # ruff: ignore[ambiguous-unicode-character-string]
+    "<details> <summary>\N{INFORMATION SOURCE}\N{VARIATION SELECTOR-16} About Codex in GitHub</summary>\n<br/>\n\n"
     "[Your team has set up Codex to review pull requests in this repo]"
     "(https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you\n"
     "- Open a pull request for review\n"
@@ -659,6 +659,32 @@ def test_build_fetch_result_codex_review_with_real_findings_still_unresponded(mo
     review = _review(
         "R1",
         body=body_with_finding,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        login="chatgpt-codex-connector[bot]",
+    )
+    mocker.patch.object(pr_review_gh, "_fetch_pages", return_value=_empty_threads())
+    mocker.patch.object(pr_review_gh, "_fetch_review_pages", return_value=[_reviews_conn([review])])
+    mocker.patch.object(pr_review_gh, "_fetch_issue_comments", return_value=[])
+    mocker.patch.object(pr_review_gh, "_fetch_pr_reactions", return_value=[])
+    _patch_identity_and_commit_date(mocker)
+
+    result = build_fetch_result("o", "r", 1)
+
+    assert result.unresponded_reviews == [review]
+
+
+def test_build_fetch_result_codex_review_with_finding_after_footer_still_unresponded(mocker: MockerFixture) -> None:
+    """A Codex review that appends a real finding after the fixed footer's closing `</details>`
+    tag still requires a response.
+
+    Regression coverage: `_is_codex_empty_review` must reject the whole body via `fullmatch`, not
+    merely find the fixed template pieces present via `.search()` — a search would still match the
+    fixed prefix and footer and silently miss a finding tacked on after them.
+    """
+    body_with_trailing_finding = _CODEX_EMPTY_REVIEW_BODY + "\n\nP.S. Also consider extracting this into a helper."
+    review = _review(
+        "R1",
+        body=body_with_trailing_finding,
         submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
         login="chatgpt-codex-connector[bot]",
     )

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -607,6 +607,90 @@ def test_build_fetch_result_shorter_review_stays_unresponded_when_only_longer_id
     assert result.unresponded_reviews == [shorter_review]
 
 
+_CODEX_EMPTY_REVIEW_BODY = (
+    "\n### 💡 Codex Review\n\n"
+    "Here are some automated review suggestions for this pull request.\n\n"
+    "**Reviewed commit:** `a4929550cb`\n    \n\n"
+    "<details> <summary>ℹ️ About Codex in GitHub</summary>\n<br/>\n\n"  # ruff: ignore[ambiguous-unicode-character-string]
+    "[Your team has set up Codex to review pull requests in this repo]"
+    "(https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you\n"
+    "- Open a pull request for review\n"
+    "- Mark a draft as ready\n"
+    '- Comment "@codex review".\n\n'
+    "If Codex has suggestions, it will comment; otherwise it will react with 👍.\n\n\n\n\n"
+    'Codex can also answer questions or update the PR. Try commenting "@codex address that feedback".\n            \n'
+    "</details>"
+)
+
+
+def test_build_fetch_result_codex_empty_review_is_not_unresponded(mocker: MockerFixture) -> None:
+    """A Codex review whose entire body is its own fixed no-findings boilerplate is excluded from
+    `unresponded_reviews` without needing a reply — every push posts one regardless of findings.
+
+    Body captured verbatim from this repo's own PR history (#3318, #3306).
+    """
+    review = _review(
+        "R1",
+        body=_CODEX_EMPTY_REVIEW_BODY,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        login="chatgpt-codex-connector[bot]",
+    )
+    mocker.patch.object(pr_review_gh, "_fetch_pages", return_value=_empty_threads())
+    mocker.patch.object(pr_review_gh, "_fetch_review_pages", return_value=[_reviews_conn([review])])
+    mocker.patch.object(pr_review_gh, "_fetch_issue_comments", return_value=[])
+    mocker.patch.object(pr_review_gh, "_fetch_pr_reactions", return_value=[])
+    _patch_identity_and_commit_date(mocker)
+
+    result = build_fetch_result("o", "r", 1)
+
+    assert result.unresponded_reviews == []
+    assert result.reviews_with_body == [review]
+
+
+def test_build_fetch_result_codex_review_with_real_findings_still_unresponded(mocker: MockerFixture) -> None:
+    """A Codex review carrying the same wrapper plus an actual finding still requires a response —
+    only the all-boilerplate body is excluded, not every review from Codex.
+    """
+    body_with_finding = _CODEX_EMPTY_REVIEW_BODY.replace(
+        "Here are some automated review suggestions for this pull request.\n\n"
+        "**Reviewed commit:** `a4929550cb`\n    \n\n",
+        "**P1** Share the outer timeout across both CLI calls.\n    \n\n",
+    )
+    review = _review(
+        "R1",
+        body=body_with_finding,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        login="chatgpt-codex-connector[bot]",
+    )
+    mocker.patch.object(pr_review_gh, "_fetch_pages", return_value=_empty_threads())
+    mocker.patch.object(pr_review_gh, "_fetch_review_pages", return_value=[_reviews_conn([review])])
+    mocker.patch.object(pr_review_gh, "_fetch_issue_comments", return_value=[])
+    mocker.patch.object(pr_review_gh, "_fetch_pr_reactions", return_value=[])
+    _patch_identity_and_commit_date(mocker)
+
+    result = build_fetch_result("o", "r", 1)
+
+    assert result.unresponded_reviews == [review]
+
+
+def test_build_fetch_result_non_codex_boilerplate_lookalike_still_unresponded(mocker: MockerFixture) -> None:
+    """A review from a different author whose body happens to match Codex's boilerplate text is
+    not exempted — only the Codex bot's own login is excluded.
+    """
+    review = _review(
+        "R1", body=_CODEX_EMPTY_REVIEW_BODY, submitted_at=datetime(2026, 1, 1, tzinfo=UTC), login="a-human-reviewer"
+    )
+    mocker.patch.object(pr_review_gh, "_fetch_pages", return_value=_empty_threads())
+    mocker.patch.object(pr_review_gh, "_fetch_review_pages", return_value=[_reviews_conn([review])])
+    mocker.patch.object(pr_review_gh, "_fetch_issue_comments", return_value=[])
+    mocker.patch.object(pr_review_gh, "_fetch_pr_reactions", return_value=[])
+    _patch_identity_and_commit_date(mocker)
+
+    result = build_fetch_result("o", "r", 1)
+
+    assert result.unresponded_reviews == [review]
+
+
 @pytest.mark.parametrize(
     ("comment_body", "expected"),
     [


### PR DESCRIPTION
## Summary
- Codex posts a fresh top-level review on every push with the same fixed no-findings body (`### 💡 Codex Review` / `Here are some automated review suggestions...` / `Reviewed commit: `<sha>`` / footer) regardless of whether it found anything.
- Real Codex findings, when present, always arrive as separate inline thread comments already tracked through `unresolved`/`resolve` — the top-level review body itself never carries them.
- `_unresponded_reviews` treated that boilerplate as content requiring an explicit PR-level reply, forcing a throwaway "acknowledging this empty review" comment on every push with no informational value.
- `_is_codex_empty_review` now excludes a Codex review from `unresponded_reviews` only when its entire body is that fixed template (verified byte-for-byte against this repo's own PR #3318/#3306 history — a review with real findings keeps the identical header/footer but replaces the template text). A Codex review with real content, or a boilerplate-lookalike body from a non-Codex author, is unaffected.

Note: the task brief that prompted this also asked to port a `ThreadPoolExecutor` fail-fast fix into a `_fetch_concurrently` function. This repo's `pr_review_gh.py` has no such function — `build_fetch_result` fetches its seven `gh` calls sequentially and always has — so there's nothing to port; that item was skipped rather than inventing unrequested concurrency.

## Test plan
- [x] `uv run pytest test_pr_review_threads.py` — 76 passed (3 new: boilerplate-only excluded, boilerplate+findings still unresponded, non-Codex lookalike still unresponded)
- [x] `uv run prek run --files .agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py .agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py` — all hooks pass (ruff lint/format, ty check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ziofEjQ1f4HB1cTiKpp9Q