### PR TITLE
fix(backlog-core): stop one corrupt cache snapshot from taking the whole sync offline

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.19",
+  "version": "11.0.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.19",
+  "version": "10.0.20",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.19",
+  "version": "7.0.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -436,29 +436,15 @@ class FileCache:
     def _work_item_snapshots(self) -> list[tuple[str, BacklogItem]]:
         """Return every durable work-item snapshot beneath the cache root.
 
-        :meth:`_save_item_snapshot`'s temp file (``tempfile.mkstemp(...,
-        suffix=".tmp")``) never matches this method's ``*.yaml`` glob, so a
-        process killed between ``mkstemp()`` and its ``finally`` cleanup
-        (session interrupt, OOM, crash) can leave one behind without this
-        enumeration ever seeing it -- no filename heuristic is needed to
-        tell an orphan apart from a real snapshot whose key happens to look
-        similar.
-
-        A snapshot that still fails to load is skipped rather than letting
-        it take the whole batch offline -- e.g. the 0-byte body a corrupted
-        write can leave, which parses to ``None`` and fails ``BacklogItem``
-        validation; a file with unparseable YAML; a file with invalid UTF-8
-        bytes, which ``load_item``'s ``path.open(encoding="utf-8")``
-        surfaces as ``UnicodeDecodeError``; a symlink whose target resolves
-        outside the cache root, which :meth:`_snapshot_path`'s own boundary
-        check surfaces as a bare ``ValueError`` from ``Path.relative_to``;
-        or any other filesystem-level failure (``OSError`` and subclasses --
-        e.g. a directory matching ``*.yaml``, or unreadable permissions) on
-        the specific path being loaded. ``ValueError`` alone covers the
-        pydantic and Unicode cases too, since both are its subclasses. One
-        bad file is logged and skipped, mirroring the per-entry salvage
-        policy :meth:`_CacheStateStore._salvage_field` already applies to
-        the durable mutation queue.
+        An orphaned :meth:`_save_item_snapshot` temp file never reaches this
+        method at all -- see that method's own comment on why. A snapshot
+        that still fails to load (bad YAML, invalid UTF-8, a symlink
+        escaping the cache root, or any other ``OSError``) is logged and
+        skipped rather than letting it take the whole batch offline,
+        mirroring the per-entry salvage policy
+        :meth:`_CacheStateStore._salvage_field` already applies to the
+        durable mutation queue. ``ValueError`` alone covers pydantic and
+        Unicode decode failures too, since both are its subclasses.
 
         Returns:
             Ordered ``(logical_key, item)`` pairs for every snapshot that

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -453,13 +453,20 @@ class FileCache:
           a leading dot since it is written straight to ``destination``.
         - A snapshot that fails to load at all -- e.g. the 0-byte body such
           an orphaned temp file has, which parses to ``None`` and fails
-          ``BacklogItem`` validation; a file with unparseable YAML; or a
-          file with invalid UTF-8 bytes, which ``load_item``'s
+          ``BacklogItem`` validation; a file with unparseable YAML; a file
+          with invalid UTF-8 bytes, which ``load_item``'s
           ``path.open(encoding="utf-8")`` surfaces as ``UnicodeDecodeError``
-          rather than a YAML or validation error. One bad file is logged and
-          skipped, mirroring the per-entry salvage policy
+          rather than a YAML or validation error; or a filesystem-level
+          failure (``OSError`` and subclasses -- e.g. a directory matching
+          ``*.yaml``, or a file whose permissions block reads) on the
+          specific path being loaded. One bad file is logged and skipped,
+          mirroring the per-entry salvage policy
           :meth:`_CacheStateStore._salvage_field` already applies to the
-          durable mutation queue.
+          durable mutation queue. (That queue-side policy also surfaces a
+          rejection *count* to callers via ``ReconcileOutcome``; this
+          snapshot-side policy does not yet have an equivalent plumbed
+          through its one caller, ``GitHubWorkItemsBackend.load_records`` --
+          tracked separately, out of scope for the crash fix here.)
 
         Returns:
             Ordered ``(logical_key, item)`` pairs for every snapshot that
@@ -475,7 +482,7 @@ class FileCache:
             relative = path.relative_to(item_root)
             try:
                 snapshots.append((relative.as_posix(), self._load_item_snapshot(relative)))
-            except (pydantic.ValidationError, YAMLError, UnicodeDecodeError) as exc:
+            except (pydantic.ValidationError, YAMLError, UnicodeDecodeError, OSError) as exc:
                 _log.warning("Work item snapshot %s: skipping corrupt/unparseable snapshot: %s", path, exc)
         return snapshots
 

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -11,7 +11,6 @@ from collections.abc import Iterable
 from io import StringIO
 from pathlib import Path
 
-import pydantic
 from ruamel.yaml import YAML, YAMLError
 
 from .file_cache_state import (
@@ -442,31 +441,33 @@ class FileCache:
 
         - An orphaned :meth:`_save_item_snapshot` temp file. That method's
           ``tempfile.mkstemp`` always names its temp file
-          ``prefix=f".{destination.name}."`` and ``suffix=".tmp.yaml"``, so
-          it still matches this method's ``*.yaml`` glob; a process killed
-          between ``mkstemp()`` and its ``finally`` cleanup (session
-          interrupt, OOM, crash) leaves one behind forever. It is excluded
-          here by matching *both* the leading-dot ``mkstemp`` prefix and the
-          ``.tmp.yaml`` suffix -- suffix alone would also match a real
-          snapshot whose logical key happens to end in ``.tmp`` (e.g.
-          ``release-1.0.tmp`` -> ``release-1.0.tmp.yaml``), which never gets
-          a leading dot since it is written straight to ``destination``.
+          ``prefix=f".{destination.name}."`` and ``suffix=".tmp.yaml"``; a
+          process killed between ``mkstemp()`` and its ``finally`` cleanup
+          (session interrupt, OOM, crash) leaves one behind forever, still
+          matching this method's ``*.yaml`` glob. Its name therefore always
+          has the shape ``.{original-name}.yaml.{random}.tmp.yaml`` -- a
+          leading dot, the embedded literal ``.yaml.`` from the destination
+          name (every destination name ends in ``.yaml``), then mkstemp's
+          random segment, then the ``.tmp.yaml`` suffix. Matching on that
+          full shape (not just the leading dot and trailing suffix)
+          excludes a real snapshot whose logical key itself starts with
+          ``.`` and ends in ``.tmp`` -- e.g. ``.release.tmp`` ->
+          ``.release.tmp.yaml`` -- which has no embedded ``.yaml.`` marker.
         - A snapshot that fails to load at all -- e.g. the 0-byte body such
           an orphaned temp file has, which parses to ``None`` and fails
           ``BacklogItem`` validation; a file with unparseable YAML; a file
           with invalid UTF-8 bytes, which ``load_item``'s
-          ``path.open(encoding="utf-8")`` surfaces as ``UnicodeDecodeError``
-          rather than a YAML or validation error; or a filesystem-level
-          failure (``OSError`` and subclasses -- e.g. a directory matching
-          ``*.yaml``, or a file whose permissions block reads) on the
-          specific path being loaded. One bad file is logged and skipped,
-          mirroring the per-entry salvage policy
-          :meth:`_CacheStateStore._salvage_field` already applies to the
-          durable mutation queue. (That queue-side policy also surfaces a
-          rejection *count* to callers via ``ReconcileOutcome``; this
-          snapshot-side policy does not yet have an equivalent plumbed
-          through its one caller, ``GitHubWorkItemsBackend.load_records`` --
-          tracked separately, out of scope for the crash fix here.)
+          ``path.open(encoding="utf-8")`` surfaces as ``UnicodeDecodeError``;
+          a symlink whose target resolves outside the cache root, which
+          :meth:`_snapshot_path`'s own boundary check surfaces as a bare
+          ``ValueError`` from ``Path.relative_to``; or any other
+          filesystem-level failure (``OSError`` and subclasses -- e.g. a
+          directory matching ``*.yaml``, or unreadable permissions) on the
+          specific path being loaded. ``ValueError`` alone covers the
+          pydantic and Unicode cases too, since both are its subclasses.
+          One bad file is logged and skipped, mirroring the per-entry
+          salvage policy :meth:`_CacheStateStore._salvage_field` already
+          applies to the durable mutation queue.
 
         Returns:
             Ordered ``(logical_key, item)`` pairs for every snapshot that
@@ -477,12 +478,16 @@ class FileCache:
             return []
         snapshots: list[tuple[str, BacklogItem]] = []
         for path in sorted(item_root.rglob("*.yaml")):
-            if path.name.startswith(".") and path.name.endswith(".tmp.yaml"):
+            if (
+                path.name.startswith(".")
+                and path.name.endswith(".tmp.yaml")
+                and ".yaml." in path.name[: -len(".tmp.yaml")]
+            ):
                 continue
             relative = path.relative_to(item_root)
             try:
                 snapshots.append((relative.as_posix(), self._load_item_snapshot(relative)))
-            except (pydantic.ValidationError, YAMLError, UnicodeDecodeError, OSError) as exc:
+            except (ValueError, YAMLError, OSError) as exc:
                 _log.warning("Work item snapshot %s: skipping corrupt/unparseable snapshot: %s", path, exc)
         return snapshots
 

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -442,17 +442,24 @@ class FileCache:
 
         - An orphaned :meth:`_save_item_snapshot` temp file. That method's
           ``tempfile.mkstemp`` always names its temp file
-          ``suffix=".tmp.yaml"``, so it still matches this method's
-          ``*.yaml`` glob; a process killed between ``mkstemp()`` and its
-          ``finally`` cleanup (session interrupt, OOM, crash) leaves one
-          behind forever. It is excluded here by the same suffix, never a
-          real snapshot.
+          ``prefix=f".{destination.name}."`` and ``suffix=".tmp.yaml"``, so
+          it still matches this method's ``*.yaml`` glob; a process killed
+          between ``mkstemp()`` and its ``finally`` cleanup (session
+          interrupt, OOM, crash) leaves one behind forever. It is excluded
+          here by matching *both* the leading-dot ``mkstemp`` prefix and the
+          ``.tmp.yaml`` suffix -- suffix alone would also match a real
+          snapshot whose logical key happens to end in ``.tmp`` (e.g.
+          ``release-1.0.tmp`` -> ``release-1.0.tmp.yaml``), which never gets
+          a leading dot since it is written straight to ``destination``.
         - A snapshot that fails to load at all -- e.g. the 0-byte body such
           an orphaned temp file has, which parses to ``None`` and fails
-          ``BacklogItem`` validation, or a file with unparseable YAML. One
-          bad file is logged and skipped, mirroring the per-entry salvage
-          policy :meth:`_CacheStateStore._salvage_field` already applies to
-          the durable mutation queue.
+          ``BacklogItem`` validation; a file with unparseable YAML; or a
+          file with invalid UTF-8 bytes, which ``load_item``'s
+          ``path.open(encoding="utf-8")`` surfaces as ``UnicodeDecodeError``
+          rather than a YAML or validation error. One bad file is logged and
+          skipped, mirroring the per-entry salvage policy
+          :meth:`_CacheStateStore._salvage_field` already applies to the
+          durable mutation queue.
 
         Returns:
             Ordered ``(logical_key, item)`` pairs for every snapshot that
@@ -463,12 +470,12 @@ class FileCache:
             return []
         snapshots: list[tuple[str, BacklogItem]] = []
         for path in sorted(item_root.rglob("*.yaml")):
-            if path.name.endswith(".tmp.yaml"):
+            if path.name.startswith(".") and path.name.endswith(".tmp.yaml"):
                 continue
             relative = path.relative_to(item_root)
             try:
                 snapshots.append((relative.as_posix(), self._load_item_snapshot(relative)))
-            except (pydantic.ValidationError, YAMLError) as exc:
+            except (pydantic.ValidationError, YAMLError, UnicodeDecodeError) as exc:
                 _log.warning("Work item snapshot %s: skipping corrupt/unparseable snapshot: %s", path, exc)
         return snapshots
 

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -436,38 +436,29 @@ class FileCache:
     def _work_item_snapshots(self) -> list[tuple[str, BacklogItem]]:
         """Return every durable work-item snapshot beneath the cache root.
 
-        Skips two kinds of on-disk noise rather than letting either take the
-        whole batch offline for every other, perfectly good snapshot:
+        :meth:`_save_item_snapshot`'s temp file (``tempfile.mkstemp(...,
+        suffix=".tmp")``) never matches this method's ``*.yaml`` glob, so a
+        process killed between ``mkstemp()`` and its ``finally`` cleanup
+        (session interrupt, OOM, crash) can leave one behind without this
+        enumeration ever seeing it -- no filename heuristic is needed to
+        tell an orphan apart from a real snapshot whose key happens to look
+        similar.
 
-        - An orphaned :meth:`_save_item_snapshot` temp file. That method's
-          ``tempfile.mkstemp`` always names its temp file
-          ``prefix=f".{destination.name}."`` and ``suffix=".tmp.yaml"``; a
-          process killed between ``mkstemp()`` and its ``finally`` cleanup
-          (session interrupt, OOM, crash) leaves one behind forever, still
-          matching this method's ``*.yaml`` glob. Its name therefore always
-          has the shape ``.{original-name}.yaml.{random}.tmp.yaml`` -- a
-          leading dot, the embedded literal ``.yaml.`` from the destination
-          name (every destination name ends in ``.yaml``), then mkstemp's
-          random segment, then the ``.tmp.yaml`` suffix. Matching on that
-          full shape (not just the leading dot and trailing suffix)
-          excludes a real snapshot whose logical key itself starts with
-          ``.`` and ends in ``.tmp`` -- e.g. ``.release.tmp`` ->
-          ``.release.tmp.yaml`` -- which has no embedded ``.yaml.`` marker.
-        - A snapshot that fails to load at all -- e.g. the 0-byte body such
-          an orphaned temp file has, which parses to ``None`` and fails
-          ``BacklogItem`` validation; a file with unparseable YAML; a file
-          with invalid UTF-8 bytes, which ``load_item``'s
-          ``path.open(encoding="utf-8")`` surfaces as ``UnicodeDecodeError``;
-          a symlink whose target resolves outside the cache root, which
-          :meth:`_snapshot_path`'s own boundary check surfaces as a bare
-          ``ValueError`` from ``Path.relative_to``; or any other
-          filesystem-level failure (``OSError`` and subclasses -- e.g. a
-          directory matching ``*.yaml``, or unreadable permissions) on the
-          specific path being loaded. ``ValueError`` alone covers the
-          pydantic and Unicode cases too, since both are its subclasses.
-          One bad file is logged and skipped, mirroring the per-entry
-          salvage policy :meth:`_CacheStateStore._salvage_field` already
-          applies to the durable mutation queue.
+        A snapshot that still fails to load is skipped rather than letting
+        it take the whole batch offline -- e.g. the 0-byte body a corrupted
+        write can leave, which parses to ``None`` and fails ``BacklogItem``
+        validation; a file with unparseable YAML; a file with invalid UTF-8
+        bytes, which ``load_item``'s ``path.open(encoding="utf-8")``
+        surfaces as ``UnicodeDecodeError``; a symlink whose target resolves
+        outside the cache root, which :meth:`_snapshot_path`'s own boundary
+        check surfaces as a bare ``ValueError`` from ``Path.relative_to``;
+        or any other filesystem-level failure (``OSError`` and subclasses --
+        e.g. a directory matching ``*.yaml``, or unreadable permissions) on
+        the specific path being loaded. ``ValueError`` alone covers the
+        pydantic and Unicode cases too, since both are its subclasses. One
+        bad file is logged and skipped, mirroring the per-entry salvage
+        policy :meth:`_CacheStateStore._salvage_field` already applies to
+        the durable mutation queue.
 
         Returns:
             Ordered ``(logical_key, item)`` pairs for every snapshot that
@@ -478,12 +469,6 @@ class FileCache:
             return []
         snapshots: list[tuple[str, BacklogItem]] = []
         for path in sorted(item_root.rglob("*.yaml")):
-            if (
-                path.name.startswith(".")
-                and path.name.endswith(".tmp.yaml")
-                and ".yaml." in path.name[: -len(".tmp.yaml")]
-            ):
-                continue
             relative = path.relative_to(item_root)
             try:
                 snapshots.append((relative.as_posix(), self._load_item_snapshot(relative)))
@@ -505,9 +490,13 @@ class FileCache:
         destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         temporary: Path | None = None
         try:
-            fd, temporary_name = tempfile.mkstemp(
-                dir=destination.parent, prefix=f".{destination.name}.", suffix=".tmp.yaml"
-            )
+            # suffix=".tmp", not ".tmp.yaml": save_item() writes valid YAML to
+            # any path regardless of extension, and a plain ".tmp" name never
+            # matches _work_item_snapshots()'s "*.yaml" glob -- an orphan left
+            # behind by a process killed before the finally block below is
+            # then invisible to that enumeration by construction, with no
+            # filename heuristic needed to tell it apart from a real snapshot.
+            fd, temporary_name = tempfile.mkstemp(dir=destination.parent, prefix=f".{destination.name}.", suffix=".tmp")
             temporary = Path(temporary_name)
             os.close(fd)
             save_item(item.model_copy(deep=True), temporary)

--- a/plugins/development-harness/backlog_core/file_cache.py
+++ b/plugins/development-harness/backlog_core/file_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import tempfile
 import warnings
@@ -10,6 +11,7 @@ from collections.abc import Iterable
 from io import StringIO
 from pathlib import Path
 
+import pydantic
 from ruamel.yaml import YAML, YAMLError
 
 from .file_cache_state import (
@@ -28,6 +30,8 @@ from .file_cache_state import (
 )
 from .models import BacklogItem, ContentRecord, ContentRef, ContentUnavailableError, ContentWrite, parse_issue_number
 from .yaml_io import load_item, load_item_text, save_item
+
+_log = logging.getLogger(__name__)
 
 
 class LegacyMigrationError(ValueError):
@@ -431,13 +435,42 @@ class FileCache:
         self._save_item_snapshot(item, relative_path)
 
     def _work_item_snapshots(self) -> list[tuple[str, BacklogItem]]:
+        """Return every durable work-item snapshot beneath the cache root.
+
+        Skips two kinds of on-disk noise rather than letting either take the
+        whole batch offline for every other, perfectly good snapshot:
+
+        - An orphaned :meth:`_save_item_snapshot` temp file. That method's
+          ``tempfile.mkstemp`` always names its temp file
+          ``suffix=".tmp.yaml"``, so it still matches this method's
+          ``*.yaml`` glob; a process killed between ``mkstemp()`` and its
+          ``finally`` cleanup (session interrupt, OOM, crash) leaves one
+          behind forever. It is excluded here by the same suffix, never a
+          real snapshot.
+        - A snapshot that fails to load at all -- e.g. the 0-byte body such
+          an orphaned temp file has, which parses to ``None`` and fails
+          ``BacklogItem`` validation, or a file with unparseable YAML. One
+          bad file is logged and skipped, mirroring the per-entry salvage
+          policy :meth:`_CacheStateStore._salvage_field` already applies to
+          the durable mutation queue.
+
+        Returns:
+            Ordered ``(logical_key, item)`` pairs for every snapshot that
+            loaded successfully.
+        """
         item_root = self._root / "items"
         if not item_root.exists():
             return []
-        return [
-            (relative.as_posix(), self._load_item_snapshot(relative))
-            for relative in (path.relative_to(item_root) for path in sorted(item_root.rglob("*.yaml")))
-        ]
+        snapshots: list[tuple[str, BacklogItem]] = []
+        for path in sorted(item_root.rglob("*.yaml")):
+            if path.name.endswith(".tmp.yaml"):
+                continue
+            relative = path.relative_to(item_root)
+            try:
+                snapshots.append((relative.as_posix(), self._load_item_snapshot(relative)))
+            except (pydantic.ValidationError, YAMLError) as exc:
+                _log.warning("Work item snapshot %s: skipping corrupt/unparseable snapshot: %s", path, exc)
+        return snapshots
 
     @staticmethod
     def _serialize_item(item: BacklogItem) -> str:

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -250,6 +250,53 @@ def test_file_cache_work_item_snapshots_keeps_real_snapshot_ending_in_tmp(tmp_pa
     assert [(key, item.title) for key, item in snapshots] == [("release-1.0.tmp.yaml", "Real item")]
 
 
+def test_file_cache_work_item_snapshots_keeps_real_snapshot_with_dot_prefixed_tmp_key(tmp_path: Path) -> None:
+    """A real snapshot whose key both starts with '.' and ends in '.tmp' must not be dropped.
+
+    Regression test: the orphan filter used to treat any filename starting
+    with '.' and ending in '.tmp.yaml' as an orphan. A legitimate key like
+    ``.release.tmp`` produces exactly that shape (``.release.tmp.yaml``)
+    without ever going through ``tempfile.mkstemp``, so it was silently and
+    permanently dropped -- with no warning logged, unlike the corrupt-YAML
+    path -- because the filter matched before the try/except ever ran. The
+    filter now also requires the embedded literal ``.yaml.`` that only a
+    real ``mkstemp`` orphan's name contains.
+    """
+    # Given: a real snapshot saved under a key that starts with "." and ends in ".tmp"
+    cache = FileCache(tmp_path)
+    cache._save_work_item_snapshot(".release.tmp", BacklogItem(title="Real item"))
+
+    # When: the provider reloads its durable snapshots
+    snapshots = FileCache(tmp_path)._work_item_snapshots()
+
+    # Then: the real item is returned, not excluded as an orphan
+    assert [(key, item.title) for key, item in snapshots] == [(".release.tmp.yaml", "Real item")]
+
+
+def test_file_cache_work_item_snapshots_skips_path_escaping_cache_root_without_crashing(tmp_path: Path) -> None:
+    """A path that resolves outside the cache root must not take the whole batch offline.
+
+    Regression test: the corrupt-snapshot guard didn't catch bare
+    ``ValueError``, but ``_snapshot_path``'s own boundary check raises
+    exactly that (via ``Path.relative_to``) when a symlink under ``items/``
+    resolves outside the cache root -- e.g. disk corruption or a
+    mis-restored backup. That ``ValueError`` used to propagate out of the
+    whole enumeration uncaught, taking the good snapshot down with it.
+    """
+    # Given: one real snapshot and a symlink whose target escapes the cache root entirely
+    cache = FileCache(tmp_path)
+    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
+    outside_target = tmp_path.parent / "outside.yaml"
+    outside_target.write_text("title: escaped")
+    (tmp_path / "items" / "issues" / "13.yaml").symlink_to(outside_target)
+
+    # When: the provider reloads its durable snapshots
+    snapshots = FileCache(tmp_path)._work_item_snapshots()
+
+    # Then: the real item is still returned; the escaping symlink is skipped, not raised
+    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+
+
 def test_file_cache_reopens_opaque_snapshot_key_with_yaml_suffix(tmp_path: Path) -> None:
     # Given: an opaque provider key and an item whose backend reference is meaningful
     cache = FileCache(tmp_path)

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -193,7 +193,11 @@ def _make_directory_matching_glob(issues_dir: Path) -> None:
 
 
 def _make_symlink_escaping_cache_root(issues_dir: Path) -> None:
-    outside_target = issues_dir.parent.parent.parent / "outside.yaml"
+    # The boundary _snapshot_path() enforces is root/"items", not root itself, so a
+    # target under root but outside root/"items" already escapes it -- and staying
+    # under root keeps this file inside pytest's per-test tmp_path sandbox, not the
+    # shared per-session temp root a level higher.
+    outside_target = issues_dir.parent.parent / "outside.yaml"
     outside_target.write_text("title: escaped")
     (issues_dir / "13.yaml").symlink_to(outside_target)
 

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -207,6 +207,28 @@ def test_file_cache_work_item_snapshots_skips_invalid_utf8_without_crashing(tmp_
     assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
 
 
+def test_file_cache_work_item_snapshots_skips_unreadable_path_without_crashing(tmp_path: Path) -> None:
+    """A filesystem-level failure on one path must not take the whole batch offline.
+
+    Regression test: the corrupt-snapshot guard only caught
+    ``(pydantic.ValidationError, YAMLError, UnicodeDecodeError)``, so an
+    ``OSError``-family failure -- e.g. a directory matching the ``*.yaml``
+    glob (a plausible artifact of an interrupted or malformed write) --
+    still propagated out of the whole enumeration uncaught, taking the
+    good snapshot down with it.
+    """
+    # Given: one real snapshot and one sibling path that is a directory, not a file
+    cache = FileCache(tmp_path)
+    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
+    (tmp_path / "items" / "issues" / "13.yaml").mkdir()
+
+    # When: the provider reloads its durable snapshots
+    snapshots = FileCache(tmp_path)._work_item_snapshots()
+
+    # Then: the real item is still returned; the unreadable path is skipped, not raised
+    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+
+
 def test_file_cache_work_item_snapshots_keeps_real_snapshot_ending_in_tmp(tmp_path: Path) -> None:
     """A real snapshot whose logical key ends in ``.tmp`` must not be mistaken for an orphan.
 

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import get_context
 from multiprocessing.synchronize import Barrier as ProcessBarrier
@@ -260,6 +261,7 @@ def test_file_cache_work_item_snapshots_skips_unreadable_path_without_crashing(t
     assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires elevated privileges on Windows")
 def test_file_cache_work_item_snapshots_skips_path_escaping_cache_root_without_crashing(tmp_path: Path) -> None:
     """A path that resolves outside the cache root must not take the whole batch offline.
 

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -146,6 +146,45 @@ def test_file_cache_lists_work_item_snapshots_by_stable_key(tmp_path: Path) -> N
     ]
 
 
+def test_file_cache_work_item_snapshots_skips_orphaned_temp_file_without_crashing(tmp_path: Path) -> None:
+    """A 0-byte orphaned ``_save_item_snapshot`` temp file must not take the whole batch offline.
+
+    Regression test: a process killed between ``tempfile.mkstemp()`` and
+    ``_save_item_snapshot``'s ``finally`` cleanup leaves an orphaned
+    ``*.tmp.yaml`` file behind (e.g. ``.1466.yaml.vosleo7o.tmp.yaml``, 0
+    bytes). It still matches ``_work_item_snapshots``' ``*.yaml`` glob, and
+    ``yaml.safe_load`` of an empty file returns ``None``, so
+    ``BacklogItem.model_validate(None)`` used to raise a pydantic
+    ``ValidationError`` that propagated out of the whole enumeration --
+    taking every other, perfectly good snapshot offline with it.
+    """
+    # Given: a cache root whose items/issues directory holds only an orphaned temp file
+    cache = FileCache(tmp_path)
+    issues_dir = tmp_path / "items" / "issues"
+    issues_dir.mkdir(parents=True)
+    (issues_dir / ".1466.yaml.vosleo7o.tmp.yaml").touch()
+
+    # When: the provider enumerates its durable snapshots
+    snapshots = cache._work_item_snapshots()
+
+    # Then: the orphan is silently excluded, not raised as a crash
+    assert snapshots == []
+
+
+def test_file_cache_work_item_snapshots_excludes_orphaned_temp_file_alongside_real_items(tmp_path: Path) -> None:
+    # Given: one real, successfully-saved snapshot and one orphaned temp file left
+    # behind beside it by a prior interrupted write for the same destination
+    cache = FileCache(tmp_path)
+    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
+    (tmp_path / "items" / "issues" / ".12.yaml.abcd1234.tmp.yaml").touch()
+
+    # When: the provider reloads its durable snapshots
+    snapshots = FileCache(tmp_path)._work_item_snapshots()
+
+    # Then: only the real item is returned -- the orphan never reaches load_item()
+    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+
+
 def test_file_cache_reopens_opaque_snapshot_key_with_yaml_suffix(tmp_path: Path) -> None:
     # Given: an opaque provider key and an item whose backend reference is meaningful
     cache = FileCache(tmp_path)

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -185,6 +185,49 @@ def test_file_cache_work_item_snapshots_excludes_orphaned_temp_file_alongside_re
     assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
 
 
+def test_file_cache_work_item_snapshots_skips_invalid_utf8_without_crashing(tmp_path: Path) -> None:
+    """A snapshot with invalid UTF-8 bytes must not take the whole batch offline.
+
+    Regression test: ``load_item`` opens snapshots with
+    ``path.open(encoding="utf-8")``, so disk corruption or a partial write
+    that leaves invalid UTF-8 bytes raises ``UnicodeDecodeError`` -- a
+    ``ValueError`` subclass, but not ``pydantic.ValidationError`` or
+    ``YAMLError`` -- which used to propagate out of the whole enumeration,
+    taking every other, perfectly good snapshot offline with it.
+    """
+    # Given: one real snapshot and one sibling with invalid UTF-8 bytes
+    cache = FileCache(tmp_path)
+    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
+    (tmp_path / "items" / "issues" / "13.yaml").write_bytes(b'title: "\xff\xfe bad utf8"')
+
+    # When: the provider reloads its durable snapshots
+    snapshots = FileCache(tmp_path)._work_item_snapshots()
+
+    # Then: the real item is still returned; the corrupt one is skipped, not raised
+    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+
+
+def test_file_cache_work_item_snapshots_keeps_real_snapshot_ending_in_tmp(tmp_path: Path) -> None:
+    """A real snapshot whose logical key ends in ``.tmp`` must not be mistaken for an orphan.
+
+    Regression test: the orphan filter used to match any filename ending in
+    ``.tmp.yaml``, not just files created by ``_save_item_snapshot``'s
+    ``tempfile.mkstemp`` (which always adds a leading-dot prefix). A
+    legitimate snapshot saved under a key like ``release-1.0.tmp`` was
+    silently and permanently excluded, with no warning logged, unlike the
+    corrupt-YAML path.
+    """
+    # Given: a real snapshot saved under a key that happens to end in ".tmp"
+    cache = FileCache(tmp_path)
+    cache._save_work_item_snapshot("release-1.0.tmp", BacklogItem(title="Real item"))
+
+    # When: the provider reloads its durable snapshots
+    snapshots = FileCache(tmp_path)._work_item_snapshots()
+
+    # Then: the real item is returned, not excluded as an orphan
+    assert [(key, item.title) for key, item in snapshots] == [("release-1.0.tmp.yaml", "Real item")]
+
+
 def test_file_cache_reopens_opaque_snapshot_key_with_yaml_suffix(tmp_path: Path) -> None:
     # Given: an opaque provider key and an item whose backend reference is meaningful
     cache = FileCache(tmp_path)

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import get_context
 from multiprocessing.synchronize import Barrier as ProcessBarrier
@@ -175,114 +176,82 @@ def test_file_cache_work_item_snapshots_orphaned_temp_file_is_invisible_to_enume
     assert snapshots == []
 
 
-def test_file_cache_work_item_snapshots_ignores_orphaned_temp_file_alongside_real_items(tmp_path: Path) -> None:
-    """An orphaned temp file beside a real snapshot for the same key must not affect it.
-
-    Regression test: confirms the orphan doesn't shadow or otherwise
-    interfere with a real, successfully-saved snapshot for the same
-    logical key sitting right beside it.
-    """
-    # Given: one real, successfully-saved snapshot and one orphaned temp file left
-    # behind beside it by a prior interrupted write for the same destination
-    cache = FileCache(tmp_path)
-    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
-    (tmp_path / "items" / "issues" / ".12.yaml.abcd1234.tmp").touch()
-
-    # When: the provider reloads its durable snapshots
-    snapshots = FileCache(tmp_path)._work_item_snapshots()
-
-    # Then: only the real item is returned -- the orphan never matches the glob
-    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+def _touch_orphaned_temp_file(issues_dir: Path) -> None:
+    (issues_dir / ".12.yaml.abcd1234.tmp").touch()
 
 
-def test_file_cache_work_item_snapshots_skips_zero_byte_yaml_without_crashing(tmp_path: Path) -> None:
-    """A 0-byte ``.yaml`` file from any source must not take the whole batch offline.
-
-    Regression test: a genuinely empty ``.yaml`` file -- e.g. a leftover
-    from before this fix, or any other write-time corruption -- still
-    matches the ``*.yaml`` glob and must still be caught by the generic
-    corrupt-snapshot salvage below, independent of the temp-file-naming
-    fix above. ``yaml.safe_load`` of an empty file returns ``None``, and
-    ``BacklogItem.model_validate(None)`` raises ``pydantic.ValidationError``.
-    """
-    # Given: one real snapshot and one sibling that is a genuinely empty .yaml file
-    cache = FileCache(tmp_path)
-    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
-    (tmp_path / "items" / "issues" / "13.yaml").touch()
-
-    # When: the provider reloads its durable snapshots
-    snapshots = FileCache(tmp_path)._work_item_snapshots()
-
-    # Then: the real item is still returned; the empty one is skipped, not raised
-    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+def _touch_zero_byte_yaml(issues_dir: Path) -> None:
+    (issues_dir / "13.yaml").touch()
 
 
-def test_file_cache_work_item_snapshots_skips_invalid_utf8_without_crashing(tmp_path: Path) -> None:
-    """A snapshot with invalid UTF-8 bytes must not take the whole batch offline.
-
-    Regression test: ``load_item`` opens snapshots with
-    ``path.open(encoding="utf-8")``, so disk corruption or a partial write
-    that leaves invalid UTF-8 bytes raises ``UnicodeDecodeError`` -- a
-    ``ValueError`` subclass, but not ``pydantic.ValidationError`` or
-    ``YAMLError`` -- which used to propagate out of the whole enumeration,
-    taking every other, perfectly good snapshot offline with it.
-    """
-    # Given: one real snapshot and one sibling with invalid UTF-8 bytes
-    cache = FileCache(tmp_path)
-    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
-    (tmp_path / "items" / "issues" / "13.yaml").write_bytes(b'title: "\xff\xfe bad utf8"')
-
-    # When: the provider reloads its durable snapshots
-    snapshots = FileCache(tmp_path)._work_item_snapshots()
-
-    # Then: the real item is still returned; the corrupt one is skipped, not raised
-    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+def _write_invalid_utf8_yaml(issues_dir: Path) -> None:
+    (issues_dir / "13.yaml").write_bytes(b'title: "\xff\xfe bad utf8"')
 
 
-def test_file_cache_work_item_snapshots_skips_unreadable_path_without_crashing(tmp_path: Path) -> None:
-    """A filesystem-level failure on one path must not take the whole batch offline.
-
-    Regression test: the corrupt-snapshot guard only caught
-    ``(pydantic.ValidationError, YAMLError, UnicodeDecodeError)``, so an
-    ``OSError``-family failure -- e.g. a directory matching the ``*.yaml``
-    glob (a plausible artifact of an interrupted or malformed write) --
-    still propagated out of the whole enumeration uncaught, taking the
-    good snapshot down with it.
-    """
-    # Given: one real snapshot and one sibling path that is a directory, not a file
-    cache = FileCache(tmp_path)
-    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
-    (tmp_path / "items" / "issues" / "13.yaml").mkdir()
-
-    # When: the provider reloads its durable snapshots
-    snapshots = FileCache(tmp_path)._work_item_snapshots()
-
-    # Then: the real item is still returned; the unreadable path is skipped, not raised
-    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+def _make_directory_matching_glob(issues_dir: Path) -> None:
+    (issues_dir / "13.yaml").mkdir()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires elevated privileges on Windows")
-def test_file_cache_work_item_snapshots_skips_path_escaping_cache_root_without_crashing(tmp_path: Path) -> None:
-    """A path that resolves outside the cache root must not take the whole batch offline.
-
-    Regression test: the corrupt-snapshot guard didn't catch bare
-    ``ValueError``, but ``_snapshot_path``'s own boundary check raises
-    exactly that (via ``Path.relative_to``) when a symlink under ``items/``
-    resolves outside the cache root -- e.g. disk corruption or a
-    mis-restored backup. That ``ValueError`` used to propagate out of the
-    whole enumeration uncaught, taking the good snapshot down with it.
-    """
-    # Given: one real snapshot and a symlink whose target escapes the cache root entirely
-    cache = FileCache(tmp_path)
-    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
-    outside_target = tmp_path.parent / "outside.yaml"
+def _make_symlink_escaping_cache_root(issues_dir: Path) -> None:
+    outside_target = issues_dir.parent.parent.parent / "outside.yaml"
     outside_target.write_text("title: escaped")
-    (tmp_path / "items" / "issues" / "13.yaml").symlink_to(outside_target)
+    (issues_dir / "13.yaml").symlink_to(outside_target)
+
+
+@pytest.mark.parametrize(
+    ("corrupt_sibling", "reason"),
+    [
+        pytest.param(
+            _touch_orphaned_temp_file,
+            "an orphaned temp file never matches the *.yaml glob at all",
+            id="orphaned_temp_file",
+        ),
+        pytest.param(
+            _touch_zero_byte_yaml,
+            "a genuinely empty .yaml file parses to None and fails BacklogItem validation",
+            id="zero_byte_yaml",
+        ),
+        pytest.param(
+            _write_invalid_utf8_yaml,
+            "invalid UTF-8 bytes raise UnicodeDecodeError, a ValueError subclass",
+            id="invalid_utf8",
+        ),
+        pytest.param(
+            _make_directory_matching_glob,
+            "a directory matching the *.yaml glob raises OSError on open()",
+            id="unreadable_path",
+        ),
+        pytest.param(
+            _make_symlink_escaping_cache_root,
+            "a symlink escaping the cache root raises a bare ValueError from Path.relative_to",
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="symlink creation requires elevated privileges on Windows"
+            ),
+            id="symlink_escaping_root",
+        ),
+    ],
+)
+def test_file_cache_work_item_snapshots_skips_corrupt_sibling_without_crashing(
+    tmp_path: Path, corrupt_sibling: Callable[[Path], None], reason: str
+) -> None:
+    """A corrupt/orphaned sibling file must not take the whole batch offline.
+
+    Regression test, one case per way a sibling file can fail: before this
+    PR's fixes, each of these independently propagated an uncaught
+    exception out of the whole enumeration, taking every other, perfectly
+    good snapshot offline with it. See ``reason`` above for why each case
+    is caught now.
+    """
+    # Given: one real, successfully-saved snapshot and one corrupt/orphaned sibling
+    cache = FileCache(tmp_path)
+    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
+    issues_dir = tmp_path / "items" / "issues"
+    corrupt_sibling(issues_dir)
 
     # When: the provider reloads its durable snapshots
     snapshots = FileCache(tmp_path)._work_item_snapshots()
 
-    # Then: the real item is still returned; the escaping symlink is skipped, not raised
+    # Then: only the real item is returned -- the corrupt sibling is skipped, not raised
     assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
 
 

--- a/plugins/development-harness/tests_backlog/test_file_cache.py
+++ b/plugins/development-harness/tests_backlog/test_file_cache.py
@@ -146,42 +146,73 @@ def test_file_cache_lists_work_item_snapshots_by_stable_key(tmp_path: Path) -> N
     ]
 
 
-def test_file_cache_work_item_snapshots_skips_orphaned_temp_file_without_crashing(tmp_path: Path) -> None:
-    """A 0-byte orphaned ``_save_item_snapshot`` temp file must not take the whole batch offline.
+def test_file_cache_work_item_snapshots_orphaned_temp_file_is_invisible_to_enumeration(tmp_path: Path) -> None:
+    """A ``_save_item_snapshot`` temp file must never match the snapshot glob.
 
-    Regression test: a process killed between ``tempfile.mkstemp()`` and
-    ``_save_item_snapshot``'s ``finally`` cleanup leaves an orphaned
-    ``*.tmp.yaml`` file behind (e.g. ``.1466.yaml.vosleo7o.tmp.yaml``, 0
-    bytes). It still matches ``_work_item_snapshots``' ``*.yaml`` glob, and
-    ``yaml.safe_load`` of an empty file returns ``None``, so
-    ``BacklogItem.model_validate(None)`` used to raise a pydantic
-    ``ValidationError`` that propagated out of the whole enumeration --
-    taking every other, perfectly good snapshot offline with it.
+    Regression test: ``_save_item_snapshot``'s ``tempfile.mkstemp`` suffix
+    is ``.tmp``, not ``.tmp.yaml``, so a process killed between
+    ``mkstemp()`` and its ``finally`` cleanup (session interrupt, OOM,
+    crash) leaves an orphan that never matches ``_work_item_snapshots``'s
+    ``*.yaml`` glob -- invisible by construction, not by a filename
+    heuristic applied after the fact. An earlier fix gave the temp file
+    suffix ``.tmp.yaml`` instead (so it still matched the glob) and tried
+    to filter it back out by name; a 0-byte body then parsed to ``None``
+    and failed ``BacklogItem`` validation, which propagated out of the
+    whole enumeration uncaught, taking every other, perfectly good
+    snapshot offline with it.
     """
     # Given: a cache root whose items/issues directory holds only an orphaned temp file
     cache = FileCache(tmp_path)
     issues_dir = tmp_path / "items" / "issues"
     issues_dir.mkdir(parents=True)
-    (issues_dir / ".1466.yaml.vosleo7o.tmp.yaml").touch()
+    (issues_dir / ".1466.yaml.vosleo7o.tmp").touch()
 
     # When: the provider enumerates its durable snapshots
     snapshots = cache._work_item_snapshots()
 
-    # Then: the orphan is silently excluded, not raised as a crash
+    # Then: the orphan never matches the *.yaml glob -- absent, not raised
     assert snapshots == []
 
 
-def test_file_cache_work_item_snapshots_excludes_orphaned_temp_file_alongside_real_items(tmp_path: Path) -> None:
+def test_file_cache_work_item_snapshots_ignores_orphaned_temp_file_alongside_real_items(tmp_path: Path) -> None:
+    """An orphaned temp file beside a real snapshot for the same key must not affect it.
+
+    Regression test: confirms the orphan doesn't shadow or otherwise
+    interfere with a real, successfully-saved snapshot for the same
+    logical key sitting right beside it.
+    """
     # Given: one real, successfully-saved snapshot and one orphaned temp file left
     # behind beside it by a prior interrupted write for the same destination
     cache = FileCache(tmp_path)
     cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
-    (tmp_path / "items" / "issues" / ".12.yaml.abcd1234.tmp.yaml").touch()
+    (tmp_path / "items" / "issues" / ".12.yaml.abcd1234.tmp").touch()
 
     # When: the provider reloads its durable snapshots
     snapshots = FileCache(tmp_path)._work_item_snapshots()
 
-    # Then: only the real item is returned -- the orphan never reaches load_item()
+    # Then: only the real item is returned -- the orphan never matches the glob
+    assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
+
+
+def test_file_cache_work_item_snapshots_skips_zero_byte_yaml_without_crashing(tmp_path: Path) -> None:
+    """A 0-byte ``.yaml`` file from any source must not take the whole batch offline.
+
+    Regression test: a genuinely empty ``.yaml`` file -- e.g. a leftover
+    from before this fix, or any other write-time corruption -- still
+    matches the ``*.yaml`` glob and must still be caught by the generic
+    corrupt-snapshot salvage below, independent of the temp-file-naming
+    fix above. ``yaml.safe_load`` of an empty file returns ``None``, and
+    ``BacklogItem.model_validate(None)`` raises ``pydantic.ValidationError``.
+    """
+    # Given: one real snapshot and one sibling that is a genuinely empty .yaml file
+    cache = FileCache(tmp_path)
+    cache._save_work_item_snapshot("#12", BacklogItem(title="Issue snapshot"))
+    (tmp_path / "items" / "issues" / "13.yaml").touch()
+
+    # When: the provider reloads its durable snapshots
+    snapshots = FileCache(tmp_path)._work_item_snapshots()
+
+    # Then: the real item is still returned; the empty one is skipped, not raised
     assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
 
 
@@ -227,50 +258,6 @@ def test_file_cache_work_item_snapshots_skips_unreadable_path_without_crashing(t
 
     # Then: the real item is still returned; the unreadable path is skipped, not raised
     assert [(key, item.title) for key, item in snapshots] == [("issues/12.yaml", "Issue snapshot")]
-
-
-def test_file_cache_work_item_snapshots_keeps_real_snapshot_ending_in_tmp(tmp_path: Path) -> None:
-    """A real snapshot whose logical key ends in ``.tmp`` must not be mistaken for an orphan.
-
-    Regression test: the orphan filter used to match any filename ending in
-    ``.tmp.yaml``, not just files created by ``_save_item_snapshot``'s
-    ``tempfile.mkstemp`` (which always adds a leading-dot prefix). A
-    legitimate snapshot saved under a key like ``release-1.0.tmp`` was
-    silently and permanently excluded, with no warning logged, unlike the
-    corrupt-YAML path.
-    """
-    # Given: a real snapshot saved under a key that happens to end in ".tmp"
-    cache = FileCache(tmp_path)
-    cache._save_work_item_snapshot("release-1.0.tmp", BacklogItem(title="Real item"))
-
-    # When: the provider reloads its durable snapshots
-    snapshots = FileCache(tmp_path)._work_item_snapshots()
-
-    # Then: the real item is returned, not excluded as an orphan
-    assert [(key, item.title) for key, item in snapshots] == [("release-1.0.tmp.yaml", "Real item")]
-
-
-def test_file_cache_work_item_snapshots_keeps_real_snapshot_with_dot_prefixed_tmp_key(tmp_path: Path) -> None:
-    """A real snapshot whose key both starts with '.' and ends in '.tmp' must not be dropped.
-
-    Regression test: the orphan filter used to treat any filename starting
-    with '.' and ending in '.tmp.yaml' as an orphan. A legitimate key like
-    ``.release.tmp`` produces exactly that shape (``.release.tmp.yaml``)
-    without ever going through ``tempfile.mkstemp``, so it was silently and
-    permanently dropped -- with no warning logged, unlike the corrupt-YAML
-    path -- because the filter matched before the try/except ever ran. The
-    filter now also requires the embedded literal ``.yaml.`` that only a
-    real ``mkstemp`` orphan's name contains.
-    """
-    # Given: a real snapshot saved under a key that starts with "." and ends in ".tmp"
-    cache = FileCache(tmp_path)
-    cache._save_work_item_snapshot(".release.tmp", BacklogItem(title="Real item"))
-
-    # When: the provider reloads its durable snapshots
-    snapshots = FileCache(tmp_path)._work_item_snapshots()
-
-    # Then: the real item is returned, not excluded as an orphan
-    assert [(key, item.title) for key, item in snapshots] == [(".release.tmp.yaml", "Real item")]
 
 
 def test_file_cache_work_item_snapshots_skips_path_escaping_cache_root_without_crashing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- A stray 0-byte `.tmp.yaml` orphan file (left behind by an interrupted atomic write via `tempfile.mkstemp(..., suffix=".tmp.yaml")`) crashed the entire backlog cache sync, because `_work_item_snapshots()` enumerated it via `rglob("*.yaml")` and tried to parse it as a `BacklogItem`.
- `_work_item_snapshots` now excludes any `*.tmp.yaml` file from enumeration.
- `_load_item_snapshot` is now wrapped in `try/except (pydantic.ValidationError, YAMLError)`, logging and skipping the bad file instead of taking down the whole cache read.

Root cause and reproduction were confirmed live: this exact orphan file blocked an active session's backlog MCP tools at the start of this work (`plugins/development-harness/backlog_core/file_cache.py`).

## Test plan
- [x] `test_file_cache_work_item_snapshots_skips_orphaned_temp_file_without_crashing` (new) — orphan-only directory, confirms empty snapshot list instead of a crash
- [x] `test_file_cache_work_item_snapshots_excludes_orphaned_temp_file_alongside_real_items` (new) — orphan alongside a real snapshot, confirms the real one still loads and the orphan is silently skipped
- [x] Full `tests_backlog` suite (618 tests) green
- [x] ruff/ty clean

Built via TDD in an isolated worktree per the user's request — reproduced the crash first, then wrote both failing tests before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHZ9qtoiRw8MW6C5gAuCXh