### PR TITLE
docs(agents): public-by-default naming, extend no-uv-workspace note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ Before validating an MCP server (protocol, Codex, or Claude plugin integration),
   and reuse what's already declared (e.g. `httpx`, `ruamel.yaml`) instead of assuming a stdlib-only
   design. Stdlib-only is a valid constraint only for a confirmed deployment restriction (airgapped,
   no pip access) — not a default posture.
+- **Public by default**: name new functions and modules without a leading underscore. Early
+  "private" naming gets cargo-culted onto things that aren't private, then breaks tests that
+  legitimately need the name — add privacy once actually needed. Existing underscored code stays
+  as-is.
 
 Before writing a script or CLI meant to be consumed by an agent (which is every script/CLI/MCP
 server in this repo), read `docs/cli-output-conventions.md`.

--- a/rules/python-development.md
+++ b/rules/python-development.md
@@ -13,6 +13,12 @@
 
 Do not create a per-plugin `pyproject.toml` sub-project or a per-plugin `uv.lock`.
 
+This extends to every directory a script imports (`backlog_core/`, `dh_core/`, `sam_schema/`,
+etc.): they have `__init__.py` and dotted imports for internal organization, but are not
+distributable packages — never build, bundle, publish, or add a `pyproject.toml` beside them.
+Doing so creates two dependency sources of truth (the script's own inline deps vs. a new
+package's) that silently diverge — a split-brain, not a cleanup.
+
 ### Invariant
 
 ```bash


### PR DESCRIPTION
## Summary
Supersedes #3390 — that branch was created before #3398's `AGENTS.md` restructure and #3389's merge, and rebasing it directly would conflict against the entire restructure diff (it's still built on the pre-#3398, unslimmed `AGENTS.md`). This PR re-applies #3390's two actual content additions onto current `main`, in their new post-restructure locations:

- **"Public by default" naming convention** → `AGENTS.md`'s Python conventions list (same content, same place it existed pre-restructure — that section wasn't moved).
- **No-uv-workspace note extension** (internal directories like `backlog_core/`, `dh_core/`, `sam_schema/` are not distributable packages, never build/bundle/publish them) → its new home, `rules/python-development.md`'s "Plugin Python — PEP 723 Scripts, No uv Workspace" section, since that content moved out of `AGENTS.md`'s gotcha list into this dedicated rules file during `#3398`.

Closes #3390 (superseded, not mergeable as-is).

## Test plan
- [x] `uv run prek run --files AGENTS.md rules/python-development.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5CenzfiGmgo4J31kPHaMc