### PR TITLE
feat(receiving-pr-reviews): add reply-and-resolve and batch commands

### DIFF
--- a/.agents/skills/receiving-pr-reviews/SKILL.md
+++ b/.agents/skills/receiving-pr-reviews/SKILL.md
@@ -29,6 +29,17 @@ description: Work through every unresolved review thread on a PR to completion �
    ```bash
    uv run ./.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py resolve --thread-id <id>
    ```
+
+   Steps 4 and 5 combined — one thread or many in one process:
+
+   ```bash
+   uv run ./.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py reply-and-resolve \
+     --pr <N> --thread-id <id> --comment-id <databaseId> --body '...'
+   uv run ./.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py reply-and-resolve-batch \
+     --pr <N> --input-file threads.json   # [{thread_id, comment_id, body}, ...]
+   ```
+
+   The batch form stops at the first failure and prints one JSON line per thread.
 6. A decision spanning threads (PR sequencing, rebase disposition), or a response to a `reviews_with_body`/`unresponded_reviews` entry, goes on the PR itself via `gh pr comment <N> -R <owner>/<repo>` — the same owner/repo this run used in step 1 — before the work it governs. When answering a specific entry, quote that review's own `url` field from step 1's output in the comment body. That quoted `url`, postdating the review, is what clears the review out of `unresponded_reviews` on the next check; chronological order alone does not.
 7. Once all current threads and reviews are addressed, re-check with `watch`, looping short calls rather than one long block:
 

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -31,8 +31,10 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import subprocess
 import time
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -585,6 +587,74 @@ def resolve(
         timeout=gh_timeout_seconds,
     )
     typer.echo(raw.strip())
+
+
+@app.command(name="reply-and-resolve")
+def reply_and_resolve(
+    pr: Annotated[int, typer.Option(help="Pull request number.")],
+    thread_id: Annotated[str, typer.Option(help="Review thread id, from `fetch`.")],
+    comment_id: Annotated[int, typer.Option(help="Review comment databaseId of the thread's FIRST comment.")],
+    body: Annotated[str, typer.Option(help="Reply text.")],
+    github: GithubOption = None,
+    gh_timeout_seconds: Annotated[
+        float | None, typer.Option(min=0, help="Seconds to bound each `gh` call to. Unbounded by default.")
+    ] = None,
+) -> None:
+    """Reply to a thread then resolve it in one call.
+
+    Prints two compact JSON lines: the created-comment response, then the
+    resolve mutation response. The resolve runs only if the reply succeeded.
+    """
+    owner, repo = _owner_repo(github, gh_timeout=gh_timeout_seconds)
+    reply_raw = run_gh(
+        ["api", "-X", "POST", f"repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies", "-f", f"body={body}"],
+        timeout=gh_timeout_seconds,
+    )
+    typer.echo(reply_raw.strip())
+    resolve_raw = run_gh(
+        ["api", "graphql", "-f", f"query={RESOLVE_THREAD_MUTATION}", "-f", f"threadId={thread_id}"],
+        timeout=gh_timeout_seconds,
+    )
+    typer.echo(resolve_raw.strip())
+
+
+@app.command(name="reply-and-resolve-batch")
+def reply_and_resolve_batch(
+    pr: Annotated[int, typer.Option(help="Pull request number.")],
+    input_file: Annotated[
+        Path, typer.Option(help="JSON file: array of {thread_id, comment_id, body} objects, one per thread.")
+    ],
+    github: GithubOption = None,
+    gh_timeout_seconds: Annotated[
+        float | None, typer.Option(min=0, help="Seconds to bound each `gh` call to. Unbounded by default.")
+    ] = None,
+) -> None:
+    """Reply to and resolve many threads on one PR in a single process.
+
+    Stops at the first failure. Prints one compact JSON line per thread:
+    {thread_id, replied, resolved}.
+    """
+    entries = json.loads(input_file.read_text())
+    owner, repo = _owner_repo(github, gh_timeout=gh_timeout_seconds)
+    for entry in entries:
+        reply_raw = run_gh(
+            [
+                "api",
+                "-X",
+                "POST",
+                f"repos/{owner}/{repo}/pulls/{pr}/comments/{entry['comment_id']}/replies",
+                "-f",
+                f"body={entry['body']}",
+            ],
+            timeout=gh_timeout_seconds,
+        )
+        resolve_raw = run_gh(
+            ["api", "graphql", "-f", f"query={RESOLVE_THREAD_MUTATION}", "-f", f"threadId={entry['thread_id']}"],
+            timeout=gh_timeout_seconds,
+        )
+        replied = json.loads(reply_raw).get("id") is not None
+        resolved = "errors" not in json.loads(resolve_raw)
+        typer.echo(json.dumps({"thread_id": entry["thread_id"], "replied": replied, "resolved": resolved}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Combine steps 4+5 of the workflow into single commands. `reply-and-resolve` handles one thread; `reply-and-resolve-batch` takes a JSON array of `{thread_id, comment_id, body}` and processes all threads on a PR in one process (previously 2N gh invocations through N shell-loop iterations). Stops at first failure; prints one JSON status line per thread. SKILL.md updated with both forms. 104 existing script tests still pass; ruff/ty/markdownlint clean.