### PR TITLE
feat(receiving-pr-reviews): GitHub MCP fallback for sandboxed hosts

### DIFF
--- a/.agents/skills/receiving-pr-reviews/SKILL.md
+++ b/.agents/skills/receiving-pr-reviews/SKILL.md
@@ -13,6 +13,8 @@ description: Work through every unresolved review thread on a PR to completion �
    uv run ./.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py fetch --pr <N> --summary
    ```
 
+   If the helper cannot use `gh` and GitHub MCP tools are available, use the lightweight [GitHub MCP fallback](./references/github-mcp-fallback.md) for this workflow instead. Do not install or reconfigure `gh` merely to avoid the fallback, and do not run both paths for the same snapshot.
+
    Read `reviews_count`, `threads_count`, `unresolved_count`, `unresponded_count`, and `blockers` together — never treat an empty `unresolved` array on its own as "nothing to do". A `threads_count` of 0 means no *inline* thread landed, not that no review landed. A non-empty `blockers` means the empty result set is expected and the fix is on the PR itself — undraft it, resolve the conflicts — not in the review queue. (Dropping `--summary` gets the same fields under `reviewability.blockers` instead of top-level `blockers`, plus the full `reviews_with_body` and each thread's complete `comments` list — a thread's `comments_truncated: true` there means it has passed 100 comments; page its `comments` connection directly before concluding anything about it. `unresponded_count` itself only exists on `--summary` output — the full form has no matching field, use `len(unresponded_reviews)` there instead.)
 
    `unresolved`/`unresponded_reviews` entries are this run's actionable input; treat every one as something to address. For `codex_approved`, see step 7. Checking several PRs at once: `--pr 41,42,44` prints one line (or, with `--summary`, one JSON block) per PR instead of one call each.

--- a/.agents/skills/receiving-pr-reviews/references/github-mcp-fallback.md
+++ b/.agents/skills/receiving-pr-reviews/references/github-mcp-fallback.md
@@ -1,0 +1,48 @@
+# GitHub MCP fallback
+
+Use this path only when the bundled helper cannot use `gh` and GitHub MCP tools are available. Preserve the main workflow's decisions and stopping conditions; this is a transport fallback, not a different review policy.
+
+## Fetch one snapshot
+
+Batch the independent read calls concurrently when the host permits it. Use the available tools whose names end with:
+
+- `github_get_pr_info` for state, draft status, mergeability, base, and exact head;
+- `github_list_pull_request_review_threads` for every thread and its resolved state;
+- `github_list_pull_request_reviews` for every submitted review and body;
+- `github_fetch_issue_comments` for PR-level responses;
+- `github_get_pr_reactions` for Codex's `+1` approval reaction;
+- `github_get_user_login` only when the authenticated comment author cannot otherwise be identified.
+
+Derive the same summary as `fetch --summary`:
+
+- `reviews_count`: all submitted reviews;
+- `threads_count`: all inline threads;
+- `unresolved`: every thread where `is_resolved` is false, and `unresolved_count` is its length;
+- `blockers`: closed or draft PR state, merge conflicts, or another explicit reviewability blocker. Treat unknown/pending mergeability as non-blocking;
+- `reviews_with_body`: submitted reviews with non-empty top-level bodies;
+- `unresponded_reviews`: each `reviews_with_body` entry not covered by the response rule below;
+- `codex_approved`: a current-revision Codex `+1` as defined below.
+
+Do not treat counts from only one endpoint as the complete snapshot.
+
+### Unresponded reviews
+
+Exclude Codex's exact fixed no-findings review wrapper; real Codex findings arrive as inline threads. Every other non-empty submitted review remains unresponded until a later PR-level comment by the authenticated user quotes that review's exact permalink. If the normalized review result lacks its permalink or timestamps, call `github_fetch_pr_comments` only for those missing fields. A response must postdate the later of the review's submission and edit timestamps.
+
+### Codex approval
+
+A `+1` counts only when its author is the exact Codex bot account and its timestamp is not older than the current head revision. When a Codex `+1` exists, use the general GitHub fetch tool to check the head commit timestamp and the latest force-push event; require the reaction to postdate both. Do not carry approval forward from an older revision.
+
+## Reply and resolve
+
+Keep the main workflow's validate-before-fix and push-before-reply rules.
+
+- Reply to an inline thread with `github_reply_to_review_comment`, targeting the first comment's numeric database ID.
+- Resolve it with `github_resolve_review_thread`, using the thread node ID.
+- Respond to a top-level review with `github_add_comment_to_issue` on the PR. Include the review's exact permalink so the next snapshot clears it from `unresponded_reviews`.
+
+Use the connector's equivalent tool when its exposed prefix differs; do not broaden beyond the current repository and PR.
+
+## Watch
+
+Re-run the same lightweight snapshot on a bounded short polling schedule. Stop and restart the main workflow when an unresolved thread or unresponded review appears. With neither present, `codex_approved: true` is completion. If no work and no approval appear during one window, begin another window only when the intended watch period has not yet been covered. Re-check blockers on every snapshot.

--- a/.agents/skills/receiving-pr-reviews/references/github-mcp-fallback.md
+++ b/.agents/skills/receiving-pr-reviews/references/github-mcp-fallback.md
@@ -11,6 +11,7 @@ Batch the independent read calls concurrently when the host permits it. Use the 
 - `github_list_pull_request_reviews` for every submitted review and body;
 - `github_fetch_issue_comments` for PR-level responses;
 - `github_get_pr_reactions` for Codex's `+1` approval reaction;
+- `github_list_pr_timeline_events` for force-push events, needed only for the Codex approval check below;
 - `github_get_user_login` only when the authenticated comment author cannot otherwise be identified.
 
 Derive the same summary as `fetch --summary`:
@@ -18,7 +19,7 @@ Derive the same summary as `fetch --summary`:
 - `reviews_count`: all submitted reviews;
 - `threads_count`: all inline threads;
 - `unresolved`: every thread where `is_resolved` is false, and `unresolved_count` is its length;
-- `blockers`: closed or draft PR state, merge conflicts, or another explicit reviewability blocker. Treat unknown/pending mergeability as non-blocking;
+- `blockers`: exactly two conditions produce one — draft PR state, and merge conflicts (mergeable state is exactly "conflicting"). No other `mergeStateStatus` value is a blocker; treat unknown/pending mergeability as non-blocking;
 - `reviews_with_body`: submitted reviews with non-empty top-level bodies;
 - `unresponded_reviews`: each `reviews_with_body` entry not covered by the response rule below;
 - `codex_approved`: a current-revision Codex `+1` as defined below.
@@ -27,11 +28,11 @@ Do not treat counts from only one endpoint as the complete snapshot.
 
 ### Unresponded reviews
 
-Exclude Codex's exact fixed no-findings review wrapper; real Codex findings arrive as inline threads. Every other non-empty submitted review remains unresponded until a later PR-level comment by the authenticated user quotes that review's exact permalink. If the normalized review result lacks its permalink or timestamps, call `github_fetch_pr_comments` only for those missing fields. A response must postdate the later of the review's submission and edit timestamps.
+Exclude Codex's exact fixed no-findings review wrapper; real Codex findings arrive as inline threads. Every other non-empty submitted review remains unresponded until a later PR-level comment by the authenticated user quotes that review's exact permalink. If the normalized review result lacks its permalink or timestamps, call `github_fetch_issue_comments` only for those missing fields. A response must postdate the later of the review's submission and edit timestamps.
 
 ### Codex approval
 
-A `+1` counts only when its author is the exact Codex bot account and its timestamp is not older than the current head revision. When a Codex `+1` exists, use the general GitHub fetch tool to check the head commit timestamp and the latest force-push event; require the reaction to postdate both. Do not carry approval forward from an older revision.
+A `+1` counts only when its author is the exact Codex bot account and its timestamp is not older than the current head revision. The current head revision is the later of the head commit's own timestamp (from `github_get_pr_info`) and the latest force-push event's timestamp (from `github_list_pr_timeline_events`) — a force-push that resets the branch onto a pre-existing commit does not change that commit's own timestamp, so the timeline event is the only signal for it. When a Codex `+1` exists, require its timestamp to postdate this current head revision. Do not carry approval forward from an older revision.
 
 ## Reply and resolve
 


### PR DESCRIPTION
## Summary

- Add a lightweight GitHub MCP fallback workflow for `receiving-pr-reviews`, for use inside Claude Code or Codex sandboxes where the bundled helper's `gh` shell-out isn't usable.
- The fallback is a transport substitute only — it preserves the main workflow's decisions and stopping conditions (unresolved/unresponded detection, Codex approval rules, validate-before-fix, push-before-reply), not a different review policy.
- `SKILL.md` gets a two-line pointer to the new reference file; the fallback itself lives in `references/github-mcp-fallback.md`.

## Test plan

- [x] `prek run` on both changed files — all hooks pass (markdownlint, ruff-format, conventional commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)