### PR TITLE
docs(tests): tighten drift-test docstring per pruning review

### DIFF
--- a/tests/test_repo_instruction_drift.py
+++ b/tests/test_repo_instruction_drift.py
@@ -52,12 +52,11 @@ def test_no_stale_dot_claude_rules_path_references() -> None:
     `.claude/rules/*.md` files that no longer exist at that path — an agent following the
     instruction literally (e.g. `.claude/CLAUDE.md:301`'s "load `.claude/rules/skill-substitution.md`
     before editing any SKILL.md") would load nothing and proceed unaware the safety rule never
-    loaded. Scoped to this repo's own root instruction files plus one file found by a repo-wide
-    grep to carry the same stale reference to *this repo's own* directory — not the whole tree,
-    since most other `.claude/rules/` mentions in the repo describe a different project's
-    convention, or the generic `.claude/` config-directory pattern that plugin-shipped files
-    (e.g. `plugins/development-harness/agents/*.md`) intentionally keep, since those files are
-    distributed to other repos and must not assume this repo's own bespoke `rules/` layout.
+    loaded. Scoped to `AGENTS.md`, `.claude/CLAUDE.md`, and `rules/prose-file-classification.md`
+    — not the whole tree, since most other `.claude/rules/` mentions describe other projects'
+    conventions, or (for plugin-shipped files distributed to other repos, e.g.
+    `plugins/development-harness/agents/*.md`) intentionally keep the portable `.claude/rules/`
+    form rather than this repo's own `rules/` layout.
     """
     targets = [
         _REPO_ROOT / "AGENTS.md",


### PR DESCRIPTION
## Summary
A leftover from an earlier writing-for-agents pruning pass — this edit was made after `#3406` had already been pushed and merged, so it never landed anywhere. Small, single-file docstring tightening: names the three target files directly instead of describing how they were found, and drops a redundant restatement.

## Test plan
- [x] `uv run pytest tests/test_repo_instruction_drift.py -q` passes
- [x] `uv run prek run --files tests/test_repo_instruction_drift.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5CenzfiGmgo4J31kPHaMc