### PR TITLE
fix(instructions): route agent-doc review to writing-for-agents

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,9 +73,14 @@ For debugging, investigation, problem solving, unknowns, or repeated errors: use
 |-------|---------|---------|
 | Starting complex task | `/dh:rt-ica <#N \| goal>` | Works backward from the goal through the prerequisite chain, classifying each as available/derivable/missing, and blocks planning until nothing is missing |
 | Delegating to sub-agent | `/agent-orchestration:delegate` | Decompose, dispatch, adjudicate |
-| Writing or reviewing an agent-facing document | `/mattpocock-skills:writing-for-agents` | Skills, `AGENTS.md`, `CLAUDE.md`, rule files, research entries — pointer wording, information hierarchy, pruning |
 | Claiming task complete | `/dh:verify-done` | Runs "Is It Done?" checklist |
 | Writing or improving a process | `/process-siren:improve-processes` | Evaluates process completeness, improves before Mermaid conversion |
+
+**Agent-facing documents** — skills, `AGENTS.md`, `CLAUDE.md`, rule files, research entries — are written
+and reviewed against `mattpocock-skills:writing-for-agents`: pointer wording, information hierarchy,
+completion criteria, pruning. It ships outside this marketplace, so treat it as optional support — apply
+it when installed, and otherwise fall back to the conventions in this file and record that the result used
+built-in guidance only. Availability states and per-harness install paths: [Optional Supporting Skills](../plugins/the-rewrite-room/skills/the-rewrite-room/references/supporting-skills.md).
 
 **Critical Constraints:**
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,7 +73,7 @@ For debugging, investigation, problem solving, unknowns, or repeated errors: use
 |-------|---------|---------|
 | Starting complex task | `/dh:rt-ica <#N \| goal>` | Works backward from the goal through the prerequisite chain, classifying each as available/derivable/missing, and blocks planning until nothing is missing |
 | Delegating to sub-agent | `/agent-orchestration:delegate` | Decompose, dispatch, adjudicate |
-| Reviewing agent output | `/hallucination-detector:hallucination-audit` | Checks hallucinations, unverified causality |
+| Writing or reviewing an agent-facing document | `/mattpocock-skills:writing-for-agents` | Skills, `AGENTS.md`, `CLAUDE.md`, rule files, research entries — pointer wording, information hierarchy, pruning |
 | Claiming task complete | `/dh:verify-done` | Runs "Is It Done?" checklist |
 | Writing or improving a process | `/process-siren:improve-processes` | Evaluates process completeness, improves before Mermaid conversion |
 

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,7 +1,0 @@
----
-description: Alias for hallucination-detector hallucination-audit command
----
-
-# Audit (Alias)
-
-Use `/hallucination-detector:hallucination-audit` instead.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -395,7 +395,7 @@ Claude automatically activates skills based on your request. Skills have trigger
 - **rt-ica**: "planning", "prerequisites", "spec", "PRD", "ticket", "RFC", "architecture design", "multi-step task"
 - **scientific-method:scientific-thinking**: "debugging", "strange behavior", "root cause", "architecture design", "complex refactoring", "investigation"
 - **verify**: "is it done", "task complete", "before commit", "completion", "finished"
-- **audit**: "review output", "hallucination", "suspicious", "probably", "likely", "verify claims"
+- **mattpocock-skills:writing-for-agents**: "skill", "AGENTS.md", "CLAUDE.md", "rule file", "research entry", "agent-facing document"
 - **claude-skills-overview-2026**: "skill format", "SKILL.md", "skill frontmatter", "skill best practices"
 - **hooks-guide**: "hook", "PreToolUse", "PostToolUse", "hook events", "inline-agent hooks", "platform hooks"
 - **claude-plugins-reference-2026**: "plugin", "plugin.json", "marketplace", "bundle"

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -395,7 +395,7 @@ Claude automatically activates skills based on your request. Skills have trigger
 - **rt-ica**: "planning", "prerequisites", "spec", "PRD", "ticket", "RFC", "architecture design", "multi-step task"
 - **scientific-method:scientific-thinking**: "debugging", "strange behavior", "root cause", "architecture design", "complex refactoring", "investigation"
 - **verify**: "is it done", "task complete", "before commit", "completion", "finished"
-- **mattpocock-skills:writing-for-agents**: "skill", "AGENTS.md", "CLAUDE.md", "rule file", "research entry", "agent-facing document"
+- **mattpocock-skills:writing-for-agents** (external, optional): "skill", "AGENTS.md", "CLAUDE.md", "rule file", "research entry", "agent-facing document"
 - **claude-skills-overview-2026**: "skill format", "SKILL.md", "skill frontmatter", "skill best practices"
 - **hooks-guide**: "hook", "PreToolUse", "PostToolUse", "hook events", "inline-agent hooks", "platform hooks"
 - **claude-plugins-reference-2026**: "plugin", "plugin.json", "marketplace", "bundle"

--- a/plugins/scientific-method/.claude-plugin/plugin.json
+++ b/plugins/scientific-method/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scientific-method",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "author": {
     "name": "Jamie Nelson",
     "url": "https://github.com/bitflight-devops"

--- a/plugins/scientific-method/.codex-plugin/plugin.json
+++ b/plugins/scientific-method/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scientific-method",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "description": "Use when debugging, investigating root causes, designing experiments, or performing scientific analysis \u2014 enforces hypothesis-driven reasoning, evidence-first observation, causality validation, and structured output templates. Use when facing unknowns, repeated failures, or complex investigations requiring rigorous methodology.",
   "author": {
     "name": "Jamie Nelson",

--- a/plugins/scientific-method/shared/investigation-workflow.md
+++ b/plugins/scientific-method/shared/investigation-workflow.md
@@ -247,13 +247,11 @@ flowchart TB
         S1["scientific-thinking<br/>Hypothesis framework"]
         S2["rt-ica<br/>Prerequisites check"]
         S3["verify<br/>Conclusion verification"]
-        S4["audit<br/>Check for hallucinations"]
     end
 
     subgraph COMMANDS["Commands"]
         C1["/think<br/>Step-back reasoning"]
         C2["/scientific-thinking<br/>Activate method"]
-        C3["/audit<br/>Verify claims"]
     end
 
     subgraph AGENTS["Agents"]
@@ -295,7 +293,6 @@ sequenceDiagram
     Note over O: VERIFICATION
     O->>SK: Load /dh:verify-done skill
     SK-->>O: Checklist
-    O->>SK: Load audit skill
     O->>O: Chain-of-Verification
 
     Note over O: CONCLUSION


### PR DESCRIPTION
## Problem

`.claude/CLAUDE.md` listed `/hallucination-detector:hallucination-audit` as **REQUIRED** when reviewing agent output. That command cannot execute in this checkout:

- The plugin is external — registered in `.claude-plugin/marketplace.json` as `bitflight-devops/hallucination-detector`, not a local directory under `plugins/`.
- It is absent from `~/.claude/plugins` entirely (`find ~/.claude/plugins -iname '*hallucination*'` returns nothing) and from the session skill registry.

A REQUIRED gate that cannot run leaves agents two options: skip it silently, or improvise a substitute. Both are worse than no gate.

Owner's instruction: drop the lean on hallucination-detector, and use `writing-for-agents` for reviewing the entries (the triggering context was research entries under `./research/` — agent-consumed documents).

## Changes

Only sites that **mandate or route to** the skill as a workflow step were touched. Incidental prose (research entries, plan files, historical session notes, knowledge maps) was left alone.

| Site | Action | Why |
|------|--------|-----|
| `.claude/CLAUDE.md` REQUIRED table | **Replace** with `/mattpocock-skills:writing-for-agents` | Stage restated to what the skill actually covers — writing/reviewing agent-facing documents (skills, `AGENTS.md`, `CLAUDE.md`, rule files, research entries) |
| `.claude/commands/audit.md` | **Delete** | Entire body was `Use /hallucination-detector:hallucination-audit instead.` — a dangling pointer with no content of its own |
| `.claude/skills/README.md` activation index | **Replace** the dead `audit` entry | It routed to a skill that does not exist in `.claude/skills/`; slot now carries `writing-for-agents` triggers |
| `plugins/scientific-method/shared/investigation-workflow.md` | **Drop** the `audit` / `/audit` nodes and the `Load audit skill` sequence step | Shipped plugin content telling agents to load an unreachable skill. The adjacent `Chain-of-Verification` step is the real behaviour and remains |

## Where the swap does not cleanly hold

`writing-for-agents` is a writing/editing skill, not a claim-verification tool. The old row's stated purpose — *"Checks hallucinations, unverified causality"* — is **not** something `writing-for-agents` does, so this is deliberately not a like-for-like swap.

That check is not lost, because `.claude/CLAUDE.md` already states it twice. The **Critical Constraints** bullet two lines below the table is the live, always-loaded version:

> Output contains "likely", "probably", or "I think" — STOP and verify before continuing

plus `- No speculation as diagnosis — state what occurred and was observed`. The table row was the weaker duplicate of that meaning, pointing at an unreachable target. Removing it restores a single source of truth rather than removing a check.

The one real reduction: `plugins/scientific-method`'s VERIFICATION phase no longer names a claim-check asset. `Chain-of-Verification` remains as the inline step, and the plugin previously routed to something unreachable, so nothing regresses — but the asset list is now shorter by one. Routing it to `dh:fact-check` would introduce new cross-plugin coupling and is left as the owner's call.

## Deliberately left alone

All remaining `hallucination-detector` references are descriptive, not routing:

- `.claude-plugin/marketplace.json` — the registration itself. **Removing a plugin registration is the owner's call, not mine.** No concrete reason to change it was found: nothing else in the repo executes against it, and the sibling repo still exists.
- `AGENTS.md:14` and `README.md:105` — accurate statements about the marketplace roster and the external repo.
- `docs/mcp-architecture-analysis.md`, `docs/mcp-implementation-roadmap.md` — historical planning analysis.
- `plugins/development-harness/docs/sdlc-layers/arl-meta-layer.md` — ARL framework mapping table, docs not mandate.
- `.claude/knowledge/workflow-diagrams/` — knowledge maps; explicitly out of scope. These still show a `/audit` node and are now stale by one entry.

Also untouched per instruction: `.claude/skills/research-curator/` (in flight elsewhere).

## Notes

- `mattpocock-skills:writing-for-agents` is already an established dependency here — `plugins/development-harness/agents/service-docs-maintainer.md` declares it in frontmatter, and `plugins/the-rewrite-room` inventories it. Unlike hallucination-detector, it resolves in this session.
- `plugins/scientific-method/{.claude-plugin,.codex-plugin}/plugin.json` version bumps are the manifest-sync pre-commit hook, not hand edits.
- The `writing-for-agents` skill was loaded and applied to these edits: the replacement pointer front-loads its leading word, lists one trigger per branch, and the change is net-negative in lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)