### PR TITLE
fix(fastmcp-creator): update connections.py for mcp 2.x API renames

### DIFF
--- a/plugins/fastmcp-creator/.claude-plugin/plugin.json
+++ b/plugins/fastmcp-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fastmcp-creator",
   "description": "Build FastMCP 3.x Python MCP servers \u2014 covers provider/transform architecture (including CodeMode, Tool Search, and server-level transforms), component versioning, session state, authorization (MultiAuth, PropelAuth, connection-pooled token verifiers), evaluation creation, Pydantic validation, async patterns, STDIO and HTTP transports, nginx reverse proxy deployment, background tasks, Prefab Apps UI, security patterns, client SDK usage, testing, deployment, and migration from FastMCP v2. TypeScript is a legacy reference only and is not updated for v3.",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/fastmcp-creator/.codex-plugin/plugin.json
+++ b/plugins/fastmcp-creator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmcp-creator",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "description": "Build FastMCP 3.x Python MCP servers \u2014 covers provider/transform architecture (including CodeMode, Tool Search, and server-level transforms), component versioning, session state, authorization (MultiAuth, PropelAuth, connection-pooled token verifiers), evaluation creation, Pydantic validation, async patterns, STDIO and HTTP transports, nginx reverse proxy deployment, background tasks, Prefab Apps UI, security patterns, client SDK usage, testing, deployment, and migration from FastMCP v2. TypeScript is a legacy reference only and is not updated for v3.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/fastmcp-creator/.cursor-plugin/plugin.json
+++ b/plugins/fastmcp-creator/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fastmcp-creator",
   "description": "Build FastMCP 3.x Python MCP servers \u2014 covers provider/transform architecture (including CodeMode, Tool Search, and server-level transforms), component versioning, session state, authorization (MultiAuth, PropelAuth, connection-pooled token verifiers), evaluation creation, Pydantic validation, async patterns, STDIO and HTTP transports, nginx reverse proxy deployment, background tasks, Prefab Apps UI, security patterns, client SDK usage, testing, deployment, and migration from FastMCP v2. TypeScript is a legacy reference only and is not updated for v3.",
-  "version": "4.2.10",
+  "version": "4.2.11",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/fastmcp-creator/skills/fastmcp-creator/scripts/connections.py
+++ b/plugins/fastmcp-creator/skills/fastmcp-creator/scripts/connections.py
@@ -6,11 +6,12 @@ from abc import ABC, abstractmethod
 from contextlib import AbstractAsyncContextManager, AsyncExitStack
 from typing import TYPE_CHECKING, Any, Self
 
+import httpx2
 from anthropic.types import ToolParam
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -95,7 +96,7 @@ class MCPConnection(ABC):
             raise RuntimeError("No active session. Use async with context.")
         response = await self.session.list_tools()
         return [
-            ToolParam(name=tool.name, description=tool.description or "", input_schema=tool.inputSchema)
+            ToolParam(name=tool.name, description=tool.description or "", input_schema=tool.input_schema)
             for tool in response.tools
         ]
 
@@ -198,7 +199,8 @@ class MCPConnectionHTTP(MCPConnection):
         Returns:
             Async context manager for HTTP transport.
         """
-        return streamablehttp_client(url=self.url, headers=self.headers)
+        http_client = httpx2.AsyncClient(headers=self.headers) if self.headers else None
+        return streamable_http_client(url=self.url, http_client=http_client)
 
 
 def create_connection(


### PR DESCRIPTION
## Summary

`Python / ty` was failing on `main` (found while checking PR #3391's CI before merging). Root cause verified: `origin/main`'s committed `uv.lock` at `ba4d312f5` already pins `mcp==2.1.1` — an upstream `mcp` package release, unrelated to any of this session's other work. mcp 2.x renamed three things `connections.py` used:

- `mcp.client.streamable_http.streamablehttp_client` → `streamable_http_client`
- `Tool.inputSchema` → `Tool.input_schema`
- `streamable_http_client(headers=...)` removed entirely — headers now go through an `httpx2.AsyncClient` passed as `http_client=`

## Test plan

- [x] `uv run -q --locked ty check .` (CI's exact command) passes clean on the full repo
- [x] `uv run ruff check` clean
- [x] Grepped the repo for the same broken patterns elsewhere — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)