### PR TITLE
chore(codex): pin default model, context window, and multi-agent limits

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,9 @@
+model = "gpt-5.6-sol"
+model_context_window = 372000
+model_reasoning_effort = "high"
+plan_mode_reasoning_effort = "xhigh"
 [features]
 hooks = true
+
+[features.multi_agent_v2]
+max_concurrent_threads_per_session = 16

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,4 +6,5 @@ plan_mode_reasoning_effort = "xhigh"
 hooks = true
 
 [features.multi_agent_v2]
+enabled = true
 max_concurrent_threads_per_session = 16


### PR DESCRIPTION
Adds repo-local Codex defaults to .codex/config.toml: gpt-5.6-sol model, 372k context window, high reasoning effort (xhigh in plan mode), and multi_agent_v2 with 16 max concurrent threads per session. Recovered from uncommitted local state; committed on its own per request.