### PR TITLE
fix(dh): stop unregistered-section fallback heading colliding with Groomed

### DIFF
--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.18",
+  "version": "11.0.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.claude-plugin/plugin.json
+++ b/plugins/development-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "11.0.19",
+  "version": "11.0.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.19",
+  "version": "10.0.20",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.codex-plugin/plugin.json
+++ b/plugins/development-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dh",
-  "version": "10.0.18",
+  "version": "10.0.19",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.18",
+  "version": "7.0.19",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/.cursor-plugin/plugin.json
+++ b/plugins/development-harness/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dh",
   "description": "Language-agnostic development process harness implementing the Stateless Agent Methodology (SAM) 7-stage pipeline with ARL human touchpoint model and Voltron-style language plugin composition. Provides orchestration, workflows, planning, verification, and testing methodology that any language plugin can compose with.",
-  "version": "7.0.19",
+  "version": "7.0.20",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/development-harness/backlog_core/github_sync.py
+++ b/plugins/development-harness/backlog_core/github_sync.py
@@ -19,7 +19,7 @@ from . import rendering as _rendering
 from .artifact_registry import parse_manifest_section, render_manifest_section, replace_manifest_in_body
 from .entry_blocks import _deduplicate_timestamps, _render_entry_raw, parse_entries
 from .models import BacklogItem, GroomedData, Section, parse_issue_number
-from .parsing import extract_sections
+from .parsing import _GROOMED_DATE_RE, extract_sections
 
 __all__ = [
     "SECTION_HEADING",
@@ -37,7 +37,11 @@ __all__ = [
 
 _METADATA_BLOCK_RE = re.compile(r"<!--\s*backlog-metadata:\s*\n(.*?)\n-->", re.DOTALL)
 _METADATA_LINE_RE = re.compile(r"^(\w+):\s*(.*)$")
-_GROOMED_HEADING_RE = re.compile(r"^##\s+Groomed\s*\(([^)]*)\)")
+# Groomed heading gate/date extraction: canonical pattern lives in
+# parsing._GROOMED_DATE_RE (imported above), matched against the heading text
+# with its "## " prefix already stripped, so this module and parsing.py's
+# parse_md_body_sections (the legacy .md-file parser) can never disagree
+# about what counts as a real "## Groomed (date)" heading.
 _SUBSECTION_RE = re.compile(r"### ([^\n]+)\n([\s\S]*?)(?=\n### |\Z)")
 
 # Re-exported from rendering — canonical definition lives in rendering.SECTION_HEADING
@@ -205,17 +209,18 @@ def _parse_metadata_block(body: str) -> dict[str, str]:
     return result
 
 
-def _parse_groomed_section(heading: str, content: str) -> GroomedData:
-    """Parse a ``## Groomed (date)`` heading + body into a GroomedData model.
+def _parse_groomed_section(heading_name: str, content: str) -> GroomedData:
+    """Parse a ``Groomed (date)`` heading name + body into a GroomedData model.
 
     Args:
-        heading: Full heading string, e.g. ``"## Groomed (2026-03-01)"``.
+        heading_name: Heading text with the ``## `` prefix already stripped,
+            e.g. ``"Groomed (2026-03-01)"``.
         content: Section body text (content after the heading line).
 
     Returns:
         GroomedData with date and subsections populated.
     """
-    date_match = _GROOMED_HEADING_RE.match(heading)
+    date_match = _GROOMED_DATE_RE.match(heading_name)
     date = date_match.group(1).strip() if date_match else ""
     subsections: dict[str, str] = {}
     for sub_match in _SUBSECTION_RE.finditer(content):
@@ -279,10 +284,12 @@ def parse_issue_body(body: str, existing: BacklogItem | None = None) -> BacklogI
         # "Groomed", with no parens) -- misrouting a generic Section into
         # _parse_groomed_section and producing a GroomedData under "groomed"
         # alongside the correct "unknown__groomed" key, duplicating the section on
-        # round-trip. Matching the same pattern _parse_groomed_section itself
-        # requires (a date in parens) keeps the two checks in agreement.
-        if _GROOMED_HEADING_RE.match(heading):
-            parsed_sections["groomed"] = _parse_groomed_section(heading, content)
+        # round-trip. Sharing parsing._GROOMED_DATE_RE with parse_md_body_sections
+        # (the legacy .md-file parser, same collision class) means the two
+        # parsers can't independently drift out of agreement on what counts as
+        # a real Groomed heading.
+        if _GROOMED_DATE_RE.match(heading_name):
+            parsed_sections["groomed"] = _parse_groomed_section(heading_name, content)
             continue
 
         # Entry-bearing sections — routed through the same alias-aware resolver

--- a/plugins/development-harness/backlog_core/github_sync.py
+++ b/plugins/development-harness/backlog_core/github_sync.py
@@ -272,8 +272,16 @@ def parse_issue_body(body: str, existing: BacklogItem | None = None) -> BacklogI
             description = content.strip()
             continue
 
-        # Groomed section: heading starts with "Groomed"
-        if heading_name.startswith("Groomed"):
+        # Groomed section: heading matches the canonical "## Groomed (date)" form only.
+        # A loose `heading_name.startswith("Groomed")` check previously matched any
+        # unregistered section whose title-cased fallback heading happens to be
+        # "Groomed" (e.g. section key "GROOMED" -> unknown_key_to_heading ->
+        # "Groomed", with no parens) -- misrouting a generic Section into
+        # _parse_groomed_section and producing a GroomedData under "groomed"
+        # alongside the correct "unknown__groomed" key, duplicating the section on
+        # round-trip. Matching the same pattern _parse_groomed_section itself
+        # requires (a date in parens) keeps the two checks in agreement.
+        if _GROOMED_HEADING_RE.match(heading):
             parsed_sections["groomed"] = _parse_groomed_section(heading, content)
             continue
 

--- a/plugins/development-harness/backlog_core/parsing.py
+++ b/plugins/development-harness/backlog_core/parsing.py
@@ -821,8 +821,16 @@ def merge_sections(local_body: str, github_body: str) -> tuple[str, bool]:
 _H2_LEVEL = 2
 _H3_LEVEL = 3
 
-# Groomed heading: "## Groomed" with optional " (YYYY-MM-DD)" suffix.
-_GROOMED_DATE_RE = re.compile(r"^Groomed(?:\s*\((\d{4}-\d{2}-\d{2})\))?$", re.IGNORECASE)
+# Groomed heading: "Groomed (date)" only — the date group is REQUIRED, not
+# optional. A bare "Groomed" (no parens) is also what an unregistered section's
+# fallback heading collapses to via rendering.unknown_key_to_heading (e.g. a
+# section key "GROOMED" -> "Groomed", no date). Matching it here would route
+# that unrelated section into GroomedData and silently duplicate/overwrite the
+# real "Groomed (date)" section on round-trip. Canonical for both this
+# module's parse_md_body_sections (legacy .md-file parser) and
+# github_sync.parse_issue_body, which imports this same pattern instead of
+# keeping its own copy — a single definition, not two hand-synced ones.
+_GROOMED_DATE_RE = re.compile(r"^Groomed\s*\(([^)]*)\)$", re.IGNORECASE)
 
 # Entry-block wrapper markers. Must match entry_blocks.wrap_entry()'s
 # "<div><sub>{ts}</sub>\n\n{content}\n</div>" format (see find_entry_spans in
@@ -1239,9 +1247,10 @@ def parse_md_body_sections(body_text: str, added_date: str = "0000-00-00") -> di
     Splits the body on ``## `` top-level headings (respecting fenced code
     blocks), then converts each section to a typed model:
 
-    - ``## Groomed`` (with optional date suffix) → ``GroomedData``
-      ``### `` subsections become ``GroomedData.subsections`` keys; values
-      are stored verbatim so ``entry_blocks`` operations work unchanged.
+    - ``## Groomed (date)`` (parenthesized suffix required — see
+      ``_GROOMED_DATE_RE``) → ``GroomedData``. ``### `` subsections become
+      ``GroomedData.subsections`` keys; values are stored verbatim so
+      ``entry_blocks`` operations work unchanged.
     - All other sections → ``Section`` with a list of ``Entry`` objects.
       Sections with ``<div><sub>`` entry blocks are parsed into individual
       ``Entry`` instances.  Sections with plain text get a single synthetic

--- a/plugins/development-harness/tests/test_github_sync.py
+++ b/plugins/development-harness/tests/test_github_sync.py
@@ -558,6 +558,44 @@ class TestParseIssueBodyUnknownHeading:
         assert "unknown__migration_steps" in result.sections
         assert "unknown__custom_analysis" in result.sections
 
+    def test_parse_unregistered_groomed_heading_does_not_collide_with_groomed_section(self) -> None:
+        """A bare '## Groomed' heading (no date parens) is an unregistered section, not GroomedData.
+
+        Regression test for the fix that replaced a loose
+        ``heading_name.startswith("Groomed")`` check with
+        ``parsing._GROOMED_DATE_RE`` (requires a ``(date)`` suffix). An
+        unregistered section stored under a
+        key like ``"GROOMED"`` round-trips through ``unknown_key_to_heading`` to
+        the display heading ``"Groomed"`` (title-cased, no parens) — identical
+        text to what the loose check matched, misrouting it into
+        ``_parse_groomed_section`` and producing a spurious ``GroomedData`` under
+        the ``"groomed"`` key alongside the correct ``unknown__groomed`` key.
+        """
+        # Arrange — a heading identical to the unregistered-key fallback text,
+        # with no date suffix, alongside a real canonical Groomed section.
+        body = (
+            "<!-- backlog-metadata:\n"
+            "priority: P1\n"
+            "type: Feature\n"
+            "status: open\n"
+            "added: 2026-01-01\n"
+            "-->\n\n"
+            "## Groomed\n\nUnrelated content that happens to share the fallback heading.\n\n"
+            "## Groomed (2026-01-01)\n\n### Priority\n\nHigh priority.\n"
+        )
+
+        # Act
+        result = parse_issue_body(body)
+
+        # Assert — the bare heading is stored as an unknown section, not folded
+        # into "groomed", and the real Groomed section still parses correctly.
+        assert "unknown__groomed" in result.sections
+        assert isinstance(result.sections["unknown__groomed"], Section)
+        groomed = result.sections["groomed"]
+        assert isinstance(groomed, GroomedData)
+        assert groomed.date == "2026-01-01"
+        assert groomed.subsections.get("Priority") == "High priority."
+
     def test_parse_issue_body_existing_carries_non_body_fields(self) -> None:
         """parse_issue_body with existing carries over title, issue, source, plan.
 

--- a/plugins/development-harness/tests/test_md_migration.py
+++ b/plugins/development-harness/tests/test_md_migration.py
@@ -348,6 +348,38 @@ Big scope.
     assert "Scope" in groomed.subsections
 
 
+def test_parse_md_body_sections_unregistered_groomed_heading_does_not_collide() -> None:
+    """A bare '## Groomed' heading (no date parens) is an unregistered section, not GroomedData.
+
+    Mirrors ``test_github_sync.test_parse_unregistered_groomed_heading_does_not_collide_with_groomed_section``
+    for the legacy ``.md``-body parse path: an unregistered section stored
+    under a key like ``"GROOMED"`` round-trips through ``unknown_key_to_heading``
+    to the bare display heading ``"Groomed"`` (title-cased, no date). Before
+    ``_GROOMED_DATE_RE`` required the parenthesized date group, that bare
+    heading matched and was misrouted into ``GroomedData``, colliding with a
+    real ``## Groomed (date)`` section in the same body.
+    """
+    body = """\
+## Groomed
+
+Unrelated content that happens to share the fallback heading.
+
+## Groomed (2026-01-01)
+
+### Priority
+
+High priority.
+"""
+    result = parse_md_body_sections(body)
+
+    assert "unknown__groomed" in result
+    assert isinstance(result["unknown__groomed"], Section)
+    groomed = result["groomed"]
+    assert isinstance(groomed, GroomedData)
+    assert groomed.date == "2026-01-01"
+    assert groomed.subsections.get("Priority") == "High priority."
+
+
 # ---------------------------------------------------------------------------
 # parse_md_body_sections — fenced code block guard
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`main`'s CI has been red for the last several runs on `test_write_render_parse_round_trip_is_lossless` (property-based, Hypothesis). Root-caused by reproducing the exact Hypothesis-found case standalone:

An unregistered section whose title-cased fallback heading happens to equal "Groomed" (e.g. section key `GROOMED` → `unknown_key_to_heading` → heading `"Groomed"`, no parens) collided with `parse_issue_body`'s loose `heading_name.startswith("Groomed")` dispatch check, misrouting a generic `Section` into `_parse_groomed_section` and producing a `GroomedData` under `"groomed"` alongside the correct `"unknown__groomed"` key — duplicating the section on round-trip.

This is the same defect class already tracked by #2974 and #3048 (heading↔key round-trip in `backlog_core`), and the same class independently diagnosed earlier today for issue #2955's runaway growth — a different specific mechanism in that case (embedded `##` in Description text), but the same family of write-key/read-key mismatch.

Fix: match the same `_GROOMED_HEADING_RE` pattern `_parse_groomed_section` itself requires (`## Groomed (date)`, with parens) instead of a bare prefix check, so the two checks can't disagree.

## Test plan
- [x] Reproduced the exact failing Hypothesis case standalone before fixing, confirmed the fix resolves it
- [x] `uv run pytest plugins/development-harness/tests/test_github_sync.py -q` — 60 passed
- [x] `uv run prek run --files plugins/development-harness/backlog_core/github_sync.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5CenzfiGmgo4J31kPHaMc