### PR TITLE
fix(backlog): clear PR #3367 follow-ups (#3370, #3368, #3369)

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.11",
+  "version": "11.0.12",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.11",
+  "version": "10.0.12",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.11",
+  "version": "7.0.12",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -987,7 +987,12 @@ def _normalize_section_key(name: str, *, output: Output | None = None) -> str:
         recovered = resolve_section_name(stripped) or resolve_section_name(_reconstruct_unknown_heading(name))
         return recovered if recovered is not None else name
     key = heading_to_unknown_key(name)
-    _warn_unregistered_section(name, key, output)
+    # #3370: heading_to_unknown_key() itself now folds to a canonical key
+    # when the unknown__ key's reconstructed heading is registered (e.g.
+    # ":EFFORT" -> "effort") -- that is not a fallback, so warning about an
+    # "unregistered section" here would be false: the section IS registered.
+    if key.startswith("unknown__"):
+        _warn_unregistered_section(name, key, output)
     return key
 
 

--- a/plugins/development-harness/backlog_core/rendering.py
+++ b/plugins/development-harness/backlog_core/rendering.py
@@ -104,14 +104,30 @@ def heading_to_unknown_key(heading_text: str) -> str:
     key (``"unknown__files_"`` vs. ``"unknown__files"``) reproduces the exact
     write-path/parse-path key divergence this function exists to prevent.
 
+    Guards against a second divergence (#3370): the ``unknown__`` key this
+    function returns gets rendered back into a heading by
+    :func:`unknown_key_to_heading` (lower/strip/title-case). For a name like
+    ``":EFFORT"``, that reconstructed heading is ``"Effort"`` — which IS a
+    registered :data:`SECTION_HEADING` display heading. Re-parsing that
+    rendered heading then resolves to the canonical ``effort`` key, leaving
+    the item with two keys (``unknown__effort`` and ``effort``) for one
+    logical section — the same live data-loss shape #2956 fixed, since
+    :func:`github_sync.extract_sections` is last-heading-wins on reparse. So
+    before returning the ``unknown__`` key, check whether its own
+    reconstructed heading is itself registered; if so, return the canonical
+    key instead, matching what the parse leg would produce anyway.
+
     Args:
         heading_text: Raw heading or section display name.
 
     Returns:
-        Storage key such as ``"unknown__custom_analysis"``.
+        Storage key such as ``"unknown__custom_analysis"``, or the canonical
+        :class:`~.section_registry.SectionKey` value when the reconstructed
+        heading for the unknown key is itself registered.
     """
     normalised = _NON_ALNUM_RE.sub("_", heading_text.strip().lower()).strip("_")
-    return f"unknown__{normalised}"
+    key = f"unknown__{normalised}"
+    return resolve_section_name(unknown_key_to_heading(key)) or key
 
 
 def merge_entries(local_entries: list[Entry], remote_entries: list[Entry]) -> list[Entry]:

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -27,7 +27,7 @@ import sys
 import time as _time
 from datetime import UTC, datetime as _datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias, TypeGuard
+from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias, TypeGuard, TypeVar
 
 import dh_paths as _dh_paths
 import dispatch_schema as _ds
@@ -36,7 +36,7 @@ from dh_core import operations
 from fastmcp import Context, FastMCP
 from github import GithubException as _GithubException
 from mcp.types import ToolAnnotations
-from pydantic import Field
+from pydantic import BaseModel, Field
 from ruamel.yaml import YAML as _YAML
 
 from . import models as _models, sync_engine as _sync_engine
@@ -119,6 +119,7 @@ from .tool_responses import (
     BacklogSyncResponse,
     BacklogUpdateResponse,
     BacklogUpdateSamTaskStatusResponse,
+    BacklogViewResponse,
     DispatchConflictsResponse,
     DispatchCreatePlanResponse,
     DispatchItemStatusResponse,
@@ -138,6 +139,57 @@ if TYPE_CHECKING:
 
 EffortLevel: TypeAlias = Literal["low", "medium", "high", "max"]
 ItemId: TypeAlias = int | str
+
+_ResponseModel = TypeVar("_ResponseModel", bound=BaseModel)
+
+
+def _respond(
+    cls: type[_ResponseModel], payload: Mapping[str, object], *, exclude_none: bool = True, exclude_unset: bool = False
+) -> _ResponseModel:
+    """Validate a tool payload and return its wire dict (#3369).
+
+    Every ``@mcp.tool`` function is annotated ``-> SomeResponse`` but actually
+    returns ``response.model_dump(...)`` (a plain dict) -- ``ty`` accepts that
+    mismatch when the ``model_validate(...).model_dump(...)`` chain appears
+    directly in a ``return`` statement, but rejects it the moment the same
+    chain is wrapped in a helper annotated ``-> dict[str, object]`` (or
+    ``-> dict[str, Any]``). Declaring this helper ``-> _ResponseModel`` (a
+    TypeVar bound to ``BaseModel``, matching the class passed in) is what
+    keeps every call site's declared return type checkable.
+
+    ``exclude_none`` defaults to ``True`` -- the pattern nearly all ~70+
+    standard call sites use -- so a tool that legitimately needs a
+    load-bearing ``None`` to survive onto the wire (see ``sync_status``'s
+    docstring for why that tool bypasses this helper entirely) must pass
+    ``exclude_none=False`` explicitly, making the decision a visible,
+    searchable keyword rather than a convention a future call site has to
+    remember to deviate from.
+
+    ``exclude_unset`` defaults to ``False``. ``backlog_view`` (#3368) is the
+    one caller that needs it ``True``, paired with ``exclude_none=False``:
+    each of its branches builds a small, precise payload dict against
+    ``BacklogViewResponse``'s ~55 possible fields, and several legitimately
+    set a key to ``None`` (e.g. ``plan_address`` when an item has no plan,
+    ``issue_number`` when a selector has none) that must still appear on the
+    wire -- the exact "load-bearing None" case ``exclude_none=True`` cannot
+    represent. ``exclude_unset=True`` keeps exactly the keys each branch put
+    in *payload* (None or not) and drops the ~45 fields that branch never
+    mentioned, reproducing what the pre-#3368 code did by returning a plain
+    dict with no model in between.
+
+    Args:
+        cls: The Pydantic response model class for this tool.
+        payload: Raw fields to validate into ``cls``.
+        exclude_none: Forwarded to ``model_dump()``. Defaults to ``True``.
+        exclude_unset: Forwarded to ``model_dump()``. Defaults to ``False``.
+
+    Returns:
+        The validated model's dumped dict, typed as ``cls`` for the
+        annotation-checking caller (FastMCP serializes the dict identically
+        to the model instance at the wire boundary either way).
+    """
+    return cls.model_validate(payload).model_dump(exclude_none=exclude_none, exclude_unset=exclude_unset)
+
 
 # Module-level logger for done-callback exception reporting.
 # Named _sync_task_log so tests can patch backlog_core.server._sync_task_log.
@@ -1335,9 +1387,9 @@ async def backlog_add(
             force=force,
             output=out,
         )
-        return BacklogAddResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogAddResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogAddResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogAddResponse, {"error": str(e), **out.to_dict()})
 
 
 def _assert_config() -> None:
@@ -1749,11 +1801,7 @@ async def backlog_list(
         )
     except BacklogError as e:
         backend_status = await asyncio.to_thread(_probe_backend_status)
-        return BacklogListResponse.model_validate({
-            "error": str(e),
-            "backend": backend_status.model_dump(),
-            **out.to_dict(),
-        }).model_dump(exclude_none=True)
+        return _respond(BacklogListResponse, {"error": str(e), "backend": backend_status.model_dump(), **out.to_dict()})
 
     # "items" holds list[dict[str, str | bool]] per operations.list_items return type.
     # Filter to dict elements only to narrow the heterogeneous value union.
@@ -1832,7 +1880,7 @@ async def backlog_list(
     if match_pages is not None:
         response["match_pages"] = match_pages
         _maybe_add_pagination_notice(match_pages, out, response)
-    return BacklogListResponse.model_validate(response).model_dump(exclude_none=True)
+    return _respond(BacklogListResponse, response)
 
 
 def _build_compact_manifest(
@@ -2131,7 +2179,7 @@ async def backlog_view(
             ),
         ),
     ] = 0,
-) -> dict:
+) -> BacklogViewResponse:
     r"""View a single backlog item or GitHub issue in detail.
 
     Ordinal format: ^\d+(\.\d+)*(\.code\.\d+)?$. Examples:
@@ -2174,7 +2222,7 @@ async def backlog_view(
         disclosure_result = {"error": str(exc), "invalid_params": exc.invalid_params}
 
     if disclosure_result is not None:
-        return disclosure_result
+        return _respond(BacklogViewResponse, disclosure_result, exclude_none=False, exclude_unset=True)
     # ---- PASSTHROUGH: falls through to legacy code below -----------------------
 
     out = Output()
@@ -2218,7 +2266,12 @@ async def backlog_view(
             # response.  ``section_filter_miss`` is retained for backward compatibility.
             if result.section_filter_miss:
                 filter_expr = section if section is not None else ", ".join(sections or [])
-                return _build_section_miss_error(filter_expr, result.section_filter_valid_names, out)
+                return _respond(
+                    BacklogViewResponse,
+                    _build_section_miss_error(filter_expr, result.section_filter_valid_names, out),
+                    exclude_none=False,
+                    exclude_unset=True,
+                )
             # Auto-compact: when the response exceeds the token budget return a compact
             # section-directory form so the caller can request only what it needs.
             #
@@ -2254,11 +2307,21 @@ async def backlog_view(
             # serialised char length of the full payload the caller would receive.
             serialised = _json.dumps(full_response)
             if _view_payload_token_count(full_response) > _VIEW_TOKEN_BUDGET:
-                return _build_over_budget_view(result, len(serialised), selector)
-            return full_response
-        return _build_compact_manifest(result, full_response, selector)
+                return _respond(
+                    BacklogViewResponse,
+                    _build_over_budget_view(result, len(serialised), selector),
+                    exclude_none=False,
+                    exclude_unset=True,
+                )
+            return _respond(BacklogViewResponse, full_response, exclude_none=False, exclude_unset=True)
+        return _respond(
+            BacklogViewResponse,
+            _build_compact_manifest(result, full_response, selector),
+            exclude_none=False,
+            exclude_unset=True,
+        )
     except BacklogError as e:
-        return {"error": str(e), **out.to_dict()}
+        return _respond(BacklogViewResponse, {"error": str(e), **out.to_dict()}, exclude_none=False, exclude_unset=True)
 
 
 @mcp.tool(
@@ -2288,9 +2351,9 @@ async def backlog_sync(
         created = result.get("created", 0)
         pushed = result.get("pushed", 0)
         await ctx.info(f"Sync complete: {created} issue(s) created, {pushed} item(s) pushed")
-        return BacklogSyncResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogSyncResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogSyncResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogSyncResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2328,11 +2391,9 @@ async def backlog_link_followup(
         result = await asyncio.to_thread(
             operations.link_followup, selector=selector, followup_to=followup_to, output=out
         )
-        return BacklogLinkFollowupResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogLinkFollowupResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogLinkFollowupResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogLinkFollowupResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2364,11 +2425,9 @@ async def backlog_list_followups(
     out = Output()
     try:
         result = await asyncio.to_thread(operations.list_followups, followup_to=followup_to, output=out)
-        return BacklogListFollowupsResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogListFollowupsResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogListFollowupsResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogListFollowupsResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2418,9 +2477,9 @@ async def backlog_close(
             force=force,
             output=out,
         )
-        return BacklogCloseResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogCloseResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogCloseResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogCloseResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2473,9 +2532,9 @@ async def backlog_resolve(
             force=force,
             output=out,
         )
-        return BacklogResolveResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogResolveResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogResolveResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogResolveResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2567,9 +2626,9 @@ async def backlog_update(
             reason=reason,
             verified=verified,
         )
-        return BacklogUpdateResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogUpdateResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogUpdateResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogUpdateResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2683,9 +2742,9 @@ async def backlog_groom(
             await ctx.warning(w)
         title = result.get("title", selector)
         await ctx.info(f"Groomed: {title}")
-        return BacklogGroomResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogGroomResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogGroomResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogGroomResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2717,9 +2776,9 @@ async def backlog_normalize(
         updated = result.get("normalized", 0)
         suffix = " (dry-run)" if dry_run else ""
         await ctx.info(f"Normalized {updated} file(s){suffix}")
-        return BacklogNormalizeResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogNormalizeResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogNormalizeResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogNormalizeResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2778,9 +2837,9 @@ async def backlog_pull(
             await ctx.warning(w)
         pulled = result.get("pulled", 0)
         await ctx.info(f"Pull complete: {pulled} item(s) pulled")
-        return BacklogPullResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogPullResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogPullResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogPullResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2827,11 +2886,9 @@ async def backlog_create_sam_task(
             labels=labels,
             output=out,
         )
-        return BacklogCreateSamTaskResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogCreateSamTaskResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogCreateSamTaskResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogCreateSamTaskResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2856,9 +2913,9 @@ async def backlog_get_sam_tasks(
         result = await asyncio.to_thread(
             operations.get_sam_tasks, parent_issue_number=parent_issue_number, refresh_cache=refresh_cache, output=out
         )
-        return SamTaskLookupResult.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(SamTaskLookupResult, {**result, **out.to_dict()})
     except BacklogError as e:
-        return SamTaskLookupResult.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(SamTaskLookupResult, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -2889,13 +2946,9 @@ async def backlog_update_sam_task_status(
         result = await asyncio.to_thread(
             operations.update_sam_task_status, issue_number=issue_number, new_status=new_status, repo=repo, output=out
         )
-        return BacklogUpdateSamTaskStatusResponse.model_validate({**result, **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogUpdateSamTaskStatusResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogUpdateSamTaskStatusResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogUpdateSamTaskStatusResponse, {"error": str(e), **out.to_dict()})
 
 
 # ---------------------------------------------------------------------------
@@ -3058,13 +3111,9 @@ async def artifact_list(
             return [e.model_dump(mode="json") for e in entries]
 
         artifacts = await asyncio.to_thread(_run)
-        return ArtifactsListResponse.model_validate({
-            "artifacts": artifacts,
-            "count": len(artifacts),
-            **out.to_dict(),
-        }).model_dump(exclude_none=True)
+        return _respond(ArtifactsListResponse, {"artifacts": artifacts, "count": len(artifacts), **out.to_dict()})
     except BacklogError as e:
-        return ArtifactsListResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(ArtifactsListResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3125,13 +3174,9 @@ async def artifact_get(
             return [e.model_dump(mode="json") for e in entries]
 
         artifacts = await asyncio.to_thread(_run)
-        return ArtifactsListResponse.model_validate({
-            "artifacts": artifacts,
-            "count": len(artifacts),
-            **out.to_dict(),
-        }).model_dump(exclude_none=True)
+        return _respond(ArtifactsListResponse, {"artifacts": artifacts, "count": len(artifacts), **out.to_dict()})
     except BacklogError as e:
-        return ArtifactsListResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(ArtifactsListResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3209,11 +3254,9 @@ async def artifact_read(
             )
 
         result = await asyncio.to_thread(_run)
-        return ArtifactReadResponse.model_validate({**result.model_dump(mode="json"), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(ArtifactReadResponse, {**result.model_dump(mode="json"), **out.to_dict()})
     except BacklogError as e:
-        return ArtifactReadResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(ArtifactReadResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3236,11 +3279,9 @@ async def backlog_get_ready_sam_tasks(
         result = await asyncio.to_thread(
             operations.get_ready_sam_tasks, parent_issue_number=parent_issue_number, output=out
         )
-        return BacklogGetReadySamTasksResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogGetReadySamTasksResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogGetReadySamTasksResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogGetReadySamTasksResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3286,11 +3327,9 @@ async def backlog_strike_entry(
         result = await asyncio.to_thread(
             operations.strike_entry, selector=selector, entry_id=entry_id, reason=reason, section=section, output=out
         )
-        return BacklogStrikeEntryResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogStrikeEntryResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogStrikeEntryResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogStrikeEntryResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3315,11 +3354,9 @@ async def backlog_list_labels(
     out = Output()
     try:
         result = await asyncio.to_thread(operations.list_labels, limit=limit, output=out)
-        return BacklogListLabelsResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogListLabelsResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogListLabelsResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogListLabelsResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3355,11 +3392,9 @@ async def backlog_list_merged_prs(
     out = Output()
     try:
         result = await asyncio.to_thread(operations.list_merged_prs, search=search, limit=limit, output=out)
-        return BacklogListMergedPrsResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogListMergedPrsResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogListMergedPrsResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogListMergedPrsResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3385,9 +3420,7 @@ async def backlog_list_milestones(
     try:
         result = await asyncio.to_thread(operations.list_milestones, state=state, output=out)
     except BacklogError as e:
-        return BacklogListMilestonesResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogListMilestonesResponse, {"error": str(e), **out.to_dict()})
     response = BacklogListMilestonesResponse.model_validate({**result, **out.to_dict()})
     dump = response.model_dump(exclude_none=True)
     # due_on is a meaningful, documented null per milestone (no due date set) --
@@ -3423,9 +3456,7 @@ async def backlog_get_soonest_milestone() -> BacklogGetSoonestMilestoneResponse:
     try:
         result = await asyncio.to_thread(operations.get_soonest_milestone, output=out)
     except BacklogError as e:
-        return BacklogGetSoonestMilestoneResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogGetSoonestMilestoneResponse, {"error": str(e), **out.to_dict()})
     response = BacklogGetSoonestMilestoneResponse.model_validate({**result, **out.to_dict()})
     # milestone=None is a meaningful, documented success value (no open
     # milestones exist), not an absent-on-this-branch field like `error` --
@@ -3464,9 +3495,7 @@ async def backlog_create_milestone(
             operations.create_milestone, title=title, description=description, due_on=due_on, output=out
         )
     except BacklogError as e:
-        return BacklogCreateMilestoneResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogCreateMilestoneResponse, {"error": str(e), **out.to_dict()})
     response = BacklogCreateMilestoneResponse.model_validate({**result, **out.to_dict()})
     dump = response.model_dump(exclude_none=True)
     # due_on is a meaningful, legitimate null (caller can create a milestone
@@ -3540,9 +3569,7 @@ async def backlog_list_issues(
             operations.list_issues, milestone=milestone, labels=labels, state=state, limit=limit, output=out
         )
     except BacklogError as e:
-        return BacklogListIssuesResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogListIssuesResponse, {"error": str(e), **out.to_dict()})
     response = BacklogListIssuesResponse.model_validate({**result, **out.to_dict()})
     dump = response.model_dump(exclude_none=True)
     # milestone is a meaningful, documented null per issue (no milestone
@@ -3576,11 +3603,9 @@ async def backlog_comment_issue(
     out = Output()
     try:
         result = await asyncio.to_thread(operations.comment_issue, issue_number=issue_number, body=body, output=out)
-        return BacklogCommentIssueResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogCommentIssueResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogCommentIssueResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogCommentIssueResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3606,11 +3631,9 @@ async def backlog_list_comments(
         result = await asyncio.to_thread(
             operations.list_comments, issue_number=issue_number, limit=limit, offset=offset, output=out
         )
-        return BacklogListCommentsResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogListCommentsResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogListCommentsResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogListCommentsResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3644,11 +3667,9 @@ async def backlog_read_comment(
         result = await asyncio.to_thread(
             operations.read_comment, issue_number=issue_number, comment_id=comment_id, output=out
         )
-        return BacklogReadCommentResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogReadCommentResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogReadCommentResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogReadCommentResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3670,11 +3691,9 @@ async def backlog_list_projects(
     out = Output()
     try:
         result = await asyncio.to_thread(operations.list_projects, owner=owner, limit=limit, output=out)
-        return BacklogListProjectsResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogListProjectsResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogListProjectsResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogListProjectsResponse, {"error": str(e), **out.to_dict()})
 
 
 @mcp.tool(
@@ -3698,11 +3717,9 @@ async def backlog_create_project(
     out = Output()
     try:
         result = await asyncio.to_thread(operations.create_project, title=title, owner=owner, output=out)
-        return BacklogCreateProjectResponse.model_validate({**result, **out.to_dict()}).model_dump(exclude_none=True)
+        return _respond(BacklogCreateProjectResponse, {**result, **out.to_dict()})
     except BacklogError as e:
-        return BacklogCreateProjectResponse.model_validate({"error": str(e), **out.to_dict()}).model_dump(
-            exclude_none=True
-        )
+        return _respond(BacklogCreateProjectResponse, {"error": str(e), **out.to_dict()})
 
 
 def _dispatch_reference(milestone_number: int) -> ContentRef:
@@ -3763,19 +3780,12 @@ async def dispatch_read(
     try:
         plan = await asyncio.to_thread(_read_dispatch_plan, milestone_number)
     except ContentUnavailableError:
-        return DispatchReadResponse.model_validate({
-            "error": "Dispatch plan not found",
-            "milestone_number": milestone_number,
-        }).model_dump(exclude_none=True)
+        return _respond(
+            DispatchReadResponse, {"error": "Dispatch plan not found", "milestone_number": milestone_number}
+        )
     except ValueError as exc:
-        return DispatchReadResponse.model_validate({
-            "error": str(exc),
-            "milestone_number": milestone_number,
-        }).model_dump(exclude_none=True)
-    return DispatchReadResponse.model_validate({
-        "milestone_number": milestone_number,
-        "plan": plan.model_dump(),
-    }).model_dump(exclude_none=True)
+        return _respond(DispatchReadResponse, {"error": str(exc), "milestone_number": milestone_number})
+    return _respond(DispatchReadResponse, {"milestone_number": milestone_number, "plan": plan.model_dump()})
 
 
 @mcp.tool(
@@ -3804,15 +3814,9 @@ async def dispatch_validate(
     try:
         plan = await asyncio.to_thread(_read_dispatch_plan, milestone_number)
     except (ContentUnavailableError, ValueError) as exc:
-        return DispatchValidateResponse.model_validate({
-            "error": str(exc),
-            "milestone_number": milestone_number,
-        }).model_dump(exclude_none=True)
+        return _respond(DispatchValidateResponse, {"error": str(exc), "milestone_number": milestone_number})
     result = await asyncio.to_thread(_ds.validate_plan_integrity, plan)
-    return DispatchValidateResponse.model_validate({
-        "milestone_number": milestone_number,
-        **dataclasses.asdict(result),
-    }).model_dump(exclude_none=True)
+    return _respond(DispatchValidateResponse, {"milestone_number": milestone_number, **dataclasses.asdict(result)})
 
 
 @mcp.tool(
@@ -3844,7 +3848,7 @@ async def dispatch_stale_check(
         ``message``. Returns ``error`` on file/parse or GitHub failure.
     """
     result = await asyncio.to_thread(operations.dispatch_stale_check, milestone_number, repo)
-    return DispatchStaleCheckResponse.model_validate(result).model_dump(exclude_none=True)
+    return _respond(DispatchStaleCheckResponse, result)
 
 
 @mcp.tool(
@@ -3900,14 +3904,17 @@ async def dispatch_create_plan(
     out = Output()
     # Verify plan.milestone.number matches the milestone_number parameter
     if plan.milestone.number != milestone_number:
-        return DispatchCreatePlanResponse.model_validate({
-            "error": (
-                f"Milestone number mismatch: parameter is {milestone_number} "
-                f"but plan.milestone.number is {plan.milestone.number}"
-            ),
-            "milestone_number": milestone_number,
-            **out.to_dict(),
-        }).model_dump(exclude_none=True)
+        return _respond(
+            DispatchCreatePlanResponse,
+            {
+                "error": (
+                    f"Milestone number mismatch: parameter is {milestone_number} "
+                    f"but plan.milestone.number is {plan.milestone.number}"
+                ),
+                "milestone_number": milestone_number,
+                **out.to_dict(),
+            },
+        )
 
     try:
         current = _get_artifact_provider().get_content(_dispatch_reference(milestone_number))
@@ -3917,10 +3924,10 @@ async def dispatch_create_plan(
         )
     else:
         if not overwrite:
-            return DispatchCreatePlanResponse.model_validate({
-                "error": "Dispatch plan already exists. Pass overwrite=True to replace it.",
-                **out.to_dict(),
-            }).model_dump(exclude_none=True)
+            return _respond(
+                DispatchCreatePlanResponse,
+                {"error": "Dispatch plan already exists. Pass overwrite=True to replace it.", **out.to_dict()},
+            )
         write = ContentWrite(
             reference=_dispatch_reference(milestone_number),
             content=plan.model_dump_json(),
@@ -3932,11 +3939,9 @@ async def dispatch_create_plan(
     try:
         await asyncio.to_thread(_get_artifact_provider().put_content, write)
     except (BacklogError, ContentConflictError, UnsupportedCapabilityError) as exc:
-        return DispatchCreatePlanResponse.model_validate({
-            "error": str(exc),
-            "milestone_number": milestone_number,
-            **out.to_dict(),
-        }).model_dump(exclude_none=True)
+        return _respond(
+            DispatchCreatePlanResponse, {"error": str(exc), "milestone_number": milestone_number, **out.to_dict()}
+        )
 
     out.info(f"Stored dispatch plan {milestone_number}")
 
@@ -4000,7 +4005,7 @@ async def dispatch_conflicts(
         failure.
     """
     result = await asyncio.to_thread(operations.dispatch_conflicts, milestone_number, repo)
-    return DispatchConflictsResponse.model_validate(result).model_dump(exclude_none=True)
+    return _respond(DispatchConflictsResponse, result)
 
 
 # ---------------------------------------------------------------------------
@@ -4082,30 +4087,35 @@ async def dispatch_wave_start(
             for item in items
         ]
     except (KeyError, ValueError) as exc:
-        return DispatchWaveStartResponse.model_validate({
-            "error": f"Malformed item entry: {exc}",
-            "milestone": milestone,
-            "wave_num": wave_num,
-        }).model_dump(exclude_none=True)
+        return _respond(
+            DispatchWaveStartResponse,
+            {"error": f"Malformed item entry: {exc}", "milestone": milestone, "wave_num": wave_num},
+        )
     try:
         wave: _DispatchWaveRecord = await asyncio.to_thread(
             _dispatch_state_manager().create_wave, milestone, wave_num, item_records
         )
     except sqlite3.IntegrityError:
-        return DispatchWaveStartResponse.model_validate({
-            "error": f"Wave {wave_num} already exists for milestone {milestone}",
-            "milestone": milestone,
-            "wave_num": wave_num,
-        }).model_dump(exclude_none=True)
-    return DispatchWaveStartResponse.model_validate({
-        "milestone": wave.milestone,
-        "wave_num": wave.wave_num,
-        "items_count": len(wave.items),
-        "status": wave.status,
-        "messages": [f"Wave {wave_num} created with {len(wave.items)} items"],
-        "warnings": [],
-        "errors": [],
-    }).model_dump(exclude_none=True)
+        return _respond(
+            DispatchWaveStartResponse,
+            {
+                "error": f"Wave {wave_num} already exists for milestone {milestone}",
+                "milestone": milestone,
+                "wave_num": wave_num,
+            },
+        )
+    return _respond(
+        DispatchWaveStartResponse,
+        {
+            "milestone": wave.milestone,
+            "wave_num": wave.wave_num,
+            "items_count": len(wave.items),
+            "status": wave.status,
+            "messages": [f"Wave {wave_num} created with {len(wave.items)} items"],
+            "warnings": [],
+            "errors": [],
+        },
+    )
 
 
 @mcp.tool(
@@ -4177,7 +4187,7 @@ async def dispatch_item_status(
         }
 
     result_dict = await asyncio.to_thread(_find_and_update)
-    return DispatchItemStatusResponse.model_validate(result_dict).model_dump(exclude_none=True)
+    return _respond(DispatchItemStatusResponse, result_dict)
 
 
 @mcp.tool(

--- a/plugins/development-harness/backlog_core/tests/_view_test_helpers.py
+++ b/plugins/development-harness/backlog_core/tests/_view_test_helpers.py
@@ -7,7 +7,8 @@ collecting this module as a test file.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Any, cast
 
 from backlog_core.backend_types import BacklogConfig
 from backlog_core.backends.memory_backend import InMemoryBackend
@@ -81,6 +82,31 @@ def _patch_github_body(mocker: MockerFixture, issue_num: int, body: str) -> None
     _configure_memory_view(mocker, item=_make_local_item(), issue_num=issue_num, body=body)
 
 
+def _call_view(**kwargs: Any) -> dict[str, object]:
+    """Call ``backlog_view`` in-process and return its wire dict, typed for tests.
+
+    ``backlog_view`` is annotated ``-> BacklogViewResponse`` for its MCP
+    ``outputSchema`` (#3368), but like every typed tool it returns a plain
+    dict at runtime -- FastMCP serialises a returned model instance or an
+    already-dumped dict identically at the wire boundary, so the annotation
+    describes the schema, not the runtime value. Tests in this module call
+    the tool function directly (bypassing the MCP ``Client``), so ``ty``
+    otherwise infers ``resp``'s type as ``BacklogViewResponse`` and rejects
+    every ``dict``-style access (``.get``, ``[...]``, ``.keys()``) below.
+    This wrapper gives call sites the ``dict`` type they've always actually
+    received.
+
+    Args:
+        **kwargs: Forwarded verbatim to ``backlog_view``.
+
+    Returns:
+        The response dict.
+    """
+    from backlog_core import server
+
+    return cast("dict[str, object]", asyncio.run(server.backlog_view(**kwargs)))
+
+
 def _resp_body(resp: dict[str, object]) -> str:
     """Return the response ``body`` as a typed ``str`` (boundary accessor).
 
@@ -132,6 +158,7 @@ __all__ = [
     "_FILLER",
     "_HUGE_SINGLE",
     "_OVER_BUDGET_BODY",
+    "_call_view",
     "_configure_memory_view",
     "_make_local_item",
     "_patch_github_body",

--- a/plugins/development-harness/backlog_core/tests/test_section_filter_error_dict.py
+++ b/plugins/development-harness/backlog_core/tests/test_section_filter_error_dict.py
@@ -47,13 +47,11 @@ selects the full ADR-3 suite.
 
 from __future__ import annotations
 
-import asyncio
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import backlog_core.server as server
-from backlog_core.tests._view_test_helpers import _patch_github_body
+from backlog_core.tests._view_test_helpers import _call_view, _patch_github_body
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -139,7 +137,7 @@ class TestSectionMissErrorDictIncludeContentTrue:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, section=_NONEXISTENT_FILTER))
+        resp = _call_view(selector="2521", summary=False, section=_NONEXISTENT_FILTER)
 
         # Assert
         assert "error" in resp, (
@@ -162,7 +160,7 @@ class TestSectionMissErrorDictIncludeContentTrue:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, section=_NONEXISTENT_FILTER))
+        resp = _call_view(selector="2521", summary=False, section=_NONEXISTENT_FILTER)
 
         # Assert — key present
         assert "valid_sections" in resp, (
@@ -195,7 +193,7 @@ class TestSectionMissErrorDictIncludeContentTrue:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, section=_NONEXISTENT_FILTER))
+        resp = _call_view(selector="2521", summary=False, section=_NONEXISTENT_FILTER)
 
         # Assert
         assert "body" not in resp, (
@@ -232,9 +230,7 @@ class TestSectionMissErrorDictCompactMode:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(
-            server.backlog_view(selector="2521", summary=False, include_content=False, section=_NONEXISTENT_FILTER)
-        )
+        resp = _call_view(selector="2521", summary=False, include_content=False, section=_NONEXISTENT_FILTER)
 
         # Assert
         assert "error" in resp, (
@@ -251,9 +247,7 @@ class TestSectionMissErrorDictCompactMode:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(
-            server.backlog_view(selector="2521", summary=False, include_content=False, section=_NONEXISTENT_FILTER)
-        )
+        resp = _call_view(selector="2521", summary=False, include_content=False, section=_NONEXISTENT_FILTER)
 
         # Assert
         assert "valid_sections" in resp, (
@@ -273,9 +267,7 @@ class TestSectionMissErrorDictCompactMode:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(
-            server.backlog_view(selector="2521", summary=False, include_content=False, section=_NONEXISTENT_FILTER)
-        )
+        resp = _call_view(selector="2521", summary=False, include_content=False, section=_NONEXISTENT_FILTER)
 
         # Assert
         assert "body" not in resp, (
@@ -309,7 +301,7 @@ class TestSectionsFilterPluralMissErrorDict:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, sections=[_NONEXISTENT_FILTER]))
+        resp = _call_view(selector="2521", summary=False, sections=[_NONEXISTENT_FILTER])
 
         # Assert
         assert "error" in resp, (
@@ -328,7 +320,7 @@ class TestSectionsFilterPluralMissErrorDict:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, sections=[_NONEXISTENT_FILTER]))
+        resp = _call_view(selector="2521", summary=False, sections=[_NONEXISTENT_FILTER])
 
         # Assert — key present
         assert "valid_sections" in resp, (
@@ -355,7 +347,7 @@ class TestSectionsFilterPluralMissErrorDict:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, sections=[_NONEXISTENT_FILTER]))
+        resp = _call_view(selector="2521", summary=False, sections=[_NONEXISTENT_FILTER])
 
         # Assert — 'body' must be absent (error dict has no content fields)
         assert "body" not in resp, (
@@ -394,7 +386,7 @@ class TestSectionMissErrorDictSuggestion:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, section=_NEAR_MISS_FILTER))
+        resp = _call_view(selector="2521", summary=False, section=_NEAR_MISS_FILTER)
 
         # Assert
         assert "suggestion" in resp, (
@@ -413,7 +405,7 @@ class TestSectionMissErrorDictSuggestion:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, section=_NEAR_MISS_FILTER))
+        resp = _call_view(selector="2521", summary=False, section=_NEAR_MISS_FILTER)
 
         # Assert — suggestion present
         assert "suggestion" in resp, f"'suggestion' key must be present for near-miss filter {_NEAR_MISS_FILTER!r}."
@@ -439,7 +431,7 @@ class TestSectionMissErrorDictSuggestion:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, sections=[_NEAR_MISS_FILTER]))
+        resp = _call_view(selector="2521", summary=False, sections=[_NEAR_MISS_FILTER])
 
         # Assert
         assert "suggestion" in resp, (
@@ -476,7 +468,7 @@ class TestSectionHitRegressionGuard:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, section=_VALID_SECTION))
+        resp = _call_view(selector="2521", summary=False, section=_VALID_SECTION)
 
         # Assert — no error
         assert "error" not in resp, (
@@ -503,7 +495,7 @@ class TestSectionHitRegressionGuard:
         _patch_issue_2521(mocker)
 
         # Act
-        resp = asyncio.run(server.backlog_view(selector="2521", summary=False, sections=[_VALID_SECTION]))
+        resp = _call_view(selector="2521", summary=False, sections=[_VALID_SECTION])
 
         # Assert — no error
         assert "error" not in resp, (
@@ -558,7 +550,7 @@ class TestSectionMissErrorDictUnresolvedSections:
         """
         _patch_github_body(mocker, issue_num=2974, body=_MISKEYED_BODY)
 
-        resp = asyncio.run(server.backlog_view(selector="2974", summary=False, section=_NONEXISTENT_FILTER))
+        resp = _call_view(selector="2974", summary=False, section=_NONEXISTENT_FILTER)
 
         assert "unresolved_sections" in resp, (
             f"Miss response must report 'unresolved_sections' when the item has a "
@@ -577,7 +569,7 @@ class TestSectionMissErrorDictUnresolvedSections:
         """
         _patch_github_body(mocker, issue_num=2974, body=_MISKEYED_BODY)
 
-        resp = asyncio.run(server.backlog_view(selector="2974", summary=False, sections=[_NONEXISTENT_FILTER]))
+        resp = _call_view(selector="2974", summary=False, sections=[_NONEXISTENT_FILTER])
 
         assert "unresolved_sections" in resp, (
             f"Plural miss response must report 'unresolved_sections' when the item has a "
@@ -597,7 +589,7 @@ class TestSectionMissErrorDictUnresolvedSections:
         """
         _patch_github_body(mocker, issue_num=2974, body=_CLEAN_BODY)
 
-        resp = asyncio.run(server.backlog_view(selector="2974", summary=False, section=_NONEXISTENT_FILTER))
+        resp = _call_view(selector="2974", summary=False, section=_NONEXISTENT_FILTER)
 
         assert "unresolved_sections" not in resp, (
             f"Miss response must NOT report 'unresolved_sections' when every section "

--- a/plugins/development-harness/backlog_core/tests/test_view_over_budget_gate.py
+++ b/plugins/development-harness/backlog_core/tests/test_view_over_budget_gate.py
@@ -17,15 +17,20 @@ Test naming: every test contains ``over_budget`` or ``numeric_section`` so
 
 from __future__ import annotations
 
-import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
 from backlog_core import operations
 from backlog_core.models import SectionEntryDict, ViewItemResult
 from backlog_core.operations import _apply_body_section_filter
-from backlog_core.tests._view_test_helpers import _HUGE_SINGLE, _OVER_BUDGET_BODY, _patch_github_body, _resp_body
+from backlog_core.tests._view_test_helpers import (
+    _HUGE_SINGLE,
+    _OVER_BUDGET_BODY,
+    _call_view,
+    _patch_github_body,
+    _resp_body,
+)
 from backlog_core.tests.conftest import REAL_CL100K_AVAILABLE
 
 if TYPE_CHECKING:
@@ -136,9 +141,8 @@ class TestOverBudgetGateHonoursNarrowing:
         delivered regardless of original item size.
         """
         _patch_github_body(mocker, 2495, _OVER_BUDGET_BODY)
-        from backlog_core import server
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False, section="RT-ICA"))
+        resp = _call_view(selector="2495", summary=False, section="RT-ICA")
 
         assert resp.get("_over_budget") is not True, (
             "A matched section narrows the body well under budget; backlog_view must NOT "
@@ -163,10 +167,9 @@ class TestOverBudgetGateHonoursNarrowing:
         RED: response is _over_budget with section_filter_miss=True.
         """
         _patch_github_body(mocker, 2495, _OVER_BUDGET_BODY)
-        from backlog_core import server
 
         # Index 2 of the body's headers is '## RT-ICA'
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False, section="2"))
+        resp = _call_view(selector="2495", summary=False, section="2")
 
         assert resp.get("section_filter_miss") is not True, (
             "section='2' (numeric index) must resolve to a real section on the raw body, "
@@ -197,9 +200,8 @@ class TestOverBudgetGateHonoursNarrowing:
         discarding the pagination the caller requested.
         """
         _patch_github_body(mocker, 2495, _MANY_SECTION_BODY)
-        from backlog_core import server
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False, offset=0, limit=2))
+        resp = _call_view(selector="2495", summary=False, offset=0, limit=2)
 
         assert resp.get("_over_budget") is not True, (
             "offset/limit pagination must be honoured on a large item; backlog_view must "
@@ -232,11 +234,8 @@ class TestOverBudgetGateHonoursNarrowing:
         returning metadata only.
         """
         _patch_github_body(mocker, 2495, _OVER_BUDGET_BODY)
-        from backlog_core import server
 
-        resp = asyncio.run(
-            server.backlog_view(selector="2495", summary=False, sections=["RT-ICA", "Issue Classification"])
-        )
+        resp = _call_view(selector="2495", summary=False, sections=["RT-ICA", "Issue Classification"])
 
         assert resp.get("_over_budget") is not True, (
             "sections=[...] narrows the payload to the named sections; backlog_view must "
@@ -278,7 +277,7 @@ class TestReviewRoundContract:
         _patch_github_body(mocker, 2495, _SINGLE_OVER_BUDGET_BODY)
         from backlog_core import server
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False, section="Huge"))
+        resp = _call_view(selector="2495", summary=False, section="Huge")
 
         assert resp.get("_over_budget") is True, (
             "section='Huge' narrows to a single slice that itself exceeds the "
@@ -351,9 +350,8 @@ class TestReviewRoundContract:
         invalid rather than reading silence as "item too big".
         """
         _patch_github_body(mocker, 2495, _OVER_BUDGET_BODY)
-        from backlog_core import server
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False, sections=["DOES-NOT-EXIST"]))
+        resp = _call_view(selector="2495", summary=False, sections=["DOES-NOT-EXIST"])
 
         assert resp.get("section_filter_miss") is True, (
             "sections=['DOES-NOT-EXIST'] matched no structured section and no body header; "
@@ -385,11 +383,10 @@ class TestEmptySectionsListBehavesLikeNone:
             "## Impact Radius\n\nimpact body\n"
         )
         _patch_github_body(mocker, 2495, SYNC_BODY)
-        from backlog_core import server
 
-        resp_empty = asyncio.run(server.backlog_view(selector="2495", summary=False, sections=[]))
+        resp_empty = _call_view(selector="2495", summary=False, sections=[])
         _patch_github_body(mocker, 2495, SYNC_BODY)
-        resp_none = asyncio.run(server.backlog_view(selector="2495", summary=False, sections=None))
+        resp_none = _call_view(selector="2495", summary=False, sections=None)
 
         assert resp_empty.get("section_filter_miss") is not True, (
             "sections=[] must not report a miss — it is equivalent to no filter. Finding #6."
@@ -397,7 +394,9 @@ class TestEmptySectionsListBehavesLikeNone:
         assert resp_empty.get("body") == resp_none.get("body"), (
             "sections=[] must return the same body as sections=None (no narrowing applied)."
         )
-        assert sorted(resp_empty.get("sections", {})) == sorted(resp_none.get("sections", {})), (
+        sections_empty = cast("dict[str, object]", resp_empty.get("sections", {}))
+        sections_none = cast("dict[str, object]", resp_none.get("sections", {}))
+        assert sorted(sections_empty) == sorted(sections_none), (
             "sections=[] must leave the sections dict identical to sections=None — it must not empty it."
         )
 
@@ -430,7 +429,7 @@ class TestUnboundedOverBudgetStillReturnsDirectory:
         )
         _patch_github_body(mocker, 2495, _GENUINELY_OVER_BUDGET_BODY)
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False))
+        resp = _call_view(selector="2495", summary=False)
 
         assert resp.get("_over_budget") is True, (
             "an unbounded genuinely-over-budget default call (no section/sections/offset/limit) must "
@@ -471,7 +470,7 @@ class TestUnboundedOverBudgetStillReturnsDirectory:
             "heuristic/token divergence boundary (a header would duplicate the run into the sections dict)."
         )
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False))
+        resp = _call_view(selector="2495", summary=False)
 
         assert resp.get("_over_budget") is not True, (
             "a large-but-compressible body (>16000 chars but <= token budget) must be delivered INLINE — "
@@ -550,7 +549,7 @@ class TestOverBudgetMeasurementCountsClearedBodySoleContent:
 
         mocker.patch.object(server.operations, "view_item", side_effect=lambda **_kwargs: _drift_view_result())
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False, sections=["RT-ICA"]))
+        resp = _call_view(selector="2495", summary=False, sections=["RT-ICA"])
 
         assert resp.get("_over_budget") is True, (
             "the drift payload (body cleared, sole section copy over budget) must return the compact "

--- a/plugins/development-harness/backlog_core/tests/test_view_pagination_section_index.py
+++ b/plugins/development-harness/backlog_core/tests/test_view_pagination_section_index.py
@@ -18,13 +18,12 @@ Test naming: every test contains ``over_budget`` or ``numeric_section`` so
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
 
 from backlog_core import operations
-from backlog_core.tests._view_test_helpers import _patch_github_body, _resp_body
+from backlog_core.tests._view_test_helpers import _call_view, _patch_github_body, _resp_body
 from backlog_core.tests.conftest import REAL_CL100K_AVAILABLE
 
 if TYPE_CHECKING:
@@ -133,7 +132,7 @@ class TestOverBudgetMeasurementExcludesDuplicatedContent:
         )
 
         _patch_github_body(mocker, 2495, body)
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False))
+        resp = _call_view(selector="2495", summary=False)
 
         assert resp.get("_over_budget") is not True, (
             "a ``## ``-headed body comfortably under budget on its own must be delivered INLINE; the "
@@ -418,7 +417,7 @@ class TestPagedSectionNoneIndexDoesNotTripOverBudget:
         )
 
         _patch_github_body(mocker, 2495, body)
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False, limit=2))
+        resp = _call_view(selector="2495", summary=False, limit=2)
 
         assert resp.get("_over_budget") is not True, (
             "an explicit paged request (limit=2) must be delivered inline; backlog_view must NOT prepend "
@@ -453,12 +452,10 @@ class TestPagedSectionNoneIndexDoesNotTripOverBudget:
         Companion offset>0 case: the page lands deeper in the body and must still be
         delivered inline (not displaced by the unbounded whole-item index).
         """
-        from backlog_core import server
-
         body = _many_heading_body(400)
         _patch_github_body(mocker, 2495, body)
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False, offset=4, limit=2))
+        resp = _call_view(selector="2495", summary=False, offset=4, limit=2)
 
         assert resp.get("_over_budget") is not True, (
             "an explicit paged request with offset>0 must be delivered inline, not replaced by the "
@@ -477,13 +474,11 @@ class TestPagedSectionNoneIndexDoesNotTripOverBudget:
         (well under budget) must still receive the prepended index so agents can
         discover available sections — the M1 behaviour (e6191da) is preserved.
         """
-        from backlog_core import server
-
         # Small body so the unpaged response stays under budget and is delivered inline.
         small_body = "## Alpha\n\naaa\n\n## Beta\n\nbbb\n\n## Gamma\n\nggg\n"
         _patch_github_body(mocker, 2495, small_body)
 
-        resp = asyncio.run(server.backlog_view(selector="2495", summary=False))
+        resp = _call_view(selector="2495", summary=False)
 
         assert resp.get("_over_budget") is not True, "premise: the small unpaged body must be delivered inline."
         body_out = _resp_body(resp)

--- a/plugins/development-harness/backlog_core/tests/test_view_sections_metadata_sync.py
+++ b/plugins/development-harness/backlog_core/tests/test_view_sections_metadata_sync.py
@@ -18,7 +18,6 @@ Test naming: every test contains ``over_budget`` or ``numeric_section`` so
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
@@ -27,7 +26,7 @@ from backlog_core import operations
 from backlog_core.models import ViewItemResult
 from backlog_core.operations import _apply_body_section_filter
 from backlog_core.parsing import split_body_sections
-from backlog_core.tests._view_test_helpers import _patch_github_body, _resp_metadata
+from backlog_core.tests._view_test_helpers import _call_view, _patch_github_body, _resp_metadata
 from backlog_core.tests.conftest import REAL_CL100K_AVAILABLE
 
 if TYPE_CHECKING:
@@ -301,11 +300,8 @@ class TestCompactValidNamesNotReportedAsMiss:
         a valid name was wrongly reported as section_filter_miss.
         """
         _patch_github_body(mocker, 2495, _SYNC_BODY)
-        from backlog_core import server
 
-        resp = asyncio.run(
-            server.backlog_view(selector="2495", summary=False, include_content=False, sections=["RT-ICA"])
-        )
+        resp = _call_view(selector="2495", summary=False, include_content=False, sections=["RT-ICA"])
 
         assert resp.get("section_filter_miss") is not True, (
             "a VALID section name in compact mode must NOT report section_filter_miss. "
@@ -321,11 +317,8 @@ class TestCompactValidNamesNotReportedAsMiss:
     def test_compact_invalid_section_name_reports_miss(self, mocker: MockerFixture) -> None:
         """An INVALID name in compact mode still reports a miss (no false negative)."""
         _patch_github_body(mocker, 2495, _SYNC_BODY)
-        from backlog_core import server
 
-        resp = asyncio.run(
-            server.backlog_view(selector="2495", summary=False, include_content=False, sections=["DOES-NOT-EXIST"])
-        )
+        resp = _call_view(selector="2495", summary=False, include_content=False, sections=["DOES-NOT-EXIST"])
 
         assert resp.get("section_filter_miss") is True, (
             "an invalid name in compact mode must still report section_filter_miss so the miss "

--- a/plugins/development-harness/backlog_core/tool_responses.py
+++ b/plugins/development-harness/backlog_core/tool_responses.py
@@ -899,7 +899,11 @@ class BacklogViewResponse(BaseModel):
     hint: str | None = Field(default=None, alias="_hint")
 
     # --- over-budget view ---
-    over_budget_flag: bool | None = Field(default=None, alias="_over_budget")
+    # Distinct from map mode's `over_budget` field below: this one carries
+    # the wire key `_over_budget` (directory-view mode); that one carries
+    # the wire key `over_budget` (map mode). Named apart, not just by a
+    # `_flag` suffix, so the two are not mistaken for each other.
+    directory_over_budget: bool | None = Field(default=None, alias="_over_budget")
     usage: str | None = Field(default=None, alias="_usage")
 
     # --- map mode ---

--- a/plugins/development-harness/backlog_core/tool_responses.py
+++ b/plugins/development-harness/backlog_core/tool_responses.py
@@ -846,15 +846,19 @@ class BacklogUpdateSamTaskStatusResponse(FallibleToolResponse):
 # section models -- measured cost: 1,904 tokens flattened vs. 2,636 with the
 # real models, against a 700-token-per-tool budget already overridden once
 # for this tool (see test_tool_output_schemas.py's _PER_TOOL_SCHEMA_OVERRIDES).
-# ponytail: nested section models flattened to fit the schema budget; restore
-# them (import SectionEntryMetadata/GroomedSectionMetadata/SectionMeta from
-# .models) if the per-tool cap is ever raised past ~2,600.
+# Deliberate simplification: nested section models flattened to
+# dict[str, object] to fit the schema budget, rather than reusing
+# ViewItemResult's real SectionEntryMetadata/GroomedSectionMetadata/
+# SectionMeta models (import them from .models to restore full fidelity
+# if the per-tool cap is ever raised past ~2,600).
 #
 # Five fields carry a leading underscore on the wire (`_summary`,
-# `_full_chars`, `_hint`, `_over_budget`, `_usage`) -- not valid Python
-# identifiers, so each is declared under a plain field name with an `alias`,
-# and `serialize_by_alias=True` makes `model_dump(exclude_none=True)` (the
-# call pattern every tool uses, with no explicit `by_alias=True`) emit the
+# `_full_chars`, `_hint`, `_over_budget`, `_usage`). A leading underscore is
+# a valid Python identifier, but Pydantic treats such a field name as a
+# private attribute rather than a model field by default, so each is
+# declared under a plain field name with an `alias` instead, and
+# `serialize_by_alias=True` makes `model_dump(exclude_none=True)` (the call
+# pattern every tool uses, with no explicit `by_alias=True`) emit the
 # underscored key. `populate_by_name=True` lets `model_validate()` accept
 # either spelling.
 class BacklogViewResponse(BaseModel):

--- a/plugins/development-harness/backlog_core/tool_responses.py
+++ b/plugins/development-harness/backlog_core/tool_responses.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 from typing import Literal
 
 from dispatch_schema import ConflictGroup
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from .models import DispatchSpawnSummary, DispatchWaveSummary, Output, RegisterResult
 
@@ -78,6 +78,7 @@ __all__ = [
     "BacklogSyncResponse",
     "BacklogUpdateResponse",
     "BacklogUpdateSamTaskStatusResponse",
+    "BacklogViewResponse",
     "CommentEntry",
     "DispatchConflictsResponse",
     "DispatchCreatePlanResponse",
@@ -830,6 +831,105 @@ class BacklogUpdateSamTaskStatusResponse(FallibleToolResponse):
 
     new_status: str | None = None
     """Status value that was applied, echoed back from the request."""
+
+
+# backlog_view is the one deliberately multi-mode tool (#3368): one flat,
+# all-Optional model covers all seven response shapes -- map, navigate,
+# extract, compact summary manifest, over-budget view, full detail, and the
+# four error arms -- rather than a `ModelA | ModelB` return-type union, which
+# FastMCP's schema introspection does not recognise (silently wraps the
+# result under x-fastmcp-wrap-result, a wire-protocol regression). Every
+# field is optional because no single call path populates them all.
+#
+# `sections`/`sections_metadata` are flattened to `dict[str, object]` /
+# `list[dict[str, object]]` rather than reusing ViewItemResult's real nested
+# section models -- measured cost: 1,904 tokens flattened vs. 2,636 with the
+# real models, against a 700-token-per-tool budget already overridden once
+# for this tool (see test_tool_output_schemas.py's _PER_TOOL_SCHEMA_OVERRIDES).
+# ponytail: nested section models flattened to fit the schema budget; restore
+# them (import SectionEntryMetadata/GroomedSectionMetadata/SectionMeta from
+# .models) if the per-tool cap is ever raised past ~2,600.
+#
+# Five fields carry a leading underscore on the wire (`_summary`,
+# `_full_chars`, `_hint`, `_over_budget`, `_usage`) -- not valid Python
+# identifiers, so each is declared under a plain field name with an `alias`,
+# and `serialize_by_alias=True` makes `model_dump(exclude_none=True)` (the
+# call pattern every tool uses, with no explicit `by_alias=True`) emit the
+# underscored key. `populate_by_name=True` lets `model_validate()` accept
+# either spelling.
+class BacklogViewResponse(BaseModel):
+    """Response for ``backlog_view`` -- covers all seven of its disclosure-mode shapes."""
+
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
+    # --- full detail (mirrors ViewItemResult; see .models) ---
+    title: str | None = None
+    priority: str | None = None
+    description: str | None = None
+    source: str | None = None
+    added: str | None = None
+    plan: str | None = None
+    issue: str | None = None
+    file_path: str | None = None
+    groomed: str | None = None
+    status: str | None = None
+    number: int | None = None
+    state: str | None = None
+    body: str | None = None
+    labels: list[str] | None = None
+    milestone: str | None = None
+    sections: dict[str, object] | None = None
+    sections_metadata: list[dict[str, object]] | None = None
+    sections_index: str | None = None
+    body_truncated: bool | None = None
+    body_remaining_entries: int | None = None
+    body_total_entries: int | None = None
+    body_remaining_lines: int | None = None
+    body_total_lines: int | None = None
+    section_filter_miss: bool | None = None
+    messages: list[str] | None = None
+    warnings: list[str] | None = None
+    errors: list[str] | None = None
+
+    # --- compact summary manifest ---
+    issue_number: int | None = None
+    plan_address: str | None = None
+    summary_flag: bool | None = Field(default=None, alias="_summary")
+    full_chars: int | None = Field(default=None, alias="_full_chars")
+    hint: str | None = Field(default=None, alias="_hint")
+
+    # --- over-budget view ---
+    over_budget_flag: bool | None = Field(default=None, alias="_over_budget")
+    usage: str | None = Field(default=None, alias="_usage")
+
+    # --- map mode ---
+    selector: str | None = None
+    total_sections: int | None = None
+    total_est_tokens: int | None = None
+    map_text: str | None = None
+    over_budget: bool | None = None
+    struck_ordinals: list[str] | None = None
+
+    # --- navigate / extract modes ---
+    ordinal: str | None = None
+    content: str | None = None
+    total_tokens: int | None = None
+    returned_tokens: int | None = None
+    truncated: bool | None = None
+    next_call: str | None = None
+    child_map: str | None = None
+    has_children: bool | None = None
+    struck: bool | None = None
+    entry_id: str | None = None
+
+    # --- error arms ---
+    error: str | None = None
+    invalid_params: dict[str, object] | None = None
+    requested_ordinal: str | None = None
+    valid_ordinals: list[str] | None = None
+    valid_sections: list[str] | None = None
+    unresolved_sections: list[str] | None = None
+    suggestion: str | None = None
 
 
 # Shared error-arm shape for dispatch_* tools keyed by a GitHub milestone

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -15,7 +15,7 @@ from backlog_core.github_sync import merge_item, parse_issue_body, render_issue_
 from backlog_core.models import BacklogItem, Entry, GroomedData, Section
 from backlog_core.operations import _normalize_section_key
 from backlog_core.parsing import extract_sections
-from hypothesis import HealthCheck, given, settings, strategies as st
+from hypothesis import HealthCheck, example, given, settings, strategies as st
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1115,6 +1115,10 @@ class TestSectionRoundTripProperty:
 
     @given(section_name=_section_name_strategy, content=_content_strategy)
     @settings(max_examples=200, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    # #3370 regression pin: ":EFFORT" -> "unknown__effort" -> heading "Effort"
+    # -> re-resolves to canonical "effort" on reparse, duplicating the key.
+    # Hypothesis doesn't reliably draw this case on its own; pin it explicitly.
+    @example(section_name=":EFFORT", content="## Fake Heading Inside Content")
     def test_write_render_parse_round_trip_is_lossless(self, section_name: str, content: str) -> None:
         """A section written locally survives a GitHub render -> parse -> merge cycle intact.
 

--- a/plugins/development-harness/tests/test_tool_output_schemas.py
+++ b/plugins/development-harness/tests/test_tool_output_schemas.py
@@ -1,9 +1,7 @@
 """Asserts every backlog_core MCP tool advertises a real output schema, not
 an unconstrained object. See plugins/development-harness/backlog_core/tool_responses.py.
 
-TOOLS_NOT_YET_TYPED tracks tools whose return-type annotation hasn't been
-migrated to a Pydantic model yet -- shrinks across the rollout's commits.
-Once empty, delete this set and the skip branch below.
+All 43 tools are typed as of #3368 (backlog_view, the last holdout).
 """
 
 from __future__ import annotations
@@ -39,16 +37,19 @@ EXCLUDED_TOOLS = {"profile_list", "profile_load"}  # different ownership, out of
 # sam_plan's per-tool cost.
 _MAX_TOTAL_SCHEMA_TOKENS = 13000
 _MAX_SINGLE_TOOL_SCHEMA_TOKENS = 700
+
+# backlog_view (#3368) is the deliberate multi-mode outlier: one tool
+# advertising seven response shapes (map/navigate/extract/summary/
+# over-budget/full-detail/error) behind a single flat, all-Optional model --
+# see BacklogViewResponse in tool_responses.py. Measured at 1,904 tokens.
+# Held to its own explicit ceiling so the 700-token cap keeps its teeth for
+# the other 42 tools rather than being raised 3x for all of them.
+_PER_TOOL_SCHEMA_OVERRIDES = {"backlog_view": 2000}
 _ENCODING = tiktoken.get_encoding("cl100k_base")
 
 
 def _schema_tokens(schema: dict[str, object]) -> int:
     return len(_ENCODING.encode(json.dumps(schema, sort_keys=True)))
-
-
-TOOLS_NOT_YET_TYPED = {
-    "backlog_view"  # deferred to commit 4/4 -- deliberately complex disclosure-mode shape
-}
 
 
 async def _tool_schemas() -> dict[str, dict[str, object]]:
@@ -59,25 +60,21 @@ async def _tool_schemas() -> dict[str, dict[str, object]]:
 async def test_all_typed_tools_advertise_a_real_output_schema() -> None:
     schemas = await _tool_schemas()
     for name, schema in schemas.items():
-        if name in TOOLS_NOT_YET_TYPED:
-            continue
         assert schema.get("properties"), f"{name}: no properties in output schema"
         assert schema.get("additionalProperties") is not True, f"{name}: still unconstrained object"
         assert "x-fastmcp-wrap-result" not in schema, f"{name}: Union return type wrapped the result -- wire regression"
-
-
-async def test_every_registered_tool_is_accounted_for() -> None:
-    # Catches a renamed/added/removed tool falling through the cracks of TOOLS_NOT_YET_TYPED.
-    schemas = await _tool_schemas()
-    assert set(schemas) >= TOOLS_NOT_YET_TYPED, "TOOLS_NOT_YET_TYPED references a tool that no longer exists"
 
 
 async def test_output_schemas_stay_within_token_budget() -> None:
     schemas = await _tool_schemas()
     per_tool = {name: _schema_tokens(schema) for name, schema in schemas.items()}
     total = sum(per_tool.values())
-    over_budget = {name: n for name, n in per_tool.items() if n > _MAX_SINGLE_TOOL_SCHEMA_TOKENS}
-    assert not over_budget, f"Tool(s) exceed {_MAX_SINGLE_TOOL_SCHEMA_TOKENS}-token schema budget: {over_budget}"
+    over_budget = {
+        name: n
+        for name, n in per_tool.items()
+        if n > _PER_TOOL_SCHEMA_OVERRIDES.get(name, _MAX_SINGLE_TOOL_SCHEMA_TOKENS)
+    }
+    assert not over_budget, f"Tool(s) exceed their per-tool schema budget: {over_budget}"
     assert total <= _MAX_TOTAL_SCHEMA_TOKENS, (
         f"Total outputSchema tokens across all tools ({total}) exceeds budget of {_MAX_TOTAL_SCHEMA_TOKENS}"
     )


### PR DESCRIPTION
## Summary
- **#3370** — `heading_to_unknown_key()` folds an unregistered name whose reconstructed heading is itself registered (e.g. `:EFFORT` -> `unknown__effort` -> heading "Effort" -> canonical `effort`), closing a two-keys-for-one-section data-loss path (#2956's bug class). Pinned with a deterministic hypothesis `@example`.
- **#3368** — `backlog_view` gets a real Pydantic `outputSchema` (`BacklogViewResponse`, one flat all-Optional model covering its seven response shapes) instead of an unconstrained `dict`, with a per-tool schema-budget override since it doesn't fit the standard 700-token cap.
- **#3369** — extracts `_respond()`, a shared helper replacing ~76 near-identical `Cls.model_validate(...).model_dump(...)` call sites in `server.py`. `sync_status`/`sync_now` and the milestone/issue validate-then-patch sites are intentionally left untouched.

#3368 and #3369 landed in one commit: the `_respond()` sweep rewrites the same `backlog_view` call sites #3368 introduces.

## Test plan
- [x] `test_write_render_parse_round_trip_is_lossless` passes with the new `@example(":EFFORT", ...)` pin
- [x] `test_tool_output_schemas.py` passes; measured total schema tokens 12,215/13,000
- [x] Full `plugins/development-harness` suite: 5,464 passed, 0 failed
- [x] `ruff check` / `ty check` clean across the plugin (verified independently by three `linting-root-cause-resolver` agents)

Closes #3370
Closes #3368
Closes #3369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJKcsaFtUM5PcPFh9cy1aw
