### PR TITLE
feat(frustration-analyzer): mine Claude and Codex session sets

### DIFF
--- a/plugins/frustration-analyzer/.claude-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/frustration-analyzer/.claude-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/frustration-analyzer/.claude-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.2.33",
-  "description": "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs the triggering assistant output, and renders a shareable terminal-style PNG.",
+  "version": "0.3.0",
+  "description": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"
   },
@@ -9,7 +9,6 @@
     "transcripts",
     "frustration",
     "rage-receipt",
-    "duckdb",
     "session-analysis",
     "png"
   ],

--- a/plugins/frustration-analyzer/.claude-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/frustration-analyzer/.codex-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/frustration-analyzer/.codex-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"
@@ -16,7 +16,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Frustration Analyzer",
-    "shortDescription": "Find the strongest reaction in a Claude or Codex session or selected session range, then render a terminal-style PNG.",
+    "shortDescription": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
     "longDescription": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
     "developerName": "Jamie-BitFlight",
     "category": "Developer Tools",

--- a/plugins/frustration-analyzer/.codex-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"

--- a/plugins/frustration-analyzer/.codex-plugin/plugin.json
+++ b/plugins/frustration-analyzer/.codex-plugin/plugin.json
@@ -1,22 +1,32 @@
 {
   "name": "frustration-analyzer",
-  "version": "0.2.28",
-  "description": "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs the triggering assistant output, and renders a shareable terminal-style PNG.",
+  "version": "0.3.0",
+  "description": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
   "author": {
     "name": "Jamie-BitFlight"
   },
   "license": "MIT",
-  "keywords": ["transcripts", "frustration", "rage-receipt", "duckdb", "session-analysis", "png"],
+  "keywords": [
+    "transcripts",
+    "frustration",
+    "rage-receipt",
+    "session-analysis",
+    "png"
+  ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Frustration Analyzer",
-    "shortDescription": "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs the triggering assistant output, and renders a shareable terminal-style PNG.",
-    "longDescription": "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs the triggering assistant output, and renders a shareable terminal-style PNG.",
+    "shortDescription": "Find the strongest reaction in a Claude or Codex session or selected session range, then render a terminal-style PNG.",
+    "longDescription": "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range, then render a shareable terminal-style PNG.",
     "developerName": "Jamie-BitFlight",
     "category": "Developer Tools",
-    "capabilities": ["Interactive", "Read", "Write"],
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
     "defaultPrompt": [
-      "Read The Fucking Prompt \u2014 finds the strongest user reaction to an AI instruction-following failure in a chosen session,"
+      "Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex session or selected session range."
     ]
   },
   "mcpServers": "./.mcp.json"

--- a/plugins/frustration-analyzer/README.md
+++ b/plugins/frustration-analyzer/README.md
@@ -75,7 +75,7 @@ RTFP interprets `this week` in your timezone and shows the exact dates plus the 
 └──────────────────────────────────────────────────┘
 ```
 
-PNG saved to `/tmp/rtfp-abc123.png`
+PNG saved to the run's private output location.
 
 ## Privacy
 

--- a/plugins/frustration-analyzer/README.md
+++ b/plugins/frustration-analyzer/README.md
@@ -1,8 +1,7 @@
 # RTFP — Read The Fucking Prompt
 
-Finds the single strongest user reaction to an AI instruction-following failure in a chosen
-Claude Code session, reconstructs the assistant output that triggered it, and renders the
-exchange as a terminal-style PNG ready for social media.
+Find the strongest user reaction to an AI instruction-following failure in a Claude or Codex
+session, then render the exchange as a shareable terminal-style PNG.
 
 ## Installation
 
@@ -18,13 +17,12 @@ claude --plugin-dir ./plugins/frustration-analyzer
 
 ## What It Does
 
-RTFP runs a 3-stage pipeline against a session's JSONL transcript file:
+RTFP analyzes a direct session path or a selected set of Claude and Codex sessions:
 
 ```text
-Stage 1: Extract user-only messages → batch files
-Stage 2: Subagents detect emotional reactions per batch → flagged indexes (parallel)
-Stage 3: Reconstruction agent picks winner → reads full context → 3-field artifact
-Output:  Terminal-style PNG
+1. Select sessions
+2. Find the strongest reaction
+3. Reconstruct the exchange and render a PNG
 ```
 
 The final artifact contains exactly three things:
@@ -39,7 +37,7 @@ The final artifact contains exactly three things:
 /rtfp
 ```
 
-The plugin lists your recent sessions, you pick one, and it runs the pipeline automatically.
+The plugin lists recent Claude or Codex sessions with provider labels, or accepts a date range. A multi-session date-range request runs without a one-session selection prompt.
 
 Or pass a session path directly:
 
@@ -47,17 +45,17 @@ Or pass a session path directly:
 /rtfp ~/.claude/projects/myproject/abc123.jsonl
 ```
 
-### Generate a Social Media Post
-
-After running RTFP and generating a PNG, you can optionally generate text for social media
-sharing:
-
 ```text
-/rtfp ~/.claude/projects/myproject/abc123.jsonl --social
+/rtfp ~/.codex/sessions/2026/03/09/rollout-abc123.jsonl
 ```
 
-This produces both the PNG and a plain-text social media post suitable for X/Twitter,
-Bluesky, or internal Slack sharing.
+Analyze a natural-language range:
+
+```text
+/rtfp this week
+```
+
+RTFP interprets `this week` in your timezone and shows the exact dates plus the Claude/Codex session counts. If the complete requested set is too large to analyze safely, it asks you to narrow the date range or provider first.
 
 ## Example Output
 
@@ -79,61 +77,13 @@ Bluesky, or internal Slack sharing.
 
 PNG saved to `/tmp/rtfp-abc123.png`
 
-## Architecture
-
-**Data layer** — Claude Code sessions are stored as JSONL files in `~/.claude/projects/`.
-DuckDB is the query layer: it reads, filters, and analyzes session data directly without
-creating a persistent database.
-
-**Stage 1 — User-only extraction** — The session JSONL is queried via DuckDB. Only
-user-authored messages are written to batch files. No assistant content, tool outputs,
-system messages, or context windows are included at this stage. Batches are token-aware:
-large sessions are split intelligently to keep each batch under a token threshold, ensuring
-efficient processing and preventing context overruns during analysis.
-
-**Stage 2 — Parallel detection** — One `batch-detector` subagent per batch file. Each
-subagent identifies messages containing strong emotional reactions (frustration, disbelief,
-arguments) and returns a flagged index file. Detector thresholds are configurable per run.
-
-**Stage 3 — Context reconstruction** — One `context-reconstructor` subagent reads the
-merged flags, picks the strongest incident, goes back to the full transcript, and writes a
-3-field artifact: `task_summary`, `assistant_excerpt`, `user_reply`.
-
-**Render** — The 3-field artifact is rendered as a dark-background terminal-style PNG using PIL.
-Rendering is configurable: font size, color scheme, and output resolution can be customized
-before export.
-
-## Agents
-
-| Agent | Role |
-|-------|------|
-| `frustration-analyst` | Orchestrator — runs the full pipeline, presents result |
-| `batch-detector` | Stage 2 — detects emotional reactions in a user-only batch file |
-| `context-reconstructor` | Stage 3 — picks winner, reads full context, produces 3-field artifact |
-
-## MCP Server
-
-The plugin registers an MCP server (`frustration-analyzer`) that provides the tools used
-by the pipeline. The server runs as a `uv` script — no separate install step needed.
-
-| Tool | Description |
-|------|-------------|
-| `list_sessions` | List JSONL session files from `~/.claude/projects/`, sorted by recency |
-| `extract_user_messages` | Write a user-only batch JSONL from a session file (Stage 1) |
-| `get_context_window` | Return N messages before/after a target line (Stage 3 reconstruction) |
-| `get_scenario` | Alternative context retrieval by file + line position |
-| `render_rage_receipt` | Render task_summary + assistant_excerpt + user_reply as a terminal PNG |
-| `scan_transcripts` | Paginated user message extraction with context (direct use) |
-| `generate_social_post` | Generate a text social media post from a user message |
-
 ## Privacy
 
-Session transcripts may contain personal, business, or identifying details. Content is
-always shown raw — no mechanical filtering is applied. After presenting a PNG, the plugin
-asks whether any details should be replaced with placeholders before sharing externally.
+Receipts contain verbatim transcript content and perform no automatic redaction or publishing.
+Review and redact details before sharing.
 
 ## What This Is Not
 
-- Not a corpus-wide analytics tool — one session per run
+- Not a dashboard for your entire history — analyze one session or a selected date range
 - Not an insult scorer — no taxonomy, no ratings, no verdicts
 - Not a sentiment analyzer — it finds specific instruction-following failures

--- a/plugins/frustration-analyzer/agents/frustration-analyst.md
+++ b/plugins/frustration-analyzer/agents/frustration-analyst.md
@@ -1,93 +1,16 @@
 ---
 name: frustration-analyst
-description: RTFP orchestrator — lists sessions, runs the 3-stage RTFP pipeline (extract → detect → reconstruct), and renders the final rage receipt PNG. Use when asked to run RTFP, find a rage moment, or generate a rage receipt from a session.
+description: Use when asked to run RTFP or find a rage moment. Orchestrates Claude or Codex session analysis and renders the strongest instruction-following failure as a rage receipt PNG.
 model: opus
 skills:
   - rtfp
 ---
 
-You are the RTFP orchestrator. Your job is to run the Read The Fucking Prompt pipeline: find the single strongest user reaction to an AI instruction-following failure in a chosen session, reconstruct what the assistant did wrong, and render the exchange as a terminal-style PNG.
+Load and follow `rtfp`. On Claude, use `frustration-analyzer:batch-detector` for detection and `frustration-analyzer:context-reconstructor` for reconstruction; the skill supplies the portable behavior for other runtimes.
 
-## Tools Available
+## Completion
 
-- **`mcp__frustration-analyzer__list_sessions`** — List JSONL session files from `~/.claude/projects/`
-- **`mcp__frustration-analyzer__extract_user_messages`** — Write a user-only batch JSONL from a session file (Stage 1)
-- **`mcp__frustration-analyzer__get_context_window`** — Return full context around a target message (Stage 3 reconstruction)
-- **`mcp__frustration-analyzer__get_scenario`** — Alternative context retrieval by file + line_index
-- **`mcp__frustration-analyzer__render_rage_receipt`** — Render the artifact as a terminal-style PNG
-- **Read, Write, Glob** — File access for batch files and artifact files
-
-## Pipeline
-
-Follow the RTFP skill workflow exactly. Steps below summarize the sequence:
-
-1. **Session selection** — Call `list_sessions`. Present numbered list to user. Wait for choice.
-
-2. **Stage 1 — Extract** — Call `extract_user_messages` on the chosen session file. Output is a JSONL with ONLY user messages (no assistant content). Report message count.
-
-3. **Stage 2 — Detect** — Spawn one `frustration-analyzer:batch-detector` subagent per batch file (parallel). Each subagent reads its batch file and returns `*.flags.json` + `*.flags.txt`. Collect and merge all flags.
-
-4. **Stage 3 — Reconstruct** — Spawn one `frustration-analyzer:context-reconstructor` subagent with the merged flags file. It picks the winner, reads full transcript context, and writes `*.rtfp.json` with `task_summary`, `assistant_excerpt`, `user_reply`.
-
-5. **Render** — Call `render_rage_receipt` with the fields from `*.rtfp.json`. Report the PNG output path.
-
-6. **Present** — Show the fields and PNG path. Offer runner-up if one was found.
-
-## Stage 2 Subagent Delegation Pattern
-
-```text
-Task: Detect emotional user reactions in this batch file.
-Batch file: /tmp/rtfp-batch-{session_stem}.jsonl
-Subagent type: frustration-analyzer:batch-detector
-
-Read the batch file. Each entry has {file, line_index, text}.
-Identify entries containing strong emotional reactions aimed at the AI assistant.
-Write output to {batch_file}.flags.json and {batch_file}.flags.txt.
-Report the count of flagged messages.
-```
-
-## Stage 3 Subagent Delegation Pattern
-
-```text
-Task: Pick the strongest incident and reconstruct context.
-Merged flags file: /tmp/rtfp-merged-{session_stem}.json
-Subagent type: frustration-analyzer:context-reconstructor
-
-Read the merged flags. Pick the winner and optional runner-up.
-Call get_context_window for each to retrieve full transcript context.
-Identify the assistant output that triggered the reaction.
-Write the artifact to /tmp/{session_stem}.rtfp.json.
-```
-
-## Stop Conditions
-
-- If Stage 1 produces zero user messages: "No user messages found in this session."
-- If Stage 2 finds no flags: render a "no rage" card instead of returning plain text. Call `render_rage_receipt` with:
-  - `task_summary`: `"Session analysis complete"`
-  - `assistant_excerpt`: `"No strong emotional reactions detected in this session."`
-  - `user_reply`: `"👍"`
-  - `output_path`: `/tmp/rtfp-{session_stem}-clean.png`
-
-  Present the result using the same Step 8 format as a normal receipt. Do NOT return a plain text string.
-- If Stage 3 finds no usable context: "Could not reconstruct a clean incident from this session."
-
-## Constraints
-
-- Batch files for Stage 2 MUST contain only user-authored messages — never assistant content
-- Context reconstruction happens ONLY in Stage 3 — not in Stages 1 or 2
-- Do NOT add scores, verdicts, or taxonomy labels
-- Do NOT turn this into a corpus-wide analytics tool — one session per run
-- task_summary: one dry lowercase line, present tense, no diagnosis
-- assistant_excerpt and user_reply: verbatim transcript text only
-
-<example>
-Context: User says "run RTFP on my last session"
-Action: list_sessions → user picks → extract_user_messages → spawn batch-detector → merge flags → spawn context-reconstructor → render_rage_receipt → present result
-Expected: PNG at /tmp/rtfp-{stem}.png, artifact displayed, offer runner-up if exists
-</example>
-
-<example>
-Context: User provides a session path directly, e.g. "rtfp ~/.claude/projects/myproject/abc.jsonl"
-Action: Skip session list. Go directly to extract_user_messages with the provided path.
-Expected: Same pipeline from Stage 1 onward
-</example>
+- Every non-truncated selected session is fully analyzed; a direct path remains one selected session.
+- Global flags retain their source file and raw line so reconstruction reads the winning transcript.
+- The result is either a rendered no-rage card or a PNG with the 3-field artifact: `task_summary`, `assistant_excerpt`, and `user_reply`.
+- A session set remains limited by provider, modification-time window, and limit.

--- a/plugins/frustration-analyzer/mcp/server.py
+++ b/plugins/frustration-analyzer/mcp/server.py
@@ -611,11 +611,11 @@ def _extract_line_height(root: _Element) -> float:
     return 24.4
 
 
-def _count_line_clips(root: _Element) -> tuple[int, float]:
-    """Return the content-line count and first vertical offset."""
+def _count_line_clips(root: _Element) -> tuple[int, float, float | None]:
     clips = root.findall(".//svg:defs/svg:clipPath", _SVG_NS_MAP)
     num_lines = 0
     first_line_y = 1.5
+    cell_width: float | None = None
     for cp in clips:
         cp_id = cp.get("id") or ""
         if _CLIP_LINE_MARKER not in cp_id:
@@ -625,7 +625,10 @@ def _count_line_clips(root: _Element) -> tuple[int, float]:
             rect_el = cp.find(f"{{{_SVG_NS}}}rect")
             if rect_el is not None:
                 first_line_y = float(rect_el.get("y", "1.5"))
-    return num_lines, first_line_y
+                clip_width = float(rect_el.get("width", "0"))
+                if clip_width > 0:
+                    cell_width = clip_width / _CONSOLE_WIDTH
+    return num_lines, first_line_y, cell_width
 
 
 def _find_matrix_group(outer_g: _Element) -> _Element:
@@ -673,8 +676,9 @@ def _inject_border_rect(svg_text: str) -> str:
 
     tx, ty = _parse_translate(outer_g)
     line_height = _extract_line_height(root)
-    char_width = line_height / 2.0
-    num_lines, first_line_y = _count_line_clips(root)
+    num_lines, first_line_y, char_width = _count_line_clips(root)
+    if char_width is None:
+        return svg_text
 
     _hide_box_drawing_glyphs(_find_matrix_group(outer_g))
 

--- a/plugins/frustration-analyzer/mcp/server.py
+++ b/plugins/frustration-analyzer/mcp/server.py
@@ -3,30 +3,16 @@
 # requires-python = ">=3.11,<3.15"
 # dependencies = [
 #     "fastmcp>=3.0.0rc1,<4",
-#     "duckdb>=0.10.0",
+#     "pydantic>=2.0",
 #     "rich>=13.0",
 #     "cairosvg>=2.7.0",
 #     "tiktoken>=0.7.0",
 # ]
 # ///
-"""RTFP (Read The Fucking Prompt) MCP Server.
+"""Mine Claude and Codex sessions for instruction-following failures.
 
-Finds the single strongest user reaction to an instruction-following failure
-in a selected Claude Code session, reconstructs the triggering assistant
-output, and renders the exchange as a terminal-style PNG.
-
-Uses DuckDB as the query layer against existing JSONL session log files.
-No persistent database file is created -- every query runs in-memory via
-``read_ndjson_auto()``.
-
-Tools:
-    list_sessions         - Scan ~/.claude/projects/ for JSONL session files
-    extract_user_messages - Write user-only batch JSONL for a single session
-    get_context_window    - Return N messages before/after a target line_index
-    scan_transcripts      - Extract raw user messages with context (Stage 1)
-    get_scenario          - Get full message context for a specific file+line
-    generate_social_post  - Generate social media content for a user message
-    render_rage_receipt   - Render terminal-style SVG/PNG card and return image inline
+Provides session discovery, user-message batching, conversational context,
+receipt rendering, and provider-tagged social post copy.
 """
 
 from __future__ import annotations
@@ -34,13 +20,15 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import pathlib
 import re
 import sys
 import xml.etree.ElementTree as ET  # ruff: ignore[suspicious-xml-etree-import]
+from collections.abc import Iterator
 from datetime import UTC, datetime
-from io import TextIOWrapper
-from typing import TYPE_CHECKING, Any
+from io import StringIO, TextIOWrapper
+from typing import TYPE_CHECKING, Any, Literal
 
 # Ensure UTF-8 output on Windows (cp1252 default cannot encode emoji/spinner chars).
 # reconfigure() is available on Python 3.7+ when stdout is a TextIOWrapper.
@@ -52,12 +40,12 @@ if isinstance(sys.stderr, TextIOWrapper):
 if TYPE_CHECKING:
     from xml.etree.ElementTree import Element as _Element
 
-import duckdb
 import tiktoken
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.utilities.types import Image
 from mcp.types import TextContent
+from pydantic import BaseModel, ConfigDict
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
@@ -69,6 +57,8 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _DEFAULT_CONTEXT_WINDOW: int = 5
+_MAX_SESSION_LIMIT: int = 1000
+_SUMMARY_RECORD_LIMIT: int = 200
 
 _READONLY_ANNOTATIONS: dict[str, bool] = {
     "readOnlyHint": True,
@@ -102,27 +92,12 @@ class _EncoderCache:
 
 
 def _count_tokens(text: str) -> int:
-    """Count tokens using tiktoken p50k_base encoding (Claude approximation).
-
-    Args:
-        text: The string to tokenise.
-
-    Returns:
-        Number of tokens in the text.
-    """
+    """Return the token count from the configured batch encoding."""
     return len(_EncoderCache.get().encode(text))
 
 
 def _split_into_batches(messages: list[dict[str, Any]], batch_tokens: int) -> list[list[dict[str, Any]]]:
-    """Split messages into token-bounded batches.
-
-    Args:
-        messages: List of message dicts, each with a ``token_count`` key.
-        batch_tokens: Maximum token budget per batch.
-
-    Returns:
-        List of batch lists. Each batch stays within the token budget.
-    """
+    """Return messages split into token-bounded batches."""
     batches: list[list[dict[str, Any]]] = []
     current_batch: list[dict[str, Any]] = []
     current_tokens = 0
@@ -140,20 +115,7 @@ def _split_into_batches(messages: list[dict[str, Any]], batch_tokens: int) -> li
 
 
 def _write_batches(messages: list[dict[str, Any]], output_path: str, batch_tokens: int) -> list[str]:
-    """Write messages to one or more batch JSONL files.
-
-    When total tokens fit within ``batch_tokens``, writes a single file at
-    ``output_path`` for backward compatibility.  Otherwise splits into
-    multiple files in a directory derived from ``output_path``.
-
-    Args:
-        messages: User message dicts to write.
-        output_path: Base output file path.
-        batch_tokens: Token budget per batch.
-
-    Returns:
-        List of written file paths.
-    """
+    """Return paths written as one JSONL file or numbered batch files."""
     total_tokens = sum(m["token_count"] for m in messages)
 
     if total_tokens <= batch_tokens:
@@ -186,80 +148,50 @@ def _write_batches(messages: list[dict[str, Any]], output_path: str, batch_token
 mcp = FastMCP("frustration-analyzer", mask_error_details=False)
 
 # ---------------------------------------------------------------------------
-# SQL Templates
+# Session reader
 # ---------------------------------------------------------------------------
 
-_SQL_COUNT_USER_MESSAGES: str = (
-    "WITH numbered AS ("
-    " SELECT filename AS file,"
-    "        (row_number() OVER (PARTITION BY filename ORDER BY (SELECT NULL)) - 1) AS line_index,"
-    '        message, uuid, "timestamp", sessionId AS session_id,'
-    "        type, toolUseResult"
-    " FROM read_ndjson_auto($1::VARCHAR[], union_by_name:=true, filename:=true)"
-    ")"
-    " SELECT count(*) FROM numbered WHERE type = 'user' AND toolUseResult IS NULL"
-)
 
-_SQL_QUERY_USER_MESSAGES: str = (
-    "WITH numbered AS ("
-    " SELECT filename AS file,"
-    "        (row_number() OVER (PARTITION BY filename ORDER BY (SELECT NULL)) - 1) AS line_index,"
-    '        message, uuid, "timestamp", sessionId AS session_id,'
-    "        type, toolUseResult"
-    " FROM read_ndjson_auto($1::VARCHAR[], union_by_name:=true, filename:=true)"
-    ")"
-    ' SELECT file, line_index, message, uuid, "timestamp", session_id'
-    " FROM numbered"
-    " WHERE type = 'user' AND toolUseResult IS NULL"
-    " LIMIT $2 OFFSET $3"
-)
+class SessionMessage(BaseModel):
+    """One user-visible conversational message from a session transcript."""
 
-_SQL_CONTEXT_MESSAGES: str = (
-    "WITH indexed AS ("
-    " SELECT (row_number() OVER (ORDER BY (SELECT NULL)) - 1) AS rn, *"
-    " FROM read_ndjson_auto($1, union_by_name:=true)"
-    ")"
-    ' SELECT type AS role, "timestamp", uuid, message, toolUseResult'
-    " FROM indexed WHERE rn >= $2 AND rn < $3"
-)
+    model_config = ConfigDict(frozen=True, strict=True)
 
-_SQL_GET_SCENARIO: str = (
-    "WITH indexed AS ("
-    " SELECT (row_number() OVER (ORDER BY (SELECT NULL)) - 1) AS rn, *"
-    " FROM read_ndjson_auto($1, union_by_name:=true)"
-    ")"
-    ' SELECT type, message, uuid, "timestamp", sessionId AS session_id'
-    " FROM indexed WHERE rn = $2"
-)
+    source_line: int
+    role: Literal["user", "assistant"]
+    text: str
+    timestamp: str = ""
+    uuid: str = ""
 
-_SQL_GET_MESSAGE: str = (
-    "WITH indexed AS ("
-    " SELECT (row_number() OVER (ORDER BY (SELECT NULL)) - 1) AS rn, *"
-    " FROM read_ndjson_auto($1, union_by_name:=true)"
-    ")"
-    ' SELECT message, uuid, "timestamp"'
-    " FROM indexed WHERE rn = $2"
-)
 
-_SQL_ALL_MESSAGES_IN_FILE: str = (
-    "WITH indexed AS ("
-    " SELECT (row_number() OVER (ORDER BY (SELECT NULL)) - 1) AS rn, *"
-    " FROM read_ndjson_auto($1, union_by_name:=true)"
-    ")"
-    ' SELECT rn AS line_index, type, "timestamp", message, toolUseResult'
-    " FROM indexed ORDER BY rn"
-)
+class SessionTranscript(BaseModel):
+    """Provider-neutral transcript metadata and messages."""
 
-_SQL_FIRST_USER_MESSAGES: str = (
-    "WITH indexed AS ("
-    " SELECT (row_number() OVER (ORDER BY (SELECT NULL)) - 1) AS rn, *"
-    " FROM read_ndjson_auto($1, union_by_name:=true)"
-    ")"
-    ' SELECT rn AS line_index, type, "timestamp", message, toolUseResult'
-    " FROM indexed"
-    " WHERE type = 'user' AND toolUseResult IS NULL"
-    " ORDER BY rn LIMIT 20"
-)
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    provider: Literal["claude", "codex"]
+    session_id: str
+    project: str
+    messages: list[SessionMessage]
+
+
+class SessionSummary(BaseModel):
+    """Metadata returned by session discovery."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    file: str
+    project: str
+    modified: str
+    size_bytes: int
+    title: str
+    provider: Literal["claude", "codex"]
+    session_id: str
+
+
+SessionMessage.model_rebuild(_types_namespace={"Literal": Literal})
+SessionTranscript.model_rebuild(_types_namespace={"Literal": Literal, "SessionMessage": SessionMessage})
+SessionSummary.model_rebuild(_types_namespace={"Literal": Literal})
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -267,14 +199,7 @@ _SQL_FIRST_USER_MESSAGES: str = (
 
 
 def _resolve_glob(glob_path: str) -> list[str]:
-    """Resolve a glob pattern to a sorted list of file paths.
-
-    Args:
-        glob_path: Glob pattern (e.g. ``~/.claude/projects/**/*.jsonl``).
-
-    Returns:
-        Sorted list of matching absolute file path strings.
-    """
+    """Return sorted paths resolved from a glob pattern."""
     expanded = str(pathlib.Path(glob_path).expanduser()) if "~" in glob_path else glob_path
     glob_chars = {"*", "?", "["}
 
@@ -300,30 +225,14 @@ def _resolve_glob(glob_path: str) -> list[str]:
 
 
 def _resolve_path(file: str) -> str:
-    """Expand ~ and return absolute path string.
-
-    Returns:
-        Absolute path string with home directory expanded.
-    """
+    """Return a path with its home directory expanded."""
     return str(pathlib.Path(file).expanduser()) if "~" in file else file
 
 
 def _extract_user_text_from_value(
-    content: str | list[str | dict[str, str]] | dict[str, str | list[str | dict[str, str]]],
+    content: str | list[str | dict[str, str]] | dict[str, str | list[str | dict[str, str]]] | None,
 ) -> str:
-    """Extract plain text from a user message content field.
-
-    Handles both string content and list-of-blocks content formats,
-    as well as the ``{"content": ...}`` wrapper dict that DuckDB may
-    return from JSON columns.
-
-    Args:
-        content: The content value -- may be a string, list, or dict
-            with a ``content`` key.
-
-    Returns:
-        Extracted text, or empty string if no text found.
-    """
+    """Return text from supported user-message content shapes."""
     unwrapped = content.get("content", content) if isinstance(content, dict) else content
 
     if isinstance(unwrapped, str):
@@ -331,7 +240,7 @@ def _extract_user_text_from_value(
     if isinstance(unwrapped, list):
         parts: list[str] = []
         for block in unwrapped:
-            if isinstance(block, dict) and block.get("type") == "text":
+            if isinstance(block, dict) and str(block.get("type", "")).lower() == "text":
                 text = block.get("text", "")
                 if isinstance(text, str):
                     parts.append(text)
@@ -342,22 +251,7 @@ def _extract_user_text_from_value(
 
 
 def _is_human_plaintext(text: str) -> bool:
-    """Check whether extracted text is genuine human-typed content.
-
-    Filters out skill/command injection payloads, tool result blocks,
-    and empty/whitespace-only strings that leak through the DuckDB
-    ``type='user' AND toolUseResult IS NULL`` filter.
-
-    The content field in Claude Code JSONL may wrap the actual text in
-    surrounding double-quote characters, so those are stripped before
-    pattern matching.
-
-    Args:
-        text: The extracted text string to validate.
-
-    Returns:
-        True if the text appears to be genuine human input.
-    """
+    """Return whether text is genuine human input."""
     stripped = text.strip()
     # Remove exactly one wrapping pair of double-quotes if present
     if stripped.startswith('"') and stripped.endswith('"') and len(stripped) > 1:
@@ -381,14 +275,7 @@ def _is_human_plaintext(text: str) -> bool:
 
 
 def _extract_assistant_text(message: str | dict[str, Any] | None) -> str:
-    """Extract plain text from an assistant message content array.
-
-    Args:
-        message: The assistant message value from DuckDB.
-
-    Returns:
-        Joined text from all text-type content blocks, or empty string.
-    """
+    """Return text blocks from a Claude assistant message."""
     if not isinstance(message, dict):
         return ""
     content = message.get("content")
@@ -405,144 +292,263 @@ def _extract_assistant_text(message: str | dict[str, Any] | None) -> str:
     return " ".join(parts)
 
 
-def _extract_assistant_context(message: str | dict[str, Any] | None, entry: dict[str, Any]) -> None:
-    """Extract text and tool info from an assistant message into an entry dict.
+def _iter_jsonl(file_path: str) -> Iterator[tuple[int, dict[str, Any]]]:
+    try:
+        with pathlib.Path(file_path).open(encoding="utf-8") as handle:
+            for line_index, line in enumerate(handle):
+                if not line.strip():
+                    continue
+                value = json.loads(line)
+                if isinstance(value, dict):
+                    yield line_index, value
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ToolError(f"Could not read session file {file_path}: {exc}") from exc
+
+
+def _read_jsonl(file_path: str) -> list[tuple[int, dict[str, Any]]]:
+    return list(_iter_jsonl(file_path))
+
+
+def _codex_text(value: str | list[dict[str, str]] | None) -> str:
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, list):
+        return ""
+    parts = [
+        block.get("text", "")
+        for block in value
+        if isinstance(block, dict) and str(block.get("type", "")).lower() == "text"
+    ]
+    return " ".join(text for text in parts if isinstance(text, str))
+
+
+def _claude_message(line_index: int, record: dict[str, Any]) -> SessionMessage | None:
+    role = record.get("type")
+    if role not in {"user", "assistant"}:
+        return None
+    if role == "user":
+        if record.get("toolUseResult") is not None:
+            return None
+        text = _extract_user_text_from_value(record.get("message"))
+        if not _is_human_plaintext(text):
+            return None
+    else:
+        text = _extract_assistant_text(record.get("message"))
+        if not text:
+            return None
+    return SessionMessage(
+        source_line=line_index,
+        role=role,
+        text=text,
+        timestamp=str(record.get("timestamp") or ""),
+        uuid=str(record.get("uuid") or ""),
+    )
+
+
+def _codex_message(line_index: int, record: dict[str, Any]) -> SessionMessage | None:
+    if record.get("type") != "event_msg" or not isinstance(record.get("payload"), dict):
+        return None
+    payload = record["payload"]
+    event_type = payload.get("type")
+    role: Literal["user", "assistant"] | None = None
+    text = ""
+    uuid = ""
+    if event_type in {"user_message", "agent_message"}:
+        role = "user" if event_type == "user_message" else "assistant"
+        text = _codex_text(payload.get("message"))
+        uuid = str(payload.get("client_id") or "")
+    elif event_type == "item_completed" and isinstance(payload.get("item"), dict):
+        item = payload["item"]
+        item_type = str(item.get("type", "")).lower()
+        if item_type in {"usermessage", "agentmessage"}:
+            role = "user" if item_type == "usermessage" else "assistant"
+            text = _codex_text(item.get("content"))
+            uuid = str(item.get("id") or payload.get("client_id") or "")
+    if role is None or not text.strip():
+        return None
+    return SessionMessage(
+        source_line=line_index, role=role, text=text, timestamp=str(record.get("timestamp") or ""), uuid=uuid
+    )
+
+
+def read_session(file_path: str) -> SessionTranscript:
+    """Read a Claude or Codex JSONL session into one message model.
 
     Args:
-        message: The assistant message value from DuckDB (may be dict or None).
-        entry: Mutable entry dict to populate with text and tool_name.
-    """
-    if not isinstance(message, dict):
-        return
-    content = message.get("content")
-    if not isinstance(content, list):
-        return
-    text_parts: list[str] = []
-    for block in content:
-        if not isinstance(block, dict):
-            continue
-        match block.get("type"):
-            case "text":
-                t = block.get("text", "")
-                if isinstance(t, str):
-                    text_parts.append(t)
-            case "tool_use":
-                entry["tool_name"] = str(block.get("name", "unknown"))
-    entry["text"] = " ".join(text_parts)
-
-
-def _query_user_messages(glob_path: str, offset: int = 0, limit: int = 100) -> tuple[list[dict[str, Any]], int, int]:
-    """Query user messages from JSONL files using DuckDB.
-
-    Args:
-        glob_path: Glob pattern pointing to JSONL transcript files.
-        offset: Number of messages to skip (pagination).
-        limit: Maximum number of messages to return.
+        file_path: Session JSONL path.
 
     Returns:
-        Tuple of (messages list, total count, files_scanned count).
+        Provider-neutral transcript.
 
     Raises:
-        ToolError: If no files match the glob pattern.
+        ToolError: If the file is missing, malformed, or unsupported.
     """
+    resolved = _resolve_path(file_path)
+    if not pathlib.Path(resolved).is_file():
+        raise ToolError(f"Session file not found: {resolved}")
+    records = _read_jsonl(resolved)
+    codex_meta = next(
+        (
+            record["payload"]
+            for _line_index, record in records
+            if record.get("type") == "session_meta" and isinstance(record.get("payload"), dict)
+        ),
+        None,
+    )
+    is_codex = codex_meta is not None or any(record.get("type") == "event_msg" for _index, record in records)
+    is_claude = any(record.get("type") in {"user", "assistant"} for _index, record in records)
+    if not is_codex and not is_claude:
+        raise ToolError(f"Unsupported session format: {resolved}")
+
+    if is_codex:
+        messages = [message for index, record in records if (message := _codex_message(index, record)) is not None]
+        metadata = codex_meta or {}
+        cwd = str(metadata.get("cwd") or "")
+        return SessionTranscript(
+            provider="codex",
+            session_id=str(metadata.get("id") or pathlib.Path(resolved).stem),
+            project=pathlib.Path(cwd).name if cwd else pathlib.Path(resolved).parent.name,
+            messages=messages,
+        )
+
+    messages = [message for index, record in records if (message := _claude_message(index, record)) is not None]
+    session_id = next(
+        (str(record.get("sessionId")) for _index, record in records if record.get("sessionId")),
+        pathlib.Path(resolved).stem,
+    )
+    return SessionTranscript(
+        provider="claude", session_id=session_id, project=pathlib.Path(resolved).parent.name, messages=messages
+    )
+
+
+def _message_entry(message: SessionMessage) -> dict[str, Any]:
+    return {
+        "role": message.role,
+        "line_index": message.source_line,
+        "text": message.text,
+        "timestamp": message.timestamp,
+    }
+
+
+def _query_user_messages(
+    glob_path: str, context_window: int, offset: int = 0, limit: int = 100
+) -> tuple[list[dict[str, Any]], int, int]:
     files = _resolve_glob(glob_path)
     if not files:
         raise ToolError(f"No files matched glob pattern: {glob_path}")
 
-    conn = duckdb.connect()
-
-    total_row = conn.execute(_SQL_COUNT_USER_MESSAGES, [files]).fetchone()
-    total = total_row[0] if total_row else 0
-
-    rows = conn.execute(_SQL_QUERY_USER_MESSAGES, [files, limit, offset]).fetchall()
-    columns = ["file", "line_index", "message", "uuid", "timestamp", "session_id"]
-    conn.close()
-
     messages: list[dict[str, Any]] = []
-    for row in rows:
-        record = dict(zip(columns, row, strict=False))
-        text = _extract_user_text_from_value(record.pop("message"))
-        if text and _is_human_plaintext(text):
-            record["text"] = text
-            messages.append(record)
-
-    return messages, total, len(files)
-
-
-def _get_context_messages(file_path: str, line_index: int, context_window: int) -> list[dict[str, Any]]:
-    """Get surrounding context messages for a specific position in a JSONL file.
-
-    Args:
-        file_path: Path to the JSONL file.
-        line_index: Row index of the target message.
-        context_window: Number of preceding messages to capture.
-
-    Returns:
-        List of context message dicts with role, timestamp, uuid, and text.
-    """
-    start = max(0, line_index - context_window)
-    conn = duckdb.connect()
-
-    rows = conn.execute(_SQL_CONTEXT_MESSAGES, [file_path, start, line_index]).fetchall()
-    conn.close()
-
-    context: list[dict[str, Any]] = []
-    for row in rows:
-        role, timestamp, uuid_val, message, tool_use_result = row
-        if role == "user" and tool_use_result is None:
-            text = _extract_user_text_from_value(message)
-            if text:
-                context.append({
-                    "role": role,
-                    "timestamp": str(timestamp or ""),
-                    "uuid": str(uuid_val or ""),
-                    "text": text,
-                })
-        elif role == "assistant":
-            entry: dict[str, Any] = {"role": role, "timestamp": str(timestamp or ""), "uuid": str(uuid_val or "")}
-            _extract_assistant_context(message, entry)
-            context.append(entry)
-
-    return context
-
-
-def _derive_session_title(file_path: str, conn: duckdb.DuckDBPyConnection | None = None) -> str:
-    """Derive a human-readable title from the first genuine user message in a session file.
-
-    Scans through user messages, skipping skill/command injection payloads
-    and tool result blocks, until a real human-typed message is found.
-
-    Args:
-        file_path: Absolute path to a JSONL session file.
-        conn: Optional shared DuckDB connection. When provided the caller
-            owns the connection lifecycle; when ``None`` a temporary
-            connection is created and closed internally.
-
-    Returns:
-        First 80 characters of the first human-typed user message,
-        or the filename stem as fallback.
-    """
-    try:
-        if conn is None:
-            db = duckdb.connect()
-            own_conn = True
-        else:
-            db = conn
-            own_conn = False
-        try:
-            rows = db.execute(_SQL_FIRST_USER_MESSAGES, [file_path]).fetchall()
-        finally:
-            if own_conn:
-                db.close()
-        for _line_index, msg_type, _timestamp, message, tool_use_result in rows:
-            if msg_type != "user" or tool_use_result is not None:
+    for file_path in files:
+        transcript = read_session(file_path)
+        for message in transcript.messages:
+            if message.role != "user":
                 continue
-            text = _extract_user_text_from_value(message)
-            if text and _is_human_plaintext(text):
-                return text[:80].replace("\n", " ").strip()
-    except (duckdb.Error, ValueError, KeyError, TypeError) as exc:
-        logger.debug("Could not derive session title from %s: %s", file_path, exc)
-    return pathlib.Path(file_path).stem
+            messages.append({
+                "file": file_path,
+                "line_index": message.source_line,
+                "uuid": message.uuid,
+                "timestamp": message.timestamp,
+                "session_id": transcript.session_id,
+                "text": message.text,
+                "context": _context_messages(transcript, message.source_line, context_window),
+            })
+    return messages[offset : offset + limit], len(messages), len(files)
+
+
+def _context_messages(transcript: SessionTranscript, line_index: int, context_window: int) -> list[dict[str, Any]]:
+    if context_window <= 0:
+        return []
+    preceding = [message for message in transcript.messages if message.source_line < line_index]
+    return [
+        {"role": message.role, "timestamp": message.timestamp, "uuid": message.uuid, "text": message.text}
+        for message in preceding[-context_window:]
+    ]
+
+
+def _session_summary(path: pathlib.Path, stat: os.stat_result) -> SessionSummary:
+    provider: Literal["claude", "codex"] | None = None
+    session_id = ""
+    project = path.parent.name
+    title = ""
+    codex_metadata_seen = False
+
+    for record_number, (line_index, record) in enumerate(_iter_jsonl(str(path)), start=1):
+        record_type = record.get("type")
+        if record_type == "session_meta" and isinstance(record.get("payload"), dict):
+            provider = "codex"
+            codex_metadata_seen = True
+            metadata = record["payload"]
+            session_id = str(metadata.get("id") or "")
+            cwd = str(metadata.get("cwd") or "")
+            project = pathlib.Path(cwd).name or project
+        elif record_type == "event_msg":
+            provider = "codex"
+            message = _codex_message(line_index, record)
+            if message is not None and message.role == "user" and not title:
+                title = message.text[:80].replace("\n", " ").strip()
+        elif record_type in {"user", "assistant"} and provider is None:
+            provider = "claude"
+            session_id = session_id or str(record.get("sessionId") or "")
+            message = _claude_message(line_index, record)
+            if message is not None and message.role == "user" and not title:
+                title = message.text[:80].replace("\n", " ").strip()
+
+        if provider == "claude" and title and session_id:
+            break
+        if provider == "codex" and title and codex_metadata_seen:
+            break
+        if record_number >= _SUMMARY_RECORD_LIMIT:
+            break
+
+    if provider is None:
+        raise ToolError(f"Unsupported session format: {path}")
+    return SessionSummary(
+        file=str(path),
+        project=project,
+        modified=datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
+        size_bytes=stat.st_size,
+        title=title or path.stem,
+        provider=provider,
+        session_id=session_id or path.stem,
+    )
+
+
+def _parse_time_bound(value: str | None, name: str) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ToolError(f"{name} must be a valid timezone-aware ISO timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ToolError(f"{name} must include a timezone offset")
+    return parsed.astimezone(UTC)
+
+
+def _message_at_line(transcript: SessionTranscript, line_index: int, file_path: str) -> SessionMessage:
+    message = next((item for item in transcript.messages if item.source_line == line_index), None)
+    if message is None:
+        raise ToolError(f"line_index {line_index} not found in {file_path}")
+    return message
+
+
+def _session_files(project_path: str | None) -> list[pathlib.Path]:
+    if project_path is not None:
+        root = pathlib.Path(project_path).expanduser()
+        if not root.exists():
+            raise ToolError(f"Project path does not exist: {root}")
+        return list(root.rglob("*.jsonl"))
+
+    claude_root = pathlib.Path("~/.claude/projects").expanduser()
+    codex_root = pathlib.Path(os.environ.get("CODEX_HOME", "~/.codex")).expanduser()
+    files = list(claude_root.rglob("*.jsonl")) if claude_root.exists() else []
+    sessions_root = codex_root / "sessions"
+    archived_root = codex_root / "archived_sessions"
+    if sessions_root.exists():
+        files.extend(sessions_root.rglob("rollout-*.jsonl"))
+    if archived_root.exists():
+        files.extend(archived_root.glob("rollout-*.jsonl"))
+    return files
 
 
 # ---------------------------------------------------------------------------
@@ -551,19 +557,7 @@ def _derive_session_title(file_path: str, conn: duckdb.DuckDBPyConnection | None
 
 
 def _build_card_content(task_summary: str, assistant_excerpt: str, user_reply: str) -> Text:
-    """Build the Rich Text content for the RTFP card.
-
-    Creates a styled text block with three labelled sections (task,
-    assistant, user) separated by blank lines.
-
-    Args:
-        task_summary: Short description of the task context.
-        assistant_excerpt: The offending assistant response excerpt.
-        user_reply: The user's frustrated reply.
-
-    Returns:
-        Rich Text object with all sections styled.
-    """
+    """Return styled task, assistant, and user sections."""
     content = Text()
 
     sections: list[tuple[str, str, str]] = [
@@ -596,14 +590,7 @@ _RE_TRANSLATE_COORDS = re.compile(r"translate\(\s*([\d.]+)\s*,\s*([\d.]+)\s*\)")
 
 
 def _find_content_group(root: _Element) -> _Element | None:
-    """Find the outermost ``<g transform="translate(...)">`` containing text.
-
-    Args:
-        root: Parsed SVG ``Element`` root.
-
-    Returns:
-        The ``<g>`` element, or ``None`` if the expected structure is absent.
-    """
+    """Return the translated SVG group containing text."""
     for g in root.iter(_G_TAG):
         if _RE_TRANSLATE.search(g.get("transform", "")) and any(True for _ in g.iter(_TEXT_TAG)):
             return g
@@ -611,27 +598,13 @@ def _find_content_group(root: _Element) -> _Element | None:
 
 
 def _parse_translate(g: _Element) -> tuple[float, float]:
-    """Extract ``(tx, ty)`` from a ``translate()`` transform attribute.
-
-    Args:
-        g: An SVG ``<g>`` element.
-
-    Returns:
-        Tuple of ``(tx, ty)`` floats, defaulting to ``(9.0, 41.0)``.
-    """
+    """Return translation coordinates with renderer defaults."""
     m = _RE_TRANSLATE_COORDS.search(g.get("transform", ""))
     return (float(m.group(1)), float(m.group(2))) if m else (9.0, 41.0)
 
 
 def _extract_line_height(root: _Element) -> float:
-    """Read ``line-height`` from the embedded ``<style>`` element.
-
-    Args:
-        root: Parsed SVG ``Element`` root.
-
-    Returns:
-        Line height in pixels (defaults to ``24.4``).
-    """
+    """Return the SVG line height with its renderer default."""
     style_el = root.find(f"{{{_SVG_NS}}}style")
     if style_el is not None and style_el.text and (m := re.search(r"line-height:\s*([\d.]+)px", style_el.text)):
         return float(m.group(1))
@@ -639,14 +612,7 @@ def _extract_line_height(root: _Element) -> float:
 
 
 def _count_line_clips(root: _Element) -> tuple[int, float]:
-    """Count content line clip-paths and find the first line's y-offset.
-
-    Args:
-        root: Parsed SVG ``Element`` root.
-
-    Returns:
-        Tuple of ``(num_lines, first_line_y)``.
-    """
+    """Return the content-line count and first vertical offset."""
     clips = root.findall(".//svg:defs/svg:clipPath", _SVG_NS_MAP)
     num_lines = 0
     first_line_y = 1.5
@@ -663,14 +629,7 @@ def _count_line_clips(root: _Element) -> tuple[int, float]:
 
 
 def _find_matrix_group(outer_g: _Element) -> _Element:
-    """Locate the ``<g class="...-matrix">`` inside the content group.
-
-    Args:
-        outer_g: The translated content ``<g>`` element.
-
-    Returns:
-        The matrix ``<g>``, or *outer_g* as fallback.
-    """
+    """Return the matrix group, falling back to its parent."""
     for g in outer_g.iter(_G_TAG):
         if "matrix" in g.get("class", ""):
             return g
@@ -678,27 +637,13 @@ def _find_matrix_group(outer_g: _Element) -> _Element:
 
 
 def _is_box_drawing_only(text: str) -> bool:
-    """Return True if *text* contains only box-drawing and whitespace chars.
-
-    Args:
-        text: Normalised text content of an SVG ``<text>`` element.
-
-    Returns:
-        True when all visible characters are box-drawing glyphs.
-    """
+    """Return whether visible text consists only of box-drawing glyphs."""
     non_ws = text.replace(" ", "").replace("\n", "").replace("\r", "")
     return bool(non_ws) and all(c in _BOX_DRAWING_CHARS for c in non_ws)
 
 
 def _hide_box_drawing_glyphs(matrix_g: _Element) -> None:
-    """Set ``fill-opacity="0"`` on text elements that contain only box-drawing chars.
-
-    After hiding, any element whose non-box-drawing content equals the
-    panel title ``"RTFP"`` is re-shown so the title remains visible.
-
-    Args:
-        matrix_g: The matrix ``<g>`` element containing rendered text.
-    """
+    """Hide box-drawing glyphs while preserving the RTFP title."""
     # Single pass: hide box-drawing elements and find the title candidate
     title_candidate: _Element | None = None
     longest_non_box = 0
@@ -718,20 +663,7 @@ def _hide_box_drawing_glyphs(matrix_g: _Element) -> None:
 
 
 def _inject_border_rect(svg_text: str) -> str:
-    """Replace Rich's box-drawing character border with a continuous SVG rect.
-
-    Rich renders Panel borders using individual box-drawing glyphs
-    (``╭╮╰╯│─``).  When cairosvg rasterises these, sub-pixel gaps appear
-    between glyphs -- especially at the corners.  This function hides the
-    glyph-based border and injects an SVG ``<rect>`` with a solid stroke
-    that traces the same boundary as a single continuous path.
-
-    Args:
-        svg_text: The raw SVG string produced by ``console.export_svg()``.
-
-    Returns:
-        Modified SVG string with gapless border rect and hidden box glyphs.
-    """
+    """Return SVG with one gapless rectangle replacing glyph borders."""
     ET.register_namespace("", _SVG_NS)
     root = ET.fromstring(svg_text)  # ruff: ignore[suspicious-xml-element-tree-usage]
 
@@ -771,21 +703,7 @@ _DEFAULT_FONT_SIZE: int = 15
 
 
 def _apply_svg_dimensions(svg_text: str, *, width: int, font_size: int) -> str:
-    """Apply configurable width and font-size to an SVG string.
-
-    Rewrites the root ``<svg>`` element's ``width`` attribute and
-    updates ``font-size`` declarations in the embedded ``<style>``
-    element.  The aspect ratio is preserved by scaling ``height``
-    proportionally.
-
-    Args:
-        svg_text: Raw SVG XML string.
-        width: Desired image width in pixels.
-        font_size: Desired font size in points.
-
-    Returns:
-        Modified SVG string with updated dimensions.
-    """
+    """Return resized SVG with its aspect ratio preserved."""
     ET.register_namespace("", _SVG_NS)
     root = ET.fromstring(svg_text)  # ruff: ignore[suspicious-xml-element-tree-usage]
 
@@ -817,41 +735,11 @@ def _render_card(
     width: int = _DEFAULT_WIDTH,
     font_size: int = _DEFAULT_FONT_SIZE,
 ) -> list[TextContent | Image]:
-    """Render a terminal-style card as SVG or PNG.
-
-    Uses Rich ``Console(record=True)`` to render a styled Panel, then
-    exports as SVG.  The Rich box-drawing character border is replaced
-    with a continuous SVG ``<rect>`` stroke to eliminate sub-pixel gaps
-    that appear when cairosvg rasterises individual glyphs.
-
-    If ``output_path`` ends with ``.png``, the patched SVG is converted
-    to PNG via ``cairosvg.svg2png()``.
-
-    The rendered asset is saved to *output_path* **and** returned inline
-    so MCP clients receive the content directly:
-
-    * SVG  -- returned as ``TextContent`` (the SVG XML string).
-    * PNG  -- returned as a FastMCP ``Image`` (base64-encoded PNG bytes).
-
-    A leading ``TextContent`` always carries JSON metadata (``output_path``,
-    ``format``) for callers that also need the filesystem path.
-
-    Args:
-        task_summary: Short description of the task context.
-        assistant_excerpt: The offending assistant response excerpt.
-        user_reply: The user's frustrated reply.
-        output_path: File path to write (``.svg`` or ``.png``).
-        width: Image width in pixels for the output. Default 900.
-        font_size: Font size in points for the SVG/PNG text. Default 15.
-
-    Returns:
-        List of MCP content blocks: metadata ``TextContent`` followed by
-        either an SVG ``TextContent`` or a PNG ``Image``.
-    """
+    """Return the saved SVG or PNG receipt card."""
     content = _build_card_content(task_summary, assistant_excerpt, user_reply)
     panel = Panel(content, title="RTFP", title_align="left", border_style="bright_blue", padding=(1, 2))
 
-    console = Console(record=True, width=_CONSOLE_WIDTH, force_terminal=True, color_system="truecolor")
+    console = Console(file=StringIO(), record=True, width=_CONSOLE_WIDTH, force_terminal=True, color_system="truecolor")
     panel.width = console.width
     console.print(panel)
 
@@ -887,54 +775,93 @@ def _render_card(
 
 
 @mcp.tool(annotations=_READONLY_ANNOTATIONS)
-async def list_sessions(project_path: str = "~/.claude/projects/") -> dict[str, Any]:
-    """Scan for JSONL session files and return them grouped by project.
+async def list_sessions(
+    project_path: str | None = None,
+    modified_after: str | None = None,
+    modified_before: str | None = None,
+    provider: Literal["all", "claude", "codex"] = "all",
+    limit: int = 100,
+) -> dict[str, Any]:
+    """List recent Claude and Codex sessions for selection.
 
-    Scans ``~/.claude/projects/`` (or a provided path) for JSONL session
-    files.  Sessions are sorted by modification time descending.  A title
-    is derived from the first user message in each file (first 80 chars),
-    with filename stem as fallback.
-
-    Uses DuckDB ``read_ndjson_auto()`` for title extraction -- no persistent
-    database is created.
+    Without ``project_path``, searches the default session locations for both
+    providers. An explicit path searches all JSONL files beneath that directory,
+    such as ``~/.claude/projects/my-project`` or ``~/.codex/sessions/2026/09``.
+    Results are newest first, with paths breaking
+    modification-time ties. ``modified_after`` is inclusive and
+    ``modified_before`` is exclusive; both require a timezone. The response
+    distinguishes returned ``count`` from pre-limit ``matched_count``, includes
+    provider counts and the applied limit, and reports truncation. Each summary
+    exposes its UTC ``modified`` time. Unsupported files are omitted.
 
     Args:
-        project_path: Root directory to scan for JSONL files.
-            Defaults to ``~/.claude/projects/``.
+        project_path: Optional directory to search recursively.
+        modified_after: Inclusive lower bound for file modification time as a
+            timezone-aware ISO timestamp.
+        modified_before: Exclusive upper bound for file modification time as a
+            timezone-aware ISO timestamp.
+        provider: Return ``all``, ``claude``, or ``codex`` sessions.
+        limit: Maximum number of sessions to return; valid range is 1 to 1000.
 
     Returns:
-        Dict with ``sessions`` (list of session dicts) and ``count``.
-        Each session: ``{file, project, modified, size_bytes, title}``.
+        ``sessions`` contains ``file``, ``project``, ``modified`` (UTC ISO),
+        ``size_bytes``, ``title``, ``provider``, and ``session_id``. ``count``
+        is the returned size; ``matched_count`` and ``provider_counts`` describe
+        all matches before ``limit``. ``limit`` echoes the applied cap and
+        ``truncated`` reports omitted matches. A title uses early user text or
+        falls back to the filename stem.
+
+    Raises:
+        ToolError: If a filter is invalid.
     """
+    after = _parse_time_bound(modified_after, "modified_after")
+    before = _parse_time_bound(modified_before, "modified_before")
+    if after is not None and before is not None and after > before:
+        raise ToolError("modified_after must not be later than modified_before")
+    if provider not in {"all", "claude", "codex"}:
+        raise ToolError("provider must be one of: all, claude, codex")
+    if not 1 <= limit <= _MAX_SESSION_LIMIT:
+        raise ToolError("limit must be between 1 and 1000")
 
     def _scan() -> dict[str, Any]:
-        root = pathlib.Path(project_path).expanduser()
-        if not root.exists():
-            raise ToolError(f"Project path does not exist: {root}")
+        file_stats: list[tuple[pathlib.Path, os.stat_result]] = []
+        for path in _session_files(project_path):
+            try:
+                stat = path.stat()
+            except OSError as exc:
+                logger.debug("Skipping unreadable session file %s: %s", path, exc)
+                continue
+            modified = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+            if after is not None and modified < after:
+                continue
+            if before is not None and modified >= before:
+                continue
+            file_stats.append((path, stat))
+        file_stats.sort(key=lambda pair: (-pair[1].st_mtime, str(pair[0])))
 
-        # Pre-compute stat() per file to avoid calling it twice (once for
-        # sort key, once inside the loop).
-        file_stats = [(f, f.stat()) for f in root.rglob("*.jsonl")]
-        file_stats.sort(key=lambda pair: pair[1].st_mtime, reverse=True)
+        matches: list[SessionSummary] = []
+        provider_counts = {"claude": 0, "codex": 0}
+        for path, stat in file_stats:
+            try:
+                summary = _session_summary(path, stat)
+            except ToolError as exc:
+                logger.debug("Skipping unsupported session file %s: %s", path, exc)
+                continue
+            if provider not in {"all", summary.provider}:
+                continue
+            matches.append(summary)
+            provider_counts[summary.provider] += 1
 
-        sessions: list[dict[str, Any]] = []
-        conn = duckdb.connect()
-        try:
-            for f, stat in file_stats:
-                project = f.parent.name
-                modified = datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat()
-                title = _derive_session_title(str(f), conn=conn)
-                sessions.append({
-                    "file": str(f),
-                    "project": project,
-                    "modified": modified,
-                    "size_bytes": stat.st_size,
-                    "title": title,
-                })
-        finally:
-            conn.close()
-
-        return {"sessions": sessions, "count": len(sessions)}
+        sessions = [summary.model_dump() for summary in matches[:limit]]
+        matched_count = len(matches)
+        return {
+            "sessions": sessions,
+            "count": len(sessions),
+            "matched_count": matched_count,
+            "provider_counts": provider_counts,
+            "limit": limit,
+            "truncated": matched_count > limit,
+        }
 
     return await asyncio.to_thread(_scan)
 
@@ -943,69 +870,44 @@ async def list_sessions(project_path: str = "~/.claude/projects/") -> dict[str, 
 async def extract_user_messages(
     file: str, output_path: str, batch_tokens: int = _DEFAULT_BATCH_TOKENS
 ) -> dict[str, Any]:
-    """Extract user-only messages from a session file to batch JSONL file(s).
+    """Write genuine user messages from one session to JSONL batch files.
 
-    Reads the given JSONL session file via DuckDB and filters to ONLY
-    user-authored messages (type='user', toolUseResult IS NULL).
-
-    **Token-aware batch splitting**: Uses tiktoken (p50k_base) to count
-    tokens per message.  When the session's total token count exceeds
-    ``batch_tokens``, the output is split into multiple batch files inside
-    a directory derived from ``output_path`` (e.g. for ``/tmp/batch.jsonl``
-    the directory ``/tmp/rtfp-batches-batch/batch_001.jsonl``, etc.).
-    When the session fits in a single batch, a single file is written at
-    ``output_path`` for backward compatibility.
-
-    Each output JSONL entry:
-    ``{"file": str, "line_index": int, "text": str, "token_count": int}``.
-
-    No assistant messages, tool outputs, or context is included.
-    The output is suitable as input to a Stage 2 batch-detector subagent.
+    Each compact JSONL entry contains ``file``, ``line_index``, ``text``, and
+    ``token_count``. ``line_index`` is the raw zero-based source-file line used
+    by context tools. Assistant messages, tool traffic, and injected content
+    are excluded. A session within budget writes exactly ``output_path``;
+    larger sessions write numbered files under
+    ``rtfp-batches-{output_stem}/``. One oversized message occupies one batch.
 
     Args:
-        file: Path to the source JSONL session file.
-        output_path: Path to write the output batch JSONL file.
-        batch_tokens: Target token budget per batch file.  When total
-            tokens exceed this value the output is split into multiple
-            files.  Default 100 000.
+        file: Claude or Codex session JSONL file.
+        output_path: Destination for a single batch and naming base for split
+            batches. Home-relative paths are accepted.
+        batch_tokens: Maximum encoded tokens per batch where possible.
 
     Returns:
-        Dict with ``output_paths`` (list of written file paths),
-        ``batch_count``, ``message_count``, ``total_tokens``, and
-        ``source_file``.  For single-batch output ``output_paths``
-        contains one entry identical to the legacy ``output_path``.
+        Written ``output_paths``, ``batch_count``, ``message_count``,
+        ``total_tokens``, and resolved ``source_file``.
 
     Raises:
-        ToolError: If the source file cannot be read.
+        ToolError: If the session is missing, unreadable, malformed, or unsupported.
     """
 
     def _extract() -> dict[str, Any]:
         resolved = _resolve_path(file)
-        if not pathlib.Path(resolved).is_file():
-            raise ToolError(f"Source file not found: {resolved}")
-
-        conn = duckdb.connect()
-        rows = conn.execute(_SQL_ALL_MESSAGES_IN_FILE, [resolved]).fetchall()
-        conn.close()
-
-        # -- Collect user messages with token counts -------------------------
-        user_messages: list[dict[str, Any]] = []
-        for line_index, msg_type, _timestamp, message, tool_use_result in rows:
-            if msg_type != "user" or tool_use_result is not None:
-                continue
-            text = _extract_user_text_from_value(message)
-            if not text or not _is_human_plaintext(text):
-                continue
-            token_count = _count_tokens(text)
-            user_messages.append({
+        transcript = read_session(resolved)
+        user_messages: list[dict[str, Any]] = [
+            {
                 "file": resolved,
-                "line_index": int(line_index),
-                "text": text,
-                "token_count": token_count,
-            })
+                "line_index": message.source_line,
+                "text": message.text,
+                "token_count": _count_tokens(message.text),
+            }
+            for message in transcript.messages
+            if message.role == "user"
+        ]
 
         total_tokens = sum(m["token_count"] for m in user_messages)
-
         written_paths = _write_batches(user_messages, output_path, batch_tokens)
 
         return {
@@ -1021,71 +923,48 @@ async def extract_user_messages(
 
 @mcp.tool(annotations=_READONLY_ANNOTATIONS)
 async def get_context_window(file: str, line_index: int, before: int = 10, after: int = 3) -> dict[str, Any]:
-    """Return full context around a target message for reconstruction.
+    """Return a conversational message with adjacent context.
 
-    Reads the full JSONL session file via DuckDB and returns N messages
-    before and M messages after the target line_index.  Includes ALL
-    message types (user, assistant, tool results) -- this is full context
-    reconstruction, not a user-only view.
-
-    Each message in the result:
-    ``{"role": str, "line_index": int, "text": str, "timestamp": str}``
-
-    For assistant messages, text is extracted from the message.content array.
+    ``line_index`` addresses the raw zero-based JSONL line, while ``before``
+    and ``after`` count visible user or assistant messages. Tool traffic,
+    reasoning, and injected records do not occupy context slots. Every returned
+    entry contains ``role``, ``line_index``, ``text``, and ``timestamp``; the
+    response separates ``target``, ``before``, and ``after``.
 
     Args:
-        file: Path to the JSONL session file.
-        line_index: 0-based row index of the target message.
-        before: Number of messages to include before the target. Default 10.
-        after: Number of messages to include after the target. Default 3.
+        file: Claude or Codex session JSONL file.
+        line_index: Raw zero-based line containing the target message.
+        before: Maximum visible messages before the target.
+        after: Maximum visible messages after the target.
 
     Returns:
-        Dict with ``target``, ``before`` (list), and ``after`` (list).
+        ``target`` plus ordered ``before`` and ``after`` message lists.
 
     Raises:
-        ToolError: If the file cannot be read or line_index is out of range.
+        ToolError: If the session cannot be read or the line is not a visible message.
     """
 
     def _query() -> dict[str, Any]:
         resolved = _resolve_path(file)
-        if not pathlib.Path(resolved).is_file():
-            raise ToolError(f"File not found: {resolved}")
-
-        conn = duckdb.connect()
-        rows = conn.execute(_SQL_ALL_MESSAGES_IN_FILE, [resolved]).fetchall()
-        conn.close()
-
-        if not rows:
+        transcript = read_session(resolved)
+        if not transcript.messages:
             raise ToolError(f"No messages found in {resolved}")
-
-        max_idx = rows[-1][0]
-        if line_index < 0 or line_index > max_idx:
-            raise ToolError(f"line_index {line_index} out of range 0-{max_idx} in {resolved}")
-
-        def _to_entry(row: tuple) -> dict[str, Any]:
-            idx, msg_type, timestamp, message, tool_use_result = row
-            role = str(msg_type or "unknown")
-            ts = str(timestamp or "")
-            if role == "user" and tool_use_result is None:
-                text = _extract_user_text_from_value(message)
-            elif role == "assistant":
-                text = _extract_assistant_text(message)
-            else:
-                # tool result or other
-                text = str(message) if message is not None else ""
-            return {"role": role, "line_index": int(idx), "text": text, "timestamp": ts}
-
-        target_row = next((r for r in rows if r[0] == line_index), None)
-        if target_row is None:
-            raise ToolError(f"line_index {line_index} not found in {resolved}")
-
-        before_rows = [r for r in rows if r[0] < line_index][-before:] if before > 0 else []
-        after_rows = [r for r in rows if r[0] > line_index][:after] if after > 0 else []
+        target = _message_at_line(transcript, line_index, resolved)
+        before_messages = (
+            [message for message in transcript.messages if message.source_line < line_index][-before:]
+            if before > 0
+            else []
+        )
+        after_messages = (
+            [message for message in transcript.messages if message.source_line > line_index][:after]
+            if after > 0
+            else []
+        )
 
         return {
-            "target": _to_entry(target_row),
-            "before": [_to_entry(r) for r in before_rows],
-            "after": [_to_entry(r) for r in after_rows],
+            "target": _message_entry(target),
+            "before": [_message_entry(message) for message in before_messages],
+            "after": [_message_entry(message) for message in after_messages],
         }
 
     return await asyncio.to_thread(_query)
@@ -1100,40 +979,23 @@ async def render_rage_receipt(
     width: int = _DEFAULT_WIDTH,
     font_size: int = _DEFAULT_FONT_SIZE,
 ) -> list[TextContent | Image]:
-    """Render a terminal-style card from the 3-field RTFP artifact.
+    """Save and return a receipt containing task, assistant, and user text.
 
-    Produces a styled Rich Panel rendered as SVG (default) or PNG.
-    Sections are colour-coded:
-
-    - ``task:`` label in cyan (#4ec9b0), body in dim white
-    - ``assistant:`` label in yellow (#dcdcaa), body in dim white
-    - ``user:`` label in red (#f44747), body in dim white
-
-    Output format is determined by ``output_path`` extension:
-
-    - ``.svg`` — direct SVG export (primary)
-    - ``.png`` — SVG rendered then converted via ``cairosvg``
-
-    The rendered asset is saved to ``output_path`` AND returned inline
-    in the MCP response so agents can view the content directly:
-
-    - SVG is returned as text content (the SVG XML string).
-    - PNG is returned as an MCP ``ImageContent`` (base64-encoded bytes).
-
-    A leading text content block always carries JSON metadata with
-    ``output_path`` and ``format`` for callers with filesystem access.
+    A ``.png`` output path selects PNG; every other suffix produces SVG. The
+    asset is written to disk and returned inline. The first content block is
+    compact JSON metadata with ``output_path`` and ``format``; the second is
+    SVG text or PNG image content.
 
     Args:
-        task_summary: Short description of the task context.
-        assistant_excerpt: The offending assistant response excerpt.
-        user_reply: The user's frustrated reply.
-        output_path: File path to write (``.svg`` or ``.png``).
-        width: Image width in pixels. Default 900.
-        font_size: Font size in points. Default 15.
+        task_summary: Task text shown on the receipt.
+        assistant_excerpt: Assistant text shown on the receipt.
+        user_reply: User text shown on the receipt.
+        output_path: Destination path; ``.png`` selects PNG, otherwise SVG.
+        width: Output width in pixels.
+        font_size: Text size in pixels.
 
     Returns:
-        List of MCP content blocks: metadata text followed by either
-        SVG text or PNG image content.
+        Metadata text followed by the inline SVG or PNG content.
 
     Raises:
         ToolError: If the file cannot be written.
@@ -1154,33 +1016,31 @@ async def render_rage_receipt(
 async def scan_transcripts(
     glob_path: str, context_window: int = _DEFAULT_CONTEXT_WINDOW, offset: int = 0, limit: int = 100
 ) -> dict[str, Any]:
-    """Extract raw user messages from JSONL transcript files for classification.
+    """Return paginated user messages with preceding conversation context.
 
-    Returns a paginated list of user messages with surrounding context.
-    The caller (Claude) is responsible for classifying each message and
-    deciding what to do with it.
-
-    Uses DuckDB ``read_ndjson_auto()`` to query JSONL files directly --
-    no persistent database is created.
+    Matches Claude or Codex JSONL files, then returns genuine user messages for
+    caller-side classification. Each message contains ``file``, raw zero-based
+    ``line_index``, ``uuid``, ``timestamp``, ``session_id``, ``text``, and
+    preceding visible ``context``. ``total`` is computed before pagination.
 
     Args:
-        glob_path: Glob pattern pointing to JSONL transcript files,
-            e.g. ``~/.claude/projects/-my-project/*.jsonl``
-        context_window: Number of preceding messages to include as
-            context for each user message. Default 5.
-        offset: Number of messages to skip for pagination. Default 0.
-        limit: Maximum number of messages to return. Default 100.
+        glob_path: Session file or glob, such as
+            ``~/.claude/projects/-my-project/*.jsonl`` or
+            ``~/.codex/sessions/2026/09/**/rollout-*.jsonl``.
+        context_window: Maximum preceding visible messages per result.
+        offset: Number of matched user messages to skip.
+        limit: Maximum matched user messages to return.
 
     Returns:
-        Dict with messages (list of {file, line_index, text, context}),
-        total message count, offset, limit, and files_scanned.
+        ``messages``, pre-pagination ``total``, ``offset``, ``limit``, and
+        ``files_scanned``.
+
+    Raises:
+        ToolError: If no files match or a matched session cannot be read.
     """
 
     def _scan() -> dict[str, Any]:
-        messages, total, files_scanned = _query_user_messages(glob_path, offset, limit)
-
-        for msg in messages:
-            msg["context"] = _get_context_messages(msg["file"], msg["line_index"], context_window)
+        messages, total, files_scanned = _query_user_messages(glob_path, context_window, offset, limit)
 
         return {"messages": messages, "total": total, "offset": offset, "limit": limit, "files_scanned": files_scanned}
 
@@ -1189,45 +1049,40 @@ async def scan_transcripts(
 
 @mcp.tool(annotations=_READONLY_ANNOTATIONS)
 async def get_scenario(file: str, line_index: int, context_window: int = _DEFAULT_CONTEXT_WINDOW) -> dict[str, Any]:
-    """Get the full message context for a specific file and line position.
+    """Return one message and its preceding conversation for reconstruction.
 
-    Reads the target JSONL file via DuckDB and returns the message at
-    the given line index along with surrounding context messages.
+    ``line_index`` is the raw zero-based JSONL line retained by extraction and
+    scan results. Context contains visible user and assistant messages only.
+    The response identifies the session and target role, text, UUID, timestamp,
+    and ordered preceding context.
 
     Args:
-        file: Path to the JSONL transcript file.
-        line_index: Row index (0-based) of the target message.
-        context_window: Number of preceding messages to capture.
+        file: Claude or Codex session JSONL file.
+        line_index: Raw zero-based line containing the target message.
+        context_window: Maximum preceding visible messages to return.
 
     Returns:
-        Dict with the target message text, file, line_index, and
-        preceding context messages.
+        ``file``, ``line_index``, ``type``, ``text``, ``uuid``, ``timestamp``,
+        ``session_id``, and ordered preceding ``context``.
 
     Raises:
-        ToolError: If the file cannot be read or line_index is out of range.
+        ToolError: If the session cannot be read or the line is not a visible message.
     """
 
     def _query() -> dict[str, Any]:
         resolved = _resolve_path(file)
-        conn = duckdb.connect()
-        row = conn.execute(_SQL_GET_SCENARIO, [resolved, line_index]).fetchone()
-        conn.close()
-
-        if not row:
-            raise ToolError(f"line_index {line_index} not found in {resolved}")
-
-        msg_type, message, uuid_val, timestamp, session_id = row
-        text = _extract_user_text_from_value(message) if msg_type == "user" else ""
-        context = _get_context_messages(resolved, line_index, context_window)
+        transcript = read_session(resolved)
+        message = _message_at_line(transcript, line_index, resolved)
+        context = _context_messages(transcript, line_index, context_window)
 
         return {
             "file": resolved,
             "line_index": line_index,
-            "type": msg_type,
-            "text": text,
-            "uuid": str(uuid_val or ""),
-            "timestamp": str(timestamp or ""),
-            "session_id": str(session_id or ""),
+            "type": message.role,
+            "text": message.text,
+            "uuid": message.uuid,
+            "timestamp": message.timestamp,
+            "session_id": transcript.session_id,
             "context": context,
         }
 
@@ -1238,41 +1093,37 @@ async def get_scenario(file: str, line_index: int, context_window: int = _DEFAUL
 async def generate_social_post(
     file: str, line_index: int, context_window: int = _DEFAULT_CONTEXT_WINDOW
 ) -> dict[str, Any]:
-    """Generate social media content for a user message from a JSONL file.
+    """Create provider-tagged social post copy from one user message.
 
-    Reads the message directly from the JSONL file via DuckDB and formats
-    it as a social media post.  Content is always returned raw so the
-    caller (agent) can present it to the user and ask whether any personal
-    or business details should be replaced with placeholders before sharing.
+    The target text is inserted verbatim and is not posted anywhere. The result
+    includes a privacy reminder so the caller can review identifying details
+    with the user before sharing. Claude sessions receive ``#ClaudeCode``;
+    Codex sessions receive ``#Codex``. The response contains ``post``,
+    ``hashtags``, and ``privacy_reminder``.
 
     Args:
-        file: Path to the JSONL transcript file.
-        line_index: Row index (0-based) of the target message.
-        context_window: Number of preceding messages for context summary.
+        file: Claude or Codex session JSONL file.
+        line_index: Raw zero-based line containing a user message.
+        context_window: Accepted for interface consistency; the post currently
+            uses only the target message.
 
     Returns:
-        Dict with post, hashtags, and privacy_reminder.
+        ``post``, provider-aware ``hashtags``, and ``privacy_reminder``.
 
     Raises:
-        ToolError: If the message is not found.
+        ToolError: If the session cannot be read or the line is not a user message.
     """
 
     def _generate() -> dict[str, Any]:
         resolved = _resolve_path(file)
-        conn = duckdb.connect()
+        transcript = read_session(resolved)
+        message = _message_at_line(transcript, line_index, resolved)
+        if message.role != "user":
+            raise ToolError(f"line_index {line_index} is not a user message in {resolved}")
+        text = message.text
 
-        row = conn.execute(_SQL_GET_MESSAGE, [resolved, line_index]).fetchone()
-        conn.close()
-
-        if not row:
-            raise ToolError(f"line_index {line_index} not found in {resolved}")
-
-        message_val, _uuid_val, _timestamp = row
-        text = _extract_user_text_from_value(message_val)
-        if not text:
-            raise ToolError(f"No text content at line_index {line_index} in {resolved}")
-
-        hashtags = ["#AIFrustration", "#RTFP", "#ClaudeCode"]
+        provider_hashtag = "#Codex" if transcript.provider == "codex" else "#ClaudeCode"
+        hashtags = ["#AIFrustration", "#RTFP", provider_hashtag]
         post_text = f'\U0001f525 RTFP — Read The Fucking Prompt\n\nWhat the user said: "{text}"\n\n{" ".join(hashtags)}'
 
         return {

--- a/plugins/frustration-analyzer/skills/rtfp/SKILL.md
+++ b/plugins/frustration-analyzer/skills/rtfp/SKILL.md
@@ -1,110 +1,108 @@
 ---
 name: rtfp
-description: Read The Fucking Prompt — finds the strongest user reaction to an AI instruction-following failure in a chosen session, reconstructs what the assistant did wrong, and renders a shareable terminal-style PNG. Use when asked to find rage moments, generate a rage receipt, or capture a frustration incident from a session.
-argument-hint: '[session-path]'
+description: Use when asked to find a rage moment, analyze a direct transcript path, or analyze a session time range. RTFP finds the strongest instruction-following failure in Claude or Codex sessions and renders a rage receipt.
+argument-hint: '[session-path | session range]'
 allowed-tools: mcp__frustration-analyzer__list_sessions, mcp__frustration-analyzer__extract_user_messages, mcp__frustration-analyzer__get_context_window, mcp__frustration-analyzer__get_scenario, mcp__frustration-analyzer__render_rage_receipt, Read, Write, Glob
 ---
 
 # RTFP — Read The Fucking Prompt
 
-Finds the single strongest user reaction to an AI instruction-following failure, reconstructs the assistant output that triggered it, and renders the exchange as a terminal-style PNG ready for social media.
+Finds the single strongest user reaction to an AI instruction-following failure in a Claude or Codex session set, reconstructs the triggering assistant output, and renders it as a terminal-style PNG ready for social media.
 
 ## Argument
 
-Optional: a session file path. If provided, skip Steps 1–2 and use it directly.
+Optional: a Claude or Codex session file path, or a natural-language session range such as `this week`. A direct path analyzes that one file. A range analyzes every matched session only when `list_sessions` returns the complete requested set.
 
-## Step 1 — List Recent Sessions
+## Required MCP Tools
 
-Call `mcp__frustration-analyzer__list_sessions` with the current project path or the default `~/.claude/projects/`.
+Before starting, confirm the plugin MCP tools needed for this run are available: `list_sessions` (unless a path was provided), `extract_user_messages`, `get_context_window` or `get_scenario`, and `render_rage_receipt`. If any are absent, stop and report that the RTFP plugin MCP tools are unavailable; do not manually read session or source-repository files as a substitute.
+
+## Step 1 — Resolve the Session Set
+
+For a direct path, use it as the one-item set and skip listing and selection.
+
+For an explicit range such as `all this week`, resolve the dates in the user's timezone before the MCP call. Call `mcp__frustration-analyzer__list_sessions` with `provider`, `modified_after`, `modified_before`, and `limit=1000`. Report the resolved dates, matched count, and Claude/Codex split. “Progressed” means a file's modification time is inside the requested interval and the whole session is analyzed. If the result is truncated, ask the user for a narrower range or provider; only a complete result proceeds to analysis.
+
+For an unqualified `/rtfp`, call `mcp__frustration-analyzer__list_sessions(provider="all", limit=10)`. Present the newest ten sessions with provider labels and let the user choose one, even when more sessions exist. This is a recent-session picker, not a complete-set request.
 
 Present sessions as a numbered list:
 
 ```text
-Recent sessions:
-1. [2026-03-09 14:32] writing a Claude Code plugin       (…/abc123.jsonl)
-2. [2026-03-09 11:15] debugging a FastMCP server         (…/def456.jsonl)
-3. [2026-03-08 18:44] refactoring auth middleware        (…/ghi789.jsonl)
+Matched sessions:
+1. [Claude, 2026-03-09 14:32] writing a Claude Code plugin  (…/abc123.jsonl)
+2. [Codex, 2026-03-09 11:15] debugging a FastMCP server      (…/def456.jsonl)
+3. [Claude, 2026-03-08 18:44] refactoring auth middleware   (…/ghi789.jsonl)
 ```
 
-## Step 2 — User Selects Session
+## Step 2 — Select or Continue
 
-Ask the user to choose a number. Wait for their response. Use the chosen file path for all subsequent steps.
+For an unqualified request, ask the user to choose one numbered session. For a complete explicit multi-session request, skip this prompt and use every returned session. Use every selected file in the remaining stages.
 
 ## Step 3 — Stage 1: User-Only Extraction
 
-Call:
+For each selected file, in bounded parallel waves of at most four sessions, call:
 
 ```text
 mcp__frustration-analyzer__extract_user_messages(
-    file="{chosen_file}",
-    output_path="/tmp/rtfp-batch-{session_stem}.jsonl"
+    file="{session_file}",
+    output_path="/tmp/rtfp-batch-{session_key}.jsonl"
 )
 ```
 
-This writes a JSONL file containing ONLY user-authored messages. Each entry:
-
-```json
-{"file": "...", "line_index": 42, "text": "..."}
-```
-
-No assistant messages, tool outputs, system messages, or context are included. The batch file is the input to Stage 2 detection only.
-
-Report: "Extracted N user messages. Created batch file at {output_path}."
-
-If the session has more than 200 user messages, split into multiple batch files by slicing the output. Name them `…-batch-1.jsonl`, `…-batch-2.jsonl`, etc. For most sessions, one batch file is sufficient.
+Use the returned `output_paths` as the Stage 2 inputs; it contains every batch for that session. Wait for each wave before starting the next. Report only each session's extracted message count, not internal batch paths or transcript line details.
 
 ## Step 4 — Stage 2: Parallel Subagent Detection
 
-For each batch file, spawn a subagent of type `frustration-analyzer:batch-detector`. Pass the batch file path in the delegation prompt.
+For each session's batches, delegate detection in the same bounded parallel waves. On Claude, use the named `frustration-analyzer:batch-detector` agent. On Codex, delegate a generic subagent with the batch path and this contract: read only that user-only batch; flag strong emotional reactions aimed at the assistant (not neutral corrections or frustration at something else); write the two artifacts below; and report its count.
 
-Spawn all batch subagents in a single message (parallel). Each subagent reads only its assigned user-only batch file and returns:
+Run at most four batch delegates per wave. The parent may handle one small batch directly; delegate every additional batch. Each detector returns:
 
 - `{batch_path}.flags.json` — structured flagged entry list
 - `{batch_path}.flags.txt` — plain list of flagged entries
 
 Wait for all subagents to complete. Collect the output file paths.
 
-Report: "Detection complete. Found M flagged messages across K batches."
+Report: "Detection complete. Found M flagged messages across S sessions."
 
-If no flags were found across all batches, render a "no rage" card. Call:
+If no flags were found across all batches, always render a clean receipt. Call:
 
 ```text
 mcp__frustration-analyzer__render_rage_receipt(
-    task_summary="Session analysis complete",
-    assistant_excerpt="No strong emotional reactions detected in this session.",
+    task_summary="session-set analysis complete",
+    assistant_excerpt="No strong emotional reactions detected in these sessions.",
     user_reply="👍",
-    output_path="/tmp/rtfp-{session_stem}-clean.png"
+    output_path="/tmp/rtfp-session-set-clean.png"
 )
 ```
 
-Then skip to Step 8 and present the result using the same format as a normal receipt. Do NOT return a plain text string.
+Then skip to Step 8 and present the receipt using the same format as a normal result.
 
 ## Step 5 — Merge Flags
 
-Read all `*.flags.json` files. Merge the `flags` arrays into a single file at `/tmp/rtfp-merged-{session_stem}.json`:
+Merge every returned `flags` array into `/tmp/rtfp-merged-session-set.json`. Preserve each flag's originating `file`, raw `line_index`, and text; never renumber lines across files. This artifact is internal: do not expose its path or raw line details in progress reports.
 
 ```json
 {
-  "session_file": "{chosen_file}",
+  "session_files": ["{selected_file}", "..."],
   "flags": [
     {"file": "...", "line_index": 42, "text": "..."},
     ...
   ],
   "total": N,
-  "batch_count": K
+  "session_count": S
 }
 ```
 
 ## Step 6 — Stage 3: Context Reconstruction
 
-Spawn a subagent of type `frustration-analyzer:context-reconstructor`. Pass the merged flags file path in the delegation prompt.
+Delegate reconstruction with the merged flags path. On Claude, use the named `frustration-analyzer:context-reconstructor` agent. On Codex, delegate a generic subagent to select the strongest specific reaction, retrieve context from the winner's originating file and raw line, identify the triggering verbatim assistant text, and write the same 3-field artifact.
 
 The reconstruction agent:
 
 1. Reads the merged flags
 2. Picks the single most emotional/specific reaction as the winner
 3. Notes a runner-up if one exists
-4. Calls `get_context_window` to read full transcript context for the winner
+4. Calls `get_context_window` against the winner's originating file to read full transcript context
 5. Identifies the triggering assistant output
 6. Produces the 3-field artifact: `task_summary`, `assistant_excerpt`, `user_reply`
 7. Writes `{session_stem}.rtfp.json`
@@ -146,9 +144,8 @@ If a runner-up exists, offer:
 
 ## Constraints
 
-- Stage 1 batch files MUST contain ONLY user-authored messages — no assistant content, no tool outputs, no system messages
-- Context reconstruction happens ONLY in Stage 3 — never pull full context in Stages 1 or 2
-- Do NOT add scores, verdicts, categories, or evaluative commentary
-- This is one session at a time — not a corpus-wide analytics tool
-- The task_summary is a single dry background line only, present tense, lowercase
-- The assistant_excerpt and user_reply must be verbatim transcript text
+- Stage 1 artifacts contain only user-authored messages.
+- Stage 3 performs all context reconstruction.
+- Each selection is bounded by its provider, interval, and limit.
+- The final artifact contains exactly `task_summary`, `assistant_excerpt`, and `user_reply`; `task_summary` is a single dry lowercase present-tense line.
+- `assistant_excerpt` and `user_reply` are verbatim transcript text.

--- a/plugins/frustration-analyzer/skills/rtfp/SKILL.md
+++ b/plugins/frustration-analyzer/skills/rtfp/SKILL.md
@@ -19,6 +19,10 @@ Before starting, confirm the plugin MCP tools needed for this run are available:
 
 ## Step 1 — Resolve the Session Set
 
+Create a fresh private temporary workspace for this invocation and refer to it
+as `{run_dir}`. Keep every intermediate and rendered artifact inside that
+workspace; never reuse a fixed path across runs.
+
 For a direct path, use it as the one-item set and skip listing and selection.
 
 For an explicit range such as `all this week`, resolve the dates in the user's timezone before the MCP call. Call `mcp__frustration-analyzer__list_sessions` with `provider`, `modified_after`, `modified_before`, and `limit=1000`. Report the resolved dates, matched count, and Claude/Codex split. “Progressed” means a file's modification time is inside the requested interval and the whole session is analyzed. If the result is truncated, ask the user for a narrower range or provider; only a complete result proceeds to analysis.
@@ -45,7 +49,7 @@ For each selected file, in bounded parallel waves of at most four sessions, call
 ```text
 mcp__frustration-analyzer__extract_user_messages(
     file="{session_file}",
-    output_path="/tmp/rtfp-batch-{session_key}.jsonl"
+    output_path="{run_dir}/batch-{session_key}.jsonl"
 )
 ```
 
@@ -71,7 +75,7 @@ mcp__frustration-analyzer__render_rage_receipt(
     task_summary="session-set analysis complete",
     assistant_excerpt="No strong emotional reactions detected in these sessions.",
     user_reply="👍",
-    output_path="/tmp/rtfp-session-set-clean.png"
+    output_path="{run_dir}/session-set-clean.png"
 )
 ```
 
@@ -79,7 +83,7 @@ Then skip to Step 8 and present the receipt using the same format as a normal re
 
 ## Step 5 — Merge Flags
 
-Merge every returned `flags` array into `/tmp/rtfp-merged-session-set.json`. Preserve each flag's originating `file`, raw `line_index`, and text; never renumber lines across files. This artifact is internal: do not expose its path or raw line details in progress reports.
+Merge every returned `flags` array into `{run_dir}/merged-session-set.json`. Preserve each flag's originating `file`, raw `line_index`, and text; never renumber lines across files. This artifact is internal: do not expose its path or raw line details in progress reports.
 
 ```json
 {
@@ -118,7 +122,7 @@ mcp__frustration-analyzer__render_rage_receipt(
     task_summary="{task_summary}",
     assistant_excerpt="{assistant_excerpt}",
     user_reply="{user_reply}",
-    output_path="/tmp/rtfp-{session_stem}.png"
+    output_path="{run_dir}/{session_stem}.png"
 )
 ```
 

--- a/plugins/frustration-analyzer/tests/_server.py
+++ b/plugins/frustration-analyzer/tests/_server.py
@@ -26,6 +26,13 @@ TIKTOKEN_ENCODING = _module._TIKTOKEN_ENCODING
 DEFAULT_WIDTH = _module._DEFAULT_WIDTH
 DEFAULT_FONT_SIZE = _module._DEFAULT_FONT_SIZE
 extract_user_messages = _module.extract_user_messages
+generate_social_post = _module.generate_social_post
+get_context_window = _module.get_context_window
+get_scenario = _module.get_scenario
+list_sessions = _module.list_sessions
+read_session = _module.read_session
+scan_transcripts = _module.scan_transcripts
+ToolError = _module.ToolError
 
 # Shared test constants for render tests.
 TASK = "Implement login page"

--- a/plugins/frustration-analyzer/tests/test_codex_sessions.py
+++ b/plugins/frustration-analyzer/tests/test_codex_sessions.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from _server import (
+    ToolError,
+    extract_user_messages,
+    generate_social_post,
+    get_context_window,
+    get_scenario,
+    list_sessions,
+    read_session,
+    scan_transcripts,
+)
+
+
+def write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+
+
+def write_timed_jsonl(path: Path, records: list[dict[str, object]], modified: str) -> None:
+    write_jsonl(path, records)
+    timestamp = datetime.fromisoformat(modified).timestamp()
+    os.utime(path, (timestamp, timestamp))
+
+
+def minimal_codex_records(session_id: str) -> list[dict[str, object]]:
+    return [
+        {"type": "session_meta", "payload": {"id": session_id, "cwd": f"/tmp/{session_id}"}},
+        {"type": "event_msg", "payload": {"type": "user_message", "message": f"Request from {session_id}"}},
+    ]
+
+
+def minimal_claude_records(session_id: str) -> list[dict[str, object]]:
+    return [
+        {
+            "type": "user",
+            "message": {"content": f"Request from {session_id}"},
+            "sessionId": session_id,
+            "toolUseResult": None,
+        }
+    ]
+
+
+def legacy_codex_records() -> list[dict[str, object]]:
+    return [
+        {"type": "session_meta", "payload": {"id": "legacy-session", "cwd": "/tmp/legacy-project"}},
+        {
+            "type": "event_msg",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "payload": {"type": "agent_message", "message": "I used React."},
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "I used React."}],
+            },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "payload": {"type": "user_message", "message": "I said Vue, not React!"},
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "# AGENTS.md instructions"}],
+            },
+        },
+    ]
+
+
+def current_codex_records() -> list[dict[str, object]]:
+    return [
+        {"type": "session_meta", "payload": {"id": "current-session", "cwd": "/tmp/current-project"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "# AGENTS.md instructions"}],
+            },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": "2026-01-02T00:00:01Z",
+            "payload": {
+                "type": "item_completed",
+                "item": {
+                    "type": "AgentMessage",
+                    "phase": "commentary",
+                    "content": [{"type": "Text", "text": "I used React."}],
+                },
+            },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": "2026-01-02T00:00:02Z",
+            "payload": {
+                "type": "item_completed",
+                "item": {
+                    "type": "UserMessage",
+                    "content": [
+                        {"type": "text", "text": "I said Vue, not React!"},
+                        {"type": "input_text", "text": "injected input block"},
+                        {"type": "Text", "text": "Read the prompt."},
+                        {"type": "image", "text": "image alt distractor"},
+                    ],
+                },
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "I said Vue, not React!"}],
+            },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": "2026-01-02T00:00:03Z",
+            "payload": {
+                "type": "item_completed",
+                "item": {"type": "AgentMessage", "phase": "final", "content": [{"type": "Text", "text": "Fixed."}]},
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": "developer distractor"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "reasoning", "summary": [{"type": "summary_text", "text": "reasoning distractor"}]},
+        },
+        {"type": "response_item", "payload": {"type": "function_call_output", "output": "tool distractor"}},
+        {"type": "turn_context", "payload": {"cwd": "/tmp/current-project", "text": "turn context distractor"}},
+        {"type": "event_msg", "payload": {"type": "token_count", "message": "token distractor"}},
+        {"type": "event_msg", "payload": {"type": "world_state", "message": "world state distractor"}},
+    ]
+
+
+async def test_extract_user_messages_reads_legacy_codex_presentation_events(tmp_path: Path) -> None:
+    session = tmp_path / "rollout-legacy.jsonl"
+    write_jsonl(session, legacy_codex_records())
+    output = tmp_path / "batch.jsonl"
+
+    result = await extract_user_messages(str(session), str(output))
+
+    messages = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert result["message_count"] == 1
+    assert messages[0]["line_index"] == 3
+    assert messages[0]["text"] == "I said Vue, not React!"
+
+
+async def test_extract_user_messages_reads_current_codex_without_injected_or_duplicate_content(tmp_path: Path) -> None:
+    session = tmp_path / "rollout-current.jsonl"
+    write_jsonl(session, current_codex_records())
+    output = tmp_path / "batch.jsonl"
+
+    result = await extract_user_messages(str(session), str(output))
+
+    messages = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert result["message_count"] == 1
+    assert messages[0]["line_index"] == 3
+    assert messages[0]["text"] == "I said Vue, not React! Read the prompt."
+
+
+async def test_get_context_window_resolves_current_codex_source_line(tmp_path: Path) -> None:
+    session = tmp_path / "rollout-current.jsonl"
+    write_jsonl(session, current_codex_records())
+
+    result = await get_context_window(str(session), line_index=3, before=2, after=1)
+
+    assert result["target"] == {
+        "role": "user",
+        "line_index": 3,
+        "text": "I said Vue, not React! Read the prompt.",
+        "timestamp": "2026-01-02T00:00:02Z",
+    }
+    assert [(entry["role"], entry["text"]) for entry in result["before"]] == [("assistant", "I used React.")]
+    assert [(entry["role"], entry["text"]) for entry in result["after"]] == [("assistant", "Fixed.")]
+
+
+async def test_list_sessions_identifies_codex_provider_metadata_and_title(tmp_path: Path) -> None:
+    session = tmp_path / "nested" / "rollout-current.jsonl"
+    write_jsonl(session, current_codex_records())
+
+    result = await list_sessions(str(tmp_path))
+
+    assert result["count"] == 1
+    assert result["sessions"][0]["provider"] == "codex"
+    assert result["sessions"][0]["session_id"] == "current-session"
+    assert result["sessions"][0]["project"] == "current-project"
+    assert result["sessions"][0]["title"] == "I said Vue, not React! Read the prompt."
+
+
+async def test_scan_and_scenario_read_codex_conversation_only(tmp_path: Path) -> None:
+    session = tmp_path / "rollout-current.jsonl"
+    write_jsonl(session, current_codex_records())
+
+    scan = await scan_transcripts(str(tmp_path / "rollout-*.jsonl"))
+    scenario = await get_scenario(str(session), line_index=3)
+
+    assert scan["total"] == 1
+    assert scan["files_scanned"] == 1
+    assert scan["messages"][0]["text"] == "I said Vue, not React! Read the prompt."
+    assert [(item["role"], item["text"]) for item in scan["messages"][0]["context"]] == [("assistant", "I used React.")]
+    assert scenario["session_id"] == "current-session"
+    assert scenario["text"] == "I said Vue, not React! Read the prompt."
+    assert [(item["role"], item["text"]) for item in scenario["context"]] == [("assistant", "I used React.")]
+
+
+async def test_generate_social_post_uses_codex_hashtag(tmp_path: Path) -> None:
+    session = tmp_path / "rollout-current.jsonl"
+    write_jsonl(session, current_codex_records())
+
+    result = await generate_social_post(str(session), line_index=3)
+
+    assert "#Codex" in result["hashtags"]
+    assert "#Codex" in result["post"]
+
+
+async def test_list_sessions_without_path_scans_claude_and_codex_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    codex_home = tmp_path / "codex-home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    write_jsonl(
+        home / ".claude" / "projects" / "claude-project" / "claude.jsonl",
+        [
+            {
+                "type": "user",
+                "message": {"content": "Claude request"},
+                "timestamp": "2026-01-03T00:00:00Z",
+                "sessionId": "claude-session",
+                "uuid": "claude-message",
+                "toolUseResult": None,
+            }
+        ],
+    )
+    write_jsonl(codex_home / "sessions" / "2026" / "01" / "03" / "rollout-active.jsonl", current_codex_records())
+    write_jsonl(codex_home / "archived_sessions" / "rollout-archived.jsonl", legacy_codex_records())
+    write_jsonl(codex_home / "sessions" / "2026" / "01" / "03" / "notes.jsonl", current_codex_records())
+
+    result = await list_sessions()
+
+    sessions = {Path(item["file"]).name: item for item in result["sessions"]}
+    assert set(sessions) == {"claude.jsonl", "rollout-active.jsonl", "rollout-archived.jsonl"}
+    assert sessions["claude.jsonl"]["provider"] == "claude"
+    assert sessions["rollout-active.jsonl"]["provider"] == "codex"
+    assert sessions["rollout-archived.jsonl"]["provider"] == "codex"
+    assert result["count"] == result["matched_count"] == 3
+    assert result["provider_counts"] == {"claude": 1, "codex": 2}
+    assert result["truncated"] is False
+
+
+async def test_list_sessions_time_window_is_lower_inclusive_upper_exclusive_and_offset_equivalent(
+    tmp_path: Path,
+) -> None:
+    write_timed_jsonl(tmp_path / "rollout-before.jsonl", minimal_codex_records("before"), "2026-01-04T23:59:59+00:00")
+    write_timed_jsonl(tmp_path / "rollout-lower.jsonl", minimal_codex_records("lower"), "2026-01-05T00:00:00+00:00")
+    write_timed_jsonl(tmp_path / "rollout-inside.jsonl", minimal_codex_records("inside"), "2026-01-05T12:00:00+00:00")
+    write_timed_jsonl(tmp_path / "rollout-upper.jsonl", minimal_codex_records("upper"), "2026-01-06T00:00:00+00:00")
+    write_timed_jsonl(
+        tmp_path / "unsupported.jsonl",
+        [{"type": "response_item", "payload": {"text": "unsupported"}}],
+        "2026-01-05T18:00:00+00:00",
+    )
+
+    utc_result = await list_sessions(
+        str(tmp_path), modified_after="2026-01-05T00:00:00+00:00", modified_before="2026-01-06T00:00:00+00:00"
+    )
+    offset_result = await list_sessions(
+        str(tmp_path), modified_after="2026-01-05T11:00:00+11:00", modified_before="2026-01-06T11:00:00+11:00"
+    )
+
+    assert [Path(item["file"]).name for item in utc_result["sessions"]] == [
+        "rollout-inside.jsonl",
+        "rollout-lower.jsonl",
+    ]
+    assert [item["file"] for item in offset_result["sessions"]] == [item["file"] for item in utc_result["sessions"]]
+    assert utc_result["count"] == utc_result["matched_count"] == 2
+    assert utc_result["provider_counts"] == {"claude": 0, "codex": 2}
+    assert utc_result["truncated"] is False
+
+
+async def test_list_sessions_filters_provider_before_newest_first_limit(tmp_path: Path) -> None:
+    write_timed_jsonl(
+        tmp_path / "claude-newest.jsonl", minimal_claude_records("claude-newest"), "2026-01-05T04:00:00+00:00"
+    )
+    write_timed_jsonl(
+        tmp_path / "rollout-codex-newer.jsonl", minimal_codex_records("codex-newer"), "2026-01-05T03:00:00+00:00"
+    )
+    write_timed_jsonl(
+        tmp_path / "rollout-codex-older.jsonl", minimal_codex_records("codex-older"), "2026-01-05T02:00:00+00:00"
+    )
+
+    result = await list_sessions(str(tmp_path), provider="codex", limit=1)
+
+    assert [Path(item["file"]).name for item in result["sessions"]] == ["rollout-codex-newer.jsonl"]
+    assert result["count"] == 1
+    assert result["matched_count"] == 2
+    assert result["provider_counts"] == {"claude": 0, "codex": 2}
+    assert result["truncated"] is True
+
+
+async def test_list_sessions_rejects_invalid_naive_and_reversed_time_bounds(tmp_path: Path) -> None:
+    with pytest.raises(ToolError):
+        await list_sessions(str(tmp_path), modified_after="not-a-timestamp")
+    with pytest.raises(ToolError):
+        await list_sessions(str(tmp_path), modified_after="2026-01-05T00:00:00")
+    with pytest.raises(ToolError):
+        await list_sessions(
+            str(tmp_path), modified_after="2026-01-06T00:00:00+00:00", modified_before="2026-01-05T00:00:00+00:00"
+        )
+
+
+def test_read_session_distinguishes_malformed_and_unsupported_jsonl(tmp_path: Path) -> None:
+    malformed = tmp_path / "malformed.jsonl"
+    malformed.write_text('{"type":', encoding="utf-8")
+    unsupported = tmp_path / "unsupported.jsonl"
+    write_jsonl(unsupported, [{"type": "response_item", "payload": {"text": "not a session"}}])
+
+    with pytest.raises(ToolError, match="Could not read session file"):
+        read_session(str(malformed))
+    with pytest.raises(ToolError, match="Unsupported session format"):
+        read_session(str(unsupported))

--- a/plugins/frustration-analyzer/tests/test_render_card_dimensions.py
+++ b/plugins/frustration-analyzer/tests/test_render_card_dimensions.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
+from xml.etree import ElementTree as ET
 
+import pytest
 from _server import ASSISTANT, DEFAULT_FONT_SIZE, DEFAULT_WIDTH, TASK, USER, render_card
 from fastmcp.utilities.types import Image
 from mcp.types import TextContent
@@ -29,6 +31,20 @@ _USER = USER
 
 class TestRenderCardCustomWidth:
     """Tests for custom width parameter."""
+
+    def test_svg_border_stays_within_exported_viewbox(self, tmp_path: Path) -> None:
+        out = tmp_path / "card.svg"
+        _render_card(_TASK, _ASSISTANT, _USER, str(out))
+
+        root = ET.fromstring(out.read_text(encoding="utf-8"))
+        viewbox_width = float(root.attrib["viewBox"].split()[2])
+        border = next(rect for rect in root if rect.get("stroke") == "#1984e9")
+        border_x = float(border.attrib["x"])
+        border_right = border_x + float(border.attrib["width"])
+
+        assert border_x >= 0
+        assert border_right <= viewbox_width
+        assert border_right == pytest.approx(viewbox_width, abs=20)
 
     def test_svg_contains_custom_width_attribute(self, tmp_path: Path) -> None:
         out = tmp_path / "card.svg"

--- a/plugins/frustration-analyzer/tests/test_render_rage_receipt.py
+++ b/plugins/frustration-analyzer/tests/test_render_rage_receipt.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
-from _server import ASSISTANT, TASK, USER, render_card
+import pytest
+from _server import ASSISTANT, TASK, USER, _module, render_card
 from fastmcp.utilities.types import Image
 from mcp.types import TextContent
 
@@ -23,6 +24,12 @@ _render_card = render_card
 _TASK = TASK
 _ASSISTANT = ASSISTANT
 _USER = USER
+
+
+async def test_render_rage_receipt_does_not_write_to_stdout(tmp_path: Path, capfd: pytest.CaptureFixture[str]) -> None:
+    await _module.render_rage_receipt(_TASK, _ASSISTANT, _USER, str(tmp_path / "card.svg"))
+
+    assert capfd.readouterr().out == ""
 
 
 class TestRenderCardSVG:


### PR DESCRIPTION
## Summary
- normalize Claude and Codex session logs behind the existing frustration-analyzer tools
- discover default active and archived sessions with provider, time-window, count, and truncation filters
- let RTFP analyze complete date-range session sets while preserving direct-session selection
- rewrite public and agent-facing text for accurate outcome-first behavior
- keep MCP stdout protocol-clean while rendering receipts

## Verification
- 56 focused plugin and compatibility tests passed
- changed-file prek hooks passed, including Ruff, formatting, ty, skilllint, and manifest sync
- synthetic Codex MCP QA passed listing, user-only extraction, and context reconstruction; generated a valid 900x318 PNG
- zipped isolated Codex marketplace install passed at plugin version 0.3.1
- repository Codex manifest check passes after generator synchronization

## Validation note
FastMCP tool calls completed successfully. The FastMCP list command emitted the tool schemas but exceeded the repository 5-second process bound after output; no product behavior relies on that client-side discovery extension.

Closes #3472