### PR TITLE
fix(agents): restore content dropped by the #3398 AGENTS.md restructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,7 @@ Backlog backend for this checkout: **GitHub Issues** (`.dh/config.yaml`'s `backe
 This repo does not use Beads (`bd`) for task tracking. **Never run `bd init` or `bd setup` at the
 repo root.** If a Beads integration block reappears in this file, delete it — it does not describe
 this checkout. See `plugins/development-harness/AGENTS.md`'s "Backend Providers" section for how
-backend selection and the `backlog_*`/`sam_*` MCP tools actually work. The backlog system uses
-the configured provider's native interface and structured MCP tools
-(prefix: `mcp__plugin_dh_backlog__`) — **never edit `.claude/backlog/` files directly**.
+backend selection and the `backlog_*`/`sam_*` MCP tools actually work.
 
 ## Environment Setup (Required First)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ with its own MCP servers (`backlog_core/`, `sam_schema/`), agents, and skills. I
 Backlog backend for this checkout: **GitHub Issues** (`.dh/config.yaml`'s `backend.name: github`).
 This repo does not use Beads (`bd`) for task tracking. **Never run `bd init` or `bd setup` at the
 repo root.** If a Beads integration block reappears in this file, delete it — it does not describe
-this checkout. See `plugins/development-harness/AGENTS.md`'s "Backend Providers" section for how
-backend selection and the `backlog_*`/`sam_*` MCP tools actually work.
+this checkout. See `plugins/development-harness/AGENTS.md`'s "Backend Providers" section for the
+backend abstraction's Protocol architecture when extending or modifying `dh`'s backend code.
 
 ## Environment Setup (Required First)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,9 @@ Backlog backend for this checkout: **GitHub Issues** (`.dh/config.yaml`'s `backe
 This repo does not use Beads (`bd`) for task tracking. **Never run `bd init` or `bd setup` at the
 repo root.** If a Beads integration block reappears in this file, delete it — it does not describe
 this checkout. See `plugins/development-harness/AGENTS.md`'s "Backend Providers" section for how
-backend selection and the `backlog_*`/`sam_*` MCP tools actually work.
+backend selection and the `backlog_*`/`sam_*` MCP tools actually work. The backlog system uses
+the configured provider's native interface and structured MCP tools
+(prefix: `mcp__plugin_dh_backlog__`) — **never edit `.claude/backlog/` files directly**.
 
 ## Environment Setup (Required First)
 
@@ -94,6 +96,20 @@ This repo enforces **Conventional Commits** with `--strict --force-scope` (scope
 the `conventional-pre-commit` hook in `.pre-commit-config.yaml`.
 
 **NEVER use `--no-verify` or flags that bypass git hooks.** If a hook fails, fix the underlying issue.
+
+## Git Workflow: Commit, Push, and PR per Task
+
+Repo owner instruction, standing: commit completed work as each discrete task finishes, push the
+branch, and open a pull request for it. Do not wait for interactive approval before committing or
+pushing in this repository — this overrides Claude Code's own default "ask before committing"
+behavior here.
+
+- Follow `rules/commit-cadence-and-worktrees.md` for commit hygiene: small, file-scoped commits
+  via an explicit file list, never `git add -A`.
+- One PR per discrete task or unit of work, not one PR per session. Push the branch and run
+  `gh pr create` once a task's commit(s) land.
+- This does not extend to force-pushing, pushing directly to `main`, merging PRs, or bypassing
+  hooks (`--no-verify`) — those still need explicit approval every time.
 
 ## Working Tree Safety
 

--- a/rules/plugin-development.md
+++ b/rules/plugin-development.md
@@ -112,6 +112,3 @@ it (e.g. "load `{plugin}-meta-docs` and read the X document it lists") — confi
 exists before adding, give the entry a specific reason to read it, and drop the entry once nothing
 depends on it. Use `${CLAUDE_PLUGIN_ROOT}` for each listed path so the substitution still resolves
 correctly regardless of installation location.
-
-**Skilllint hook**: The pre-commit hook runs `uvx skilllint@latest check --fix` on SKILL.md,
-plugin.json, agent, and command files.


### PR DESCRIPTION
## Summary
- `#3398` (merged) restructured `AGENTS.md` into task-conditional docs but silently dropped a standing behavioral authorization with no replacement anywhere in the new `docs/*.md`/`rules/*.md` split, and left a verbatim-duplicated bullet in `rules/plugin-development.md`.
- Restores the "Git Workflow: Commit, Push, and PR per Task" standing authorization (agents may commit/push/open PRs without interactive approval) under `## Commit Conventions` — added deliberately in `#3397`, one commit before `#3398` dropped it; confirmed with the repo owner this is a genuine regression, not an intentional removal.
- Removes the duplicate "Skilllint hook" bullet in `rules/plugin-development.md` (was present twice, verbatim, in the same section).
- ~~Restores the `.claude/backlog/` guardrail~~ — **correction**: the repo owner confirmed `.claude/backlog/` has been deprecated for a long time and `#3398`'s removal of that guardrail was intentional, not a regression. Dropped from this PR.

Found via `/code-review` of the open-PR batch this session was working through (`#3398` merged mid-review before these findings could block it).

## Test plan
- [x] `uv run pytest tests/test_repo_instruction_drift.py -q` passes
- [x] `uv run prek run --files AGENTS.md rules/plugin-development.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5CenzfiGmgo4J31kPHaMc