### PR TITLE
fix(backlog-core): surface GitHub issue-creation failure reason from backlog_add

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.15",
+  "version": "11.0.17",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.17",
+  "version": "11.0.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.15",
+  "version": "10.0.17",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.17",
+  "version": "10.0.19",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.17",
+  "version": "7.0.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.15",
+  "version": "7.0.17",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1441,8 +1441,8 @@ def _resolve_reference(priority: str, slug: str) -> str:
     return reference
 
 
-def _try_create_github_issue(item_data: BacklogItem, repo: str, out: Output) -> int | None:
-    """Attempt to create a GitHub issue for item_data; return issue number or None.
+def _try_create_github_issue(item_data: BacklogItem, repo: str, out: Output) -> tuple[int | None, str | None]:
+    """Attempt to create a GitHub issue for item_data.
 
     Args:
         item_data: Populated BacklogItem (file_path may be empty at this stage).
@@ -1450,31 +1450,39 @@ def _try_create_github_issue(item_data: BacklogItem, repo: str, out: Output) -> 
         out: Output collector for warnings.
 
     Returns:
-        Issue number on success, None when GitHub is unavailable or creation fails.
+        ``(issue_number, None)`` on success.
+        ``(None, None)`` when GitHub is unavailable (no token, or ``try_get_github``
+        could not reach/resolve the repo) — this is the intentional local-only-create
+        fallback (#2999); it is not reported as an error because no GitHub attempt was
+        actually made to fail.
+        ``(None, reason)`` when a GitHub client was obtained but issue creation itself
+        raised ``GithubException``/``BacklogError`` — this is a genuine, actionable
+        failure and ``reason`` is the caller-visible message (#3182).
     """
     repository = try_get_github(repo)
     if repository is None:
         out.warn("  WARNING: GitHub unavailable — creating local-only item")
-        return None
+        return None, None
     try:
-        return create_issue_for_item(repository, item_data, dry_run=False, output=out)
+        return create_issue_for_item(repository, item_data, dry_run=False, output=out), None
     except (GithubException, BacklogError) as e:
-        out.warn(f"  WARNING: Issue creation failed: {e}")
-        return None
+        reason = f"Issue creation failed: {e}"
+        out.warn(f"  WARNING: {reason}")
+        return None, reason
 
 
-def _try_create_backend_issue_ref(item_data: BacklogItem, repo: str, out: Output) -> str:
-    """Create a backend issue and return the issue ref string, or empty string on failure.
+def _try_create_backend_issue_ref(item_data: BacklogItem, repo: str, out: Output) -> tuple[str, str | None]:
+    """Create a backend issue and return (issue ref, error reason or None).
 
     Dispatches to the appropriate backend-native creation path:
 
     - String-ID backends (beads): calls ``create_beads_issue_for_item`` on the
-      backend, returns the nanoid (e.g. ``"bd-a3f8"``).
+      backend, returns the nanoid (e.g. ``"bd-a3f8"``). Failure here is unchanged —
+      ``add_item``'s subsequent ``put_work_item`` call raises ``ContentUnavailableError``
+      for a still-issueless beads item (see ``BeadsBackend.put_work_item``); this
+      function's own return only ever carries ``None`` for beads' error slot.
     - Integer-ID backends (GitHub, sqlite, memory): calls
       ``_try_create_github_issue``, formats the returned number as ``"#N"``.
-
-    The return value is always a ``str``: non-empty on success, empty string
-    when the backend is unavailable or creation fails.
 
     Args:
         item_data: Populated BacklogItem (file_path may be empty at this stage).
@@ -1482,7 +1490,9 @@ def _try_create_backend_issue_ref(item_data: BacklogItem, repo: str, out: Output
         out: Output collector for warnings.
 
     Returns:
-        Issue ref string (e.g. ``"#42"`` or ``"bd-a3f8"``), or ``""`` on failure.
+        ``(ref, None)`` on success, or on the tolerated GitHub-unavailable fallback.
+        ``("", reason)`` only when the integer-ID path's own creation attempt raised —
+        propagated verbatim from ``_try_create_github_issue``.
     """
     backend = get_config().backend
     if backend.issue_id_type == "string":
@@ -1490,13 +1500,13 @@ def _try_create_backend_issue_ref(item_data: BacklogItem, repo: str, out: Output
 
         if isinstance(backend, BeadsBackend):
             nanoid = backend.create_beads_issue_for_item(item_data, output=out)
-            return nanoid or ""
+            return nanoid or "", None
         # Unknown string-ID backend — log and fall through to local-only.
         out.warn("  WARNING: String-ID backend does not support create_beads_issue_for_item — creating local-only item")
-        return ""
+        return "", None
     # Integer-ID backend path (GitHub, sqlite, memory).
-    issue_num = _try_create_github_issue(item_data, repo, out)
-    return f"#{issue_num}" if issue_num else ""
+    issue_num, error = _try_create_github_issue(item_data, repo, out)
+    return (f"#{issue_num}", None) if issue_num else ("", error)
 
 
 def _build_item_body(research_first: str, files: str, suggested_location: str) -> str:
@@ -1556,6 +1566,14 @@ def add_item(
         ``view_item`` return for this same item on every later read (see
         ``_build_list_entry`` and ``view_result_from_local_item``).
 
+        ``error`` is present only when an integer-ID backend obtained a GitHub client
+        but issue creation itself failed (see ``_try_create_github_issue``); it is
+        absent both on success and on the tolerated GitHub-unavailable local-only-create
+        path. Its presence never changes whether the item was stored — the item is
+        always persisted by the time this function returns, ``error`` only adds a
+        caller-visible reason for why ``item_ref`` is empty in the "attempted and
+        failed" sub-case.
+
     Raises:
         ValidationError: If priority or type_ is not a recognized value. No
             item is stored and no backend issue is created when raised.
@@ -1591,7 +1609,7 @@ def add_item(
         files=files,
         suggested_location=suggested_location,
     )
-    issue_ref = _try_create_backend_issue_ref(item_data, repo, out)
+    issue_ref, issue_error = _try_create_backend_issue_ref(item_data, repo, out)
     item_reference = issue_ref or _resolve_reference(priority, slug)
 
     # Build and persist the backend-owned work item. Reuse item_data.title, not the
@@ -1634,6 +1652,8 @@ def add_item(
         # See #2999.
         "item_ref": issue_ref,
     }
+    if issue_error:
+        result["error"] = issue_error
     return {**result, **out.to_dict()}
 
 

--- a/plugins/development-harness/backlog_core/operations.py
+++ b/plugins/development-harness/backlog_core/operations.py
@@ -1296,6 +1296,30 @@ def _pull_if_issue_selector(selector: str, repo: str, output: Output | None = No
 # ---------------------------------------------------------------------------
 
 
+def _validate_add_item_title(title: str) -> None:
+    """Raise ValidationError if title is empty or whitespace-only.
+
+    An empty title reaching ``create_issue_for_item`` hits that function's
+    own ``if not item.title: return None`` guard, which returns ``None``
+    without raising -- indistinguishable, downstream in
+    ``_try_create_github_issue``, from the tolerated GitHub-unavailable
+    fallback. Rejecting an empty title here, before any storage or issue
+    creation is attempted, is the root-cause fix: it keeps that guard's
+    ``None`` return meaning only "GitHub unavailable," matching the
+    contract ``_try_create_github_issue``'s docstring documents.
+
+    Args:
+        title: Raw title value supplied by the caller.
+
+    Raises:
+        ValidationError: If title is empty or whitespace-only.
+    """
+    if title.strip():
+        return
+    msg = "Title is required and cannot be empty or whitespace-only."
+    raise ValidationError(msg)
+
+
 def _validate_add_item_priority(priority: str) -> None:
     """Raise ValidationError if priority is not an accepted value for a new item.
 
@@ -1586,6 +1610,7 @@ def add_item(
             Integer-ID backends (GitHub, sqlite, memory) do not raise this —
             their local-only fallback is unconditional.
     """
+    _validate_add_item_title(title)
     _validate_add_item_priority(priority)
     _validate_add_item_type(type_)
 

--- a/plugins/development-harness/backlog_core/server.py
+++ b/plugins/development-harness/backlog_core/server.py
@@ -1386,7 +1386,11 @@ async def backlog_add(
         :class:`~backlog_core.tool_responses.BacklogAddResponse` with
         file_path, title, priority, item_ref, and output messages/warnings.
         file_path is for reference only — use backlog_update or backlog_groom
-        for all modifications. On error, ``error`` is set.
+        for all modifications. On error, ``error`` is set — either because the
+        call raised (duplicate item, invalid priority/type) or, on an
+        integer-ID backend, because GitHub issue creation itself failed after
+        a local-only item was already stored (``item_ref`` will be ``""``,
+        ``reference`` still identifies the stored item).
     """
     out = Output()
     try:

--- a/plugins/development-harness/sam_schema/backlog.py
+++ b/plugins/development-harness/sam_schema/backlog.py
@@ -74,6 +74,8 @@ def add(
     except BacklogError as exc:
         cli_output.exit_with_json_error({"error": str(exc)})
     _emit(result, output)
+    if result.get("error"):
+        raise typer.Exit(code=1)
 
 
 @app.command("list")

--- a/plugins/development-harness/sam_schema/tests/test_backlog_cli.py
+++ b/plugins/development-harness/sam_schema/tests/test_backlog_cli.py
@@ -83,6 +83,39 @@ class TestBacklogAddErrorContract:
         assert result.exit_code == 0, result.stderr
         assert json.loads(result.stdout) == {"title": "new item", "priority": "P1", "item_ref": "#123"}
 
+    def test_add_exits_nonzero_when_result_carries_an_error_without_raising(self, mocker: MockerFixture) -> None:
+        """``add_item`` returning a populated ``error`` key (not raising) still exits non-zero.
+
+        Tests: The #3182 fix's CLI half -- a GitHub issue-creation failure is
+        reported via ``result["error"]`` on an otherwise-normal return (item
+        stored locally, ``item_ref`` empty), not via a raised exception. This
+        is distinct from ``test_duplicate_item_rejection_...`` above, which
+        covers the raised-exception path.
+        How: Mock ``operations.add_item`` to return a mapping with a
+        populated ``error`` key and no exception.
+        Why: A caller parsing only the exit code must be able to detect this
+        failure mode without inspecting stdout.
+        """
+        mocker.patch(
+            "sam_schema.backlog.operations.add_item",
+            return_value={
+                "title": "new item",
+                "priority": "P1",
+                "item_ref": "",
+                "error": "Issue creation failed: boom",
+            },
+        )
+
+        result = runner.invoke(app, ["backlog", "add", "--title", "new item", "--priority", "P1"], env=_CLI_ENV)
+
+        assert result.exit_code == 1
+        assert json.loads(result.stdout) == {
+            "title": "new item",
+            "priority": "P1",
+            "item_ref": "",
+            "error": "Issue creation failed: boom",
+        }
+
 
 class TestBacklogViewRefreshForwarding:
     """``backlog view`` forwards the ``--refresh`` flag to ``operations.view_item``."""

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/create/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/create/start.md
@@ -151,11 +151,19 @@ Shared parameters:
 - `force`: optional; default false
 
 If the result contains `error` or non-empty `errors` (MCP), or the CLI exits non-zero, report the
-error and stop.
+error and stop — except the GitHub-issue-creation-failure `error` case, which Step 5 handles
+without stopping because the item was still stored.
 
 ## Step 5: Use `item_ref` from the response
 
 The `backlog_add` response contains `item_ref` — use that value directly for all downstream workflows and selector parameters.
+
+If the response also carries a non-empty `error` (MCP field, or the CLI JSON payload's `"error"` key), the backend
+issue could not be created even though the item itself was stored: `item_ref` will be `""` and `reference` is the
+only selector for this item until an issue is created for it. Report the error text to the user, use `reference`
+(not `item_ref`) in Step 6's confirmation and next-step commands, and do not treat this as the generic
+"MCP tool result contains `error`" stop condition in Error handling below — the item exists and Step 6 still
+applies, just without an issue reference.
 
 ## Step 6: Confirm write
 
@@ -182,11 +190,13 @@ Stop and report on:
 - invalid priority value
 - duplicate detected and the user chose not to proceed
 - duplicate detected in `auto` mode
-- MCP tool result contains `error` or non-empty `errors`
+- MCP tool result contains `error` or non-empty `errors` (excluding the GitHub-issue-creation-failure `error` case
+  handled in Step 5, which does not stop the workflow)
 
 ## Completion criteria
 
 Creation is complete only when:
-- `backlog_add` returns success with no `error` and no non-empty `errors`
-- `item_ref` is normalized to `#N`
-- confirmation with `item_ref` is shown to the user
+- `backlog_add` returns with no non-empty `errors` (a populated `error` field with GitHub-issue-creation-failure
+  text is not itself a stop condition — see Step 5's failure branch — but any other non-empty `error`/`errors` is)
+- `item_ref` is normalized to `#N`, or, if Step 5's failure branch applied, `reference` is used in its place
+- confirmation is shown to the user, using whichever selector (`item_ref` or `reference`) Step 5 resolved

--- a/plugins/development-harness/skills/work-backlog-item/references/workflows/create/start.md
+++ b/plugins/development-harness/skills/work-backlog-item/references/workflows/create/start.md
@@ -151,19 +151,24 @@ Shared parameters:
 - `force`: optional; default false
 
 If the result contains `error` or non-empty `errors` (MCP), or the CLI exits non-zero, report the
-error and stop — except the GitHub-issue-creation-failure `error` case, which Step 5 handles
-without stopping because the item was still stored.
+error and stop — except the GitHub-issue-creation-failure `error` case (item stored, `reference`
+present — see Step 5), which does not stop the workflow.
 
 ## Step 5: Use `item_ref` from the response
 
 The `backlog_add` response contains `item_ref` — use that value directly for all downstream workflows and selector parameters.
 
-If the response also carries a non-empty `error` (MCP field, or the CLI JSON payload's `"error"` key), the backend
-issue could not be created even though the item itself was stored: `item_ref` will be `""` and `reference` is the
-only selector for this item until an issue is created for it. Report the error text to the user, use `reference`
-(not `item_ref`) in Step 6's confirmation and next-step commands, and do not treat this as the generic
+If the response also carries a non-empty `error` **and a non-empty `reference` (or `file_path`/`title`)**, the
+backend issue could not be created even though the item itself was stored: `item_ref` will be `""` and `reference`
+is the only selector for this item until an issue is created for it. Report the error text to the user, use
+`reference` (not `item_ref`) in Step 6's confirmation and next-step commands, and do not treat this as the generic
 "MCP tool result contains `error`" stop condition in Error handling below — the item exists and Step 6 still
 applies, just without an issue reference.
+
+If the response carries a non-empty `error` and `reference`/`file_path`/`title` are all absent, the item was
+**never stored** — this is a distinct, pre-existing failure mode (e.g. a duplicate or validation error raised
+before any write). Treat this as the generic "MCP tool result contains `error`" stop condition below; there is
+no item and no selector to fall back to.
 
 ## Step 6: Confirm write
 
@@ -191,12 +196,14 @@ Stop and report on:
 - duplicate detected and the user chose not to proceed
 - duplicate detected in `auto` mode
 - MCP tool result contains `error` or non-empty `errors` (excluding the GitHub-issue-creation-failure `error` case
-  handled in Step 5, which does not stop the workflow)
+  handled in Step 5 — item stored, `reference` present — which does not stop the workflow; an `error` with no
+  `reference`/`file_path`/`title` means the item was never stored and IS a stop condition)
 
 ## Completion criteria
 
 Creation is complete only when:
-- `backlog_add` returns with no non-empty `errors` (a populated `error` field with GitHub-issue-creation-failure
-  text is not itself a stop condition — see Step 5's failure branch — but any other non-empty `error`/`errors` is)
+- `backlog_add` returns with no non-empty `errors`, and any populated `error` field is the GitHub-issue-creation-failure
+  case from Step 5 (item stored, `reference` present) — any other non-empty `error`, or one with no `reference`/
+  `file_path`/`title`, means creation did not complete
 - `item_ref` is normalized to `#N`, or, if Step 5's failure branch applied, `reference` is used in its place
 - confirmation is shown to the user, using whichever selector (`item_ref` or `reference`) Step 5 resolved

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -417,20 +417,41 @@ class TestAddItemCreatesLocalFile:
         assert result["item_ref"] == "#1632"
 
     def test_add_item_item_ref_empty_when_no_github_issue(self, mocker: MockerFixture) -> None:
-        """Verify item_ref is present but empty when GitHub issue creation fails.
+        """Verify item_ref is empty and no error is set when GitHub is unavailable.
 
-        Tests: add_item item_ref contract on the local-only-create path (#2999).
+        Tests: add_item item_ref contract on the local-only-create path (#2999), now
+               also covering that this tolerated fallback does not populate `error` (#3182).
         How: Mock try_get_github to return None (no GitHub available).
         Why: item_ref must always be present — its emptiness, not its absence, is
-             the local-only signal. A dict with no distinguishing key at all is
-             indistinguishable from a successful create by any caller that does
-             not specifically probe for the key's presence (the original #2999 bug).
+             the local-only signal. GitHub-unavailable is a supported, silent fallback,
+             not a failure — `error` distinguishes it from the sibling case where a
+             GitHub client was obtained but creation itself raised.
         """
         mocker.patch("backlog_core.operations.try_get_github", return_value=None)
 
         result = add_item(title="Local Only No Ref", description="desc", priority="P2")
 
         assert result["item_ref"] == ""
+        assert "error" not in result
+
+    def test_add_item_error_set_when_issue_creation_raises(self, mocker: MockerFixture) -> None:
+        """Verify result["error"] is populated when GitHub issue creation raises (#3182).
+
+        Tests: add_item's new caller-visible-failure contract — the defect this item fixes.
+        How: try_get_github succeeds (a client is obtained); create_issue_for_item raises
+             GithubException.
+        Why: This is the sub-case the CI defect (#3182) actually hits — a valid token but
+             a failed create call — and the one this fix's `error` field exists to surface.
+        """
+        mocker.patch("backlog_core.operations.try_get_github", return_value=mocker.Mock())
+        mocker.patch("backlog_core.operations.create_issue_for_item", side_effect=GithubException(500, "boom", None))
+
+        result = add_item(title="Flaky Create", description="desc", priority="P1")
+
+        assert result["item_ref"] == ""
+        error = result.get("error")
+        assert isinstance(error, str)
+        assert error.startswith("Issue creation failed:")
 
     def test_add_item_local_only_pending_state_visible_via_list_and_view(self, mocker: MockerFixture) -> None:
         """Verify a local-only create's pending state is visible on later reads, not just at creation.

--- a/plugins/development-harness/tests/test_backlog_core_operations.py
+++ b/plugins/development-harness/tests/test_backlog_core_operations.py
@@ -453,6 +453,30 @@ class TestAddItemCreatesLocalFile:
         assert isinstance(error, str)
         assert error.startswith("Issue creation failed:")
 
+    def test_add_item_rejects_empty_title_raises_validation_error(self, mocker: MockerFixture) -> None:
+        """Verify add_item raises ValidationError for an empty or whitespace-only title.
+
+        Tests: add_item ingress validation — empty title. Code review on #3182 found
+               that an empty title reaching create_issue_for_item hits that function's
+               own `if not item.title: return None` guard, which returns None without
+               raising — indistinguishable, downstream, from the tolerated
+               GitHub-unavailable fallback (no error, no item_ref, silent). Rejecting
+               it here, before any storage or issue creation is attempted, keeps that
+               guard's None return meaning only "GitHub unavailable."
+        How: Call add_item with title="" and title="   " (whitespace-only).
+        Why: Neither the MCP tool's title Field nor the CLI's --title option enforce
+             non-empty, so this is the only remaining check.
+        """
+        mocker.patch("backlog_core.operations.try_get_github", return_value=mocker.Mock())
+        mock_create = mocker.patch("backlog_core.operations.create_issue_for_item")
+
+        with pytest.raises(ValidationError, match="Title is required"):
+            add_item(title="", description="desc", priority="P1")
+        with pytest.raises(ValidationError, match="Title is required"):
+            add_item(title="   ", description="desc", priority="P1")
+
+        mock_create.assert_not_called()
+
     def test_add_item_local_only_pending_state_visible_via_list_and_view(self, mocker: MockerFixture) -> None:
         """Verify a local-only create's pending state is visible on later reads, not just at creation.
 

--- a/plugins/development-harness/tests/test_live_validation.py
+++ b/plugins/development-harness/tests/test_live_validation.py
@@ -193,7 +193,9 @@ class TestLiveLifecycle:
         # backlog_add returns item_ref="#N" (str); parse to int for tracking/cleanup.
         assert "item_ref" in result, f"Expected item_ref in result, got: {list(result.keys())}"
         item_ref: str = result["item_ref"]
-        assert item_ref.startswith("#"), f"Expected item_ref like '#N', got: {item_ref!r}"
+        assert item_ref.startswith("#"), (
+            f"Expected item_ref like '#N', got: {item_ref!r}, error: {result.get('error')!r}"
+        )
         issue_num = int(item_ref.lstrip("#"))
         assert issue_num > 0
         assert isinstance(result["file_path"], str)
@@ -317,7 +319,11 @@ class TestLiveLifecycle:
         )
         # backlog_add returns item_ref="#N" (str); parse to int for tracking/cleanup.
         assert "item_ref" in create_result, f"Expected item_ref, got: {list(create_result.keys())}"
-        l11_issue_num = int(create_result["item_ref"].lstrip("#"))
+        l11_item_ref: str = create_result["item_ref"]
+        assert l11_item_ref.startswith("#"), (
+            f"Expected item_ref like '#N', got: {l11_item_ref!r}, error: {create_result.get('error')!r}"
+        )
+        l11_issue_num = int(l11_item_ref.lstrip("#"))
         assert l11_issue_num > 0
         live_items["issues"].append(l11_issue_num)
 


### PR DESCRIPTION
## Summary
- `_try_create_github_issue`/`_try_create_backend_issue_ref` now return `(value, error)` tuples instead of collapsing a failure reason to `None`; `add_item` conditionally sets `result["error"]` only on the genuine creation-failure branch, never on the tolerated GitHub-unavailable branch (#2999 regression guard preserved).
- CLI `backlog add` exits non-zero when the result carries a populated `error`.
- `test_live_validation.py`'s two `item_ref` assertions now surface the error reason instead of an opaque empty-string/type-conversion failure.
- `create/start.md` documents the new three-outcome contract (created / local-only-and-fine / attempted-and-failed), including a fix (commit `51823112c`) distinguishing "item stored, issue creation failed" from the pre-existing "item never stored" (duplicate/validation) error path — caught by an independent quality-review pass before this PR was opened.

Fixes #3182

## Quality gates run
- TN verification (7/7 acceptance criteria PASS, no regressions)
- Multi-perspective review: Security APPROVE, Performance APPROVE, Quality APPROVE (after one fix cycle), Accessibility SKIP (no UI files)
- Independent code review: PASS, 0 blocking findings
- Feature verification (goal-backward): VERIFIED, no gaps
- Integration check: all producer/consumer/test/doc wiring CONNECTED
- Documentation drift audit: 0 findings

## Follow-ups filed (out of scope for this PR, tracked separately)
- #3395 — beads backend `ContentUnavailableError` not caught by `backlog_add`/CLI `add`
- #3400 — `interop/SKILL.md` has the same stored-but-errored ABORT contradiction this PR fixed elsewhere
- #3402 — `sam_task` `claim_task` swallows `ContentConflictError` into a misleading status warning under concurrent claims
- #3403 — `sam_task` `append_section` concatenates onto stale content instead of replacing on task re-run

## Test plan
- [x] `test_backlog_core_operations.py` (160 passed)
- [x] `test_frontend_parity_ops.py` default + `-m integration` (48 + 2 passed)
- [x] `test_backlog_cli.py` (10 passed)
- [x] `backlog_core`/`sam_schema` full suites (879 passed)
- [x] ruff + ty clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHZ9qtoiRw8MW6C5gAuCXh