### PR TITLE
fix(research-curator): backlink graph, dedupe validation gate, drop --layer

### DIFF
--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -415,9 +415,8 @@ below.
    backlink-target file that was already dirty in the pre-mode baseline before step 3 ever
    excludes that file from this run's commit -- the exclusion happens after the write, not before
    it (tracked in backlog #3516; fixing it requires a change to `check-backlinks` itself, outside
-   this skill). Running research-curator from an isolated worktree when another contributor may be
-   editing `./research/` concurrently avoids the collision entirely -- see
-   `rules/commit-cadence-and-worktrees.md`.
+   this skill). See step 3's known limitation below for the general timing gap this is one case
+   of, and its mitigation.
 
 3. **Compute the filtered file list** -- diff the current working tree against the pre-mode
    baseline (see [Mode Routing](#mode-routing)) to get every file under `./research/` this run
@@ -433,6 +432,15 @@ below.
    `{path} -- pre-existing uncommitted changes, not touched this run`. Call what remains **the
    filtered list**; steps 4-6 below use it and nothing else, so a pre-existing dirty file is never
    linted, staged, or committed by this run.
+
+   **Known limitation**: this only protects against a file that was already dirty *when the
+   baseline was captured*. A concurrent edit that starts on a previously-clean file after the
+   baseline but before this step runs is indistinguishable from this run's own write once it shows
+   up in the diff -- there is no locking primitive here to detect or prevent it. This is the same
+   underlying gap as step 2's check-backlinks limitation, just from the opposite timing direction.
+   Running research-curator from an isolated worktree when another contributor may be editing
+   `./research/` concurrently avoids the collision entirely, in both directions -- see
+   `rules/commit-cadence-and-worktrees.md`.
 
    If the filtered list is empty (nothing was created, refreshed, or repaired this run -- e.g. a
    clean Validate Mode pass where the backlink repair also found nothing writable to fix), skip

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -403,21 +403,27 @@ below.
      uv run .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research --fix
    ```
 
-   If stdout does **not** contain an `asymmetric_cross_references: N` line, the command failed
-   before completing its scan -- a `uv` dependency-resolution failure, a Python import error, a
-   `run_bounded.py` timeout (exit code 124), or any other crash -- rather than reporting a normal
-   structural result. Halt Post-Actions and report the failure to the user; do not treat this as
-   an acceptable non-zero exit.
+   Check the result in this order:
 
-   If stdout does contain that line: a stderr `warning: could not repair ...` line means an
-   operational I/O failure (permissions, disk space, an invalid path) reading or writing a target,
-   not a structural limitation -- halt Post-Actions and report the exact warning text. Otherwise, a
-   non-zero exit here reports asymmetric edges the script cannot structurally repair (a dangling
-   link to a missing target, or a manually authored row with a different description it refuses to
-   overwrite) -- continue to step 3 regardless of this exit code. Which files, if any, this command
-   actually modified is determined by step 3's diff, not by this step -- do not parse the printed
-   `{source} -> {target}` lines to guess at modified files, since they list every asymmetric edge
-   found *before* repair is attempted, not which repairs succeeded.
+   1. **Exit code 124** (`run_bounded.py`'s timeout signal): halt Post-Actions and report a
+      timeout, unconditionally -- even if `asymmetric_cross_references: N` already printed before
+      the timeout fired (e.g. during a repair write or the post-repair rescan), a terminated run's
+      partial state is not trustworthy to commit.
+   2. **Stdout does not contain an `asymmetric_cross_references: N` line**: the command failed
+      before completing its scan -- a `uv` dependency-resolution failure, a Python import error, or
+      any other crash -- rather than reporting a normal structural result. Halt Post-Actions and
+      report the failure to the user.
+   3. **Stderr contains a `warning: io-error, could not repair ...` line**: a genuine I/O failure
+      (permissions, disk space, an invalid path) reading or writing a target. Halt Post-Actions and
+      report the exact warning text.
+   4. **Otherwise**: continue to step 3 regardless of this exit code. This covers both a clean
+      structural non-zero exit (a dangling link to a missing target) and a
+      `warning: structural, could not repair ...` line (a malformed entry the script cannot parse,
+      e.g. a Cross-References row with no markdown link -- confirmed against the real vault's one
+      persistent unrepairable edge). Which files, if any, this command actually modified is
+      determined by step 3's diff, not by this step -- do not parse the printed
+      `{source} -> {target}` lines to guess at modified files, since they list every asymmetric
+      edge found *before* repair is attempted, not which repairs succeeded.
 
    **Known limitation**: this command has no per-file exclude option, so it can write into a
    backlink-target file that was already dirty in the pre-mode baseline before step 3 ever

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -20,10 +20,15 @@ Orchestrate research entry creation, maintenance, and validation in `./research/
 ## Mode Routing
 
 Parse `<mode_args/>` to select operating mode. Before executing any mode below, capture a
-`git status --porcelain -- ./research/` baseline -- this is the invocation's pre-write state,
-taken before this run's own README update, curator agent, or analysis agent writes anything.
-Post-Actions' Backlink Repair step compares against this baseline, not a fresh snapshot, to tell
-this run's own writes apart from another contributor's pre-existing uncommitted work.
+`git status --porcelain --untracked-files=all -- ./research/` baseline -- this is the
+invocation's pre-write state, taken before this run's own README update, curator agent, or
+analysis agent writes anything. `--untracked-files=all` is required: the default mode collapses
+an untracked directory to one line (`?? research/new-category/`) instead of listing the files
+inside it, while step 3 below always lists individual files via `git ls-files --others` -- without
+this flag, a pre-existing untracked file inside a new untracked directory would never match
+anything in the baseline and would be misclassified as this run's own work. Post-Actions' steps
+compare against this baseline, not a fresh snapshot, to tell this run's own writes apart from
+another contributor's pre-existing uncommitted work.
 
 The following diagram is the authoritative procedure for mode routing. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
 

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -19,7 +19,11 @@ Orchestrate research entry creation, maintenance, and validation in `./research/
 
 ## Mode Routing
 
-Parse `<mode_args/>` to select operating mode.
+Parse `<mode_args/>` to select operating mode. Before executing any mode below, capture a
+`git status --porcelain -- ./research/` baseline -- this is the invocation's pre-write state,
+taken before this run's own README update, curator agent, or analysis agent writes anything.
+Post-Actions' Backlink Repair step compares against this baseline, not a fresh snapshot, to tell
+this run's own writes apart from another contributor's pre-existing uncommitted work.
 
 The following diagram is the authoritative procedure for mode routing. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
 
@@ -379,22 +383,23 @@ the Commit step stages exactly that list, nothing else.
 
 2. **Backlink Repair** -- deterministically repair the bidirectional cross-reference graph across
    the whole vault, not just entries this run touched (asymmetric edges can persist from any
-   prior run that predates this check). First snapshot which vault files are already dirty, so a
-   pre-existing uncommitted edit from another contributor is never folded into this run's commit:
+   prior run that predates this check):
 
    ```bash
-   git status --porcelain -- ./research/
    uv run .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research --fix
    ```
 
    Each printed `{source} -> {target}` line preceding the `backlinks_repaired:` count names a
    `{target}` file this command may have modified.
 
-   - If `{target}` was **not** in the `git status` snapshot above (clean before this step): add it
-     to the tracked file list.
-   - If `{target}` **was** already dirty in that snapshot: leave it out of the tracked file list --
-     do not stage someone else's in-progress work alongside the repair -- and report it to the user
-     as `{path} -- pre-existing uncommitted changes, backlink repair not committed this run`.
+   - If `{target}` was **not** dirty in the pre-write baseline captured before this mode started
+     (see [Mode Routing](#mode-routing)): add it to the tracked file list. This includes an entry
+     this run itself just created or refreshed, even though it is now dirty by the time this step
+     runs -- it was clean at baseline, so it is this run's own write, not someone else's.
+   - If `{target}` **was** already dirty in that baseline (present before this run wrote anything):
+     leave it out of the tracked file list -- do not stage someone else's in-progress work alongside
+     the repair -- and report it to the user as `{path} -- pre-existing uncommitted changes, backlink
+     repair not committed this run`.
 
    This command exits non-zero whenever any asymmetric edge remains after the fix pass, including
    edges it cannot structurally repair (a dangling link to a missing target, or a manually authored

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -374,12 +374,18 @@ which files this run touched by diffing the current working tree against the pre
 captured in [Mode Routing](#mode-routing) -- no file path needs manual tracking through the steps
 below.
 
-1. **README Update** -- add or update entries in `./research/README.md` category tables. This is
-   a shared restatement of the mode-specific README step each mode's own flow already gates
-   (Default/Batch step 6d, Rerun step 6/`UpdateDate(s)`) -- it does not run as a fresh, ungated
-   pass. Do not add a row, or refresh the Last Updated date on an existing row, for any entry
-   marked "created with issues" or "refreshed with issues" earlier in this run; that entry's
-   README state stays exactly as it was before this run started
+1. **README Update** -- if `./research/README.md` was already dirty in the pre-mode baseline
+   (see [Mode Routing](#mode-routing)), report to the user: `./research/README.md -- pre-existing
+   uncommitted changes present; this run's README update will not be committed` before proceeding
+   -- the update below still needs to happen so the mode's own entry is recorded, but step 3 will
+   exclude README.md from this run's commit, so the edit lands mixed into someone else's
+   uncommitted file rather than silently being treated as if nothing was wrong. Otherwise, add or
+   update entries in `./research/README.md` category tables as usual. This is a shared restatement
+   of the mode-specific README step each mode's own flow already gates (Default/Batch step 6d,
+   Rerun step 6/`UpdateDate(s)`) -- it does not run as a fresh, ungated pass. Do not add a row, or
+   refresh the Last Updated date on an existing row, for any entry marked "created with issues" or
+   "refreshed with issues" earlier in this run; that entry's README state stays exactly as it was
+   before this run started
 
 2. **Backlink Repair** -- deterministically repair the bidirectional cross-reference graph across
    the whole vault, not just entries this run touched (asymmetric edges can persist from any

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -378,14 +378,29 @@ the Commit step stages exactly that list, nothing else.
 
 2. **Backlink Repair** -- deterministically repair the bidirectional cross-reference graph across
    the whole vault, not just entries this run touched (asymmetric edges can persist from any
-   prior run that predates this check):
+   prior run that predates this check). First snapshot which vault files are already dirty, so a
+   pre-existing uncommitted edit from another contributor is never folded into this run's commit:
 
    ```bash
+   git status --porcelain -- ./research/
    uv run .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research --fix
    ```
 
    Each printed `{source} -> {target}` line preceding the `backlinks_repaired:` count names a
-   `{target}` file this command may have modified. Add every such target to the tracked file list.
+   `{target}` file this command may have modified.
+
+   - If `{target}` was **not** in the `git status` snapshot above (clean before this step): add it
+     to the tracked file list.
+   - If `{target}` **was** already dirty in that snapshot: leave it out of the tracked file list --
+     do not stage someone else's in-progress work alongside the repair -- and report it to the user
+     as `{path} -- pre-existing uncommitted changes, backlink repair not committed this run`.
+
+   This command exits non-zero whenever any asymmetric edge remains after the fix pass, including
+   edges it cannot structurally repair (a dangling link to a missing target, or a manually authored
+   row with a different description it refuses to overwrite). That non-zero exit reports remaining
+   edges; it is not a failure of this step -- continue to step 3 regardless of this command's exit
+   code. Only a failure to run the command at all (script or vault path not found) halts
+   Post-Actions here.
 
 3. **Lint** -- run formatting checks on all modified files:
 

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -19,21 +19,17 @@ Orchestrate research entry creation, maintenance, and validation in `./research/
 
 ## Mode Routing
 
-Parse `<mode_args/>` to select operating mode. Optional `--layer 0|1|2` filters discovery by SDLC layer when used with knowledge-explorer or refresh-research.
+Parse `<mode_args/>` to select operating mode.
 
 The following diagram is the authoritative procedure for mode routing. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
 
 ```mermaid
 flowchart TD
     Start(["Parse <mode_args/>"]) --> Q1{"Does <mode_args/> contain --batch?"}
-    Q1 -->|"Yes — batch flag present"| Q1Layer{"Does <mode_args/> also contain --layer 0, 1, or 2?"}
+    Q1 -->|"Yes — batch flag present"| Batch(["Execute Batch Mode"])
     Q1 -->|"No — batch flag absent"| Q2{"Does <mode_args/> contain --rerun?"}
-    Q1Layer -->|"Yes — layer filter present"| BatchLayer(["Execute Batch Mode with layer filter applied"])
-    Q1Layer -->|"No — no layer filter"| Batch(["Execute Batch Mode"])
-    Q2 -->|"Yes — rerun flag present"| Q2Layer{"Does <mode_args/> also contain --layer 0, 1, or 2?"}
+    Q2 -->|"Yes — rerun flag present"| Rerun(["Execute Rerun Mode"])
     Q2 -->|"No — rerun flag absent"| Q3{"Does <mode_args/> contain --validate?"}
-    Q2Layer -->|"Yes — layer filter present"| RerunLayer(["Execute Rerun Mode with layer filter applied"])
-    Q2Layer -->|"No — no layer filter"| Rerun(["Execute Rerun Mode"])
     Q3 -->|"Yes — validate flag present"| Validate(["Execute Validate Mode"])
     Q3 -->|"No — no flags matched — <mode_args/> contains a URL only"| Default(["Execute Default Mode — single URL"])
 ```

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -426,8 +426,15 @@ below.
    Exclude any path that was **already** dirty in the baseline -- that is another contributor's
    pre-existing uncommitted work, not something this run produced -- and report it to the user as
    `{path} -- pre-existing uncommitted changes, not touched this run`. Call what remains **the
-   filtered list**; steps 4 and 5 below use it and nothing else, so a pre-existing dirty file is
-   never linted, staged, or committed by this run.
+   filtered list**; steps 4-6 below use it and nothing else, so a pre-existing dirty file is never
+   linted, staged, or committed by this run.
+
+   If the filtered list is empty (nothing was created, refreshed, or repaired this run -- e.g. a
+   clean Validate Mode pass where the backlink repair also found nothing writable to fix), skip
+   steps 4-6 entirely: there is nothing to lint, commit, or push, and this is not a failure. Do not
+   invoke `prek run --files` with an empty list -- with no paths given, it falls back to its normal
+   staged-file selection instead of processing nothing, which could run auto-fixing hooks against
+   whatever another contributor already has staged.
 
 4. **Lint** -- run formatting checks on exactly the filtered list:
 
@@ -435,11 +442,8 @@ below.
    uv run prek run --files [the filtered list]
    ```
 
-5. **Commit** -- if the filtered list is empty (nothing was created, refreshed, or repaired this
-   run -- e.g. a clean Validate Mode pass where the backlink repair also found nothing writable to
-   fix), skip this step and step 6: there is nothing to commit, and this is not a failure.
-   Otherwise, stage and commit **exactly** the filtered list, immune to whatever else might already
-   be staged in the working tree -- never a blanket `git add -A`, a directory-wide
+5. **Commit** -- stage and commit **exactly** the filtered list, immune to whatever else might
+   already be staged in the working tree -- never a blanket `git add -A`, a directory-wide
    `git add ./research/`, or a pathless `git commit -m` (which commits the entire index, not just
    these paths):
 

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -406,6 +406,14 @@ below.
    parse the printed `{source} -> {target}` lines to guess at modified files, since they list every
    asymmetric edge found *before* repair is attempted, not which repairs succeeded.
 
+   **Known limitation**: this command has no per-file exclude option, so it can write into a
+   backlink-target file that was already dirty in the pre-mode baseline before step 3 ever
+   excludes that file from this run's commit -- the exclusion happens after the write, not before
+   it (tracked in backlog #3516; fixing it requires a change to `check-backlinks` itself, outside
+   this skill). Running research-curator from an isolated worktree when another contributor may be
+   editing `./research/` concurrently avoids the collision entirely -- see
+   `rules/commit-cadence-and-worktrees.md`.
+
 3. **Compute the filtered file list** -- diff the current working tree against the pre-mode
    baseline (see [Mode Routing](#mode-routing)) to get every file under `./research/` this run
    touched:

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -369,10 +369,10 @@ Validation complete:
 
 ## Post-Actions
 
-Shared by all modes. Execute after any mode completes successfully. Step 4 (Commit)
-derives exactly which files this run touched by diffing the current working tree against the
-pre-mode baseline captured in [Mode Routing](#mode-routing) -- no file path needs manual
-tracking through the steps below.
+Shared by all modes. Execute after any mode completes successfully. Step 3 derives exactly
+which files this run touched by diffing the current working tree against the pre-mode baseline
+captured in [Mode Routing](#mode-routing) -- no file path needs manual tracking through the steps
+below.
 
 1. **README Update** -- add or update entries in `./research/README.md` category tables. This is
    a shared restatement of the mode-specific README step each mode's own flow already gates
@@ -396,38 +396,45 @@ tracking through the steps below.
    Otherwise, a non-zero exit here reports asymmetric edges the script cannot structurally repair
    (a dangling link to a missing target, or a manually authored row with a different description
    it refuses to overwrite) -- continue to step 3 regardless of this exit code. Which files, if
-   any, this command actually modified is determined by step 4's diff, not by this step -- do not
+   any, this command actually modified is determined by step 3's diff, not by this step -- do not
    parse the printed `{source} -> {target}` lines to guess at modified files, since they list every
    asymmetric edge found *before* repair is attempted, not which repairs succeeded.
 
-3. **Lint** -- run formatting checks on every file this run touched (the same diff step 4 uses):
+3. **Compute the filtered file list** -- diff the current working tree against the pre-mode
+   baseline (see [Mode Routing](#mode-routing)) to get every file under `./research/` this run
+   touched:
 
    ```bash
    git diff --name-only -- ./research/
    git ls-files --others --exclude-standard -- ./research/
-   uv run prek run --files ./research/README.md [files from the two commands above]
    ```
 
-4. **Commit** -- diff the current working tree against the pre-mode baseline (see
-   [Mode Routing](#mode-routing)) to get the exact list of files under `./research/` this run
-   touched: modified paths from `git diff --name-only -- ./research/`, plus new paths from
-   `git ls-files --others --exclude-standard -- ./research/`. Exclude any path that was **already**
-   dirty in the baseline -- that is another contributor's pre-existing uncommitted work, not
-   something this run produced -- and report it to the user as `{path} -- pre-existing uncommitted
-   changes, not committed this run` instead of staging it.
+   Exclude any path that was **already** dirty in the baseline -- that is another contributor's
+   pre-existing uncommitted work, not something this run produced -- and report it to the user as
+   `{path} -- pre-existing uncommitted changes, not touched this run`. Call what remains **the
+   filtered list**; steps 4 and 5 below use it and nothing else, so a pre-existing dirty file is
+   never linted, staged, or committed by this run.
 
-   If the resulting list is empty (nothing was created, refreshed, or repaired this run -- e.g. a
-   clean Validate Mode pass where the backlink repair also found nothing writable to fix), skip
-   this step and step 5: there is nothing to commit, and this is not a failure. Otherwise, stage
-   and commit exactly that list -- never a blanket `git add -A` or a directory-wide
-   `git add ./research/`:
+4. **Lint** -- run formatting checks on exactly the filtered list:
 
    ```bash
-   git add ./research/README.md ./research/{category}/{name}.md [...files from the diff above]
-   git commit -m "docs(research): [action] [resource names]"
+   uv run prek run --files [the filtered list]
    ```
 
-5. **Push** -- push to current branch:
+5. **Commit** -- if the filtered list is empty (nothing was created, refreshed, or repaired this
+   run -- e.g. a clean Validate Mode pass where the backlink repair also found nothing writable to
+   fix), skip this step and step 6: there is nothing to commit, and this is not a failure.
+   Otherwise, stage and commit **exactly** the filtered list, immune to whatever else might already
+   be staged in the working tree -- never a blanket `git add -A`, a directory-wide
+   `git add ./research/`, or a pathless `git commit -m` (which commits the entire index, not just
+   these paths):
+
+   ```bash
+   git add [the filtered list]
+   git commit [the filtered list] -m "docs(research): [action] [resource names]"
+   ```
+
+6. **Push** -- push to current branch:
 
    ```bash
    git push -u origin HEAD

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -394,22 +394,30 @@ below.
 
 2. **Backlink Repair** -- deterministically repair the bidirectional cross-reference graph across
    the whole vault, not just entries this run touched (asymmetric edges can persist from any
-   prior run that predates this check):
+   prior run that predates this check). Run it bounded, per `scripts/run_bounded.py`'s documented
+   convention for any external command that may hang -- a stalled `uv` dependency resolution or
+   vault scan would otherwise block every mode indefinitely:
 
    ```bash
-   uv run .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research --fix
+   uv run scripts/run_bounded.py --timeout-seconds 180 -- \
+     uv run .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research --fix
    ```
 
-   If this command's stderr contains any `warning: could not repair ...` line: that is an
-   operational I/O failure (permissions, disk space, an invalid path) reading or writing a target,
-   not a structural limitation. Halt Post-Actions and report the exact warning text to the user.
+   If stdout does **not** contain an `asymmetric_cross_references: N` line, the command failed
+   before completing its scan -- a `uv` dependency-resolution failure, a Python import error, a
+   `run_bounded.py` timeout (exit code 124), or any other crash -- rather than reporting a normal
+   structural result. Halt Post-Actions and report the failure to the user; do not treat this as
+   an acceptable non-zero exit.
 
-   Otherwise, a non-zero exit here reports asymmetric edges the script cannot structurally repair
-   (a dangling link to a missing target, or a manually authored row with a different description
-   it refuses to overwrite) -- continue to step 3 regardless of this exit code. Which files, if
-   any, this command actually modified is determined by step 3's diff, not by this step -- do not
-   parse the printed `{source} -> {target}` lines to guess at modified files, since they list every
-   asymmetric edge found *before* repair is attempted, not which repairs succeeded.
+   If stdout does contain that line: a stderr `warning: could not repair ...` line means an
+   operational I/O failure (permissions, disk space, an invalid path) reading or writing a target,
+   not a structural limitation -- halt Post-Actions and report the exact warning text. Otherwise, a
+   non-zero exit here reports asymmetric edges the script cannot structurally repair (a dangling
+   link to a missing target, or a manually authored row with a different description it refuses to
+   overwrite) -- continue to step 3 regardless of this exit code. Which files, if any, this command
+   actually modified is determined by step 3's diff, not by this step -- do not parse the printed
+   `{source} -> {target}` lines to guess at modified files, since they list every asymmetric edge
+   found *before* repair is attempted, not which repairs succeeded.
 
    **Known limitation**: this command has no per-file exclude option, so it can write into a
    backlink-target file that was already dirty in the pre-mode baseline before step 3 ever

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -369,10 +369,10 @@ Validation complete:
 
 ## Post-Actions
 
-Shared by all modes. Execute after any mode completes successfully. Track every file path
-written or modified by any step below (agent-created/refreshed entries, README.md,
-insight/utilization files, cross-reference files, backlink-repaired files) in a running list --
-the Commit step stages exactly that list, nothing else.
+Shared by all modes. Execute after any mode completes successfully. Step 4 (Commit)
+derives exactly which files this run touched by diffing the current working tree against the
+pre-mode baseline captured in [Mode Routing](#mode-routing) -- no file path needs manual
+tracking through the steps below.
 
 1. **README Update** -- add or update entries in `./research/README.md` category tables. This is
    a shared restatement of the mode-specific README step each mode's own flow already gates
@@ -389,39 +389,41 @@ the Commit step stages exactly that list, nothing else.
    uv run .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research --fix
    ```
 
-   Each printed `{source} -> {target}` line preceding the `backlinks_repaired:` count names a
-   `{target}` file this command may have modified.
+   If this command's stderr contains any `warning: could not repair ...` line: that is an
+   operational I/O failure (permissions, disk space, an invalid path) reading or writing a target,
+   not a structural limitation. Halt Post-Actions and report the exact warning text to the user.
 
-   - If `{target}` was **not** dirty in the pre-write baseline captured before this mode started
-     (see [Mode Routing](#mode-routing)): add it to the tracked file list. This includes an entry
-     this run itself just created or refreshed, even though it is now dirty by the time this step
-     runs -- it was clean at baseline, so it is this run's own write, not someone else's.
-   - If `{target}` **was** already dirty in that baseline (present before this run wrote anything):
-     leave it out of the tracked file list -- do not stage someone else's in-progress work alongside
-     the repair -- and report it to the user as `{path} -- pre-existing uncommitted changes, backlink
-     repair not committed this run`.
+   Otherwise, a non-zero exit here reports asymmetric edges the script cannot structurally repair
+   (a dangling link to a missing target, or a manually authored row with a different description
+   it refuses to overwrite) -- continue to step 3 regardless of this exit code. Which files, if
+   any, this command actually modified is determined by step 4's diff, not by this step -- do not
+   parse the printed `{source} -> {target}` lines to guess at modified files, since they list every
+   asymmetric edge found *before* repair is attempted, not which repairs succeeded.
 
-   This command exits non-zero whenever any asymmetric edge remains after the fix pass, including
-   edges it cannot structurally repair (a dangling link to a missing target, or a manually authored
-   row with a different description it refuses to overwrite). That non-zero exit reports remaining
-   edges; it is not a failure of this step -- continue to step 3 regardless of this command's exit
-   code. Only a failure to run the command at all (script or vault path not found) halts
-   Post-Actions here.
-
-3. **Lint** -- run formatting checks on all modified files:
+3. **Lint** -- run formatting checks on every file this run touched (the same diff step 4 uses):
 
    ```bash
-   uv run prek run --files ./research/README.md [tracked file list from steps 1-2]
+   git diff --name-only -- ./research/
+   git ls-files --others --exclude-standard -- ./research/
+   uv run prek run --files ./research/README.md [files from the two commands above]
    ```
 
-4. **Commit** -- if the tracked file list is empty (nothing was created, refreshed, or repaired
-   this run -- e.g. a clean Validate Mode pass where the backlink repair also found nothing
-   writable to fix), skip this step and step 5: there is nothing to commit, and this is not a
-   failure. Otherwise, stage and commit exactly the tracked file list -- never a blanket
-   `git add -A` or a directory-wide `git add ./research/`:
+4. **Commit** -- diff the current working tree against the pre-mode baseline (see
+   [Mode Routing](#mode-routing)) to get the exact list of files under `./research/` this run
+   touched: modified paths from `git diff --name-only -- ./research/`, plus new paths from
+   `git ls-files --others --exclude-standard -- ./research/`. Exclude any path that was **already**
+   dirty in the baseline -- that is another contributor's pre-existing uncommitted work, not
+   something this run produced -- and report it to the user as `{path} -- pre-existing uncommitted
+   changes, not committed this run` instead of staging it.
+
+   If the resulting list is empty (nothing was created, refreshed, or repaired this run -- e.g. a
+   clean Validate Mode pass where the backlink repair also found nothing writable to fix), skip
+   this step and step 5: there is nothing to commit, and this is not a failure. Otherwise, stage
+   and commit exactly that list -- never a blanket `git add -A` or a directory-wide
+   `git add ./research/`:
 
    ```bash
-   git add ./research/README.md ./research/{category}/{name}.md [...tracked file list]
+   git add ./research/README.md ./research/{category}/{name}.md [...files from the diff above]
    git commit -m "docs(research): [action] [resource names]"
    ```
 

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -125,25 +125,7 @@ Load [Duplicate Detection](./references/duplicate-detection.md) (shared with Bat
    ```
 
 4. **Wait** for structured result (status, file path, category, key findings)
-5. **Validate** -- if research status is not `failed`, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) on the created or refreshed file:
-
-   a. Run fix script:
-
-   ```bash
-   uv run .claude/skills/research-curator/scripts/fix_research_formatting.py {file-path-from-agent-result}
-   ```
-
-   b. Run validator:
-
-   ```bash
-   uv run .claude/skills/research-curator/scripts/validate_research.py main --json {file-path-from-agent-result}
-   ```
-
-   c. If validator returns any error-severity issue: mark entry as "created with issues" (or "refreshed with issues" when step 2 routed to `--rerun`), skip steps 6–7, report to user with exact error text from validator JSON
-
-   d. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: the agent just wrote this file this invocation, so it already has the research date, source URL, version, and access dates needed to satisfy these. Spawn `@research-curator` with `--fix` and the exact warning issue list from the JSON, then repeat steps a-b on the same file. If errors or any of these four warning types still remain after the retry, treat as step c.
-
-   e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` and info-severity items do not block this step -- proceed to step 6
+5. **Validate** -- if research status is not `failed`, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) on the created or refreshed file. On its "mark issues" outcome: mark entry as "created with issues" (or "refreshed with issues" when step 2 routed to `--rerun`), skip steps 6–7, and report to user with the exact error or warning text from validator JSON. On its "proceed" outcome, continue to step 6.
 
 6. **Spawn four tasks concurrently** -- if research status is not `failed`:
 
@@ -194,13 +176,7 @@ Extract all tokens after `--batch` matching `https?://` as target URLs. Non-URL 
 
 ### Wave Spawning
 
-Spawn up to 5 `@research-curator` agents per wave via Agent tool. Wait for all agents in the current wave before spawning the next. After all waves complete, for each successful entry, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries):
-
-1. Run fix script: `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py {file}`
-2. Run validator: `uv run .claude/skills/research-curator/scripts/validate_research.py main --json {file}`
-3. If validator returns any error-severity issue: mark entry as "created with issues", skip analysis agents for that entry, include in output report with exact error text
-4. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: spawn `@research-curator` with `--fix` and the exact warning issue list, then repeat steps 1-2 on the same file. If errors or any of these four warning types still remain after the retry, treat as step 3.
-5. If validator passes with zero errors and zero warnings from the four checks in step 4 (`cross_references_absent` does not block this step): spawn concurrent analysis agents — `@research-insight-extractor`, `@research-utilization-assessor`, and `@research-cross-referencer` (up to 5 entries processed concurrently, each with its own set of analysis agents)
+Spawn up to 5 `@research-curator` agents per wave via Agent tool. Wait for all agents in the current wave before spawning the next. After all waves complete, for each successful entry, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries). On its "mark issues" outcome: mark entry as "created with issues", skip analysis agents for that entry, and include the exact error or warning text in the output report. On its "proceed" outcome: spawn concurrent analysis agents — `@research-insight-extractor`, `@research-utilization-assessor`, and `@research-cross-referencer` (up to 5 entries processed concurrently, each with its own set of analysis agents).
 
 See [Batch Mode reference](./references/batch-mode.md) for the complete wave spawning diagram.
 
@@ -281,19 +257,9 @@ flowchart TD
 
 3. Agent reads existing entry, re-gathers fresh data, updates content and freshness tracking
 4. Apply pre-relay quality checklist to agent result
-5. **Validate** -- run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) on the updated file:
+5. **Validate** -- run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) on the updated file. On its "mark issues" outcome: mark entry as "refreshed with issues", skip step 7, and report to user with the exact error or warning text from validator JSON. On its "proceed" outcome, continue to step 6.
 
-   a. Run fix script: `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py ./research/{category}/{name}.md`
-
-   b. Run validator: `uv run .claude/skills/research-curator/scripts/validate_research.py main --json ./research/{category}/{name}.md`
-
-   c. If validator returns any error-severity issue: mark entry as "refreshed with issues", skip step 7, report to user with exact error text from validator JSON
-
-   d. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: the agent just refreshed this file this invocation, so it already has the facts to satisfy these. Spawn `@research-curator` with `--fix` and the exact warning issue list, then repeat steps a-b. If errors or any of these four warning types still remain after the retry, treat as step c.
-
-   e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` does not block this step -- proceed to step 6
-
-6. Update README with refreshed date (only reached on the clean path from step 5 -- an entry marked "refreshed with issues" in step 5c never gets a refreshed date)
+6. Update README with refreshed date (only reached on the "proceed" outcome of step 5 -- an entry marked "refreshed with issues" by step 5's "mark issues" outcome never gets a refreshed date)
 7. Concurrently spawn three analysis agents:
 
    ```text
@@ -310,19 +276,9 @@ flowchart TD
 2. Spawn agents in waves of 5 (same pattern as Batch Mode)
 3. Each agent receives `--rerun ./research/{category}/{name}.md`
 4. Apply pre-relay quality checklist after each wave
-5. **Validate** -- for each successfully updated entry, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) before spawning analysis agents:
+5. **Validate** -- for each successfully updated entry, run the [Validation Gate for New/Refreshed Entries](./references/validation-rules.md#validation-gate-for-newrefreshed-entries) before spawning analysis agents. On its "mark issues" outcome: mark that entry as "refreshed with issues" and skip analysis agents for it. On its "proceed" outcome: include the entry in analysis agent dispatch (step 7).
 
-   a. Run fix script: `uv run .claude/skills/research-curator/scripts/fix_research_formatting.py {file}`
-
-   b. Run validator: `uv run .claude/skills/research-curator/scripts/validate_research.py main --json {file}`
-
-   c. If validator returns any error-severity issue: mark entry as "refreshed with issues", skip analysis agents for that entry
-
-   d. If validator returns zero errors but any warning-severity issue from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`: spawn `@research-curator` with `--fix` and the exact warning issue list, then repeat steps a-b on the same file. If errors or any of these four warning types still remain after the retry, treat as step c.
-
-   e. If validator passes with zero errors and zero warnings from the four checks in (d) -- `cross_references_absent` does not block this step -- include in analysis agent dispatch (step 7)
-
-6. Update README once after all waves complete, refreshing freshness dates only for entries that passed validation in step 5 -- an entry marked "refreshed with issues" in step 5c does not get a refreshed date
+6. Update README once after all waves complete, refreshing freshness dates only for entries that passed validation in step 5 -- an entry marked "refreshed with issues" by step 5's "mark issues" outcome does not get a refreshed date
 7. For each entry that passed validation: spawn concurrent analysis agents per entry (up to 5 entries concurrently) — `@research-insight-extractor`, `@research-utilization-assessor`, `@research-cross-referencer`
 
 </rerun_mode>

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -412,7 +412,10 @@ Validation complete:
 
 ## Post-Actions
 
-Shared by all modes. Execute after any mode completes successfully.
+Shared by all modes. Execute after any mode completes successfully. Track every file path
+written or modified by any step below (agent-created/refreshed entries, README.md,
+insight/utilization files, cross-reference files, backlink-repaired files) in a running list --
+the Commit step stages exactly that list, nothing else.
 
 1. **README Update** -- add or update entries in `./research/README.md` category tables. This is
    a shared restatement of the mode-specific README step each mode's own flow already gates
@@ -420,20 +423,33 @@ Shared by all modes. Execute after any mode completes successfully.
    pass. Do not add a row, or refresh the Last Updated date on an existing row, for any entry
    marked "created with issues" or "refreshed with issues" earlier in this run; that entry's
    README state stays exactly as it was before this run started
-2. **Lint** -- run formatting checks on all modified files:
+
+2. **Backlink Repair** -- deterministically repair the bidirectional cross-reference graph across
+   the whole vault, not just entries this run touched (asymmetric edges can persist from any
+   prior run that predates this check):
 
    ```bash
-   uv run prek run --files ./research/README.md [new-or-modified-files]
+   uv run .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research --fix
    ```
 
-3. **Commit** -- stage and commit all research and insight changes:
+   Each printed `{source} -> {target}` line preceding the `backlinks_repaired:` count names a
+   `{target}` file this command may have modified. Add every such target to the tracked file list.
+
+3. **Lint** -- run formatting checks on all modified files:
 
    ```bash
-   git add ./research/
+   uv run prek run --files ./research/README.md [tracked file list from steps 1-2]
+   ```
+
+4. **Commit** -- stage and commit exactly the tracked file list -- never a blanket `git add -A`
+   or a directory-wide `git add ./research/`:
+
+   ```bash
+   git add ./research/README.md ./research/{category}/{name}.md [...tracked file list]
    git commit -m "docs(research): [action] [resource names]"
    ```
 
-4. **Push** -- push to current branch:
+5. **Push** -- push to current branch:
 
    ```bash
    git push -u origin HEAD
@@ -542,6 +558,6 @@ YYYY-MM-DD
 - Agent: `@research-insight-extractor` at `.claude/agents/research-insight-extractor.md` -- extracts backlog improvements from research entries
 - Agent: `@research-utilization-assessor` at `.claude/agents/research-utilization-assessor.md` -- assesses direct API/service utilization opportunities
 - Agent: `@research-cross-referencer` at `.claude/agents/research-cross-referencer.md` -- appends Cross-References section to research entries
-- Agent: `@research-backlink-detector` at `.claude/agents/research-backlink-detector.md` -- adds backlinks in cited entries during Batch Mode's sequential backlink pass
+- Agent: `@research-backlink-detector` at `.claude/agents/research-backlink-detector.md` -- manual/ad-hoc backlink repair for a single entry; the deterministic `check-backlinks --fix` invocation in [Post-Actions](#post-actions) now covers all four modes and superseded this agent's former sequential pass in Batch Mode
 
 SOURCE: Agent result relay rules and pre-relay checklist adapted from `plugins/summarizer/skills/agent-result-relay/SKILL.md` (accessed 2026-03-06).

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -414,8 +414,11 @@ the Commit step stages exactly that list, nothing else.
    uv run prek run --files ./research/README.md [tracked file list from steps 1-2]
    ```
 
-4. **Commit** -- stage and commit exactly the tracked file list -- never a blanket `git add -A`
-   or a directory-wide `git add ./research/`:
+4. **Commit** -- if the tracked file list is empty (nothing was created, refreshed, or repaired
+   this run -- e.g. a clean Validate Mode pass where the backlink repair also found nothing
+   writable to fix), skip this step and step 5: there is nothing to commit, and this is not a
+   failure. Otherwise, stage and commit exactly the tracked file list -- never a blanket
+   `git add -A` or a directory-wide `git add ./research/`:
 
    ```bash
    git add ./research/README.md ./research/{category}/{name}.md [...tracked file list]

--- a/.claude/skills/research-curator/SKILL.md
+++ b/.claude/skills/research-curator/SKILL.md
@@ -310,10 +310,11 @@ flowchart TD
     RunScriptAll --> ParseJSON
     ParseJSON --> HasErrors{"Does parsed output contain<br>any error-severity issues?"}
     HasErrors -->|"Yes — N error-severity issues found"| SpawnFix["Spawn @research-curator agents in waves of 5<br>Each agent receives --fix flag<br>PLUS the exact error list for that entry from JSON output<br>(not a summary — the raw issue text)"]
-    HasErrors -->|"No — zero error-severity issues"| ReportClean(["Report: all entries passed. Include exact warning and info counts. Stop."])
+    HasErrors -->|"No — zero error-severity issues"| ReportClean["Report: all entries passed. Include exact warning and info counts."]
     SpawnFix --> RelayCheck["Apply pre-relay quality checklist<br>to all fix-agent results"]
     RelayCheck --> ReportSummary["Report validation summary with exact counts<br>(total scanned, passed, errors fixed, warnings noted, info items)"]
     ReportSummary --> PostActions(["Execute Post-Actions — lint, commit, push"])
+    ReportClean --> PostActions
 ```
 
 ### Script Invocation

--- a/.claude/skills/research-curator/references/batch-mode.md
+++ b/.claude/skills/research-curator/references/batch-mode.md
@@ -49,9 +49,8 @@ flowchart TD
     SpawnAnalysisPartial --> Partial["Update ./research/README.md<br>with clean entries only<br>(concurrent with analysis agents)"]
     UpdateAll --> WaitAnalysis["Wait for all analysis agents to complete<br>Collect IMMEDIATE_ATTENTION items from insight results<br>Collect PROPOSALS_WRITTEN counts from utilization results<br>Collect CROSS_REFERENCES_ADDED counts from cross-referencer results"]
     Partial --> WaitAnalysis
-    WaitAnalysis --> BacklinkPass["For each successful entry in sequence (one at a time):<br>spawn @research-backlink-detector<br>'Add backlinks for {file-path}'<br>wait for completion before spawning next<br>(sequential to prevent write races on shared cited entries)"]
-    BacklinkPass --> NotifyUser["If any IMMEDIATE_ATTENTION items exist:<br>report each to user with issue number and reason<br>Otherwise: report total backlog items created count<br>Report total utilization proposals written<br>Report total cross-references added<br>Report total BACKLINKS_ADDED count<br>Relay non-empty SKIPPED lists verbatim"]
-    NotifyUser --> PostActions(["Execute Post-Actions — lint, commit, push"])
+    WaitAnalysis --> NotifyUser["If any IMMEDIATE_ATTENTION items exist:<br>report each to user with issue number and reason<br>Otherwise: report total backlog items created count<br>Report total utilization proposals written<br>Report total cross-references added<br>Relay non-empty SKIPPED lists verbatim"]
+    NotifyUser --> PostActions(["Execute Post-Actions — lint, commit, push, and vault-wide backlink repair"])
 ```
 
 **Wave size**: Maximum 5 concurrent @research-curator agents per wave.
@@ -59,8 +58,6 @@ flowchart TD
 **Sequential waves**: Wait for all agents in current wave to complete before spawning next wave. This prevents overwhelming MCP tool rate limits.
 
 **Analysis phase concurrency**: After all curator waves complete, analysis agents spawn concurrently per entry: up to 5 entries, each spawning its own insight-extractor, utilization-assessor, and cross-referencer. This is distinct from the 5-agent curator wave limit.
-
-**Backlink phase serialization**: After all analysis agents complete, backlink-detector agents run **sequentially** — one entry at a time. Concurrent backlink passes on multiple entries that cite a shared target file would produce a write race (each agent reads a stale snapshot and the last writer drops the other's row). Sequential execution prevents this.
 
 **Validation gate**: Every entry a curator agent successfully wrote this wave passes through the [Validation Gate for New/Refreshed Entries](./validation-rules.md#validation-gate-for-newrefreshed-entries) before it is eligible for the analysis-agent fan-out. Error-severity issues, and warning-severity issues from `header_fields`, `access_dates`, `freshness_tracking`, or `url_format`, are must-fix — the researching agent already has the facts (today's date, the source URL, the version and access dates it just gathered), so a single `--fix` retry is spawned for gated warnings before an entry is marked "created with issues." `cross_references_absent` is not part of this gate.
 
@@ -93,8 +90,6 @@ Files created: [list]
 README updated: Yes
 Utilization proposals written: N files
 Cross-references added: N entries updated
-Backlinks added: N rows across M entries
-Backlink skipped: [(path, reason), ...] (omitted when empty)
 ```
 
 ---

--- a/.claude/skills/research-curator/references/batch-mode.md
+++ b/.claude/skills/research-curator/references/batch-mode.md
@@ -44,7 +44,7 @@ flowchart TD
     UpdateAll --> WaitAnalysis["Wait for all analysis agents to complete<br>Collect IMMEDIATE_ATTENTION items from insight results<br>Collect PROPOSALS_WRITTEN counts from utilization results<br>Collect CROSS_REFERENCES_ADDED counts from cross-referencer results"]
     Partial --> WaitAnalysis
     WaitAnalysis --> NotifyUser["If any IMMEDIATE_ATTENTION items exist:<br>report each to user with issue number and reason<br>Otherwise: report total backlog items created count<br>Report total utilization proposals written<br>Report total cross-references added<br>Relay non-empty SKIPPED lists verbatim"]
-    NotifyUser --> PostActions(["Execute Post-Actions — lint, commit, push, and vault-wide backlink repair"])
+    NotifyUser --> PostActions(["Execute Post-Actions — vault-wide backlink repair, then lint, commit, push (see SKILL.md for the authoritative step order)"])
 ```
 
 **Wave size**: Maximum 5 concurrent @research-curator agents per wave.
@@ -90,9 +90,13 @@ Cross-references added: N entries updated
 
 ## Post-Batch Actions
 
-These happen ONCE after all waves complete (not per-entry):
+These happen ONCE after all waves complete (not per-entry). This restates `SKILL.md`'s
+Post-Actions section for Batch Mode; SKILL.md's numbered steps there are authoritative for exact
+command invocations and ordering.
 
 1. Update `./research/README.md` with all new entries
-2. Run `uv run prek run --files` on README and all new entry files
-3. Commit all changes in a single commit
-4. Push to current branch
+2. Repair the bidirectional cross-reference graph across the whole vault (`check-backlinks --fix`)
+3. Run `uv run prek run --files` on the filtered list -- README, new entry files, and any files
+   step 2 repaired
+4. Commit all changes in a single commit
+5. Push to current branch

--- a/.claude/skills/research-curator/references/batch-mode.md
+++ b/.claude/skills/research-curator/references/batch-mode.md
@@ -4,12 +4,6 @@ Processing multiple URLs in parallel via `--batch`.
 
 ---
 
-## Layer Filter
-
-When `--layer 0|1|2` is also present, apply the layer filter to scope category selection. Pass the layer value to each `@research-curator` agent as context so it classifies entries within the appropriate SDLC layer.
-
----
-
 ## URL Parsing
 
 Extract URLs from the `--batch` argument. Input format:

--- a/.claude/skills/research-curator/scripts/validate_research.py
+++ b/.claude/skills/research-curator/scripts/validate_research.py
@@ -954,9 +954,16 @@ def check_backlinks(
             try:
                 if _repair_one_asymmetric_pair(bl, source, target, vault_path):
                     repaired += 1
-            except (OSError, ValueError):
+            except OSError as exc:
                 typer.echo(
-                    f"warning: could not repair {source.relative_to(vault_path)} -> {target.relative_to(vault_path)}",
+                    f"warning: io-error, could not repair {source.relative_to(vault_path)} -> "
+                    f"{target.relative_to(vault_path)}: {exc}",
+                    err=True,
+                )
+            except ValueError as exc:
+                typer.echo(
+                    f"warning: structural, could not repair {source.relative_to(vault_path)} -> "
+                    f"{target.relative_to(vault_path)}: {exc}",
                     err=True,
                 )
 

--- a/.claude/skills/research-curator/scripts/validate_research.py
+++ b/.claude/skills/research-curator/scripts/validate_research.py
@@ -810,14 +810,16 @@ def _repair_one_asymmetric_pair(bl: types.ModuleType, source: Path, target: Path
 
     CrossRefRow = bl.CrossRefRow  # type: ignore[attr-defined]
 
+    # forward_row's entry_name is always target's own display name -- a cross-reference
+    # row's entry_name names the *other* entry a row points at, never the file the table
+    # lives in. source_name must therefore never come from forward_row.
+    source_name: str = source.stem
     if forward_row is not None:
-        source_name: str = getattr(forward_row, "entry_name", source.stem)
         forward_rel: str = getattr(forward_row, "relationship", "")
         backlink_relationship = bl.transform_to_backlink_description(
             forward_rel, source_name, source_category, bl.category_of(target, vault_path)
         )
     else:
-        source_name = source.stem
         backlink_relationship = f"referenced by {source_name} ({source_category})"
 
     backlink_row = CrossRefRow(


### PR DESCRIPTION
## Summary

Skill Lapidary audit findings for `.claude/skills/research-curator/SKILL.md`, three owner-approved changes:

- **Bidirectional cross-reference graph (goal 5)**: `check-backlinks --fix` existed but no mode ever invoked it — Default/Rerun-single/Rerun-all did nothing, and only Batch Mode ran a sequential `@research-backlink-detector` agent pass. Wired the deterministic script into the shared `## Post-Actions` step instead, so all four modes get it from one invocation. Verified against `./research/`: **823 asymmetric edges, 822 auto-repairable, 1 permanently unrepairable** (a malformed entry — see below). `research-backlink-detector`'s own doc already documents invoking it via `check-backlinks`, and its workflow is functionally identical to the script's repair logic, so Batch Mode's sequential pass (and its write-race justification) is now redundant and removed. The agent remains available for manual/ad-hoc use.
- **Duplicated validation-gate procedure**: the gated-warning list and its a–e/1–5 handling procedure were restated in full 4 times (Default, Batch, Rerun-single, Rerun-all) despite every copy already linking to `references/validation-rules.md`'s authoritative flowchart. Collapsed each to a link plus the flowchart's own terminal-outcome labels ("mark issues" / "proceed"), preserving genuinely mode-specific detail. Also fixed two now-stale "step 5c" references left over from the collapse. **SKILL.md: 547 lines before this PR, ~593 after** the review-hardening rounds below (against Claude Code's 500-line recommendation).
- **`--layer` flag removed**: only `batch-mode.md` defined any layer behavior (batch only), the flag was absent from `argument-hint`, and `SKILL.md` said it applies to two *other* skills — this skill was documenting someone else's flag. It filters on entries' `layer:` metadata, carried by only 5 of ~513 entries. Owner confirmed never using it. Removed the routing branches, the describing sentence, and `batch-mode.md`'s Layer Filter section.

Also narrowed `## Post-Actions`' commit step from a directory-wide `git add ./research/` to an explicit tracked-file list, per `AGENTS.md`'s file-scoped commit requirement.

### Review-driven hardening (Codex, 10 rounds — every finding verified locally, not accepted on claim)

Codex's review caught a long, genuinely serious sequence of correctness gaps in the Post-Actions design as first written. Highlights:

- **The most severe finding**: the vault's one permanently-unrepairable edge (`coding-agents/pilot-shell.md -> coding-agents/soulforge.md`, caused by a malformed Cross-References table with no markdown link) raises the *same* exception-handling path, and the script emitted *identical* warning text, for a genuine I/O failure and a structural parse failure. An earlier hardening round had (correctly, per Codex's own prior finding) made Post-Actions halt on any such warning — meaning this PR would have made Post-Actions halt on **every single invocation, forever**, until someone hand-fixes `soulforge.md`. Fixed at the script level: `validate_research.py`'s exception handler now emits distinguishable `io-error` vs `structural` warning text, verified end-to-end against a live copy of the real vault (822/823 repaired, correct warning text for the remaining edge).
- A pre-existing bug in `_repair_one_asymmetric_pair()` (not otherwise touched by this PR) mislabeled every backlink row it writes — used the *target's* display name instead of the *source's*. Reproduced locally, fixed, re-verified. This function was never exercised at vault scale before this PR, so shipping without this fix would have corrupted vault content on every run.
- The commit/lint file list was originally derived by parsing the script's printed text output; replaced with an actual `git diff` against a pre-mode baseline — more robust, and closes several related gaps (empty-list handling for `prek`, untracked-file granularity, pathspec'd commits immune to pre-staged unrelated work).
- The whole invocation is now bounded (`scripts/run_bounded.py`, per AGENTS.md's own convention) with correct exit-code precedence: timeout (124) always halts, even if the scan had already printed partial output.
- `batch-mode.md`'s own diagram and its separate Post-Batch Actions list both described Post-Actions in the wrong order (or omitted repair) relative to SKILL.md's authoritative procedure — fixed to match.
- Two remaining gaps — `check-backlinks` silently swallowing scan-phase errors, and a cosmetic slug-vs-title label quality issue — require further script changes; tracked as backlog **#3516** rather than open-ended scope expansion into a documentation PR.

## Test plan

- [x] `check-backlinks ./research`: 823 asymmetric edges before wiring
- [x] Full documented command chain (`run_bounded.py` → `uv run` → `check-backlinks --fix`) run end-to-end against a live copy of `./research/`: 822/823 repaired, correct `warning: structural, ...` text for the one remaining edge
- [x] Reproduced and fixed the entry-name mislabeling bug with a local two-entry scratch vault (before/after)
- [x] Reproduced `prek run --files`'s empty-list fallback behavior with a throwaway repo + local echo hook
- [x] Reproduced `git status --porcelain`'s untracked-directory collapsing behavior with a throwaway repo
- [x] `ruff check`, `ruff format --check`, and `ty check` clean on the modified Python script
- [x] `uv run prek run --files` clean on every changed file after every commit
- [x] Grepped for remaining `--layer` references across the skill directory — none found
- [x] Verified every touched Mermaid diagram still matches its prose, and all markdown links/anchors resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)