### PR TITLE
chore(repo): add .mailmap for consistent contributor identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Jamie Nelson <stack@bitflight.io> <jamie@bitflight.io>
+Jamie Nelson <stack@bitflight.io> <jamie.nelson@assaabloy.com>


### PR DESCRIPTION
## Summary

- Add `.mailmap` collapsing 4 (name, email) identity variants of the primary maintainer — `Jamie McGregor Nelson`/`Jamie Nelson` crossed with `jamie@bitflight.io`/`stack@bitflight.io`/a corporate address — into one canonical `Jamie Nelson <stack@bitflight.io>`.
- Non-destructive: `.mailmap` only affects display in `git log`/`shortlog`/`blame` and GitHub's contributor graph. No commit author is rewritten, no force-push, no impact on other clones or open PRs.
- Prompted by `git-history-recon`'s Bus Factor pipeline reporting 3 apparent contributors accounting for 80% of commits, when 2 of those "contributors" were the same person under different git configs across machines — understating actual single-owner concentration risk.

## Test plan

- [x] `git shortlog -sn HEAD --no-merges` now shows one collapsed "Jamie Nelson" row (1942 commits) instead of 2 split rows
- [x] Raw `git log --format='%an <%ae>'` confirms the 4 original identities are untouched in the actual commit objects — `.mailmap` is purely a display-layer mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)