### PR TITLE
chore(marketplace): pin merged versioner revision

### DIFF
--- a/.github/workflows/bump-marketplace.yml
+++ b/.github/workflows/bump-marketplace.yml
@@ -38,12 +38,12 @@ jobs:
           fetch-depth: 0
 
       - name: Repair version collisions
-        uses: Jamie-BitFlight/agent-marketplace-versioner@6699fa049c8784e7aecd2426d0ee81e0055e8ff1
+        uses: Jamie-BitFlight/agent-marketplace-versioner@9aa39ed1f661d647cd02ae35348abe4e45279606
         with:
           command: repair
 
       - name: Synchronize marketplace
-        uses: Jamie-BitFlight/agent-marketplace-versioner@6699fa049c8784e7aecd2426d0ee81e0055e8ff1
+        uses: Jamie-BitFlight/agent-marketplace-versioner@9aa39ed1f661d647cd02ae35348abe4e45279606
         with:
           command: sync
           marketplace: 'true'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Require plugin.json version bump for every changed plugin
         if: github.event_name == 'pull_request'
-        uses: Jamie-BitFlight/agent-marketplace-versioner@6699fa049c8784e7aecd2426d0ee81e0055e8ff1
+        uses: Jamie-BitFlight/agent-marketplace-versioner@9aa39ed1f661d647cd02ae35348abe4e45279606
         with:
           command: check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,7 +155,7 @@ repos:
         types: [shell]
 
   - repo: https://github.com/Jamie-BitFlight/agent-marketplace-versioner
-    rev: 6699fa049c8784e7aecd2426d0ee81e0055e8ff1
+    rev: 9aa39ed1f661d647cd02ae35348abe4e45279606
     hooks:
       - id: agent-marketplace-versioner
 


### PR DESCRIPTION
Advances the shared hook and action from the pre-merge review SHA to the merged versioner commit `9aa39ed1f661d647cd02ae35348abe4e45279606`.

Verification:
- `uv run prek run --files .pre-commit-config.yaml .github/workflows/bump-marketplace.yml .github/workflows/code-quality.yml`
- `uv run pytest -m integration tests/test_marketplace_versioner_integration.py --no-cov`