### PR TITLE
fix(research-curator): repair broken validator command, rerun ordering, missing links, and ty resolution

### DIFF
--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -414,7 +414,12 @@ Validation complete:
 
 Shared by all modes. Execute after any mode completes successfully.
 
-1. **README Update** -- add or update entries in `./research/README.md` category tables
+1. **README Update** -- add or update entries in `./research/README.md` category tables. This is
+   a shared restatement of the mode-specific README step each mode's own flow already gates
+   (Default/Batch step 6d, Rerun step 6/`UpdateDate(s)`) -- it does not run as a fresh, ungated
+   pass. Do not add a row, or refresh the Last Updated date on an existing row, for any entry
+   marked "created with issues" or "refreshed with issues" earlier in this run; that entry's
+   README state stays exactly as it was before this run started
 2. **Lint** -- run formatting checks on all modified files:
 
    ```bash

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -281,8 +281,7 @@ flowchart TD
 
 3. Agent reads existing entry, re-gathers fresh data, updates content and freshness tracking
 4. Apply pre-relay quality checklist to agent result
-5. Update README with refreshed date
-6. **Validate** -- run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) on the updated file:
+5. **Validate** -- run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) on the updated file:
 
    a. Run fix script: `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py ./research/{category}/{name}.md`
 
@@ -292,8 +291,9 @@ flowchart TD
 
    d. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: the agent just refreshed this file this invocation, so it already has the facts to satisfy these. Spawn `@research-curator` with `--fix` and the exact warning issue list, then repeat steps a-b. If errors or any of these four warning types still remain after the retry, treat as step c.
 
-   e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` does not block this step -- proceed to step 7
+   e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` does not block this step -- proceed to step 6
 
+6. Update README with refreshed date (only reached on the clean path from step 5 -- an entry marked "refreshed with issues" in step 5c never gets a refreshed date)
 7. Concurrently spawn three analysis agents:
 
    ```text
@@ -310,8 +310,7 @@ flowchart TD
 2. Spawn agents in waves of 5 (same pattern as Batch Mode)
 3. Each agent receives `--rerun ./research/{category}/{name}.md`
 4. Apply pre-relay quality checklist after each wave
-5. Update README once after all waves complete
-6. **Validate** -- for each successfully updated entry, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) before spawning analysis agents:
+5. **Validate** -- for each successfully updated entry, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) before spawning analysis agents:
 
    a. Run fix script: `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py {file}`
 
@@ -323,6 +322,7 @@ flowchart TD
 
    e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` does not block this step -- include in analysis agent dispatch (step 7)
 
+6. Update README once after all waves complete, refreshing freshness dates only for entries that passed validation in step 5 -- an entry marked "refreshed with issues" in step 5c does not get a refreshed date
 7. For each entry that passed validation: spawn concurrent analysis agents per entry (up to 5 entries concurrently) — `@research-insight-extractor`, `@research-utilization-assessor`, `@research-cross-referencer`
 
 </rerun_mode>
@@ -367,7 +367,7 @@ flowchart TD
 ### Script Invocation
 
 ```bash
-uv run .claude/skills/research-curator/scripts/validate_research.py --json ./research/{target}
+uv run .claude/skills/research-curator/scripts/validate_research.py main --json ./research/{target}
 ```
 
 ### Fix Agent Delegation
@@ -531,9 +531,12 @@ YYYY-MM-DD
 - [Entry Template](./references/entry-template.md) -- standard format for all research entries
 - [Validation Rules](./references/validation-rules.md) -- checks and severity mapping for `--validate` mode
 - [Batch Mode](./references/batch-mode.md) -- wave spawning workflow for `--batch` mode
+- [Duplicate Detection](./references/duplicate-detection.md) -- shared pre-spawn check for Default Mode and Batch Mode
+- [Repo Access Procedure](./references/repo-access-procedure.md) -- tested shallow-clone procedure for repository research
 - Agent: `@research-curator` at `.claude/agents/research-curator.md` -- single-entry research executor
 - Agent: `@research-insight-extractor` at `.claude/agents/research-insight-extractor.md` -- extracts backlog improvements from research entries
 - Agent: `@research-utilization-assessor` at `.claude/agents/research-utilization-assessor.md` -- assesses direct API/service utilization opportunities
 - Agent: `@research-cross-referencer` at `.claude/agents/research-cross-referencer.md` -- appends Cross-References section to research entries
+- Agent: `@research-backlink-detector` at `.claude/agents/research-backlink-detector.md` -- adds backlinks in cited entries during Batch Mode's sequential backlink pass
 
 SOURCE: Agent result relay rules and pre-relay checklist adapted from `plugins/summarizer/skills/agent-result-relay/SKILL.md` (accessed 2026-03-06).

--- a/.claude/skills/research-curator/scripts/fix_research_formatting.py
+++ b/.claude/skills/research-curator/scripts/fix_research_formatting.py
@@ -15,6 +15,7 @@ Run this script BEFORE validate_research.py, not as a replacement for it.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
 
@@ -209,9 +210,6 @@ def _apply_fixes(lines: list[str], issues: FileIssues) -> list[str]:
 # ---------------------------------------------------------------------------
 # File-level orchestration
 # ---------------------------------------------------------------------------
-
-
-from dataclasses import dataclass
 
 
 @dataclass

--- a/.claude/skills/research-curator/scripts/fix_research_formatting.py
+++ b/.claude/skills/research-curator/scripts/fix_research_formatting.py
@@ -2,6 +2,9 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = ["typer>=0.21"]
+#
+# [tool.ty.environment]
+# root = ["."]
 # ///
 """Fix common markdown formatting issues in research entries.
 


### PR DESCRIPTION
## Summary

Fixes five verified inconsistencies in the `research-curator` skill: four from a Skill Lapidary dry-run audit, plus a `ty` unresolved-import finding raised mid-review.

### F1 — Broken validator invocation in SKILL.md

`SKILL.md`'s Validate Mode "Script Invocation" block documented:

```
uv run .claude/skills/research-curator/scripts/validate_research.py --json ./research/{target}
```

Reproduced by execution:

```
Usage: validate_research.py [OPTIONS] COMMAND [ARGS]...
Error: No such option: --json
```

`validate_research.py` is a Typer app whose command is `main`. Four other call sites in the same file already used the correct `main --json` form. Fixed the one broken copy to match. Re-ran both forms before/after: the old form still fails with the same error on `origin/main`; the fixed form now runs against `./research/` and produces JSON.

### F2 — Rerun Mode prose contradicted its own authoritative diagram

The Rerun Mode Mermaid diagram (declared authoritative) validates first and only updates `README.md` on the clean path; on the errors/gated-warnings path it skips straight to Post-Actions without touching README. The prose numbered lists for "Single Entry Rerun" and "All Entries Rerun" did the opposite: they updated README *before* running validation, and did so unconditionally — meaning an entry that failed validation would still get a refreshed date recorded in README.

Reordered both prose lists (Validate before README-update; README-update only reached on the clean path) to match the diagram. Kept all step content, the `a`–`e` sub-step lettering, and all cross-references to the Validation Gate anchor intact — only the position of the "Update README" step moved.

### F3 — Reference Links section omitted bundled files/agents actually in use

Added three entries missing from `## Reference Links`:

- `./references/duplicate-detection.md` — already linked inline at lines 109/114/209, missing from the list
- `./references/repo-access-procedure.md` — reached from `.claude/agents/research-curator.md:91`
- `@research-backlink-detector` (`.claude/agents/research-backlink-detector.md`) — used by `references/batch-mode.md` lines 52/63

Deliberately left out `./references/frontmatter-generation.md` (separate unresolved finding — conflicts with `entry-template.md`'s schema; linking it would make a conflicting schema reachable).

### F4 — Mid-file import in fix_research_formatting.py

`from dataclasses import dataclass` sat at line 214, after several function definitions, under a "File-level orchestration" banner comment (ruff E402 shape). Moved it into the top isort block (after `from __future__ import annotations`, before `pathlib`/`typing`); left the banner comment in place. No behavior change.

### F5 — ty unresolved-import for typer/rich.console

`ty` reported `unresolved-import` for `typer` and `rich.console` in `fix_research_formatting.py`, resolving against a `~/.cache/uv/archive-v0/.../python3.14/site-packages` path (a PEP-723 ephemeral script environment) instead of the project `.venv`.

Root cause, per the `python-engineering:ty` skill's documented policy for this exact class of problem: a PEP-723 standalone script (a `# /// script ... ///` header) has **no first-party roots by default** under `ty` — the project's `pyproject.toml` config does not automatically extend to it. The fix is `[tool.ty.environment] root = [...]` declared *inside the script's own inline metadata block*, not `extra-paths` in the root `pyproject.toml` (that option is for third-party/non-conventionally-installed paths, not for granting first-party roots).

Applied the minimal form the skill documents (`root = ["."]`, matching this repo's own existing precedent in `scripts/validate_codex_plugin_isolated.py`, one of ~30 PEP-723 scripts in this repo already using this pattern):

```python
# /// script
# requires-python = ">=3.11"
# dependencies = ["typer>=0.21"]
#
# [tool.ty.environment]
# root = ["."]
# ///
```

Verified with `uv run ty check` against the script file directly (not the project root): clean, no unresolved-import. Also confirmed the script's declared and transitive dependencies (`typer`, `rich`) still resolve and the script's own `--check` behavior is unchanged.

(An earlier round of investigation checked several other hypotheses — `requires-python` upper bounds, dependency-declaration patterns, editor interpreter pins, ambient `VIRTUAL_ENV` — and found no differentiator; none of those was the actual fix. The `python-engineering:ty` skill's documented policy for standalone-script `unresolved-import` was.)

## Verification

- `uv run .claude/skills/research-curator/scripts/validate_research.py main --json ./research/` — runs (JSON output, no CLI usage error)
- `uv run .claude/skills/research-curator/scripts/validate_research.py --json ./research/` — reproduces the original `No such option: --json` error on `origin/main` (confirms the bug existed)
- `uv run pytest tests/research_backlinks/ -q` — 95 passed
- `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py --check ./research/` — 522 files scanned, 0 need fixing, 86 with warnings (import move and ty root pin are behavior-neutral)
- `uv run ruff check` / `uv run ruff format --check` on the touched Python file — clean
- `uv run ty check .claude/skills/research-curator/scripts/fix_research_formatting.py` (direct file invocation, matching the skill's verification instruction) — clean, no unresolved-import
- `uv run prek run --files .claude/skills/research-curator/SKILL.md .claude/skills/research-curator/scripts/fix_research_formatting.py` — all hooks pass
- Confirmed the `#validation-gate-for-newrefreshed-entries` anchor (and all other links/anchors touched) still resolves in `references/validation-rules.md`

## Test plan

- [x] Both validator invocation forms executed before/after
- [x] `tests/research_backlinks/` suite passes
- [x] `fix_research_formatting.py --check` shows no behavior change from the import move / ty root pin
- [x] ruff + ty clean on the touched Python file (ty verified via direct file invocation per the documented fix)
- [x] prek hooks pass on both touched files
- [x] Markdown links/anchors touched resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
