### PR TITLE
fix(research-curator): close deferred date-alias gap in cross_references_absent

### DIFF
--- a/.claude/skills/research-curator/scripts/validate_research.py
+++ b/.claude/skills/research-curator/scripts/validate_research.py
@@ -408,12 +408,15 @@ def reference_date_yaml(
     Prefers the body Freshness Tracking section's Last Verified -- the value a
     rerun actually updates -- over any frontmatter date field, matching the
     precedence ``reference_date_text`` already applies for the text-header
-    format. Falls back to frontmatter's ``freshness_tracking.last_verified``,
-    the legacy corpus's bare ``metadata.verified`` spelling, then
-    ``research_date``/``date``, for entries with no body section at all.
-    Checking frontmatter first would let a stale frontmatter value -- one a
-    rerun updated only in the body -- wrongly exempt an entry that is actually
-    past the cutoff; the corpus already has entries in this exact state (e.g.
+    format. Falls back to frontmatter's ``freshness_tracking.last_verified``
+    (and its ``date_last_reviewed`` alias from the second historical schema --
+    see ``_YAML_FRESHNESS_ALIASES``), the legacy corpus's bare
+    ``metadata.verified`` spelling, then ``research_date``/``date`` (and their
+    ``date_created`` alias -- see ``_YAML_HEADER_ALIASES``), for entries with
+    no body section at all. Checking frontmatter first would let a stale
+    frontmatter value -- one a rerun updated only in the body -- wrongly
+    exempt an entry that is actually past the cutoff; the corpus already has
+    entries in this exact state (e.g.
     ``research/context-management/claude-mem.md``: frontmatter ``2026-01-31``,
     body ``2026-05-08``).
 
@@ -424,7 +427,7 @@ def reference_date_yaml(
     if body_date:
         return body_date
     flat = flatten_yaml_items(frontmatter)
-    for key in ("last_verified", "verified", "research_date", "date"):
+    for key in ("last_verified", "date_last_reviewed", "verified", "research_date", "date", "date_created"):
         value = flat.get(key)
         if value:
             return str(value)

--- a/tests/research_backlinks/test_cross_references_check.py
+++ b/tests/research_backlinks/test_cross_references_check.py
@@ -290,6 +290,150 @@ class TestYamlEntryVerifiedOnlyFallback:
         assert issues[0]["severity"] == "warning"
 
 
+def _write_yaml_entry_second_schema_only(path: Path, *, research_date: str, cross_references: bool) -> None:
+    """Write a YAML-frontmatter entry using the second historical schema's flat date keys.
+
+    Mirrors the live corpus shape (e.g. ``research/coding-agents/claude-codepro.md``):
+    root-level ``date_created``/``date_last_reviewed`` keys (not nested under
+    ``metadata``, and not the first schema's ``research_date``/``last_verified``
+    spellings) with no body ``## Freshness Tracking`` section, so resolution
+    depends entirely on ``reference_date_yaml`` recognizing ``date_last_reviewed``
+    as an alias.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frontmatter = f"""\
+---
+title: "Example"
+category: "developer-tools"
+resource_url: "https://example.com/example"
+date_created: "{research_date}"
+date_last_reviewed: "{research_date}"
+status: published
+---
+
+# Example
+
+## Overview
+
+Example test entry.
+
+## Problem Addressed
+
+Test.
+
+## Key Features
+
+- Feature A
+
+## Technical Architecture
+
+Simple.
+
+## Installation & Usage
+
+```bash
+pip install example
+```
+
+## Relevance to Claude Code Development
+
+Test.
+
+## References
+
+- [Example](https://example.com) (accessed {research_date})
+"""
+    if cross_references:
+        frontmatter += """
+## Cross-References
+
+| Entry | Category | Relationship |
+|-------|----------|--------------|
+| [Other](../other/other.md) | other | related |
+"""
+    path.write_text(frontmatter, encoding="utf-8")
+
+
+class TestYamlEntrySecondSchemaDateAliases:
+    """A YAML entry using the second schema's ``date_last_reviewed``/``date_created`` keys.
+
+    Regression guard for the deferred item recorded on PR #3508: once
+    ``_YAML_HEADER_ALIASES``/``_YAML_FRESHNESS_ALIASES`` accept
+    ``date_created``/``date_last_reviewed`` for field-completeness checks,
+    ``reference_date_yaml``'s own precedence list must also recognize those
+    spellings, or the ``cross_references_absent`` exemption never resolves a
+    date for entries using the second schema with no body Freshness Tracking
+    section.
+    """
+
+    def test_pre_cutoff_date_last_reviewed_exempts_yaml_entry(self, tmp_path: Path) -> None:
+        """A pre-cutoff ``date_last_reviewed`` exempts the entry with no body date at all."""
+        entry = tmp_path / "example.md"
+        _write_yaml_entry_second_schema_only(entry, research_date="2026-01-15", cross_references=False)
+        result = _run_json(entry)
+        assert result["entries"][0]["format"] == "yaml_frontmatter"
+        assert _issues_for(result, "cross_references_absent") == []
+
+    def test_post_cutoff_date_last_reviewed_still_warns_yaml_entry(self, tmp_path: Path) -> None:
+        """The ``date_last_reviewed`` alias must not suppress the warning for a post-cutoff entry."""
+        entry = tmp_path / "example.md"
+        _write_yaml_entry_second_schema_only(entry, research_date="2026-06-01", cross_references=False)
+        result = _run_json(entry)
+        issues = _issues_for(result, "cross_references_absent")
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "warning"
+
+    def test_pre_cutoff_date_created_alone_exempts_yaml_entry(self, tmp_path: Path) -> None:
+        """``date_created`` alone (no ``date_last_reviewed``) also resolves and exempts a pre-cutoff entry."""
+        entry = tmp_path / "example.md"
+        frontmatter = """\
+---
+title: "Example"
+category: "developer-tools"
+resource_url: "https://example.com/example"
+date_created: "2026-01-15"
+status: published
+---
+
+# Example
+
+## Overview
+
+Example test entry.
+
+## Problem Addressed
+
+Test.
+
+## Key Features
+
+- Feature A
+
+## Technical Architecture
+
+Simple.
+
+## Installation & Usage
+
+```bash
+pip install example
+```
+
+## Relevance to Claude Code Development
+
+Test.
+
+## References
+
+- [Example](https://example.com) (accessed 2026-01-15)
+"""
+        entry.parent.mkdir(parents=True, exist_ok=True)
+        entry.write_text(frontmatter, encoding="utf-8")
+        result = _run_json(entry)
+        assert result["entries"][0]["format"] == "yaml_frontmatter"
+        assert _issues_for(result, "cross_references_absent") == []
+
+
 def _write_yaml_entry_stale_frontmatter(path: Path, *, frontmatter_date: str, body_date: str) -> None:
     """Write a YAML entry whose frontmatter ``verified`` predates a fresher body Last Verified.
 

--- a/tests/research_backlinks/test_cross_references_check.py
+++ b/tests/research_backlinks/test_cross_references_check.py
@@ -290,7 +290,7 @@ class TestYamlEntryVerifiedOnlyFallback:
         assert issues[0]["severity"] == "warning"
 
 
-def _write_yaml_entry_second_schema_only(path: Path, *, research_date: str, cross_references: bool) -> None:
+def write_yaml_entry_second_schema_only(path: Path, *, research_date: str, cross_references: bool) -> None:
     """Write a YAML-frontmatter entry using the second historical schema's flat date keys.
 
     Mirrors the live corpus shape (e.g. ``research/coding-agents/claude-codepro.md``):
@@ -369,7 +369,7 @@ class TestYamlEntrySecondSchemaDateAliases:
     def test_pre_cutoff_date_last_reviewed_exempts_yaml_entry(self, tmp_path: Path) -> None:
         """A pre-cutoff ``date_last_reviewed`` exempts the entry with no body date at all."""
         entry = tmp_path / "example.md"
-        _write_yaml_entry_second_schema_only(entry, research_date="2026-01-15", cross_references=False)
+        write_yaml_entry_second_schema_only(entry, research_date="2026-01-15", cross_references=False)
         result = _run_json(entry)
         assert result["entries"][0]["format"] == "yaml_frontmatter"
         assert _issues_for(result, "cross_references_absent") == []
@@ -377,7 +377,7 @@ class TestYamlEntrySecondSchemaDateAliases:
     def test_post_cutoff_date_last_reviewed_still_warns_yaml_entry(self, tmp_path: Path) -> None:
         """The ``date_last_reviewed`` alias must not suppress the warning for a post-cutoff entry."""
         entry = tmp_path / "example.md"
-        _write_yaml_entry_second_schema_only(entry, research_date="2026-06-01", cross_references=False)
+        write_yaml_entry_second_schema_only(entry, research_date="2026-06-01", cross_references=False)
         result = _run_json(entry)
         issues = _issues_for(result, "cross_references_absent")
         assert len(issues) == 1


### PR DESCRIPTION
## Summary

- Closes the deferred follow-up recorded on PR #3508: `reference_date_yaml`'s date-precedence list only checked `last_verified`/`verified`/`research_date`/`date`, missing the `date_last_reviewed`/`date_created` spellings that `_YAML_HEADER_ALIASES`/`_YAML_FRESHNESS_ALIASES` already accept for the `header_fields`/`freshness_tracking` checks (merged in #3506/#3508).
- Extends the tuple to `("last_verified", "date_last_reviewed", "verified", "research_date", "date", "date_created")`, preserving the existing precedence group order (Last-Verified-equivalent keys before Research-Date-equivalent keys, matching what a rerun actually updates).
- Adds regression tests in `tests/research_backlinks/test_cross_references_check.py` covering: a second-schema entry (`date_last_reviewed`/`date_created`, no body Freshness Tracking section) resolving correctly both pre- and post-cutoff, and `date_created` alone (no `date_last_reviewed`) also resolving.

## Verification (per task instructions)

Measured `cross_references_absent` corpus-wide before and after the fix, on the full `research/` tree:

| | count | affected files |
|---|---|---|
| Before | 26 | (baseline confirmed) |
| After  | 26 | identical file set — zero diff |

The fix does not change any corpus outcome today: every one of the 20 live entries using `date_created`/`date_last_reviewed` either (a) already resolves its date via a body `## Freshness Tracking` "Last Verified" label — which `reference_date_yaml` already prefers over frontmatter — or (b) already carries a `## Cross-References` section, short-circuiting the date check entirely. This closes a latent inconsistency between the alias tables and `reference_date_yaml`'s own fallback (a real code-correctness gap, verified by reading the function against `_YAML_HEADER_ALIASES`/`_YAML_FRESHNESS_ALIASES`), not a currently-observed corpus defect.

## Test plan

- [x] `uv run pytest tests/research_backlinks/test_cross_references_check.py -q` — 13 passed (10 pre-existing + 3 new)
- [x] `uv run pytest tests/research_backlinks/ -q` — 113 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on both touched files — clean
- [x] `uv run ty check` on `validate_research.py` — clean
- [x] Corpus-wide `main ./research/ --json` run before and after — `cross_references_absent` count unchanged at 26, identical file set
- [x] prek hooks passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)