### PR TITLE
feat(research-curator): add 3 research entries; enforce warnings on new entries

### DIFF
--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -125,7 +125,7 @@ Load [Duplicate Detection](./references/duplicate-detection.md) (shared with Bat
    ```
 
 4. **Wait** for structured result (status, file path, category, key findings)
-5. **Validate** -- if research status is not `failed`, run the validation gate on the created or refreshed file:
+5. **Validate** -- if research status is not `failed`, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) on the created or refreshed file:
 
    a. Run fix script:
 
@@ -139,9 +139,11 @@ Load [Duplicate Detection](./references/duplicate-detection.md) (shared with Bat
    uv run .claude/skills/research-curator/scripts/validate_research.py main --json {file-path-from-agent-result}
    ```
 
-   c. If validator returns errors: mark entry as "created with issues" (or "refreshed with issues" when step 2 routed to `--rerun`), skip steps 6–7, report to user with exact error text from validator JSON
+   c. If validator returns any error-severity issue: mark entry as "created with issues" (or "refreshed with issues" when step 2 routed to `--rerun`), skip steps 6–7, report to user with exact error text from validator JSON
 
-   d. If validator passes: proceed to step 6
+   d. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: the agent just wrote this file this invocation, so it already has the research date, source URL, version, and access dates needed to satisfy these. Spawn `@research-curator` with `--fix` and the exact warning issue list from the JSON, then repeat steps a-b on the same file. If errors or any of these four warning types still remain after the retry, treat as step c.
+
+   e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` and info-severity items do not block this step -- proceed to step 6
 
 6. **Spawn four tasks concurrently** -- if research status is not `failed`:
 
@@ -192,12 +194,13 @@ Extract all tokens after `--batch` matching `https?://` as target URLs. Non-URL 
 
 ### Wave Spawning
 
-Spawn up to 5 `@research-curator` agents per wave via Agent tool. Wait for all agents in the current wave before spawning the next. After all waves complete, for each successful entry:
+Spawn up to 5 `@research-curator` agents per wave via Agent tool. Wait for all agents in the current wave before spawning the next. After all waves complete, for each successful entry, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries):
 
 1. Run fix script: `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py {file}`
 2. Run validator: `uv run .claude/skills/research-curator/scripts/validate_research.py main --json {file}`
-3. If validator returns errors: mark entry as "created with issues", skip analysis agents for that entry, include in output report with exact error text
-4. If validator passes: spawn concurrent analysis agents — `@research-insight-extractor`, `@research-utilization-assessor`, and `@research-cross-referencer` (up to 5 entries processed concurrently, each with its own set of analysis agents)
+3. If validator returns any error-severity issue: mark entry as "created with issues", skip analysis agents for that entry, include in output report with exact error text
+4. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: spawn `@research-curator` with `--fix` and the exact warning issue list, then repeat steps 1-2 on the same file. If errors or any of these four warning types still remain after the retry, treat as step 3.
+5. If validator passes with zero errors and zero warnings from the four checks in step 4 (`cross_references_absent` does not block this step): spawn concurrent analysis agents — `@research-insight-extractor`, `@research-utilization-assessor`, and `@research-cross-referencer` (up to 5 entries processed concurrently, each with its own set of analysis agents)
 
 See [Batch Mode reference](./references/batch-mode.md) for the complete wave spawning diagram.
 
@@ -249,16 +252,22 @@ flowchart TD
     VerifyFile -->|"Yes — file exists"| ReadFile["Read ./research/category/name.md<br>extract current content and metadata"]
     ReadFile --> Spawn1["Spawn @research-curator via Agent tool<br>prompt: --rerun ./research/category/name.md"]
     Spawn1 --> RelayCheck1["Apply pre-relay quality checklist"]
-    RelayCheck1 --> UpdateDate["Update ./research/README.md<br>refresh freshness date for this entry"]
+    RelayCheck1 --> Validate1["Run the Validation Gate for New/Refreshed Entries<br>(validation-rules.md) on this file"]
+    Validate1 -->|"errors, or gated warnings remain<br>after --fix retry"| Issues1(["Mark entry refreshed with issues<br>Skip analysis agents for it<br>Report exact issue text to user"])
+    Validate1 -->|"clean"| UpdateDate["Update ./research/README.md<br>refresh freshness date for this entry"]
     FindAll --> WaveSpawn["Spawn @research-curator agents in waves of 5<br>each receives --rerun ./research/category/name.md<br>wait for each wave before spawning next"]
     WaveSpawn --> RelayCheck2["Apply pre-relay quality checklist<br>to all wave results"]
-    RelayCheck2 --> UpdateDates["Update ./research/README.md<br>refresh freshness dates for all re-researched entries"]
+    RelayCheck2 --> ValidateN["Run the Validation Gate for New/Refreshed Entries<br>(validation-rules.md) on each updated entry"]
+    ValidateN -->|"an entry has errors, or gated<br>warnings remain after --fix retry"| IssuesN["Mark that entry refreshed with issues<br>Skip analysis agents for it<br>Include exact issue text in report"]
+    ValidateN -->|"clean entries"| UpdateDates["Update ./research/README.md<br>refresh freshness dates for all re-researched entries"]
     UpdateDate --> SpawnAnalysis1["Concurrently spawn analysis agents:<br>@research-insight-extractor 'Extract improvements from ./research/category/name.md'<br>@research-utilization-assessor 'Assess utilization opportunities from ./research/category/name.md'<br>@research-cross-referencer 'Add cross-references to ./research/category/name.md'"]
     SpawnAnalysis1 --> WaitAnalysis1["Wait for all agents<br>Surface IMMEDIATE_ATTENTION items from insight result<br>Report utilization proposal count<br>Report cross-references added count"]
     WaitAnalysis1 --> PostActions(["Execute Post-Actions — lint, commit, push"])
+    Issues1 --> PostActions
     UpdateDates --> SpawnAnalysisN["For each updated entry (concurrent, up to 5 entries)<br>spawn analysis agents per entry:<br>@research-insight-extractor<br>@research-utilization-assessor<br>@research-cross-referencer"]
     SpawnAnalysisN --> WaitAnalysisN["Wait for all analysis agents<br>Collect IMMEDIATE_ATTENTION items<br>Report total utilization proposals and cross-references added"]
     WaitAnalysisN --> PostActions
+    IssuesN --> PostActions
 ```
 
 ### Single Entry Rerun
@@ -273,15 +282,17 @@ flowchart TD
 3. Agent reads existing entry, re-gathers fresh data, updates content and freshness tracking
 4. Apply pre-relay quality checklist to agent result
 5. Update README with refreshed date
-6. **Validate** -- run the validation gate on the updated file:
+6. **Validate** -- run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) on the updated file:
 
    a. Run fix script: `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py ./research/{category}/{name}.md`
 
    b. Run validator: `uv run .claude/skills/research-curator/scripts/validate_research.py main --json ./research/{category}/{name}.md`
 
-   c. If validator returns errors: mark entry as "refreshed with issues", skip step 7, report to user with exact error text from validator JSON
+   c. If validator returns any error-severity issue: mark entry as "refreshed with issues", skip step 7, report to user with exact error text from validator JSON
 
-   d. If validator passes: proceed to step 7
+   d. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: the agent just refreshed this file this invocation, so it already has the facts to satisfy these. Spawn `@research-curator` with `--fix` and the exact warning issue list, then repeat steps a-b. If errors or any of these four warning types still remain after the retry, treat as step c.
+
+   e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` does not block this step -- proceed to step 7
 
 7. Concurrently spawn three analysis agents:
 
@@ -300,15 +311,17 @@ flowchart TD
 3. Each agent receives `--rerun ./research/{category}/{name}.md`
 4. Apply pre-relay quality checklist after each wave
 5. Update README once after all waves complete
-6. **Validate** -- for each successfully updated entry, run the validation gate before spawning analysis agents:
+6. **Validate** -- for each successfully updated entry, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) before spawning analysis agents:
 
    a. Run fix script: `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py {file}`
 
    b. Run validator: `uv run .claude/skills/research-curator/scripts/validate_research.py main --json {file}`
 
-   c. If validator returns errors: mark entry as "refreshed with issues", skip analysis agents for that entry
+   c. If validator returns any error-severity issue: mark entry as "refreshed with issues", skip analysis agents for that entry
 
-   d. If validator passes: include in analysis agent dispatch (step 7)
+   d. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: spawn `@research-curator` with `--fix` and the exact warning issue list, then repeat steps a-b on the same file. If errors or any of these four warning types still remain after the retry, treat as step c.
+
+   e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` does not block this step -- include in analysis agent dispatch (step 7)
 
 7. For each entry that passed validation: spawn concurrent analysis agents per entry (up to 5 entries concurrently) — `@research-insight-extractor`, `@research-utilization-assessor`, `@research-cross-referencer`
 
@@ -329,7 +342,7 @@ Run structural validation and fix error-severity issues.
 The validator script (`validate_research.py`) checks each entry file against the rules in [Validation Rules](./references/validation-rules.md). It emits JSON with three severity levels:
 
 - **error** -- structural violations that make entries unusable (missing required fields, broken links, malformed frontmatter). Auto-fixed by spawning `@research-curator` with `--fix` and the specific issue list.
-- **warning** -- quality issues that don't break entries (stale dates, thin summaries). Reported to user; not auto-fixed.
+- **warning** -- quality issues that don't break entries (stale dates, thin summaries). For the entries Validate Mode scans here -- pre-existing entries this invocation did not itself create or refresh -- reported to user; not auto-fixed. This is the intentionally lighter touch appropriate for legacy content some other agent wrote before the skill enforced these fields strictly. It does not apply to entries Default Mode, Batch Mode, or Rerun Mode just created or refreshed in the current invocation -- those follow the stricter [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries), which must-fixes four of these warning checks before the entry is reported complete.
 - **info** -- informational observations (entry age, word count). Reported to user; no action.
 
 ### Validation Workflow
@@ -373,7 +386,7 @@ Issues to fix (from validator JSON):
 Severity handling per [Validation Rules](./references/validation-rules.md):
 
 - **error** -- spawn `@research-curator` with `--fix` flag and the exact issue list extracted from JSON
-- **warning** -- include exact warning text in report to user; do not auto-fix
+- **warning** -- include exact warning text in report to user; do not auto-fix. This applies to entries Validate Mode scans here -- entries this invocation did not itself create or refresh. Validate Mode never re-researches (that is `--rerun`'s job), so it does not have fresh facts in hand the way a researching agent does; the lighter report-only touch is the correct behavior for this legacy content, unlike the must-fix rule Default/Batch/Rerun Mode apply to the same four checks on entries they just wrote (see [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries)).
 - **info** -- include exact info text in report; no action needed
 
 For error-severity fixes, spawn agents in waves of 5 (same pattern as Batch Mode).

--- a/.claude/skills/research-curator/references/batch-mode.md
+++ b/.claude/skills/research-curator/references/batch-mode.md
@@ -41,11 +41,12 @@ flowchart TD
     QMore -->|"Yes — advance to next batch of 5"| WNa
     QMore -->|"No — all URLs processed"| Collect
     Collect --> RelayCheck["Apply pre-relay quality checklist<br>to all collected agent results"]
-    RelayCheck --> Results{"Did any agent return status: failed?"}
-    Results -->|"No — all succeeded"| SpawnAnalysis["For each successful entry (up to 5 entries concurrently)<br>spawn analysis agents per entry:<br>- @research-insight-extractor 'Extract improvements from {file-path}'<br>- @research-utilization-assessor 'Assess utilization opportunities from {file-path}'<br>- @research-cross-referencer 'Add cross-references to {file-path}'"]
-    Results -->|"Yes — one or more failed"| SpawnAnalysisPartial["For each successful entry only (up to 5 concurrently)<br>spawn analysis agents per entry:<br>- @research-insight-extractor<br>- @research-utilization-assessor<br>- @research-cross-referencer<br>Relay each failure with exact reason to user"]
-    SpawnAnalysis --> UpdateAll["Update ./research/README.md<br>add all new entries to category tables<br>(concurrent with analysis agents)"]
-    SpawnAnalysisPartial --> Partial["Update ./research/README.md<br>with successful entries only<br>(concurrent with analysis agents)"]
+    RelayCheck --> Gate["For each entry with status: succeeded<br>run the Validation Gate for New/Refreshed Entries<br>(validation-rules.md): fix_research_formatting.py<br>+ validate_research.py --json; on a gated warning<br>(header_fields/access_dates/freshness_tracking/url_format)<br>spawn @research-curator --fix and retry once"]
+    Gate --> Results{"Per entry: did the curator agent fail,<br>or do errors / gated warnings remain<br>after the validation gate retry?"}
+    Results -->|"No for an entry — clean"| SpawnAnalysis["For each clean entry (up to 5 entries concurrently)<br>spawn analysis agents per entry:<br>- @research-insight-extractor 'Extract improvements from {file-path}'<br>- @research-utilization-assessor 'Assess utilization opportunities from {file-path}'<br>- @research-cross-referencer 'Add cross-references to {file-path}'"]
+    Results -->|"Yes for an entry — curator failure, or validation issues remain"| SpawnAnalysisPartial["Mark that entry failed or created with issues<br>Skip analysis agents for it<br>Relay the exact failure or issue text to user"]
+    SpawnAnalysis --> UpdateAll["Update ./research/README.md<br>add all clean new entries to category tables<br>(concurrent with analysis agents)"]
+    SpawnAnalysisPartial --> Partial["Update ./research/README.md<br>with clean entries only<br>(concurrent with analysis agents)"]
     UpdateAll --> WaitAnalysis["Wait for all analysis agents to complete<br>Collect IMMEDIATE_ATTENTION items from insight results<br>Collect PROPOSALS_WRITTEN counts from utilization results<br>Collect CROSS_REFERENCES_ADDED counts from cross-referencer results"]
     Partial --> WaitAnalysis
     WaitAnalysis --> BacklinkPass["For each successful entry in sequence (one at a time):<br>spawn @research-backlink-detector<br>'Add backlinks for {file-path}'<br>wait for completion before spawning next<br>(sequential to prevent write races on shared cited entries)"]
@@ -60,6 +61,8 @@ flowchart TD
 **Analysis phase concurrency**: After all curator waves complete, analysis agents spawn concurrently per entry: up to 5 entries, each spawning its own insight-extractor, utilization-assessor, and cross-referencer. This is distinct from the 5-agent curator wave limit.
 
 **Backlink phase serialization**: After all analysis agents complete, backlink-detector agents run **sequentially** — one entry at a time. Concurrent backlink passes on multiple entries that cite a shared target file would produce a write race (each agent reads a stale snapshot and the last writer drops the other's row). Sequential execution prevents this.
+
+**Validation gate**: Every entry a curator agent successfully wrote this wave passes through the [Validation Gate for New/Refreshed Entries](./validation-rules.md#validation-gate-for-newrefreshed-entries) before it is eligible for the analysis-agent fan-out. Error-severity issues, and warning-severity issues from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`, are must-fix — the researching agent already has the facts (today's date, the source URL, the version and access dates it just gathered), so a single `--fix` retry is spawned for gated warnings before an entry is marked "created with issues." `cross_references_absent` is not part of this gate.
 
 ---
 

--- a/.claude/skills/research-curator/references/validation-rules.md
+++ b/.claude/skills/research-curator/references/validation-rules.md
@@ -1,6 +1,6 @@
 # Validation Rules
 
-Checks performed by `./scripts/validate_research.py` and severity mapping for the `/research-curator --validate` mode.
+Checks performed by `./scripts/validate_research.py` and severity mapping for the `/research-curator` skill. The severity levels (error/warning/info) are a fixed reporting schema in the script's JSON output — the script itself does not know or care which mode is calling it. What differs by mode is *handling* of that JSON output: see [Validation Gate for New/Refreshed Entries](#validation-gate-for-newrefreshed-entries) below for Default Mode, Batch Mode, and Rerun Mode (the entry file was just created or rewritten by a `@research-curator` agent this invocation); see Validate Mode's Issue Handling section in `SKILL.md` for pre-existing entries an invocation did not itself touch.
 
 ---
 
@@ -19,9 +19,34 @@ Checks performed by `./scripts/validate_research.py` and severity mapping for th
 - **url_format**: All URLs must be valid `http://` or `https://` format
 - **cross_references_absent**: Entry does not contain a `## Cross-References` section. Expected for entries created or last verified on or after 2026-03-12. Entries with Research Date or Last Verified before this date are exempt. Note for `validate_research.py` implementers: gate this warning on the Research Date or Last Verified field value — exempt entries with dates before 2026-03-12.
 
+> **Handling differs by mode, not by severity.** `header_fields`, `access_dates`, `freshness_tracking`, and `url_format` stay warning-severity in the JSON output no matter who calls the script. But for an entry that Default Mode, Batch Mode, or Rerun Mode just created or refreshed *this invocation*, these four are must-fix before the entry is reported complete — the researching agent already holds every fact they need (today's research/verification date, the source URL it was given, the version and access dates it just gathered), so there is no legitimate reason to leave them open on output the agent itself just produced. See [Validation Gate for New/Refreshed Entries](#validation-gate-for-newrefreshed-entries) below. `cross_references_absent` is explicitly excluded from this must-fix rule — its own date-based exemption above is unrelated and unaffected. For pre-existing entries that Validate Mode scans without this invocation having written them, all four checks remain report-only, per Validate Mode's Issue Handling in `SKILL.md`.
+
 ### Info Severity (optional)
 
 - **formatting_suggestions**: Minor markdown formatting issues (missing blank lines around fences, inconsistent heading levels)
+
+---
+
+## Validation Gate for New/Refreshed Entries
+
+Applies only when Default Mode, Batch Mode, or Rerun Mode is the reason an entry file exists in its current form this invocation — a `@research-curator` agent just created or rewrote it. Does not apply to Validate Mode scanning entries this invocation did not itself write; those follow the lighter report-only handling in Validate Mode's Issue Handling (`SKILL.md`).
+
+This is the authoritative procedure for what the orchestrator does with the `fix_research_formatting.py` + `validate_research.py --json` output on such a file:
+
+```mermaid
+flowchart TD
+    Start(["fix_research_formatting.py + validate_research.py --json<br>ran on an entry this invocation just created or refreshed"]) --> HasErr{"Any error-severity issue<br>in the JSON output?"}
+    HasErr -->|"Yes"| MarkIssues(["Mark entry created/refreshed with issues<br>Skip analysis-agent fan-out for this entry<br>Report exact error text from JSON to user"])
+    HasErr -->|"No"| HasGatedWarn{"Any warning-severity issue from<br>header_fields, access_dates,<br>freshness_tracking, or url_format?<br>(cross_references_absent excluded)"}
+    HasGatedWarn -->|"No"| Proceed(["Entry is complete — proceed to<br>analysis-agent fan-out"])
+    HasGatedWarn -->|"Yes"| SpawnFix["Spawn @research-curator with --fix flag<br>PLUS the exact warning issue list from JSON<br>(the agent already has these facts: today's<br>research/verification date, the source URL,<br>the version and access dates it just gathered)"]
+    SpawnFix --> Rerun["Re-run fix_research_formatting.py<br>then validate_research.py --json on the same file"]
+    Rerun --> HasErr2{"Any error-severity issue,<br>or any warning from the four<br>gated checks, remaining?"}
+    HasErr2 -->|"Yes"| MarkIssues
+    HasErr2 -->|"No"| Proceed
+```
+
+The retry is expected to always resolve these four checks, since the researching agent already gathered every fact needed to satisfy them. Reaching `MarkIssues` after the retry means a genuinely un-fillable field — report it as an issue on the entry rather than silently accepting it as an acceptable warning to leave open.
 
 ---
 
@@ -49,6 +74,8 @@ flowchart TD
 ---
 
 ## JSON Output Schema
+
+This schema (`check`, `severity`, `message`, `line`) is identical regardless of which mode invoked the script — `validate_research.py` has no mode awareness. Only the orchestrator's handling of warning-severity issues differs by mode, per [Validation Gate for New/Refreshed Entries](#validation-gate-for-newrefreshed-entries) above.
 
 ```json
 {

--- a/.claude/skills/research-curator/scripts/validate_research.py
+++ b/.claude/skills/research-curator/scripts/validate_research.py
@@ -329,7 +329,7 @@ def _check_url_format(lines: list[str]) -> list[Issue]:
         List of ``Issue`` dicts, one per malformed URL.
     """
     issues: list[Issue] = []
-    bare_url_pattern = re.compile(r"(?<!\()(?<!<)(?:www\.)\S+", re.IGNORECASE)
+    bare_url_pattern = re.compile(r"(?<!\()(?<!<)(?<!https://)(?<!http://)(?:www\.)\S+", re.IGNORECASE)
 
     for i, line in enumerate(lines):
         for match in bare_url_pattern.finditer(line):

--- a/research/README.md
+++ b/research/README.md
@@ -536,6 +536,7 @@ Agent SDKs, orchestration frameworks, and comparative studies of multi-agent arc
 | [omnigent.md](./agent-frameworks/omnigent.md) | Omnigent v0.1.0 (Databricks) — Python 3.12+ multi-agent harness for orchestrating Claude Code, Codex, Cursor, Pi without rewriting; unified YAML policy enforcement (ALLOW/DENY/ASK), cross-device session sync via WebSocket, MCP support (Apache 2.0) | 2026-06-18 |
 | [ponytail.md](./agent-frameworks/ponytail.md) | Ponytail v4.7.0 — "lazy senior developer mode" for AI agents; 6-rung decision ladder (YAGNI→stdlib→native→deps→one-liner→minimal code) with benchmark results: 80–94% code reduction, 42–75% cost reduction, 3–6× faster; 13 platform support (MIT) | 2026-06-18 |
 | [flue.md](./agent-frameworks/flue.md) | Flue — TypeScript agent harness framework providing durable-first execution, sandboxes, typed tools, MCP integration, subagent delegation, and 20+ channel adapters (Slack, Teams, Discord, GitHub); deploys to Node.js, Cloudflare Workers, GitHub Actions, GitLab CI/CD, Daytona, Render (Apache-2.0, v1.0.0-beta.9) | 2026-07-03 |
+| [deepseek-harness.md](./agent-frameworks/deepseek-harness.md) | DeepSeek Harness (`dsh`) — DeepSeek AI's open-source agent harness; everything-is-a-plugin architecture on Cordis; 30+ capability packages (core loop, LLM access, shell/fs/web execution, subagent delegation, workflow, skills, session persistence); Service Definition/Provider/Consumer seam pattern; bridges Claude Code, Codex, OpenCode, GitHub coding agents via shared wire protocol; developer preview, no security audit (MIT) | 2026-09-11 |
 
 **Key Topics**:
 
@@ -1259,6 +1260,7 @@ AI research newsletters, curated resource collections, and tools for staying cur
 | [OpenSpace.md](./ai-research-tools/OpenSpace.md) | OpenSpace — self-evolving skills engine for AI agents: autonomous skill development, 46% token reduction via reuse, collective skill sharing across agent networks (1.7K stars, MIT, v0.1.0) | 2026-03-28   |
 | [meta-harness.md](./ai-research-tools/meta-harness.md) | Meta-Harness — End-to-end optimization framework for model harnesses (LLM context management infrastructure) using agentic proposer with execution traces | 2026-04-06   |
 | [notebooklm.md](./ai-research-tools/notebooklm.md) | NotebookLM (Google NotebookLM; LM = "Language Model") is a research and note-taking online tool developed by Google Labs that uses Google Gemini to assist users in interacting with their documents.... | 2026-01-31 |
+| [zvec-grep.md](./ai-research-tools/zvec-grep.md) | zvec-grep — local-first hybrid workspace search (ripgrep + BM25 + vector) for humans and AI agents; MCP integration for Claude Code, Codex, Qwen, OpenCode, Cursor, Qoder; daemon-based auto/server/direct modes (@zvec/zvec-grep v0.2.1, Apache 2.0, pre-v1.0) | 2026-09-11 |
 
 **Key Topics**:
 
@@ -1384,6 +1386,7 @@ Interactive prompt development platforms and tools for iterating on LLM prompts,
 | [ctxforge.md](./prompt-engineering/ctxforge.md)           | ctxforge — protocol-based context engineering framework; 16 markdown workflows auto-loaded via intent detection (~95% accuracy); 30+ performance/quality directives; project.md cross-session memory; ~15K token overhead (7.5%); v3.1.2, 22 stars | 2026-03-17 |
 | [system-prompts-ai-tools.md](./prompt-engineering/system-prompts-ai-tools.md) | x1xhlol/system-prompts-and-models-of-ai-tools — 30,000+ lines of leaked system prompts and model configs for 30+ AI tools including Claude Code, Cursor, Windsurf, Devin AI, Copilot, v0, Replit (117.9K stars, GPL-3.0) | 2026-02-23 |
 | [prompt-optimizer.md](./prompt-engineering/prompt-optimizer.md) | prompt-optimizer v2.11.6 — TypeScript monorepo (31K stars); dual-mode optimization (system + user prompts), multi-model adapters (OpenAI/Gemini/DeepSeek/Grok/Zhipu), MCP server, 4 deployment paths (Vercel/Electron/Chrome extension/Docker), structured evaluation with compare, image generation T2I/I2I | 2026-06-18 |
+| [open-spdd.md](./prompt-engineering/open-spdd.md) | OpenSPDD — Go CLI turning AI coding prompts into "executable design contracts" via the 7-dimension REASONS Canvas (Requirements, Entities, Approach, Structure, Operations, Norms, Safeguards); bidirectional `/spdd-sync` keeps design docs and code aligned; generates commands for Cursor, Claude Code, Copilot, Antigravity, OpenCode, Codex (MIT, unversioned) | 2026-09-11 |
 
 **Key Topics**:
 

--- a/research/agent-frameworks/deepseek-harness.md
+++ b/research/agent-frameworks/deepseek-harness.md
@@ -1,0 +1,245 @@
+---
+resource: DeepSeek Harness
+acronym: dsh
+description: "Open-source agent harness with everything-is-a-plugin architecture powered by Cordis"
+status: developer preview
+release_date: 2026
+repository: https://github.com/deepseek-ai/deepseek-harness
+documentation: https://deepseek-harness.github.io/deepseek-harness/
+research_date: 2026-09-11
+source_url: https://github.com/deepseek-ai/deepseek-harness
+version_at_research: "unversioned (developer preview, no tagged release at research time)"
+license: MIT
+language: TypeScript (Node.js)
+freshness_tracking:
+  last_verified: 2026-09-11
+  version_at_verification: "unversioned (developer preview, no tagged release at research time)"
+  next_review: 2026-12-11
+  last_verified_source: "Repository README.md, AGENTS.md, packages/README.md, SAFETY.md"
+---
+
+# DeepSeek Harness
+
+## Overview
+
+**DeepSeek Harness** (`dsh`) is "an open-source agent harness developed by [DeepSeek AI](https://deepseek.com)" built on an **"everything-is-a-plugin architecture and powered by [Cordis](https://github.com/cordiverse/cordis)"** (README.md, lines 5-7). The design philosophy is rooted in compositional spatiotemporal patterns as described in "A Programming Paradigm for Spatiotemporal Composability" (arXiv 2608.25512).
+
+The harness orchestrates AI agent execution by composing modular capabilities—LLM access, shell execution, filesystem operations, web access, subagent delegation—through a plugin registry where every feature is contributed as a plugin. The core agent loop coordinates sessions, model requests, and tool invocations through a unified event model.
+
+## Problem Addressed
+
+Existing agent frameworks couple capabilities tightly to the core loop, making it difficult to extend or replace components independently. DeepSeek Harness addresses this by using Cordis (a capability-plugin framework) to define discrete service contracts—capability seams—where each seam specifies a Service Definition (abstract interface), Service Provider (implementation), and Consumer (model-facing integration). This separation enables swapping providers (e.g., local vs. cloud shell execution) and composing capabilities declaratively from configuration without changing core code.
+
+## Key Features
+
+### Everything-Is-a-Plugin Architecture
+
+Every feature—model access, shell execution, filesystem operations, web browsing, skill management, subagent coordination—registers as a plugin through Cordis. "The harness is assembled from npm packages under `packages/`, grouped by capability family: sessions and the agent loop, model-facing tools, shell and filesystem execution, web access, subagents, and the rest" (packages/README.md, line 12). Plugins register through Cordis effects and event listeners; the system discovers and loads them from configuration (cordis.yml) at runtime.
+
+**Source**: README.md line 7; packages/README.md lines 12-80; AGENTS.md capability seam conventions.
+
+### Modular Capability Families
+
+The harness organizes packages into capability families, each owning a Service Definition / Service Provider / Consumer pattern:
+
+- **Core loop** (`core/`): "Product API spine: sessions, prompts, tools, agent services, and the concrete loop" (packages/README.md, line 31)
+- **LLM capability** (`llm/`): "LLM capability family: abstract service + provider adapters" (line 38)
+- **Shell execution** (`shell/`): "Bash capability family: executor seam, local impl, model-facing tools" (line 41)
+- **Filesystem** (`fs/`): "Filesystem capability family: seam, local impl, model-facing file tools, discovery tools" (line 45)
+- **Web access** (`web/`): "Web capability family: seam, search/fetch providers, model-facing web tools" (line 55)
+- **Subagent delegation** (`subagent/`): "Subagent capability family: provider-registry contract and model-facing delegation tools" (line 50)
+- **Workflow execution** (`workflow/`): "Workflow seam, worker-thread engine, and model-facing `workflow`/`ralph` tools" (line 53)
+- **Code execution** (`code-runtime/`): "Code-execution capability family: Service Definition + worker-thread provider + PTC mode Consumer" (line 43)
+
+All packages are scoped `@deepseek-ai/dsh-*` (packages/README.md, line 12).
+
+**Source**: packages/README.md lines 29-75; AGENTS.md convention "A capability seam comprises Service Definition / Service Provider / Consumer roles."
+
+### Session-Centric Event Model
+
+The harness persists agent execution as structured session events. "Model-visible ⟺ logged: anything that reaches a model request must be reconstructable from the session log; a new model-visible input requires a session event" (AGENTS.md conventions). Sessions record tool calls, model responses, state transitions, and user actions in a durable log. "Session version/status" maintains compatibility across API changes through a monotonic schema version and migration chains.
+
+**Source**: AGENTS.md sections on session format, log versioning, and model-visible contracts.
+
+### Multi-Engine Runtime Support
+
+DeepSeek Harness coordinates with Claude Code, Codex, OpenCode, and GitHub's coding agents. The `hooks/` package provides "Hook bridges + the shared Claude Code / Codex wire-protocol library" (packages/README.md, line 64). The SDK (`sdk/`) exposes a "JSON-RPC protocol and TypeScript client/server" for out-of-process integration (line 71). The `acp/` package provides "Automation-only Agent Client Protocol server" (line 72).
+
+**Source**: packages/README.md lines 64, 71, 72; AGENTS.md integration conventions.
+
+### Web UI and Headless Execution
+
+The harness provides a Web GUI (browser-based UI in `client/` and server in `host/`) for interactive use and headless execution for automation. Installation launches the Web UI at `http://127.0.0.1:3080` by default (README.md, line 27). Headless mode runs workflows without a UI; snapshot tests replay recorded sessions through the same profiles.
+
+**Source**: README.md lines 19-27; AGENTS.md test conventions.
+
+## Technical Architecture
+
+### Agent Loop and Session Coordination
+
+The agent loop is the core orchestrator:
+
+1. Receive model response containing tool calls or text
+2. Execute tools, recording results in the session event log
+3. Prepare the next model request with context, tools, and history
+4. Loop until model indicates task completion
+
+Each agent has an "initiator" (the caller—human user, webhook, or automation system) that owns the session lifecycle. "Under `ctx.agents.withInitiator()`, recover the Agent at each orchestration entry, derive `agent.session`, and let operation-local helpers close over it" (AGENTS.md package conventions).
+
+**Source**: AGENTS.md sections on initiator scope and agent loop organization; packages/core/README.md.
+
+### Capability Seam Pattern
+
+Each capability is structured as three orthogonal roles:
+
+1. **Service Definition**: Abstract TypeScript interface (e.g., `ShellService`) describing the capability's contract—methods, parameters, return types
+2. **Service Provider**: Concrete implementation registered to the Cordis context (e.g., local shell execution, E2B remote sandbox, pwsh on Windows)
+3. **Consumer**: Model-facing tool definitions and execution logic that invoke the service (e.g., `shell_execute` tool that calls `shell.run()`)
+
+Plugins depend on Service Definitions, never on concrete providers. The provider is swappable via configuration without changing consumers. This pattern applies to LLM access, shell execution, filesystem operations, subagent delegation, and every other major feature.
+
+"Extension plugins depend on Service Definitions, never concrete providers" (packages/README.md, line 95). "A capability seam comprises Service Definition / Service Provider / Consumer roles. It is complete, never one role; split only when roles evolve independently" (AGENTS.md).
+
+**Source**: AGENTS.md capability seam conventions; packages/README.md line 95; package READMEs (core, llm, shell, fs, etc.).
+
+### Plugin Loading and Composition
+
+Plugins register through Cordis when the harness loads a profile. A profile is a `cordis.yml` file that declares:
+
+- Which plugins to load (by package name or path)
+- Plugin configuration (service bindings, credentials, options)
+- Conditional composition (JavaScript expressions for feature flags)
+
+The loader discovers plugins from the workspace (local packages), NPM registry, or GitHub (via the `dsh-plugin` topic). "Cordis allows `!!js` (never `!js`) under plugin `config` and entry `disabled`; other metadata stays literal, so conditional composition also uses overlays" (AGENTS.md).
+
+At runtime, plugins call `ctx.plugin(name, PluginClass, config)` to register. "Every contribution goes through `ctx.effect()` / `ctx.on()`; a registry's `register()` returns the disposer" (AGENTS.md).
+
+**Source**: AGENTS.md conventions on plugin registration and Cordis loading; packages/preset/README.md for profile structure.
+
+### Type System and TypeScript at Scale
+
+The harness compiles under strict TypeScript with `strict: true` and `noImplicitAny`. All exports have JSDoc. "Trust TypeScript at typed same-process boundaries. Do not add runtime validation, fallback behavior, or hostile-input tests solely for values the static interface requires" (AGENTS.md).
+
+The `typert/` package "Type graph generation, artifact loading, and runtime registry" (packages/README.md, line 33) handles type artifacts (JSON schemas, Pydantic models) from external tools and makes them available at runtime for validation and tool schema generation.
+
+**Source**: AGENTS.md type safety section; packages/typert/README.md.
+
+## Installation & Usage
+
+### Install from NPM
+
+```bash
+npx @deepseek-ai/dsh web
+```
+
+"The command starts the Web UI at `http://127.0.0.1:3080` by default and opens it in the default browser for a local launch. An SSH launch only prints the host URL because the SSH client or editor owns the local forwarded address" (README.md, lines 27-28). Pass `--no-open` to run the server without opening a browser.
+
+**Source**: README.md lines 19-27.
+
+### Install from Source
+
+```bash
+git clone https://github.com/deepseek-ai/deepseek-harness.git
+cd deepseek-harness
+pnpm install
+pnpm run build
+pnpm dsh web
+```
+
+"`pnpm run build` prepares the repository artifacts. `pnpm dsh web` uses those built artifacts without rebuilding" (README.md, lines 41-42). The project requires Node.js `^22.19 || >=24` and pnpm as package manager.
+
+**Source**: README.md lines 29-42; AGENTS.md.
+
+### Run Headless Task
+
+```bash
+pnpm dsh --profile headless "task"  # requires DEEPSEEK_API_KEY
+```
+
+Headless mode executes agent tasks from the CLI without the Web UI, suitable for automation and CI/CD.
+
+**Source**: AGENTS.md commands section.
+
+### Configuration
+
+Behavior is configured in `cordis.yml` (or overlays for conditional composition). "No hardcoded tunables in plugins: deployment-varying choices are validated `Config` fields changeable from cordis.yml; a `DEFAULT_*` constant or test hook is not configurability" (AGENTS.md). The project reads `DEEPSEEK_API_KEY`, optional `DEEPSEEK_BASE_URL`, and a root `.env` file for real-API tests and demos. "Never commit credentials" (AGENTS.md).
+
+**Source**: AGENTS.md conventions on configuration and secrets.
+
+## Relevance to Claude Code Development
+
+DeepSeek Harness is highly relevant to Claude Code development in four dimensions:
+
+1. **Agent orchestration patterns**: The plugin architecture, capability seams, and session event model are directly applicable to extending Claude Code's agent infrastructure. The separation of Service Definition / Provider / Consumer roles enables building new capabilities without modifying the core loop—a pattern used across Cordis-based systems.
+
+2. **Multi-harness interoperability**: The `hooks/` package bridges Claude Code, Codex, OpenCode, and GitHub's coding agents through a shared wire protocol. Understanding this integration helps coordinate agent development across platforms.
+
+3. **Session persistence and replay**: The session log-based architecture enables recording, replaying, and debugging agent execution. This is directly applicable to Claude Code's session storage, recovery, and audit trails.
+
+4. **Skill and plugin ecosystems**: The `dsh-plugin` discovery mechanism and plugin loading patterns inform how Claude Code can support third-party skill development and plugin composition.
+
+5. **Type-driven tool integration**: The Typert type system and tool schema generation provide a model for representing external tool APIs in a type-safe, model-visible way.
+
+## Limitations and Caveats
+
+**Status**: "DeepSeek Harness is in _developer preview_ and iterating rapidly. **THERE WILL BE COMPATIBILITY-BREAKING CHANGES.**" (README.md, lines 11-13). This is not production software.
+
+**Security**: "DeepSeek Harness is experimental developer-preview software. It has not undergone a security audit and must not be treated as secure or production-ready" (SAFETY.md, lines 6-7). "The project can execute model-generated code and commands, load third-party plugins, and access the network, processes, credentials, and files made available to it. Incorrect model output, defects, misconfiguration, malicious input, or untrusted plugins may damage the host computer, modify or delete files, disclose data or credentials, or cause other unintended effects" (SAFETY.md, lines 9-10).
+
+**Sandboxing**: "Sandboxing, approval prompts, and permission controls can reduce risk, but they do not guarantee isolation or prevent damage. Even correctly enforced restrictions cannot protect resources that the project is allowed to access" (SAFETY.md, lines 11-13).
+
+**External contributions**: "DeepSeek Harness is still at an early stage and under active development. We are sorry that we cannot accept external pull requests at the moment" (CONTRIBUTING.md, line 9). The team invites community plugin development and ecosystem contributions instead.
+
+**API stability**: Public APIs are pre-stable; "update every consumer" when APIs change (AGENTS.md). The `experimental/` package group is unreleased and for internal use only.
+
+**Source**: README.md lines 11-15; SAFETY.md; CONTRIBUTING.md lines 9-12; AGENTS.md API stability section.
+
+## References
+
+- **Repository**: <https://github.com/deepseek-ai/deepseek-harness> (accessed 2026-09-11)
+- **Official Documentation**: <https://deepseek-harness.github.io/deepseek-harness/> (accessed 2026-09-11)
+- **GitHub Discussions**: <https://github.com/deepseek-ai/deepseek-harness/discussions> (accessed 2026-09-11)
+- **Discord Community**: <https://discord.gg/Ycq5dCaS4> (accessed 2026-09-11)
+- **Plugin Discovery**: GitHub topic [`dsh-plugin`](https://github.com/topics/dsh-plugin) (accessed 2026-09-11)
+- **Cordis Framework**: <https://github.com/cordiverse/cordis> (accessed 2026-09-11)
+- **Spatial Composability Paper**: <https://arxiv.org/abs/2608.25512> (accessed 2026-09-11)
+- **Official Docs Page**: <https://www.deepseek.com/harness/en/> (attempted 2026-09-11 — inaccessible, connection reset; not counted as accessed)
+
+## Freshness Tracking
+
+**Last Verified**: 2026-09-11
+
+**Sources Read**:
+- README.md (primary entry point)
+- AGENTS.md (comprehensive development conventions)
+- SAFETY.md (experimental status and risk disclosure)
+- CONTRIBUTING.md (contribution guidelines)
+- LICENSE (MIT)
+- packages/README.md (package organization and capability families)
+
+**Official Docs Page**: Attempted to fetch <https://www.deepseek.com/harness/en/> but received a connection reset error. Entry relies on repository documentation.
+
+**Confidence by Section**:
+- **Identity/Metadata**: high (repository README, LICENSE, AGENTS.md)
+- **Key Features**: high (documented in README, packages/README, AGENTS.md)
+- **Technical Architecture**: high (AGENTS.md conventions, package READMEs, module structure)
+- **Installation & Usage**: high (README.md, AGENTS.md commands)
+- **Limitations**: high (SAFETY.md, CONTRIBUTING.md)
+- **Relevance to Claude Code**: medium (inferred from architecture documentation and hooks/SDK packages; not explicitly stated in sources)
+
+**Next Review**: 2026-12-11
+
+**Notes**: This entry focuses on the harness architecture and developer-facing contracts. User-facing features (Web UI capabilities, model behavior, specific tool implementations) are documented in the official repository but were not the focus of this entry. The official docs site was inaccessible; entry is grounded entirely in the repository documentation, which is comprehensive and authoritative.
+
+## Cross-References
+
+| Entry | Category | Relationship |
+|-------|----------|--------------|
+| [Flue](./flue.md) | agent-frameworks | TypeScript agent harness with comparable durable execution model and plugin-based capability composition |
+| [Pi Mono](./pi-mono.md) | agent-frameworks | TypeScript monorepo demonstrating unified agent runtime with modular capability packages and multi-interface support |
+| [Claude Code Harness](./claude-code-harness.md) | agent-frameworks | Complementary Go-native harness with 5-verb orchestration workflow and guardrail infrastructure patterns |
+| [Mission Control](./mission-control.md) | agent-frameworks | Autonomous orchestration engine applying similar multi-stage agent composition and decision-routing patterns |
+| [OpenFang](./openfang.md) | agent-frameworks | Rust Agent OS sharing SKILL.md native support and service-layered capability architecture with Cordis pattern equivalents |
+| [Orchestra](./orchestra.md) | agent-frameworks | DAG-based task orchestrator with comparable context-aware composition and resumable agent state patterns |
+| [Superpowers](./superpowers.md) | agent-frameworks | Skills-driven agent framework sharing capability family organization and subagent coordination patterns |
+| [Everything Claude Code](./everything-claude-code.md) | agent-frameworks | Comprehensive multi-agent system with hook-based automation and extensible skill ecosystem architecture |

--- a/research/ai-research-tools/zvec-grep.md
+++ b/research/ai-research-tools/zvec-grep.md
@@ -1,0 +1,368 @@
+---
+title: "zvec-grep — Local-First Hybrid Workspace Search"
+resource_url: "https://github.com/zvec-ai/zvec-grep"
+resource_npm: "@zvec/zvec-grep"
+research_date: "2026-09-11"
+source_url: "https://github.com/zvec-ai/zvec-grep"
+version_at_research: "0.2.1"
+current_version: "0.2.1"
+license: "Apache 2.0"
+language: "TypeScript/JavaScript"
+freshness_tracking:
+  last_verified: "2026-09-11"
+  version_at_verification: "0.2.1"
+  next_review: "2026-12-11"
+  confidence:
+    identity_metadata: "high"
+    features: "high"
+    architecture: "high"
+    usage_examples: "high"
+    limitations: "medium"
+---
+
+## Overview
+
+**zvec-grep** is a local-first search layer designed for both humans and AI agents. It unifies ripgrep (exact text and regex search), BM25 (lexical ranking), and vector search (semantic retrieval) behind a single interface. The tool is published as the npm package `@zvec/zvec-grep` (v0.2.1) and is licensed under Apache 2.0. Written in TypeScript, it requires Node.js 22 or newer.
+
+According to the README, zvec-grep is "powered by [zvec](https://github.com/alibaba/zvec), unifies ripgrep, BM25, and vector search behind one local-first interface." Users can search from the terminal directly or allow AI agents (via MCP integration) to search on their behalf.
+
+## Problem Addressed
+
+Agents and developers struggle to find relevant code and documentation across large workspaces using keyword search alone. The tool solves four specific problems:
+
+1. **Keyword limitations**: Queries often fail when exact keywords are not known in advance, especially for architectural questions that cross multiple files and modules.
+
+2. **Context bloat in agent systems**: Baseline retrieval approaches require many tool calls, produce noisy results, and consume excessive model context tokens.
+
+3. **Format fragmentation**: Real workspaces contain source code, configuration files, documentation, and data; a single search tool should handle all formats while preserving structure.
+
+4. **Privacy and control**: Remote-first search systems send workspace content to external services, violating data residency requirements and increasing latency.
+
+The README states: "zg works best when evidence spans files or modules and the target location is unknown, especially for call-chain, data-flow, and architectural questions."
+
+## Key Features
+
+### Hybrid Search with Multiple Retrieval Paths
+
+zvec-grep offers three search modes that can be combined:
+
+- **Lexical (BM25)**: Ranked keyword and phrase matching via BM25. Selected with `--fts <query>`.
+- **Vector (semantic)**: Embedding-based similarity search. Selected with `--vector <query>`.
+- **Exact/Regex (ripgrep)**: Exhaustive text or regex matching via `@vscode/ripgrep` (managed). Invoked with `--rg`.
+
+These modes can be mixed: `zg --fts "loadTheme" --vector "where user prefs are restored" --fuse` combines multiple groups and fuses results into a single ranked output. According to the benchmarks, this approach reduces tool calls, input tokens, and agent reasoning time compared to baseline retrieval.
+
+### Agent Integration (MCP)
+
+The tool exposes an MCP (Model Context Protocol) server endpoint on localhost via the local daemon. Agents (Claude Code, Codex, Qwen Code, Qoder, OpenCode, Cursor) can call `zvec_grep_search` with a query and receive ranked results. Installation is one command: `zg --install --target claude --yes`. The MCP interface supports:
+
+- **Symbol-aware retrieval**: Prefer exact matches on function names, class names, or module identifiers with `--prefer-symbol`.
+- **Symbol type filtering**: Restrict results to `module`, `class`, `interface`, `function`, `value`, or `alias`.
+- **Time-based filtering**: Search files modified before or after a timestamp with `--modified-before` and `--modified-after`.
+
+### Multi-Format Indexing and Search
+
+The tool indexes and searches across multiple content types:
+
+- **Source code**: Symbols (functions, classes, modules) are extracted and indexed; search results preserve line references and context.
+- **Structured data**: JSON, YAML, and TOML are partially parsed; search results link to document structures.
+- **Plain text and prose**: Documents are chunked and indexed for retrieval; results return focused sections with full source location.
+
+Per the README: "Multi-format search — search source code, documents, and structured data while preserving useful structure and source locations."
+
+### Configurable Embedding Models
+
+Instead of hardcoding one embedding service, zvec-grep lets users choose:
+
+- **Local embedding**: `local/potion-retrieval-32m` and other Potion models run on CPU/GPU without sending data outside the machine. Potion models default to 2 worker threads; `--embedding-concurrency <n>` scales this.
+- **Remote embedding**: Hugging Face, Qwen, and others can be configured; data is sent only when the user explicitly authorizes with `--allow-remote`.
+- **Per-index model**: Each indexed workspace stores its embedding model preference; changing it requires `zg --index --rebuild --embedding <model>`.
+
+### Index Refresh Strategies
+
+The tool offers three refresh modes to keep search results up-to-date:
+
+- `--refresh wait`: Block the search until pending index updates complete (default).
+- `--refresh background`: Return stale results immediately while reindexing in the background.
+- `--refresh off`: Skip index refresh and return only cached results.
+
+### Command-Line Interface (CLI)
+
+The primary `zg` command is a search interface; maintenance operations use long action flags to avoid collisions with natural query words (e.g., `zg --index`, `zg --status`, `zg --install`). Positional arguments are always interpreted as search queries.
+
+Core commands:
+- `zg <query>`: Hybrid search (lexical + vector by default).
+- `zg --index [root]`: Build, update, or drop the workspace index.
+- `zg --status [root]`: Inspect index state and readiness.
+- `zg --install --target <agent>`: Integrate with a specific agent (claude, codex, qwen, qoder, opencode, cursor, or all).
+- `zg --config provider set <name> --api-key <key>`: Store embedding provider credentials.
+- `zg --server`: Manage the local MCP server (start, stop, status, logs).
+
+Example searches from the README:
+
+```bash
+zg "theme preference persistence on startup"
+zg --fts "loadTheme" -g "src/**" -t ts
+zg --vector "where user preferences are restored" --limit 5
+zg "plugin lifecycle" --preview full
+zg --rg -i -C 2 -g "*.ts" "dark mode" src
+```
+
+### Server and Execution Modes
+
+zvec-grep can run as:
+
+1. **Auto mode** (default): Starts a long-running daemon if needed; subsequent commands reuse it for faster response times.
+2. **Server mode**: Explicitly starts or connects to the shared MCP server.
+3. **Direct mode**: Runs each search in a new process without a persistent daemon.
+
+All three modes call the same search engine; the difference is process lifetime and coordination overhead. MCP requests always arrive through the Server.
+
+## Technical Architecture
+
+### System Overview
+
+The architecture diagram from `docs/05-architecture.md` shows:
+
+```text
+Human or script → zg CLI → auto / server / direct → Local Server
+Agent → MCP client →                               → Engine
+        → Direct runtime
+
+Server and Direct routes both call:
+  zvec-grep engine
+    ├── Indexed search (BM25 + vector + RRF)
+    ├── Managed ripgrep (exact text + regex)
+    └── Indexing (scan + extract + embed)
+
+Workspace files → Managed ripgrep
+                → Indexing → Workspace index (.zvec-grep/)
+                Workspace index → Indexed search → Results
+                Managed ripgrep → Results
+```
+
+### Core Components
+
+**Entry points**:
+- **CLI** (`src/cli/`): Parses command-line arguments, routes to the appropriate action, and formats results for terminal output.
+- **MCP Server** (`src/daemon/http-server.ts`): Exposes the search interface as HTTP-based MCP tools for agent consumption.
+
+**Daemon and execution**:
+- **Daemon** (`src/daemon/`): Long-running server process that coordinates indexing, watches file changes, manages the embedding model pool, and serves MCP requests.
+  - `server-controller.ts`: Lifecycle and coordination.
+  - `http-server.ts`: HTTP server for MCP transport.
+  - `job-scheduler.ts`: Schedules indexing and embedding jobs.
+  - `watch-manager.ts`: Monitors file system changes.
+  - `model-pool.ts`: Manages embedding model instances and concurrency.
+  - `workspace-read-session-cache.ts`: Caches file reads to reduce disk I/O.
+  - `config.ts`: Persists and loads configuration.
+
+**Retrieval and indexing**:
+- **zvec library** (`@zvec/zvec` v0.7.0): Rust-based vector database with SQLite backend. Stores embeddings, metadata, and supports similarity search.
+- **Ripgrep** (`@vscode/ripgrep` v1.18.0): Lexical and regex search via the VS Code ripgrep package.
+- **Tree-sitter** (`web-tree-sitter` v0.20.8, `tree-sitter-wasms` v0.1.13): AST parsing for symbol extraction (functions, classes, modules).
+
+**Ranking and fusion**:
+- **Reciprocal Rank Fusion (RRF)**: When multiple search groups are queried (e.g., `--fts` + `--vector`), results are merged and re-ranked by reciprocal rank to balance diverse evidence.
+
+**Embedding**:
+- **Hugging Face Transformers** (`@huggingface/transformers` v3.8.1) and **Hugging Face Tokenizers** (`@huggingface/tokenizers` v0.1.3): Support for local embedding models (Potion, Jina) and remote providers.
+- **Web Assembly (WASM)**: Local embeddings run in WASM threads to parallelize inference on multi-core systems.
+
+**MCP Protocol**:
+- **MCP Server** (`@modelcontextprotocol/server` v2.0.0), **Core** (v2.0.0), **Node** (v2.0.0): Implements the Model Context Protocol for agent communication.
+
+**Schema and configuration**:
+- **Zod** (v4.2.0): Validates configuration objects, query parameters, and MCP payloads.
+- **JSONC Parser** (`jsonc-parser` v3.3.1): Reads `.zvec-grep/config.json` with comment support.
+
+### Data Flow
+
+1. **Indexing**: When `zg --index` runs, the engine scans workspace files (respecting `.gitignore`), extracts symbols and text chunks via tree-sitter and custom extractors, embeds them using the selected model, and stores embeddings + metadata in the `.zvec-grep/index/` directory (backed by the zvec database).
+
+2. **Search**: A query is routed through the selected retrieval paths:
+   - Lexical results are fetched from the index and ranked by BM25 score.
+   - Vector results are computed by embedding the query and finding nearest neighbors in the zvec database.
+   - Ripgrep results are computed by scanning the workspace with the supplied pattern.
+   - Results are merged, deduplicated, and ranked by reciprocal rank fusion if multiple groups exist.
+
+3. **Output**: Results include file paths, line ranges, snippet previews, symbol names, and relevance scores. The CLI formats them as readable text or JSON; the MCP server formats them according to the MCP response schema.
+
+### Storage and Trust Boundary
+
+Per `docs/05-architecture.md`:
+- **Workspace index**: Stored in `.zvec-grep/` under the indexed project root. Includes embeddings, symbol metadata, and file checksums.
+- **Configuration**: Stored in `~/.zvec-grep/config.json` (global). Includes provider credentials, model preferences, and per-index overrides.
+- **Local by default**: Files and local embeddings stay on disk; remote embeddings require explicit user permission via `--allow-remote` or interactive confirmation.
+
+### Extension Points
+
+**Agent integrations**: The `--install` and `--uninstall` commands manage MCP tool registrations in agent configuration files (e.g., `.claude/config.json` for Claude Code, `coder_settings.json` for Qoder).
+
+**Embedding provider abstraction**: New providers can be added to the configuration without code changes by setting `--config provider set <name> --api-key <key>` and referencing them as `<name>/<model>`.
+
+**File type filtering**: The CLI accepts ripgrep-compatible file type flags (`-t`, `-T`, `-g`, `--iglob`), which are passed through to the ripgrep and indexing routines.
+
+## Installation & Usage
+
+### Prerequisites
+
+- Node.js 22 or newer (checked at runtime; `npm` will warn if an older version is detected).
+- For local embedding models: at least 2 GB of free disk space for model downloads and at least 4 GB of RAM.
+
+### Installation
+
+Install the npm package globally:
+
+```bash
+npm install -g @zvec/zvec-grep
+```
+
+The `zg` command will be available in your shell.
+
+### Quick Start
+
+1. **Index a workspace**:
+
+   ```bash
+   cd /path/to/my/workspace
+   zg --index --embedding local/potion-retrieval-32m
+   ```
+
+   This scans the workspace, downloads the embedding model (if not cached), and builds the index in `.zvec-grep/`.
+
+2. **Search from the terminal**:
+
+   ```bash
+   zg "theme preference persistence on startup"
+   ```
+
+   Results are printed with file paths, line numbers, snippets, and relevance scores.
+
+3. **Integrate with an agent** (e.g., Claude Code):
+
+   ```bash
+   zg --install --target claude --yes
+   ```
+
+   The MCP server is registered in `~/.claude/config.json` and will start automatically when Claude Code needs it.
+
+4. **Use from an agent prompt**:
+   Once installed, agents automatically decide when and how to search. For example:
+
+   ```text
+   # In Claude Code or OpenCode
+   "An unseen creature left a few marks. What did the detective infer? Cite local evidence."
+   ```
+
+   The agent calls `zvec_grep_search` and receives ranked results from the indexed workspace.
+
+### Configuration Examples
+
+**Configure a remote embedding provider**:
+
+```bash
+zg --config provider set qwen --api-key "$DASHSCOPE_API_KEY"
+zg --config model set qwen/text-embedding-v4 --default
+zg --index --embedding qwen/text-embedding-v4
+```
+
+**Search with multiple query groups**:
+
+```bash
+zg --fts "loadTheme" --vector "where theme is restored" --fuse --limit 10
+```
+
+**Search only recent changes**:
+
+```bash
+zg "plugin lifecycle" --modified-after "2 weeks ago"
+```
+
+**Use ripgrep directly (no index)**:
+
+```bash
+zg --rg -i -C 2 -g "*.ts" "dark mode" src/
+```
+
+### Help and Debugging
+
+The CLI is self-documenting:
+
+```bash
+zg --help                    # General help
+zg --help search             # Search command help
+zg --help index              # Indexing help
+zg --help models             # List available embedding models
+zg --help file-types         # List supported file types
+```
+
+If a command fails, rerun it with `--debug` to see detailed diagnostics:
+
+```bash
+zg "query" --debug
+zg --index --debug
+zg --server status --debug
+```
+
+## Relevance to Claude Code Development
+
+zvec-grep is directly relevant to Claude Code development in several ways:
+
+1. **Agent information retrieval**: Claude Code agents need to search large codebases efficiently. zvec-grep's ranked, multi-modal retrieval reduces token consumption and improves answer quality compared to naive keyword search or baseline RAG.
+
+2. **MCP integration example**: zvec-grep demonstrates how to build a production-grade MCP server that exposes domain-specific tools (search, indexing, status) to agents. The implementation includes HTTP transport, tool schemas, error handling, and authentication—useful patterns for other MCP integrations.
+
+3. **Hybrid retrieval patterns**: The combination of BM25, vector search, and ripgrep in a single tool shows how to layer different retrieval strategies. This is applicable to other domains (documentation search, issue tracking, configuration management).
+
+4. **Local-first architecture**: The design keeps data on the user's machine by default, with optional remote services. This pattern is valuable for privacy-sensitive agent workflows.
+
+5. **Multi-agent compatibility**: zvec-grep supports Claude Code, Codex, Qwen Code, Qoder, OpenCode, and Cursor. This demonstrates how to build tooling that works across the agent ecosystem, relevant for plugin developers.
+
+## Limitations and Caveats
+
+**Work-in-progress status**: The README and docs explicitly state: "zvec-grep is a work in progress. Commands and configuration may change before the first stable release." This means the CLI, configuration format, and MCP tool interface may break between versions before v1.0.
+
+**Version 0.2.1 current as of 2026-09-11**: The published version is `0.2.1`. Checking `npm view @zvec/zvec-grep versions` or the GitHub releases page will show the latest available version.
+
+**Node.js 22 requirement**: The tool requires Node.js 22 or newer. This is a hard requirement checked at runtime. Users on Node.js 20 or 21 cannot use it without upgrading.
+
+**Embedding model downloads**: Local embedding models are downloaded on demand (e.g., Potion models are 10–100 MB each depending on size). First-run indexing on a large workspace may take several minutes while embedding tasks run on worker threads.
+
+**Index storage and space**: The `.zvec-grep/index/` directory contains embeddings and metadata. For a typical large repository (e.g., Django or Matplotlib), this can range from 100 MB to several GB depending on the embedding model and indexing settings. The index is stored in SQLite and is not human-readable.
+
+**Ripgrep compatibility**: The `--rg` mode is managed ripgrep (not a shell invocation), so shell-specific features (pipes, redirects, subshells) are not supported. However, standard ripgrep flags (`-i`, `-C`, `-g`, `--type`, etc.) work as expected.
+
+**No limitations documented regarding**: search accuracy per query type, maximum workspace size, or minimum performance guarantees. The benchmarks show improvements over baseline on three large codebases (Pylint, Matplotlib, Django), but generalization to other domains is not guaranteed.
+
+## References
+
+- **GitHub Repository**: <https://github.com/zvec-ai/zvec-grep> (accessed 2026-09-11)
+- **npm Package**: <https://www.npmjs.com/package/@zvec/zvec-grep> (accessed 2026-09-11)
+- **Official Documentation**:
+  - [Agent integrations](https://github.com/zvec-ai/zvec-grep/blob/main/docs/01-agents.md) (accessed 2026-09-11)
+  - [CLI guide](https://github.com/zvec-ai/zvec-grep/blob/main/docs/02-cli.md) (accessed 2026-09-11)
+  - [MCP guide](https://github.com/zvec-ai/zvec-grep/blob/main/docs/03-mcp.md) (accessed 2026-09-11)
+  - [Retrieval pipeline](https://github.com/zvec-ai/zvec-grep/blob/main/docs/04-pipeline.md) (accessed 2026-09-11)
+  - [Architecture](https://github.com/zvec-ai/zvec-grep/blob/main/docs/05-architecture.md) (accessed 2026-09-11)
+  - [Server and execution modes](https://github.com/zvec-ai/zvec-grep/blob/main/docs/06-server.md) (accessed 2026-09-11)
+  - [Embedding models](https://github.com/zvec-ai/zvec-grep/blob/main/docs/07-embedding.md) (accessed 2026-09-11)
+  - [Roadmap](https://github.com/zvec-ai/zvec-grep/blob/main/docs/08-roadmap.md) (accessed 2026-09-11)
+- **Benchmarks**:
+  - [SWE-QA-Bench](https://github.com/zvec-ai/zvec-grep/tree/main/benchmarks/swe-qa-bench) (accessed 2026-09-11) — Claude Code + Opus 5 retrieval evaluation
+  - [BrowseComp-Plus](https://github.com/zvec-ai/zvec-grep/tree/main/benchmarks/browse-comp-plus) (accessed 2026-09-11) — Codex gpt-5.6-sol retrieval evaluation
+- **Contributing Guide**: <https://github.com/zvec-ai/zvec-grep/blob/main/CONTRIBUTING.md> (accessed 2026-09-11)
+- **License**: Apache License 2.0 (<https://github.com/zvec-ai/zvec-grep/blob/main/LICENSE>) (accessed 2026-09-11)
+
+## Cross-References
+
+| Entry | Category | Relationship |
+|-------|----------|--------------|
+| [zvec](../ml-infrastructure/zvec.md) | ml-infrastructure | vector database library used as the underlying embedding storage layer |
+| [CocoIndex Code](../mcp-ecosystem/cocoindex-code.md) | mcp-ecosystem | competing MCP-based semantic code search with AST-based symbol extraction |
+| [Grepai](../developer-tools/grepai.md) | developer-tools | alternative semantic code search tool with call graph analysis for agents |
+| [Samuraizer](./samuraizer.md) | ai-research-tools | full-stack knowledge base with semantic search and RAG chat patterns |
+| [SourceSync.ai](../context-management/sourcesyncai.md) | context-management | managed RAG platform using hybrid search with multi-source retrieval |
+| [Chroma](../data-infrastructure/chroma.md) | data-infrastructure | vector database with HNSW/Spann indices and hybrid search support |
+| [Jina AI](../context-management/jina-ai.md) | context-management | embeddings and reranking infrastructure supporting multi-modal search systems |
+| [Kythe](../developer-tools/kythe.md) | developer-tools | code intelligence platform with language-agnostic AST-based symbol extraction |

--- a/research/insights/2026-09-11-deepseek-harness-improvements.md
+++ b/research/insights/2026-09-11-deepseek-harness-improvements.md
@@ -1,0 +1,107 @@
+# Improvement Proposals: DeepSeek Harness
+
+**Research entry**: ./research/agent-frameworks/deepseek-harness.md
+**Generated**: 2026-09-11
+**Patterns assessed**: 8
+**Backlog items created**: 3 (stored locally; GitHub issue creation returned 403 — GraphQL is unavailable from this session, so no issue numbers were assigned and each item needs a `backlog_sync` from a session that can reach the REST API)
+**Deferred (low confidence)**: 3
+**Skipped (already covered or incompatible)**: 2
+
+---
+
+## Improvement 1: plugin-settings has no criterion for which values must become settings
+
+**Source pattern**: "No hardcoded tunables in plugins: deployment-varying choices are validated `Config` fields changeable from cordis.yml; a `DEFAULT_*` constant or test hook is not configurability" — Installation & Usage → Configuration (deepseek-harness.md line 161, quoting the upstream AGENTS.md).
+**Local system**: `plugins/plugin-creator/skills/plugin-settings/SKILL.md`
+**Confidence**: High
+**Impact**: Medium
+**Backlog**: created as `p1-plugin-settings-skill-has-no-criterion-for-which-values-must` (no issue number — GitHub issue creation returned 403)
+
+### Current state
+
+The skill's "When to Use This Pattern" decision tree (lines 13-25) begins at `"Plugin needs user-configurable behavior"` and branches only on *kind of state* — per-project configuration, agent coordination state, hook activation control, loop iteration state. Every branch presumes the decision that a value should be configurable has already been made elsewhere.
+
+"Best Practices" (lines 167-206) covers defaults when the file is absent, field validation, atomic updates, and the restart requirement — all of which describe how to *read* a setting that already exists. Nothing in the file states which values must become settings fields in the first place, and nothing states the negative case: that a constant carrying a default, or an override that only tests use, is not configurability.
+
+### Target state
+
+`plugin-settings/SKILL.md` carries a classification step ahead of the existing state-kind branch: a value that varies by project, machine, or environment is deployment-varying and belongs in the settings frontmatter; a value fixed by the plugin's design stays a constant. The negative case is stated explicitly — a `DEFAULT_*`-style constant inside a hook or script, or a test-only override hook, does not satisfy the requirement.
+
+### Measurable signal
+
+- `grep -n "deployment-varying" plugins/plugin-creator/skills/plugin-settings/SKILL.md` returns at least one match.
+- The "When to Use This Pattern" mermaid has a decision node that asks whether the value varies by deployment *before* branching on state kind.
+- Running `/plugin-creator:plugin-settings` against a hook script containing a hardcoded numeric threshold produces a statement naming that threshold as deployment-varying and directing it into frontmatter, rather than only explaining how to parse frontmatter.
+
+---
+
+## Improvement 2: no rule bounds runtime validation to trust boundaries
+
+**Source pattern**: "Trust TypeScript at typed same-process boundaries. Do not add runtime validation, fallback behavior, or hostile-input tests solely for values the static interface requires" — Technical Architecture → Type System and TypeScript at Scale (deepseek-harness.md line 117, quoting the upstream AGENTS.md).
+**Local system**: `rules/exception-handling.md`, `rules/silent-failure-prevention.md`
+**Confidence**: High
+**Impact**: Medium
+**Backlog**: created as `p1-no-rule-bounds-runtime-validation-to-trust-boundaries-so-sil` (no issue number — GitHub issue creation returned 403)
+
+### Current state
+
+`rules/exception-handling.md` (26 lines) addresses one defensive anti-pattern only — broad `except Exception` catches — and explicitly names its training-data origin. It says nothing about redundant type or value guards.
+
+`rules/silent-failure-prevention.md` lines 40-66 ("Branching on Input Values Requires an Explicit Fallback") requires every `if`/`elif` chain or match "on an input value" to end in a branch that acts or raises. The rule never defines which inputs it means. Read literally at a same-process call whose parameters are annotated (and, per `AGENTS.md` Code Conventions, increasingly Pydantic `BaseModel` fields), it mandates fallback branches for states the static interface already excludes.
+
+A grep of `rules/` and `docs/` for `defensive|trust the type|isinstance check|redundant validation|already guarantee` returns a single hit — `docs/dh-backend-beads/comparison-research/07-skills-hooks-beads-integration.md` line 406, a one-off case note proposing a defensive widening, not a rule. No rule file in the repo bounds where validation belongs.
+
+### Target state
+
+A rule states that runtime validation, fallback branches, and hostile-input tests belong at trust boundaries — parsed JSON/YAML, CLI arguments, subprocess output, network and MCP payloads, filesystem content — and not at same-process calls whose parameter types the annotations or Pydantic models already guarantee. `rules/silent-failure-prevention.md`'s "input value" wording points at that boundary definition so the two rules cannot be read as requiring guards on internal typed calls.
+
+### Measurable signal
+
+- `grep -rn "trust boundary" rules/` returns at least one match in a rule file.
+- The "Branching on Input Values Requires an Explicit Fallback" section in `rules/silent-failure-prevention.md` names which inputs the requirement covers.
+- A reviewer rejecting an `isinstance()` guard (or a `None` fallback) on a parameter that is annotated and called only in-process can cite a rule file path for the rejection.
+
+---
+
+## Improvement 3: component selection terminates at one component, with no capability-completeness check
+
+**Source pattern**: "A capability seam comprises Service Definition / Service Provider / Consumer roles. It is complete, never one role; split only when roles evolve independently" and "Extension plugins depend on Service Definitions, never concrete providers" — Technical Architecture → Capability Seam Pattern (deepseek-harness.md lines 89-97).
+**Local system**: `plugins/plugin-creator/skills/component-patterns/SKILL.md`
+**Confidence**: High
+**Impact**: Medium
+**Backlog**: created as `p1-component-patterns-selection-tree-terminates-at-one-componen` (no issue number — GitHub issue creation returned 403)
+
+### Current state
+
+The Component Selection Framework (lines 42-59) is a single-exit decision tree: each leaf names exactly one component type and one creator skill — Hook, MCP Server, Agent, Skill, or legacy Command. The Quick Reference (lines 63-82) reinforces the exclusive framing by listing each type's differentiators side by side.
+
+"Cross-Component Patterns" (lines 136-199) covers shared `lib/` code, layered directories, and modular extensions — how files are organized, not how one capability is composed from more than one component. Nothing in the file states that a capability delivered as an MCP server or a hook also needs a model-facing consumer — a skill or agent that tells the model when and how to invoke it. A plugin can therefore pass the skill's guidance while shipping tools that no skill or agent ever routes to.
+
+### Target state
+
+`component-patterns/SKILL.md` carries a completeness step after the selection tree: for the component type selected, name which companion component(s) must ship for the capability to be reachable by a model. The MCP-server case is stated explicitly — the server plus the skill or agent that documents when to call its tools — and the same check applies to hooks that inject context no runtime text explains.
+
+### Measurable signal
+
+- `grep -n "model-facing" plugins/plugin-creator/skills/component-patterns/SKILL.md` returns a match inside a completeness section (not only in a SOURCE line).
+- The MCP leaf of the selection tree routes onward to the pairing requirement instead of terminating at "Use an MCP Server".
+- A plugin review run through this skill reports an MCP server whose tools are referenced by no skill or agent in the same plugin as incomplete, rather than as correctly structured.
+
+---
+
+## Deferred Proposals (confidence too low to backlog)
+
+| Pattern | Confidence | Reason |
+|---|---|---|
+| DeepSeek Harness as a fifth entry in `harness_compatibility.json` (`harnesses` currently lists claude-code, codex, hermes, kimi) — the entry documents a `hooks/` package providing "Hook bridges + the shared Claude Code / Codex wire-protocol library" (line 62) | Medium | The entry establishes only that dsh speaks the Claude Code hook wire protocol. It does not state that dsh loads Claude Code plugin manifests, skills, or agents. Adding a harness column commits every plugin to a compatibility claim that no read source supports. Raise confidence by verifying against the dsh repository whether a `.claude-plugin/plugin.json` plugin is loadable, and whether a `SKILL.md` is discovered. The harness is also in developer preview with declared compatibility-breaking changes (lines 181-189), so the matrix entry would need re-verification on every dsh release. |
+| Snapshot tests that "replay recorded sessions through the same profiles" (line 68) applied to `.claude/skills/session-historian/SKILL.md`, which indexes `~/.claude/projects/` JSONL transcripts for recall only | Medium | dsh owns its own execution loop and can therefore replay a session deterministically. This repo ships markdown skills consumed by harnesses it does not control, so a recorded Claude Code transcript is not re-executable through the same path. A compatible weaker form — using recorded transcripts as an activation-evaluation corpus — is plausible but is not the pattern the entry describes, and overlaps existing evaluation work (`research/insights/2026-05-09-agent-skills-eval-improvements.md`). Raise confidence by determining whether any harness this repo targets exposes a replay entry point. |
+| "Model-visible ⟺ logged: anything that reaches a model request must be reconstructable from the session log; a new model-visible input requires a session event" (line 56) | Low | The rule presumes ownership of a session event store. This repo's nearest equivalents — the dh artifact manifest and SAM task records — already persist what stages hand to each other, and the remaining model-visible injections (hook-injected rule pointers, skill loads) are written by harnesses this repo does not own. Whether an unlogged model-visible input actually exists here was not established by reading any file; the gap is inferred. Raise confidence by auditing one dispatch path end to end for inputs that reach a subagent prompt and are recorded nowhere readable. |
+
+---
+
+## Skipped Patterns
+
+| Pattern | Reason skipped |
+|---|---|
+| Provider swapping via configuration — "Extension plugins depend on Service Definitions, never concrete providers" (line 97), plugins loaded from a `cordis.yml` profile | Already covered. `plugins/development-harness/AGENTS.md` "Composition Model" maps abstract roles to concrete agents through a language manifest resolved at runtime, with `dh:task-worker` as the fallback when no manifest matches, and `docs/backend-providers.md` defines the `WorkItemBackend`/`ContentProvider`/`TaskBackend` protocol split with independently selectable `github`/`sqlite`/`memory`/`beads` families. This is the same definition-vs-provider separation, already implemented. (The narrower question of whether dh profiles support overlay/conditional composition is recorded above as unexamined.) |
+| Plugin discovery by GitHub topic (`dsh-plugin`), with the loader resolving plugins from workspace, NPM registry, or GitHub (lines 109, 199) | Incompatible with the consuming harness. Claude Code discovers plugins through marketplace manifests — this repo's `.claude-plugin/marketplace.json`, per `AGENTS.md` Repository Overview — not through repository topics, and no entry in the research file claims otherwise. Tagging the repository would affect GitHub search results only, changing nothing an agent reads. |

--- a/research/insights/2026-09-11-open-spdd-improvements.md
+++ b/research/insights/2026-09-11-open-spdd-improvements.md
@@ -1,0 +1,141 @@
+# Improvement Proposals: OpenSPDD
+
+**Research entry**: ./research/prompt-engineering/open-spdd.md
+**Generated**: 2026-09-11
+**Patterns assessed**: 5
+**Backlog items created**: 2 (references: `p1-architect-spec-template-emits-no-component-design-or-type-sy`, `p1-architect-artifact-carries-no-constraints-or-anti-goals-so-s`)
+**Deferred (low confidence)**: 1
+**Skipped (already covered or tracked)**: 3
+
+> **Backlog reference note**: `backlog_add` stored both items, but native GitHub issue creation
+> failed in this session (`GitHub GraphQL is not available from Claude Code sessions`, 403), so
+> neither item has an issue number yet. Both carry the slug reference shown above and will receive
+> an issue number on the next successful backend sync.
+
+---
+
+## Improvement 1: Architect spec template emits no Component Design or Type System Design sections
+
+**Source pattern**: "High-level detail ('Create BillingService')" vs "Precise details — method
+signatures, parameters, error handling, dependency injection patterns" — the Operations dimension
+of the REASONS Canvas (research entry, "Problem Addressed" table, and "Implementation Layer (How)"
+under Key Features)
+**Local system**: `plugins/development-harness/skills/planning/SKILL.md` (producer),
+`plugins/development-harness/agents/contract-verification.md` (consumer)
+**Confidence**: High
+**Impact**: High
+**Backlog**: `p1-architect-spec-template-emits-no-component-design-or-type-sy` created (P1, Feature)
+
+### Current state
+
+`planning/SKILL.md` registers `artifact_type="architect"` (lines 88-96) and defines the full
+content template (lines 100-179). Its Solution Design section contains only `### Approach`,
+`### Components` (`1. **<Component Name>** — <purpose and responsibility>`), `### Interactions`,
+and `### Boundaries`. `context-integration/SKILL.md` re-registers the same `architect` artifact and
+adds Scope Analysis, Conflict Report, Resource Map, Integration Points, and File Impact Summary.
+Neither template contains a `## Component Design` section or a `## Type System Design` section.
+
+`agents/contract-verification.md` (Contract Extraction Process, Steps 1-2) fetches the `architect`
+artifact and extracts contracts exclusively from "the Component Design section (typically titled
+`## Component Design` or `## 4. Component Design`)" and the Type System Design section.
+`skills/implement-feature/SKILL.md` (lines 153-168) dispatches this agent after every completed
+task and instructs it to "read its Component Design and Type System Design sections".
+
+The producing stages never emit the sections the consuming verifier reads. The verifier's normal
+path is to find no contracts and report a clean result, so signature and type-contract drift passes
+S5/S6 unexamined while appearing verified.
+
+This is the producer side. #3317 covers the consumer side (contract-verification matching only two
+heading variants with no fallback) and assumes the sections exist somewhere; it does not address
+their absence from every upstream template.
+
+### Target state
+
+The `architect` artifact carries per-component interface detail at the granularity
+contract-verification extracts: each component's function names with parameter names, parameter
+types, and return types, plus the domain type contracts. The section heading in the producing
+template matches the heading contract-verification looks for, and the two are documented as one
+contract rather than two independently-worded conventions.
+
+### Measurable signal
+
+- `grep -n "Component Design" plugins/development-harness/skills/planning/SKILL.md` (or the S3
+  template, whichever stage owns the detail) returns a match inside the artifact content template.
+- `grep -n "Type System Design"` returns a match in the same template.
+- The heading strings present in the producing template are byte-identical to at least one variant
+  listed in `agents/contract-verification.md` Steps 1-2.
+- A run of `/dh:implement-feature` on a feature with an interface change produces a
+  contract-verification result naming at least one extracted `expected_signature`, rather than
+  "No contract concerns" with zero contracts in scope.
+
+---
+
+## Improvement 2: Architect artifact carries no constraints or anti-goals for S4 to derive task Constraints from
+
+**Source pattern**: "Constraint Layer (Boundary) — **Norms (N)**: Coding standards and patterns to
+follow; **Safeguards (S)**: Constraints and guardrails defining what must not be done" (research
+entry, Key Features → The REASONS Canvas Framework), and "No constraints on AI — AI improvises
+freely | Explicit constraints define 'how' (Norms) and 'what not to do' (Safeguards)" (Problem
+Addressed table)
+**Local system**: `plugins/development-harness/skills/planning/SKILL.md` (producer),
+`plugins/development-harness/skills/task-decomposition/SKILL.md` (consumer)
+**Confidence**: High
+**Impact**: Medium
+**Backlog**: `p1-architect-artifact-carries-no-constraints-or-anti-goals-so-s` created (P1, Feature)
+
+### Current state
+
+`task-decomposition/SKILL.md` Step 2 "Embed Complete Context" (lines 53-62) requires each generated
+task to embed "Patterns to follow (from resource map)" and "Constraints and anti-goals that apply
+to this specific task". Step 3 makes `5. **Constraints** — what the agent must not do` a mandatory
+CLEAR section, and the output template at line 220 emits a `## Constraints` heading for every task.
+The same `## Constraints` block is mandatory in `generate-task/SKILL.md` (lines 69-72).
+
+S4's only input is the `architect` artifact (`task-decomposition/SKILL.md` lines 116-122).
+"Patterns to follow" has a named upstream source — the Resource Map written by
+`context-integration/SKILL.md`. Constraints and anti-goals have none. `planning/SKILL.md`'s
+artifact template (lines 100-179) carries `### Boundaries` (in scope / out of scope — a scope
+statement, not a behavioral prohibition) and a Risk Assessment table (likelihood / impact /
+mitigation), and no section stating what an implementer must not do or which existing patterns must
+be followed. `context-integration/SKILL.md` adds no such section either.
+
+Every task's `## Constraints` block is therefore produced by the decomposer with no upstream source.
+Guardrails a human decided during design — "do not add a new dependency for this", "reuse the
+existing retry wrapper", "never widen this public signature" — have nowhere to be recorded in the
+pipeline, and reach the worker only if the decomposer independently re-derives them.
+
+### Target state
+
+The `architect` artifact carries a constraint section with two distinguishable kinds of content:
+patterns and standards this work must follow, and prohibitions this work must not violate —
+separate from `### Boundaries` (scope) and from the Risk Assessment table (probabilistic risks with
+mitigations). S4 derives each task's `## Constraints` block from that section by selection, and
+states what it did when the section is empty, rather than composing constraints from nothing.
+
+### Measurable signal
+
+- The artifact content template in `planning/SKILL.md` contains a constraint section distinct from
+  `### Boundaries` and `## Risk Assessment`.
+- `task-decomposition/SKILL.md` Step 2 names that section as the source for "Constraints and
+  anti-goals", the same way it names the resource map as the source for "Patterns to follow".
+- Running S2 then S4 on one feature: at least one string in a generated task's `## Constraints`
+  block appears verbatim, or as a direct narrowing, of a line in the architect artifact's
+  constraint section.
+
+---
+
+## Deferred Proposals (confidence too low to backlog)
+
+| Pattern | Confidence | Reason |
+|---|---|---|
+| Bidirectional sync coverage in the proportional quality gate — `complete-implementation/SKILL.md`'s proportional gate (T1-T5, lines ~169-172) has no `context-refinement` task, so no `Post-Implementation Annotations` are written back to the `architect` artifact for small changes; the full gate (line 386) does include T6 `context-refinement`. | Medium | The omission is plausibly deliberate — the gate is named "proportional" and deliberately runs a reduced task set for small changes. Raising confidence requires the design rationale for which tasks the proportional gate drops (an ADR or the gate's own selection criteria), not just the observed difference between the two task lists. |
+
+---
+
+## Skipped Patterns
+
+| Pattern | Reason skipped |
+|---|---|
+| Bidirectional synchronization via `/spdd-sync` — reverse-syncing code changes back into the design document (research entry, Relevance item 3) | Already implemented, and more strongly. `plugins/development-harness/docs/plan-artifact-lifecycle.md` "Divergence policy" defines recording criteria, a two-way classification (`design-refinement` / `intent-divergence`), a `Divergence Notes` note shape, and a post-execution Freshness report. `agents/context-refinement.md` line 182 re-registers the `architect` artifact with a `## Post-Implementation Annotations` section appended, dispatched as T6 of the full quality gate in `complete-implementation/SKILL.md` (line 386). OpenSPDD's own entry lists its sync as manual, convention-based and unenforced ("Spec Drift Risk"); the local mechanism is dispatched by the gate rather than relying on team discipline. |
+| Cross-tool compilation — one methodology emitted into each tool's native command format, with marker-file auto-detection (research entry, Relevance item 2) | Already tracked. 29 open backlog items cover it per plugin (e.g. #3481 development-harness, #3491 plugin-creator, #3496 scientific-method), against the `claude-code` / `codex` / `hermes` / `kimi` target set recorded in `harness_compatibility.json`. |
+| Capability vs. Control — "when multiple 'correct' solutions exist, choosing which one is a human trade-off decision, not an AI logical inference" (research entry, Key Design Insights; Relevance item 4) | Not actionable as stated — a framing principle with no observable target state in any file. Its concrete expressions (explicit constraints, explicit prohibitions) are captured as Improvement 2; the remaining content is philosophy. |

--- a/research/insights/2026-09-11-zvec-grep-improvements.md
+++ b/research/insights/2026-09-11-zvec-grep-improvements.md
@@ -1,0 +1,101 @@
+# Improvement Proposals: zvec-grep
+
+**Research entry**: ./research/ai-research-tools/zvec-grep.md
+**Generated**: 2026-09-11
+**Patterns assessed**: 7
+**Backlog items created**: 2 — `p1-semantic-code-search-routes-lexical-and-semantic-search-as-m`, `p1-codebase-analyzer-gates-its-primary-search-tool-on-an-unveri`
+**Deferred (low confidence)**: 2
+**Skipped (already covered or tracked)**: 3
+
+> **Backlog sync note (2026-09-11)**: both items were stored in the backlog, but GitHub issue
+> creation failed for each with `GitHub GraphQL is not available from Claude Code sessions`, so
+> neither carries an issue number yet. They are addressable by the slug references above. Run
+> `mcp__plugin_dh_backlog__backlog_sync` (or `backlog_pull`) from a session with REST-backed issue
+> creation to assign numbers, then replace the slugs here.
+
+---
+
+## Improvement 1: semantic-code-search routes lexical and semantic search as mutually exclusive, with no combined path for cross-file questions
+
+**Source pattern**: "Hybrid Search with Multiple Retrieval Paths" — `zg --fts "loadTheme" --vector "where user prefs are restored" --fuse` combines multiple groups and fuses results into a single ranked output; the entry's Problem Addressed section quotes the README: "zg works best when evidence spans files or modules and the target location is unknown, especially for call-chain, data-flow, and architectural questions."
+**Local system**: `/home/user/claude_skills/plugins/python3-development/skills/semantic-code-search/SKILL.md`
+**Confidence**: High
+**Impact**: Medium
+**Backlog**: created as `p1-semantic-code-search-routes-lexical-and-semantic-search-as-m` (P1, Feature) — GitHub issue number pending, see sync note above
+
+### Current state
+
+`semantic-code-search/SKILL.md` is an 18-line file whose entire routing rule is line 14:
+
+> Prefer Grep/Glob when you know exact identifiers, filenames, or string literals. Prefer semantic search when you know what the code *does* but not what it's *called*.
+
+This is a two-branch exclusive router keyed on one variable — whether the agent knows the identifier. It has no third branch, and the "when to use" list at lines 9-12 (search by meaning, explore unfamiliar parts, find implementations without exact names, find similar patterns) describes only single-path semantic use.
+
+The question shape zvec-grep names as its best case — evidence spanning files or modules where the target location is unknown (call-chain, data-flow, architectural questions) — is not addressed by either branch. An agent holding a partial identifier *and* a behavioral description is instructed to pick one path, not to run both and reconcile.
+
+The agent wrapper at `/home/user/claude_skills/plugins/python3-development/agents/semantic-code-search.md` line 9 reinforces the exclusivity from the other direction: "If the tool is unavailable, report BLOCKED — do not fall back to pattern-based search."
+
+Note on partial coverage: `/home/user/claude_skills/plugins/development-harness/agents/codebase-analyzer.md` does show both paths side by side per focus area (e.g. its "For conventions focus" block pairs `ccc search error handling exception raise catch` with `Grep(pattern="raise |except |try:")`), and its Search Tool Priority (line 118) says to use Grep "after ccc narrows the search space". That is a sequential narrowing recipe inside one agent, not a routing rule in the skill that owns the decision — and it exists only in that agent, not in the skill other callers load.
+
+### Target state
+
+`semantic-code-search/SKILL.md` carries a third routing branch for the cross-file / unknown-location question shape, stating that both retrieval paths run and their results are reconciled rather than one being chosen. The branch names the question shapes that trigger it (call-chain, data-flow, architectural / "where does X end up" questions) and says what reconciliation means for the agent: run the semantic query, run the lexical query for any identifier fragment in hand, and treat a file surfaced by both as higher-confidence than one surfaced by either alone.
+
+### Measurable signal
+
+- `grep -c 'Prefer' /home/user/claude_skills/plugins/python3-development/skills/semantic-code-search/SKILL.md` — the file contains a branch beyond the two `Prefer ...` sentences on line 14.
+- `grep -n 'call-chain\|data-flow\|both' /home/user/claude_skills/plugins/python3-development/skills/semantic-code-search/SKILL.md` returns at least one match in a routing branch.
+- The new branch states a reconciliation rule, verifiable by reading the file: an instruction covering what to do when the two paths return overlapping or disjoint file sets.
+
+---
+
+## Improvement 2: codebase-analyzer gates its primary search tool on an unverifiable freshness judgment with no index-state probe
+
+**Source pattern**: "Index Refresh Strategies" (`--refresh wait` / `background` / `off`) and the CLI's `zg --status [root]`: "Inspect index state and readiness."
+**Local system**: `/home/user/claude_skills/plugins/development-harness/agents/codebase-analyzer.md`
+**Confidence**: High
+**Impact**: Medium
+**Backlog**: created as `p1-codebase-analyzer-gates-its-primary-search-tool-on-an-unveri` (P1, Refactor) — GitHub issue number pending, see sync note above
+
+### Current state
+
+`codebase-analyzer.md` line 116 makes `ccc search` the highest-priority exploration tool and conditions its correctness on a judgment the agent cannot evaluate:
+
+> 1. **ccc search** — semantic search for concepts, behaviors, and patterns across the full codebase. Preferred for "find all places that do X" questions. Requires the index to be current — run `ccc index` at session start if the codebase has changed recently.
+
+"if the codebase has changed recently" is not observable from anything the agent has. There is no probe named, no threshold, and no stated behavior for the stale case. A stale index returns a well-formed, ranked, confidently-worded result set that silently omits code added since the last index run — and that result set feeds the PATTERNS.md / ARCHITECTURE.md artifacts the agent registers (Step 4: Register Artifact), which downstream stages then read as authoritative.
+
+A readiness probe pattern already exists elsewhere in the repo but checks a different condition. `/home/user/claude_skills/plugins/development-harness/skills/codebase-auditor/SKILL.md` lines 60-63 run `ccc search "test" --limit 1` and, on `"Not in an initialized project directory"`, run `ccc init` then `ccc index`. That detects *absence* of an index, not *staleness* of one — an index built a hundred commits ago passes that probe.
+
+zvec-grep makes both states first-class: `zg --status` reports index state and readiness as data, and `--refresh wait|background|off` makes the stale-index policy an explicit, named choice rather than an unstated default.
+
+Relationship to existing backlog: issue #1042 ("feat: Incremental commit-anchored codebase analysis") covers staleness of the *analysis artifact* — storing `commit_sha` on `ArtifactEntry` and diffing `{sha}..HEAD` so unchanged files are not re-analyzed. Its acceptance criteria name only `backlog_core/models.py`, `artifact_list`, and the differential-analysis path; none touch `ccc index` or search-index currency. This proposal is about the search index that feeds the analysis, not the artifact the analysis produces. The two are adjacent and should reference each other.
+
+### Target state
+
+`codebase-analyzer.md`'s Search Tool Priority replaces the "if the codebase has changed recently" judgment with a probe-and-policy step the agent can execute and report: a named command that reads index state, a stated rule for what counts as stale, and a stated action for each outcome (proceed, reindex first, or proceed and record the search as index-limited in the artifact). The agent's Step 5 return records which outcome occurred, so a consumer of the artifact can tell whether its findings rest on a current index.
+
+### Measurable signal
+
+- `grep -n 'if the codebase has changed recently' /home/user/claude_skills/plugins/development-harness/agents/codebase-analyzer.md` returns no match.
+- The Search Tool Priority section names a concrete command whose output the agent reads to decide, and states an action for each outcome — verifiable by reading lines around 112-120.
+- The agent's structured return (Step 5: Return Confirmation) includes an index-state field, so a run of the agent produces output naming whether the index was current, was rebuilt, or was used stale.
+
+---
+
+## Deferred Proposals (confidence too low to backlog)
+
+| Pattern | Confidence | Reason |
+|---|---|---|
+| Symbol-aware retrieval and symbol-type filtering (`--prefer-symbol`; restrict to `module`/`class`/`interface`/`function`/`value`/`alias`) | Medium | The gap is inferred, not observed. `mcp__cocoindex-code__search`'s parameter surface was not read — cocoindex-code is described as AST-based, so equivalent filtering may already be exposed and simply undocumented in `semantic-code-search/SKILL.md`. To raise: read the tool schema for `mcp__cocoindex-code__search` and confirm whether symbol-type narrowing is available but unmentioned (a docs gap) or absent (a capability gap). |
+| Local-first embedding with an explicit `--allow-remote` data-egress gate before workspace content leaves the machine | Medium | The pattern is clear in the research entry and `AGENTS.md`'s Security Considerations covers credentials but states no rule about workspace content reaching an embedding provider. Whether a gap exists depends on whether cocoindex-code embeds locally or calls out, which was not verified. To raise: determine cocoindex-code's embedding path from its own source, then check whether any repo rule governs workspace-content egress. |
+
+---
+
+## Skipped Patterns
+
+| Pattern | Reason skipped |
+|---|---|
+| Time-based filtering (`--modified-before` / `--modified-after`) to scope search to recent changes | Already covered. `codebase-analyzer.md` line 117 makes git-forensics MCP the second-priority tool specifically for "co-change analysis and hot spot detection ... churn that Grep cannot find" — recency-scoped discovery is an existing, stronger path (it ranks by change coupling, not just a timestamp cutoff). |
+| One-command multi-agent MCP registration (`zg --install --target claude\|codex\|qwen\|qoder\|opencode\|cursor\|all` writing into each agent's config file) | Architecturally incompatible, and the incompatibility is deliberate. `/home/user/claude_skills/docs/cross-harness-smoke-tests.md` ("Common to every harness", step 1) requires installing "through that harness's own install mechanism (not the authoring checkout — an installed consumer is the point of the test)". A self-install path that writes harness config directly would bypass the exact mechanism the repo's verification depends on. |
+| Production MCP server implementation patterns — HTTP transport, tool schemas, error handling, authentication | Too abstract to express as an observable before/after state. The research entry's Relevance point 2 says these are "useful patterns" without naming a specific mechanism absent from `plugins/fastmcp-creator/`; no concrete target state can be written from it without first inventing the requirement. |

--- a/research/insights/2026-09-11-zvec-grep-utilization.md
+++ b/research/insights/2026-09-11-zvec-grep-utilization.md
@@ -1,0 +1,217 @@
+# Utilization Proposals: zvec-grep
+
+**Research entry**: ./research/ai-research-tools/zvec-grep.md
+**Generated**: 2026-09-11
+**Integration surfaces found**: 3 (npm package | CLI | MCP server)
+**Proposals written**: 3
+**Skipped**: 1
+
+---
+
+## Utilization 1: context-gathering agent → zvec-grep
+
+**Research entry**: ./research/ai-research-tools/zvec-grep.md
+**Caller**: ./.claude/agents/context-gathering.md
+**Integration mechanism**: MCP (Model Context Protocol)
+**Replaces or adds**: Augments the agent's current file-reading workflow with semantic search for discovering architectural context
+**Setup cost**: Low (npm install + MCP server registration)
+**Integration surface**: MCP tool `zvec_grep_search`; CLI `zg --vector "<query>"`
+
+### Why this caller
+
+The context-gathering agent reads files and traces call paths to build comprehensive context manifests for tasks. Its current workflow relies on manual Grep and file-reading to locate related code, database models, authentication patterns, and service boundaries. zvec-grep's semantic search (`--vector`) would accelerate discovery of these "tangentially relevant" systems — especially for architectural questions that span multiple files and modules. The agent explicitly notes "Include ANYTHING tangentially relevant" and "Spare no tokens" — vector search directly addresses this goal by ranking relevance across the codebase without requiring exact keywords.
+
+Reference: `./.claude/agents/context-gathering.md` lines 27-39 (research step and artifact gathering) would benefit from `zg --vector "where is authentication checked for this feature"` rather than manually reading auth files.
+
+### Integration sketch
+
+```python
+# Pseudo-code integration pattern
+from zvec_grep_client import ZvecGrepMCP
+
+
+async def gather_architectural_context(task_domain: str) -> List[RelevantFile]:
+    """Use zvec-grep to find related components across the codebase."""
+
+    client = ZvecGrepMCP()
+
+    # Semantic search for related systems
+    results = await client.zvec_grep_search(query=f"where is {task_domain} implemented", limit=10)
+
+    # Results include file paths, line numbers, relevance scores
+    # Agent reads returned files to build context manifest
+    for result in results:
+        if result.confidence > 0.7:  # High relevance threshold
+            context.add_file(result.file_path, result.snippet)
+```
+
+**MCP invocation** (once installed):
+
+```text
+Agent calls MCP tool: zvec_grep_search
+Input: { query: "where authentication is validated in this codebase", limit: 10 }
+Output: Ranked results with file paths, line numbers, code snippets
+```
+
+**CLI fallback** (for testing or standalone use):
+
+```bash
+zg --vector "authentication validation" --modified-after "1 month ago" --limit 10
+```
+
+---
+
+## Utilization 2: find-cause skill → zvec-grep
+
+**Research entry**: ./research/ai-research-tools/zvec-grep.md
+**Caller**: ./.claude/skills/find-cause/SKILL.md
+**Integration mechanism**: CLI subprocess + result parsing
+**Replaces or adds**: Improves evidence gathering by replacing keyword-only Grep with hybrid search (BM25 + vector + ripgrep)
+**Setup cost**: Low (npm install)
+**Integration surface**: CLI `zg <query>`, `zg --fts "<query>"`, `zg --rg -i -C 2 -g "*.ts" "<pattern>"`
+
+### Why this caller
+
+The find-cause skill's Step 2 and Step 3 investigate root causes by reading source files and searching for evidence. The current evidence chain relies on Grep and manual file reading, which requires exact keywords or regex patterns to locate relevant code. zvec-grep's multi-mode search would strengthen the investigation by:
+
+1. **BM25 lexical search** (`--fts`) — ranked keyword matching when the exact term is unknown
+2. **Vector search** (`--vector`) — semantic queries like "where is this error handled?" without knowing the exact variable/function name
+3. **Ripgrep integration** (`--rg`) — exact matches and regex patterns when patterns are known
+
+Reference: `./.claude/skills/find-cause/SKILL.md` lines 100-107 list the evidence verification paths. zvec-grep's multi-format indexing (source code symbols, structured data, plain text) directly maps to this requirement: "can you observe it directly by running the system, or must you read source/docs?"
+
+### Integration sketch
+
+```bash
+#!/bin/bash
+# Pseudo-code: find-cause skill using zvec-grep to gather evidence
+
+# Step 1: Semantic search for the problem area
+zg --vector "where is the timeout error handled" --limit 5
+
+# Step 2: If semantic search returns candidates, confirm with exact match
+zg --rg -i -C 3 "TIMEOUT_ERROR\|timeout.*error" src/
+
+# Step 3: Fallback to BM25 if exact match fails
+zg --fts "timeout handling retry logic" --limit 10
+
+# All results are ranked and include file:line citations
+# Agent parses output and adds to evidence chain
+```
+
+**Invoke via subprocess**:
+
+```python
+import subprocess
+import json
+
+result = subprocess.run(["zg", "--vector", "error handling pattern", "--limit", "10"], capture_output=True, text=True)
+
+# Parse JSON output (zg supports --json flag)
+evidence = json.loads(result.stdout)
+for item in evidence:
+    print(f"Evidence: {item['file']}:{item['line']} - {item['snippet']}")
+```
+
+---
+
+## Utilization 3: codebase-analyzer agent → zvec-grep
+
+**Research entry**: ./research/ai-research-tools/zvec-grep.md
+**Caller**: ./plugins/development-harness/agents/codebase-analyzer.md
+**Integration mechanism**: MCP (Model Context Protocol) or CLI
+**Replaces or adds**: Accelerates pattern discovery and symbol-aware retrieval when analyzing CLI commands, testing patterns, and module structure
+**Setup cost**: Medium (npm install + MCP registration in development-harness plugin configuration)
+**Integration surface**: MCP tool `zvec_grep_search` with `prefer_symbol` flag; CLI `zg --prefer-symbol --type function "pattern"`
+
+### Why this caller
+
+The codebase-analyzer agent explores codebases to extract CLI patterns, architecture, testing patterns, and conventions. Its current workflow relies on Grep and Read to trace patterns across files. zvec-grep's **symbol-aware retrieval** (`--prefer-symbol`) would directly accelerate this:
+
+1. **CLI command patterns** — Find all CLI subcommands and their implementations: `zg --prefer-symbol --type function "handleCommand" --limit 20`
+2. **Testing fixtures** — Locate test utilities and fixtures: `zg --vector "test fixture for mocking" --prefer-symbol --type function`
+3. **Module structure** — Understand dependencies and boundaries: `zg --prefer-symbol --type module "exports from auth"`
+
+Reference: `./plugins/development-harness/agents/codebase-analyzer.md` lines 40-54 (philosophy and prescriptive approach) emphasize accurate file paths and concrete patterns. zvec-grep's symbol extraction and line-number accuracy directly support this requirement.
+
+### Integration sketch
+
+```typescript
+// Pseudo-code: codebase-analyzer using zvec-grep MCP
+
+async function discoverCliPatterns(): Promise<CliPattern[]> {
+  const client = createMCPClient('zvec-grep');
+
+  // Query 1: Find all CLI command handlers
+  const results = await client.zvec_grep_search({
+    query: 'function that handles CLI commands',
+    prefer_symbol: true,
+    type_filter: ['function'],
+    limit: 50
+  });
+
+  // Query 2: Find test utilities
+  const testUtils = await client.zvec_grep_search({
+    query: 'test fixture mock setup',
+    prefer_symbol: true,
+    modified_after: '1 week ago'
+  });
+
+  // Results include symbol names, file paths, line ranges
+  // Enables registration of artifact with concrete references
+  return extractPatterns(results);
+}
+```
+
+**CLI alternative** (for development/validation):
+
+```bash
+zg --prefer-symbol --type function "pattern discovery" --limit 20
+zg --vector "testing fixture boilerplate" --prefer-symbol --limit 10
+zg --rg -i -g "test*.ts" "beforeEach\|setUp" --modified-after "1 month ago"
+```
+
+---
+
+## Skipped Systems
+
+| Local System | Reason skipped |
+|---|---|
+| `research-context-agent` (`./.claude/agents/research-context-agent.md`) | Already specialized in searching the research knowledge base itself, not codebases. Integration would add search across general code, which is outside its scope. No overlap with zvec-grep's use case (code/codebase search, not research KB). |
+
+---
+
+## Integration Notes
+
+### Prerequisites
+
+1. **Node.js 22+** — zvec-grep requires Node.js 22 or newer
+2. **npm install** — `npm install -g @zvec/zvec-grep` or as a project dependency
+3. **Workspace indexing** — First run `zg --index --embedding local/potion-retrieval-32m` to build the search index
+4. **MCP server registration** — Add to `.mcp.json` or agent tool configuration:
+
+   ```json
+   {
+     "mcpServers": {
+       "zvec-grep": {
+         "command": "zg",
+         "args": ["--server"]
+       }
+     }
+   }
+   ```
+
+### Cost Breakdown
+
+- **Setup cost**: Low for CLI, Medium for MCP (requires .mcp.json registration)
+- **First run**: ~2-5 minutes to index a large codebase (embedding model download + indexing)
+- **Search latency**: <500ms for cached queries; <2s for initial vector embeddings
+- **Storage**: 100MB–1GB per indexed workspace depending on code volume and embedding model
+
+### Recommended Adoption Order
+
+1. **Phase 1** (Quick win): Integrate with `find-cause` skill via CLI. No MCP setup required.
+2. **Phase 2** (Agent benefit): Register MCP server and integrate `codebase-analyzer` agent for pattern discovery.
+3. **Phase 3** (Context acceleration): Integrate `context-gathering` agent with MCP for architectural queries.
+
+All three proposals are independent and can be implemented in parallel or sequentially.

--- a/research/prompt-engineering/open-spdd.md
+++ b/research/prompt-engineering/open-spdd.md
@@ -1,0 +1,242 @@
+# OpenSPDD
+
+## Identity
+
+**Name**: OpenSPDD (Structured Prompt-Driven Development)
+**Repository**: <https://github.com/gszhangwei/open-spdd>
+**Source URL**: <https://github.com/gszhangwei/open-spdd>
+**Research Date**: 2026-09-11
+**Version at Research**: unversioned (no tags; development in progress)
+**License**: MIT
+**Author**: gszhangwei
+**Primary Language**: Go 1.23
+**Latest Commit**: As of shallow clone: Merge pull request #19 (star-history-chart fix)
+**Release Versions**: Not yet versioned with tags (development in progress)
+
+## Overview
+
+"OpenSPDD is a methodology and cross-platform CLI tool for the AI coding era. It upgrades AI coding prompts from 'disposable inputs' to 'executable design contracts' with bidirectional synchronization between design and implementation" (README.md, line 17). The tool provides a structured framework for expressing design intent, architectural decisions, and execution constraints in a format that AI coding agents can reliably consume and maintain over time.
+
+## Problem Addressed
+
+Typical AI coding workflows generate plan documents with fundamental limitations:
+
+| Problem | OpenSPDD's Approach |
+|---------|-------------------|
+| Plans are task lists with no binding constraints | REASONS Canvas is a design contract with explicit norms and safeguards |
+| No constraints on AI — AI improvises freely | Explicit constraints define "how" (Norms) and "what not to do" (Safeguards) |
+| High-level detail ("Create BillingService") | Precise details — method signatures, parameters, error handling, dependency injection patterns |
+| No traceability; docs don't sync with code | Bidirectional sync via `/spdd-sync` command keeps design and implementation aligned |
+| Vague validation ("done when complete") | Explicit validation — exact error messages, HTTP status codes in Safeguards |
+| Implicit dependencies — AI infers them | Explicit execution order defined in Operations |
+
+## Key Features
+
+### The REASONS Canvas Framework
+
+OpenSPDD's core is a 7-dimensional structured design framework spanning three layers:
+
+**Strategic Layer (Why/What)**:
+- **Requirements (R)**: Business goals and scope
+- **Entities (E)**: Domain model expressed as Mermaid class diagrams
+- **Approach (A)**: Solution strategy and trade-offs
+
+**Implementation Layer (How)**:
+- **Structure (S)**: Architecture, inheritance, dependencies
+- **Operations (O)**: Precise implementation tasks in order, including method signatures and error handling
+
+**Constraint Layer (Boundary)**:
+- **Norms (N)**: Coding standards and patterns to follow
+- **Safeguards (S)**: Constraints and guardrails defining what must not be done
+
+This framework acts as both a checklist (reminding developers to consider all dimensions) and a consumable artifact (executable by AI agents).
+
+### Core Commands
+
+"Five core commands comprise the SPDD workflow" (README.md, lines 293–300):
+
+1. **`/spdd-analysis`**: Strategic analysis of requirements — decomposes business requirements into concepts, risks, and design considerations
+2. **`/spdd-reasons-canvas`**: Generates structured REASONS Canvas design documents from analysis
+3. **`/spdd-generate`**: Generates code from structured SPDD prompt files, following the contract defined in REASONS Canvas
+4. **`/spdd-prompt-update`**: Updates existing SPDD prompt with new requirements
+5. **`/spdd-sync`**: Reverse-synchronizes code changes back to SPDD prompt files, keeping design documents current
+
+### Optional Commands (Beta)
+
+Available via `openspdd generate <command>`:
+
+- **`spdd-story`**: Decomposes feature requirements into INVEST-compliant stories with acceptance criteria
+- **`spdd-code-review`**: Reviews code against REASONS Canvas, detecting intent drift and violations
+- **`spdd-api-test`**: Generates self-contained shell scripts with cURL commands for API testing
+- **`spdd-reverse`**: Reverse-engineers existing code into a REASONS Canvas prompt for legacy onboarding
+
+### Cross-Platform Toolchain Integration
+
+"Supports Cursor, Claude Code, GitHub Copilot, Antigravity, OpenCode, and Codex" (README.md, line 96). Each tool receives auto-generated commands in its native format:
+
+- **Cursor**: `.cursor/commands/spdd-*.md`
+- **Claude Code**: `.claude/commands/spdd-*.md`
+- **GitHub Copilot**: `.github/copilot-prompts/spdd-*.md`
+- **Antigravity**: `.antigravity/commands/spdd-*.md`
+- **OpenCode**: `.opencode/commands/spdd-*.md` (command naming follows markdown filename)
+- **Codex**: `.agents/skills/<id>/SKILL.md` (project-scoped skill bundles per agentskills.io standard)
+
+Auto-detection identifies the AI tool based on marker files (`.cursor/`, `.claude/`, `.github/copilot-instructions.md`, etc.) and generates appropriate templates.
+
+## Technical Architecture
+
+### Core Dependencies
+
+- **charmbracelet/huh** (v0.6.0): Interactive form/menu UI for command selection
+- **fatih/color** (v1.18.0): Terminal color output
+- **spf13/cobra** (v1.8.1): CLI framework for command structure and flags
+
+The full dependency tree includes charmbracelet's terminal UI ecosystem (bubbles, bubbletea, lipgloss) and related terminal/OS abstractions.
+
+### CLI Command Structure
+
+The tool follows a hierarchical command structure (inferred from cmd/ directory):
+
+- **`init`**: Auto-detects AI tool and initializes the project with command templates
+- **`generate`**: Generates SPDD command files (interactive or specified)
+- **`list`**: Lists available commands with optional filtering by category
+- **`version`**: Prints installed version
+- **`uninstall`**: Safely removes the binary and first-run markers
+- **`pathcheck`**: Verifies PATH configuration and provides shell-specific hints
+
+### Single Binary Distribution
+
+"All templates embedded via Go's embed directive" (README.md, line 98). This means SPDD templates for all supported tools are compiled into the binary, eliminating runtime file lookups and enabling single-file installation.
+
+### Workflow Engine
+
+The `/spdd-sync` command implements bidirectional synchronization: it parses generated code, detects deviations from the REASONS Canvas specification, and updates the Canvas to reflect the actual implementation. This prevents design documents from becoming stale.
+
+## Installation & Usage
+
+### Installation Methods
+
+1. **Homebrew (macOS/Linux)**: `brew install gszhangwei/tools/openspdd` or `brew tap gszhangwei/tools && brew install openspdd`
+2. **Go install**: `go install github.com/gszhangwei/open-spdd/cmd/openspdd@latest` (requires Go 1.23+; installs to `$(go env GOPATH)/bin/openspdd`)
+3. **Installer script**: Clone repo and run `./scripts/install.sh [version-tag]`
+4. **Manual download**: GitHub Releases page (binary archives for Linux, macOS, Windows)
+
+The first run of `openspdd` auto-detects PATH and prints shell-specific setup commands for `.bashrc` / `.zshrc`.
+
+### Uninstall
+
+`openspdd uninstall` detects installation method (Homebrew or go install) and removes the binary. Supports `--dry-run` (preview), interactive confirmation (default), and `--yes` (non-interactive).
+
+### Quick Start Workflow
+
+```bash
+# Initialize project (auto-detects AI tool)
+openspdd init
+
+# Generate all default SPDD commands
+openspdd generate --all
+
+# In AI coding tool, follow the workflow:
+/spdd-analysis @requirements/feature.md          # Strategic analysis
+/spdd-reasons-canvas @spdd/analysis/xxx.md       # Generate REASONS Canvas
+/spdd-generate @spdd/prompt/xxx.md               # Generate code from Canvas
+/spdd-sync @spdd/prompt/xxx.md                   # Sync code changes back
+```
+
+For simpler features, skip Step 1 and provide requirements directly to `/spdd-reasons-canvas`.
+
+### Available Commands Listing
+
+```bash
+openspdd list              # List default commands
+openspdd list --optional   # List beta/optional commands
+openspdd list --all        # List all commands
+openspdd list -c Development  # Filter by category
+```
+
+## Key Design Insights
+
+### Capability vs. Control
+
+"There is a class of control needs that capability improvements alone cannot eliminate: when multiple 'correct' solutions exist, choosing which one is a human trade-off decision, not an AI logical inference" (design-philosophy.md, lines 31–33).
+
+OpenSPDD addresses the control dimension — how to ensure AI's understanding aligns with design intent, how to pick the one solution the project actually needs among multiple technically correct options, and how to define what must not be done. This is distinct from capability improvements (larger context windows, better inference), which address understanding but not decision-making.
+
+### Structured Prompts vs. Codebase Scanning
+
+Code records "what is," not "what should be" and lacks "why." Codebase scanning cannot recover lost design intent or distinguish deliberate architectural choices from historical compromises. "Codebase scanning is one of the most important capabilities of current AI coding tools. Understanding its boundaries helps us work with it more effectively" (design-philosophy.md, lines 136–197). REASONS Canvas complements scanning by externalizing intent in a structured, versionable artifact.
+
+### Bidirectional Synchronization Challenge
+
+"Do structured prompts themselves also become outdated?" (design-philosophy.md, line 380). The design philosophy acknowledges that specs become stale when code changes. Current mitigation: manually run `/spdd-sync` after code review to detect and update spec changes. Future direction: automated sync detection after each code update.
+
+## Limitations and Caveats
+
+### Not Suitable For
+
+- **Rapid prototyping**: Overhead too high for exploratory, disposable code
+- **One-off scripts**: ROI too low for use-and-discard functionality
+- **Simple tasks**: Fixing typos, adding logs, simple changes don't justify structured overhead
+
+Structured prompts are for "core business logic, systems requiring long-term maintenance and multi-person collaboration" (design-philosophy.md, lines 365–378).
+
+### Spec Drift Risk
+
+Bidirectional sync is manual and convention-based, not enforced. If code changes are made without running `/spdd-sync`, the REASONS Canvas diverges from implementation. This is mitigated through team discipline, not guaranteed by the tool.
+
+### Maturity and Versioning
+
+The repository has no release tags or version numbers (as of shallow clone). Commands marked "Optional (Beta)" — `spdd-story`, `spdd-code-review`, `spdd-api-test`, `spdd-reverse` — are not installed by default and may change. The tool is "still under continuous iteration" (design-philosophy.md, line 451).
+
+## Relevance to Claude Code Development
+
+OpenSPDD is highly relevant to Claude Code as a framework for:
+
+1. **Structured prompt design**: Provides a reusable template system for expressing design intent in a machine-parseable format
+2. **Cross-tool compatibility**: Demonstrates how a single design methodology can be compiled into tool-specific command formats (CLAUDE.md, .claude/commands/, etc.)
+3. **Bidirectional synchronization patterns**: The `/spdd-sync` workflow offers a reference implementation for keeping design documents and code aligned — a known challenge in agent-driven development
+4. **Control-layer design**: Separates capability improvements from control problems, directly applicable to Claude Code's evolving agent coordination needs
+
+For Claude Code specifically, REASONS Canvas is complementary to CLAUDE.md (repo-level conventions) — Canvas works at feature-level granularity while CLAUDE.md covers project-level patterns.
+
+## References
+
+- **GitHub Repository**: <https://github.com/gszhangwei/open-spdd> (accessed 2026-09-11) (primary source for README, LICENSE, design-philosophy.md, go.mod)
+- **README.md**: <https://github.com/gszhangwei/open-spdd/blob/main/README.md> (accessed 2026-09-11) — line references throughout (features, installation, usage, supported environments)
+- **docs/design-philosophy.md**: <https://github.com/gszhangwei/open-spdd/blob/main/docs/design-philosophy.md> (accessed 2026-09-11) — comprehensive exploration of capability vs. control, codebase scanning limitations, and structured prompt philosophy
+- **Installation**: Homebrew tap: <https://github.com/gszhangwei/tools> (accessed 2026-09-11) (formula provides installation)
+- **Build Requirements**: Go 1.23+ (from go.mod, accessed 2026-09-11)
+
+## Freshness Tracking
+
+| Section | Confidence | Last Verified | Notes |
+|---------|-----------|---|---|
+| Identity/Metadata | high | 2026-09-11 | MIT license, Go 1.23 from go.mod; no versioned releases yet |
+| Overview/Problem Addressed | high | 2026-09-11 | Direct quotes from README.md and design-philosophy.md |
+| Key Features | high | 2026-09-11 | REASONS Canvas, core commands, optional commands extracted from README |
+| Technical Architecture | high | 2026-09-11 | Dependency analysis from go.mod; CLI structure from cmd/ directory inspection |
+| Installation & Usage | high | 2026-09-11 | Installation methods and quick start from README.md |
+| Design Insights | high | 2026-09-11 | Philosophical foundations from design-philosophy.md |
+| Limitations | medium | 2026-09-11 | Maturity and spec-drift challenges inferred from source; not explicitly documented as limitations |
+| Relevance | medium | 2026-09-11 | Relevance to Claude Code assessed from framework design; specific Claude Code integration not yet demonstrated in repository |
+
+**Version at Verification**: unversioned (no tags at time of research)
+
+**Next Review**: 2026-12-11 (3 months)
+
+**Review Trigger**: Major version release, significant API changes to command structure, or new integration with Claude Code toolchain.
+
+---
+
+## Cross-References
+
+| Entry | Category | Relationship |
+|-------|----------|--------------|
+| [Spec Workflow MCP](../mcp-ecosystem/spec-workflow-mcp.md) | mcp-ecosystem | spec-driven development workflow with Requirements→Design→Tasks approval gates and real-time dashboard |
+| [System Prompts for AI Tools](./system-prompts-ai-tools.md) | prompt-engineering | explores system prompt design patterns for AI coding tools and agents |
+| [Prompt Engine](./prompt-engine.md) | prompt-engineering | automated prompt generation tool complementing structured prompt design methodology |
+| [Google AI Studio](./google-ai-studio.md) | prompt-engineering | interactive playground for designing and testing prompts for AI agents with 20+ models |
+| [OpenSpec MCP](../mcp-ecosystem/openspec-mcp.md) | mcp-ecosystem | MCP implementation of spec-driven development with 50+ tools and approval state machine |
+| [Everything Claude Code](../agent-frameworks/everything-claude-code.md) | agent-frameworks | comprehensive Claude Code agent harness with 65+ skills for structured orchestration workflows |
+| [Claude Code Harness](../agent-frameworks/claude-code-harness.md) | agent-frameworks | foundational Claude Code control framework providing 5-verb design methodology and guardrails |
+| [Claude Pilot](../developer-tools/claude-pilot.md) | developer-tools | spec-driven enforcement layer for Claude Code with design specification support and /spec workflow |


### PR DESCRIPTION
## Summary

- Add three research entries via `/research-curator`, each with an insight-extraction pass, a utilization assessment (where applicable), and a cross-reference pass:
  - `research/prompt-engineering/open-spdd.md` — OpenSPDD, a Go CLI turning AI coding prompts into "executable design contracts" via the 7-dimension REASONS Canvas
  - `research/ai-research-tools/zvec-grep.md` — zvec-grep, a local-first hybrid (ripgrep + BM25 + vector) workspace search tool with MCP integration for multiple coding agents
  - `research/agent-frameworks/deepseek-harness.md` — DeepSeek Harness (`dsh`), DeepSeek AI's open-source everything-is-a-plugin agent harness (developer preview)
- Fix a `validate_research.py` false-positive: the `url_format` check's regex only excluded `www.` matches preceded by `(` or `<`, so it flagged every correctly-schemed `https://www...` URL as missing a scheme. Extended the negative lookbehind to also exclude `www.` immediately preceded by `http://` or `https://`.
- Correct the `research-curator` skill's validation-gate instructions (`SKILL.md`, `references/validation-rules.md`, `references/batch-mode.md`) so that warning-severity issues from `header_fields`, `access_dates`, `freshness_tracking`, and `url_format` are **must-fix** for entries Default/Batch/Rerun Mode just created or refreshed in the current invocation — the researching agent already holds every fact needed to satisfy them (today's date, the source URL it was given, the version and access dates it just gathered). Pre-existing entries scanned by Validate Mode keep today's report-only warning handling (the appropriate lighter touch for legacy content). The `cross_references_absent` 2026-03-12 date-based exemption is unchanged.

## Test plan

- [x] `uv run .claude/skills/research-curator/scripts/validate_research.py main --json` on all three new entries: 0 errors, 0 fixable warnings (one honest exception left on deepseek-harness.md for a source URL that returned a connection reset — annotated as attempted/inaccessible rather than fabricating an access date)
- [x] `uv run prek run --files <all changed files>` — full hook suite (ruff, ty, markdownlint, skilllint, conventional-commit, research entry validator) passes
- [x] Verified the `url_format` regex fix against both previously-false-flagged URLs (`https://www.npmjs.com/...`, `https://www.deepseek.com/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvocrp9HWzzuS1ttU4XnBT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dvocrp9HWzzuS1ttU4XnBT)_