### PR TITLE
fix(receiving-pr-reviews): upstream 4 fixes from skill-lapidary's vendored copy

### DIFF
--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -117,8 +117,8 @@ _GH = shutil.which("gh") or "gh"
 # cover a whole `gh api --paginate` run — every page requested sequentially inside one subprocess —
 # on an arbitrarily large PR over an arbitrarily slow link, and `build_fetch_result` now makes
 # seven such calls per snapshot rather than the two it made when the old 30-second cap was written.
-# This repository has no source for that number (CLAUDE.md, "No invented constraints"), so `fetch`
-# and `watch` expose `--gh-timeout-seconds` instead, unbounded by default, and `watch` additionally
+# This repository has no source for that number, so `fetch` and `watch` expose
+# `--gh-timeout-seconds` instead, unbounded by default, and `watch` additionally
 # bounds each *poll* by its own `--timeout-seconds` deadline, which the caller chose.
 
 _ISSUE_COMMENT_ADAPTER: TypeAdapter[list[IssueComment]] = TypeAdapter(list[IssueComment])
@@ -191,7 +191,7 @@ def detect_repo_identity(*, gh_timeout: float | None = None) -> tuple[str, str]:
     Relies entirely on `gh`'s own remote resolution (the same one `gh pr view`, `gh pr comment`
     etc. use for this checkout) -- this function adds no guessing of its own. A wrong owner/repo
     would send a reply to the wrong repository, so a caller unable to detect must stop rather than
-    fall back to a default (CLAUDE.md, "No invented constraints").
+    fall back to a default.
 
     Args:
         gh_timeout: Seconds to bound the `gh` call to, or `None` for no bound -- see `run_gh`.

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -107,8 +107,7 @@ def _owner_repo(github: str | None, *, gh_timeout: float | None) -> tuple[str, s
 
     Detection relies entirely on `gh repo view`'s own remote resolution for this checkout -- see
     `pr_review_gh.detect_repo_identity`. A wrong owner/repo would send a reply to the wrong
-    repository, so a failed detection stops the command rather than falling back to a guess
-    (CLAUDE.md, "No invented constraints").
+    repository, so a failed detection stops the command rather than falling back to a guess.
 
     Args:
         github: The `--github` value, already format-validated by `_validate_github_option`, or
@@ -120,15 +119,15 @@ def _owner_repo(github: str | None, *, gh_timeout: float | None) -> tuple[str, s
 
     Raises:
         typer.Exit: Autodetection was attempted (no `--github` given) and failed -- `gh` is
-            missing, unauthenticated, or this checkout has no GitHub remote `gh` recognizes.
-            Exits with code 1; nothing else is printed to stdout.
+            missing, unauthenticated, timed out, or this checkout has no GitHub remote `gh`
+            recognizes. Exits with code 1; nothing else is printed to stdout.
     """
     if github is not None:
         owner, repo = github.split("/", 1)
         return owner, repo
     try:
         return detect_repo_identity(gh_timeout=gh_timeout)
-    except (FileNotFoundError, subprocess.CalledProcessError, ValidationError) as exc:
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired, ValidationError) as exc:
         typer.echo(
             f"Could not detect this checkout's GitHub repository via `gh repo view` ({exc}). "
             "Pass --github owner/repo to specify it explicitly.",
@@ -468,9 +467,9 @@ def watch(
     it and stops once less than that remains — the point past which `gh_timeout_budget` would
     starve the call to nothing anyway. No fixed safety margin is reserved: this repository has no
     source for how long seven sequential `gh api` round trips take, and inventing one would be a
-    guess (CLAUDE.md, "No invented constraints"). The final sub-interval stretch of a window is
-    therefore left unpolled by design — the next `watch` call's own first fetch covers it, which is
-    exactly why the loop pattern above is documented as back-to-back calls.
+    guess. The final sub-interval stretch of a window is therefore left unpolled by design — the
+    next `watch` call's own first fetch covers it, which is exactly why the loop pattern above is
+    documented as back-to-back calls.
 
     Exits non-zero, with nothing printed to stdout, if the *last* re-poll attempted this window
     failed (a transient `gh` failure — see the exception handling inside the loop). An earlier
@@ -523,11 +522,13 @@ def watch(
             # the clock it is a real network stall and leaves the tail unconfirmed.
             last_poll_ok = time.monotonic() >= deadline
             continue
-        except subprocess.CalledProcessError:
-            # A non-zero exit is an authentication, rate-limit, API or GraphQL error. The deadline
-            # cannot cause it and cannot excuse it, so it is a failed poll whatever the clock says
-            # — reporting `timed_out: true` off stale state here would tell a caller the PR is
-            # clean when nothing was actually checked.
+        except (subprocess.CalledProcessError, ValidationError):
+            # A non-zero exit is an authentication, rate-limit, API or GraphQL error; a
+            # `ValidationError` is `build_fetch_result`'s own `.model_validate()` rejecting a
+            # malformed or unexpected response shape. Neither is something the deadline caused or
+            # excuses, so it is a failed poll whatever the clock says — reporting `timed_out: true`
+            # off stale state here would tell a caller the PR is clean when nothing was actually
+            # checked.
             last_poll_ok = False
             continue
     if poll_attempts and not last_poll_ok:

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -196,6 +196,15 @@ def _state(
     )
 
 
+def _validation_error() -> ValidationError:
+    """A real `ValidationError` instance, for use as a mock `side_effect`."""
+    try:
+        pr_review_models.GitHubCommitDate.model_validate({"committedDate": "not-a-timestamp"})
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("expected ValidationError")
+
+
 def _reviews_conn(nodes: list[ReviewNode]) -> pr_review_gh.ReviewsConnection:
     return pr_review_gh.ReviewsConnection(totalCount=len(nodes), nodes=nodes)
 
@@ -1026,13 +1035,22 @@ def test_fetch_uses_detected_github_when_not_overridden(mocker: MockerFixture) -
     assert fetch_mock.call_args.args[:2] == ("detected-owner", "detected-repo")
 
 
-def test_fetch_exits_nonzero_and_names_github_flag_when_detection_fails(mocker: MockerFixture) -> None:
+@pytest.mark.parametrize(
+    "detection_error",
+    [subprocess.CalledProcessError(1, ["gh"]), subprocess.TimeoutExpired(cmd=["gh"], timeout=30)],
+    ids=["called-process-error", "timeout-expired"],
+)
+def test_fetch_exits_nonzero_and_names_github_flag_when_detection_fails(
+    detection_error: Exception, mocker: MockerFixture
+) -> None:
     """When autodetection fails, `fetch` exits non-zero and names `--github` as the way out.
 
     A wrong owner/repo would send a reply to the wrong repository, so a failed detection must stop
-    the command rather than fall back to a guess.
+    the command rather than fall back to a guess. Regression coverage for `TimeoutExpired`: a
+    `--gh-timeout-seconds`-bounded `gh repo view` call that exceeds it must produce this same clean
+    exit rather than an unhandled exception.
     """
-    mocker.patch.object(pr_review_threads, "detect_repo_identity", side_effect=subprocess.CalledProcessError(1, ["gh"]))
+    mocker.patch.object(pr_review_threads, "detect_repo_identity", side_effect=detection_error)
     fetch_mock = mocker.patch.object(pr_review_threads, "build_fetch_result")
 
     result = runner.invoke(app, ["fetch", "--pr", "3208"])
@@ -1279,6 +1297,42 @@ def test_watch_survives_transient_gh_failure_mid_window(mocker: MockerFixture) -
     data = json.loads(result.output)
     assert data["timed_out"] is False
     assert data["state"]["unresolved_count"] == 1
+
+
+def test_watch_survives_a_validation_error_mid_window(mocker: MockerFixture) -> None:
+    """A malformed `gh` API response mid-window (`build_fetch_result`'s own `.model_validate()`
+    rejecting it) does not crash `watch` — it counts as no fresh data for that one poll, the same
+    as a `CalledProcessError`, and the loop continues toward `deadline` on its own schedule.
+    """
+    mocker.patch.object(
+        pr_review_threads, "build_fetch_result", side_effect=[_state(), _validation_error(), _state(unresolved_count=1)]
+    )
+    mocker.patch.object(pr_review_threads.time, "sleep")
+
+    result = runner.invoke(app, ["watch", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "40"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["timed_out"] is False
+    assert data["state"]["unresolved_count"] == 1
+
+
+def test_watch_fails_loudly_on_a_validation_error_at_the_deadline(mocker: MockerFixture) -> None:
+    """A `ValidationError` from the last poll of a window is a failed poll, the same as a
+    non-zero `gh` exit — it is not explained or excused by the deadline, so reporting
+    `timed_out: true` off stale state here would tell a caller the PR is clean when the last check
+    actually raised.
+    """
+    mocker.patch.object(pr_review_threads, "build_fetch_result", side_effect=[_state(), _validation_error()])
+    mocker.patch.object(pr_review_threads.time, "sleep")
+    mocker.patch.object(pr_review_threads.time, "monotonic", side_effect=[0.0, 0.0, 100.0, 100.0])
+
+    result = runner.invoke(app, ["watch", "--pr", "3208", "--interval-seconds", "10", "--timeout-seconds", "100"])
+
+    assert result.exit_code != 0
+    assert "the last of 1 poll(s) this window failed" in result.output
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)
 
 
 def test_watch_fails_loudly_when_every_poll_fails(mocker: MockerFixture) -> None:

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -1030,8 +1030,7 @@ def test_fetch_exits_nonzero_and_names_github_flag_when_detection_fails(mocker: 
     """When autodetection fails, `fetch` exits non-zero and names `--github` as the way out.
 
     A wrong owner/repo would send a reply to the wrong repository, so a failed detection must stop
-    the command rather than fall back to a guess (CLAUDE.md, "No invented constraints" — the same
-    principle rules out silently guessing an identity here).
+    the command rather than fall back to a guess.
     """
     mocker.patch.object(pr_review_threads, "detect_repo_identity", side_effect=subprocess.CalledProcessError(1, ["gh"]))
     fetch_mock = mocker.patch.object(pr_review_threads, "build_fetch_result")


### PR DESCRIPTION
## Summary
- Removes a fabricated `(CLAUDE.md, "No invented constraints")` citation from 4 sites — that phrase doesn't exist in this repo's CLAUDE.md, so the underlying rationale is kept without the false citation.
- `_owner_repo`'s except clause now also catches `subprocess.TimeoutExpired`, matching `detect_repo_identity`'s documented behavior.
- `watch`'s poll-loop except clause now also catches `pydantic.ValidationError` (alongside `CalledProcessError`), since `build_fetch_result`'s `.model_validate()` calls can raise it on a malformed API response.

These fixes originated from a `/code-review` pass on skill-lapidary's vendored copy of this skill (commit 6872790 there) and are being upstreamed to the canonical source per a cross-session flag.

## Test plan
- [x] `uv run python -m pytest .agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py -q` — 101 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mus6t1NZkzsV65K5mZDJEs