### PR TITLE
refactor(research-curator): make the skill self-contained, add an entry review rubric

### DIFF
--- a/.claude/agents/research-backlink-detector.md
+++ b/.claude/agents/research-backlink-detector.md
@@ -80,18 +80,10 @@ inline the transform table here.
 
 ## Section Format
 
-Backlink rows use the same canonical table format as the research-cross-referencer:
-
-```markdown
-## Cross-References
-
-| Entry | Category | Relationship |
-|-------|----------|--------------|
-| [Source Entry Name](../source-category/source-entry.md) | source-category | {transformed backlink description} |
-```
-
-Relative paths in the backlink row are relative to the **cited entry's** own directory, not
-the source entry's directory. Use `pathlib.Path` to compute the correct relative path.
+Backlink rows use the same canonical table as forward rows:
+[Cross-Reference Format](./../skills/research-curator/references/cross-reference-format.md).
+Its Link Paths section is the one that governs here — a backlink row's path is relative to the
+**cited** entry's directory, the file being written into, not the source entry's.
 
 ---
 

--- a/.claude/agents/research-cross-referencer.md
+++ b/.claude/agents/research-cross-referencer.md
@@ -51,32 +51,10 @@ flowchart TD
 
 ## Section Format
 
-The section is appended after `## Freshness Tracking` for legacy text-header entries, or after
-`## References` when the entry has no body Freshness Tracking heading (freshness data lives in
-frontmatter instead). Use relative paths from the entry's own directory:
-
-- Same-category entries: `./other-entry.md`
-- Different-category entries: `../other-category/filename.md`
-
-```markdown
----
-
-## Cross-References
-
-| Entry | Category | Relationship |
-|-------|----------|--------------|
-| [Resource Name](../other-category/filename.md) | other-category | {specific one-phrase relationship} |
-| [Resource Name](./same-category-file.md) | same-category | {specific one-phrase relationship} |
-```
-
-The **Relationship** column must name the specific conceptual link. It must never be a generic
-label like "related tool". Good examples:
-
-- "alternative MCP server transport approach"
-- "provides the embedding layer this tool queries"
-- "shares async task execution model"
-- "complements this tool's data collection with analysis"
-- "overlapping use case: structured agent output validation"
+Write the table, place it, and compute its link paths per
+[Cross-Reference Format](./../skills/research-curator/references/cross-reference-format.md).
+Load it before editing the entry — it is the single source of truth for the column shape, the
+placement anchor, the relative-path rule, and the bar the **Relationship** phrase must clear.
 
 ---
 

--- a/.claude/agents/research-curator.md
+++ b/.claude/agents/research-curator.md
@@ -15,6 +15,8 @@ Single-entry research executor. Creates comprehensive research entries for tools
 - Standalone -- spawned directly via Agent tool with a URL/resource name
 - Orchestrated -- spawned by the `/research-curator` skill as a worker in batch/rerun/fix workflows
 
+The entry contract this agent writes against — extraction phases, fidelity rules, per-section depth, template and categories — lives in the skill's references, not here. Load each at the step that names it.
+
 ---
 
 ## Research Workflow
@@ -48,7 +50,7 @@ flowchart TD
     Organize --> Write[Phase 3 — Write entry grounded in extracts]
     Write --> Confidence[Phase 4 — Assign confidence per section]
     Confidence --> Validate[Phase 5 — Verify every claim traces to an extract]
-    Validate --> SelectCat[Select category from list]
+    Validate --> SelectCat[Select category from entry-template.md flowchart]
     SelectCat --> WriteFile[Write entry to ./research/category/resource-name.md]
     WriteFile --> Return[Return structured result]
 
@@ -94,7 +96,7 @@ Tested procedure — environment-scope caveat and full reproduced evidence in [r
 2. Explore via `Read`/`Grep`/`Glob` with the worktree path — never `cd` (doesn't persist between Bash calls in this environment).
 3. A `gh api`/`curl api.github.com` 403 on an out-of-scope repo is final — go to step 5, don't retry.
 4. Never call `add_repo` to route around step 3 — it's reserved for explicit user requests.
-5. Blocked metadata that's still needed (e.g. latest release version): pull from in-clone data (`CITATION.cff`, manifests, `CHANGELOG.md`) or mark unavailable per Fidelity Rule 3. Do NOT chase stars/forks/contributor counts via any fallback — see Rule 2a, that data is never gathered.
+5. Blocked metadata that's still needed (e.g. latest release version): pull from in-clone data (`CITATION.cff`, manifests, `CHANGELOG.md`) or mark unavailable in the Rule 3 language. Do NOT chase stars/forks/contributor counts via any fallback — Rule 2a puts that data out of scope permanently.
 
 </repo_access_procedure>
 
@@ -106,7 +108,7 @@ After cloning, `./.worktrees/{repo-name}/` is the primary source entry point for
 - `gh api repos/{owner}/{repo}/releases/latest` via Bash -- latest release version and date
 - When interacting with THIS repo (claude_skills), always use `-R Jamie-BitFlight/claude_skills` flag
 
-Do NOT query stars, forks, or contributor counts — see Rule 2a. That data is out of scope
+Do NOT query stars, forks, or contributor counts — Rule 2a. That data is out of scope
 regardless of whether the repo is in-session or out-of-scope.
 
 **Fallback**:
@@ -122,280 +124,35 @@ regardless of whether the repo is in-session or out-of-scope.
 
 <methodology>
 
-This agent applies a two-phase extractive approach before writing any content. Skipping extraction and writing directly from memory or inference is FORBIDDEN.
+Load [Extraction Methodology](./../skills/research-curator/references/extraction-methodology.md) before extracting anything, and follow its phases in order. It carries the extract record format, the three Doc-Sufficiency Check questions, the Phase 1b file tiers and exclusions, and what counts as a claim requiring a source.
 
-### Phase 1: Extract Key Passages
+The phase order never changes:
 
-BEFORE writing any section of the entry, extract relevant quotes and data points from primary sources. Record each extract with its source.
-
-Use this format during extraction (internal working notes, not written to the entry file):
-
-```text
-EXTRACTED PASSAGES — {resource-name}
-
-1. "{exact quote or data point}"
-   Source: {URL or tool + section}
-   Relevance: {which entry section this feeds}
-
-2. "{exact quote or data point}"
-   Source: {URL or tool + section}
-   Relevance: {which entry section this feeds}
-```
-
-Apply this to EVERY section: features, architecture, installation steps, usage examples, limitations. Numbers, version strings, benchmark figures, and configuration values MUST be quoted verbatim from source — never paraphrased or estimated.
-
-**Relevance values**: Use the exact section names from the entry template — Overview, Problem Addressed, Key Features, Technical Architecture, Installation & Usage, Relevance to Claude Code Development, References, Freshness Tracking. This enables the doc-sufficiency check after Phase 1 to filter extracts by section.
-
-### Doc-Sufficiency Check (run immediately after Phase 1 completes)
-
-Record the result as a working note — do NOT write it to the entry file.
-
-1. Scan your Phase 1 extracts tagged with `Relevance: Technical Architecture` or `Relevance: Key Features`.
-2. Answer each question YES or NO:
-   - Q1: Do any extracts name at least 2 specific component, module, or class names (not generic descriptions like "has a plugin system")?
-   - Q2: Do any extracts describe how data or control flows between at least 2 named components (not generic statements like "processes data")?
-   - Q3: Do any extracts name an extension point, plugin interface, hook system, or registration mechanism with its concrete API?
-3. If ANY answer is NO: record working note "Architecture depth requirements unsatisfied — triggering code analysis" and proceed to Phase 1b.
-4. If ALL answers are YES: record working note "Architecture depth requirements satisfied from docs" and skip to Phase 2.
-
-### Phase 1b: Code Analysis (conditional)
-
-This phase triggers ONLY when the doc-sufficiency check recorded "Architecture depth requirements unsatisfied — triggering code analysis". It reads source files from the shallow clone to extract architectural evidence that documentation did not provide.
-
-**Phase 1b Procedure** (when triggered):
-
-1. **Detect primary language**: Check for `pyproject.toml` (Python), `package.json`
-   (Node.js/TypeScript), `Cargo.toml` (Rust), `go.mod` (Go), `pom.xml` / `build.gradle`
-   (Java/Kotlin). If none found, count file extensions via Glob to determine the dominant
-   language.
-
-2. **Read files in tier order** — stop at 12 files total:
-
-   **Tier 1 — Entrypoints** (read these first):
-
-   - Python: `**/main.py`, `**/cli.py`, `**/app.py`, `**/__main__.py`, `**/server.py`, `**/wsgi.py`, `**/asgi.py`
-   - Node/TS: `**/index.ts`, `**/index.js`, `**/main.ts`, `**/main.js`, `**/app.ts`, `**/app.js`, `**/server.ts`, `**/server.js`
-   - Go: `**/main.go`, `**/cmd/**/main.go`
-   - Rust: `**/main.rs`, `**/lib.rs`
-   - Java/Kotlin: `**/Application.java`, `**/Main.java`, `**/App.kt`
-   - Ruby: `**/config.ru`, `**/Rakefile`, `**/bin/*`
-
-   **Tier 2 — Type/schema declarations** (read after Tier 1):
-
-   - Python: `**/models.py`, `**/schema.py`, `**/schemas.py`, `**/types.py`, `**/models/*.py`
-   - Node/TS: `**/types.ts`, `**/types.d.ts`, `**/schema.ts`, `**/models/*.ts`, `**/interfaces.ts`
-   - Go: `**/types.go`, `**/models.go`
-   - Rust: `**/types.rs`, `**/models.rs`, `**/schema.rs`
-   - Any language: `**/*.proto`, `**/openapi.yaml`, `**/openapi.yml`, `**/openapi.json`, `**/schema.graphql`, `**/schema.json`
-
-   **Tier 3 — Index/barrel files** (read last):
-
-   - Python: `**/__init__.py` (top-level package directories only — skip deeply nested), `**/api.py`, `**/routes.py`, `**/urls.py`
-   - Node/TS: `**/index.ts` (in subdirectories — barrel exports), `**/exports.ts`
-   - Go: `**/doc.go`
-   - Rust: `**/mod.rs`
-   - Any language: `**/plugin.py`, `**/plugins/*.py`, `**/extensions/*.ts`, `**/middleware/*.py`, files matching `**/register*`
-
-   **Exclusions** — never read:
-
-   - Test files: `**/test_*.py`, `**/*_test.go`, `**/*.test.ts`, `**/*.spec.ts`, `**/*_test.*`, `**/*.test.*`
-   - Dependency dirs: `**/node_modules/**`, `**/.venv/**`, `**/vendor/**`, `**/__pycache__/**`
-   - Build artifacts: `**/*.min.js`, `**/*.bundle.js`, `**/dist/**`, `**/build/**`, `**/target/**`
-   - Files over 500 lines: skip and note "Skipped {path}: {N} lines (over 500-line limit)"
-
-   **Selection within a tier**: Prefer files in `src/` over root. Prefer shorter paths over
-   deeper paths. Read each file fully (do not use line limits). Increment the file counter after
-   each Read. Stop when counter reaches 12 or all tiers are exhausted. Record how many candidate
-   files remain unread when budget is exhausted.
-
-3. **Extract architectural evidence** from each file read. Record extracts using this format:
-
-   ```text
-   N. "{exact code passage — class definition, function signature, import block, or schema}"
-      Source: {relative-path}:{start-end lines} — {exported name}
-      Relevance: Technical Architecture | Key Features
-      Confidence: code-read
-   ```
-
-   Focus extraction on:
-
-   - Class/struct definitions with their public methods (architecture)
-   - Function signatures that reveal data flow (architecture)
-   - Import statements that reveal component dependencies (architecture)
-   - Schema/model field definitions (architecture)
-   - Registration patterns — decorators, register() calls, plugin lists (extension points)
-   - Configuration handling that reveals supported options (features)
-
-4. **Merge code extracts with Phase 1 extracts**. Both sets feed into Phase 2 identically.
-   Code extracts are distinguished only by their `Confidence: code-read` tag.
-
-### Phase 2: Write From Extracts
-
-Write each entry section by organizing the extracted passages for that section, then composing prose or structured content grounded in those extracts.
-
-REQUIRED verification step: Before finalizing a section, confirm that every factual claim in that section traces to at least one extracted passage. If a claim cannot be traced, either find a source passage or remove the claim.
-
-### What Counts as a Claim Requiring a Source
-
-- Version numbers ("v2.3.1")
-- Performance figures ("processes 10k events/sec")
-- Feature descriptions ("supports async/await")
-- License type
-- Architectural assertions ("uses a DAG-based task graph")
-- Installation commands (verify against official docs, not inferred)
-- Compatibility statements ("requires Python 3.11+")
-
-SOURCE: "Extract before abstracting" methodology from [fidelity-rules.md](./../../plugins/summarizer/skills/summarizer/references/fidelity-rules.md) Rule 2 (accessed 2026-03-06). Quote-grounding technique from Anthropic prompt engineering documentation (<https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/long-context-tips>, accessed 2026-02-06).
+1. **Phase 1 — Extract**: pull exact passages from every primary source, each recorded with its source and the entry section it feeds. Writing any section before this is FORBIDDEN.
+2. **Doc-Sufficiency Check**: three binary questions over the architecture and feature extracts. Any NO triggers Phase 1b.
+3. **Phase 1b — Code analysis**, only when the check answered NO: read source files from the shallow clone in tier order, up to 12 files, and merge the code extracts into the Phase 1 set.
+4. **Phase 2 — Write**: compose each section from its extracts, then confirm every factual claim in that section traces to at least one extract before finalizing the section.
 
 </methodology>
 
 ---
 
-## Fidelity Rules
+## Entry Contract
 
-<fidelity_rules>
+Every entry this agent produces must satisfy the Fidelity Rules (1, 2, 2a, 3, 4) and the per-section Depth Requirements in [Entry Quality Standards](./../skills/research-curator/references/entry-quality-standards.md). Load it before Phase 2 and keep it in context while writing — it is the bar the entry is reviewed against.
 
-These rules apply to every research entry produced by this agent.
+Two of its rules bind gathering, before any writing begins:
 
-### Rule 1: Read Before Writing
-
-NEVER describe a resource based on its name, URL path, or domain alone. ALWAYS fetch and read primary sources before writing any section.
-
-If a source cannot be accessed: write "Unable to access [source]: [reason]" in the entry's References section. Do NOT infer content.
-
-### Rule 2: Preserve Counts and Specifics
-
-Write exact numbers as found in primary sources when the number describes what the resource
-does or how well it does it. NEVER substitute vague quantifiers for a capability figure.
-Popularity metrics (stars, downloads, forks) are out of scope entirely — see Rule 2a.
-
-| Source Says | Write | NEVER Write |
-|-------------|-------|-------------|
-| "supports 12 languages" | "supports 12 languages" | "many languages" |
-| "v0.8.2, released 2025-11-03" | "v0.8.2 (released 2025-11-03)" | "recent release" |
-| "benchmark: 45ms p99 latency" | "45ms p99 latency" | "low latency" |
-
-### Rule 2a: No Popularity Statistics
-
-Do NOT gather or write star counts, download counts, fork counts, or contributor counts.
-These describe how popular a resource is, not what it does, how it does it, or why it's
-valuable — they don't inform the review or utility judgments this entry exists to support,
-and a reader can query them programmatically at any time via `gh api repos/{owner}/{repo}`
-if genuinely needed. There is no "Key Statistics" section in the entry template; do not
-add one, and do not fold this data into another section.
-
-### Rule 3: Distinguish Absence from Nonexistence
-
-Use precise language when information is not found in sources.
-
-| Situation | Write | NEVER Write |
-|-----------|-------|-------------|
-| Searched but not in source | "Not mentioned in documentation" | "Doesn't support X" |
-| Source inaccessible | "Unable to access [source]" | "Not available" |
-| Source doesn't cover topic | "Outside the scope of reviewed sources" | "Not supported" |
-| Contradictory sources | "Source A states X; Source B states Y" | "The answer is X" |
-
-### Rule 4: State Confidence Explicitly
-
-Each major section of the entry MUST have a confidence level. Record this in the entry's Freshness Tracking section as a confidence map.
-
-**Confidence levels**:
-
-- `high` -- full primary source read, official documentation, recent and dated
-- `medium` -- partial read, informal source, or single source with no corroboration
-- `low` -- inferred, dated source (>12 months), or source conflict
-
-**Factors that reduce confidence**: source truncated, source is informal (blog post vs official docs), sources contradict each other, content required interpretation rather than extraction.
-
-**Factors that increase confidence**: full read of official documentation, multiple sources agree, content is structured/machine-readable (API spec, package manifest), source is dated and recent.
-
-SOURCE: Confidence scoring methodology from [fidelity-rules.md](./../../plugins/summarizer/skills/summarizer/references/fidelity-rules.md) Rule 6 (accessed 2026-03-06).
-
-</fidelity_rules>
+- **Rule 2a** — never gather star, download, fork, or contributor counts. Not via `gh api`, not via web search, not from a README badge; in session scope or out of it.
+- **Rule 3** — when a source cannot be reached, or does not cover a topic, say exactly that. "Not mentioned in documentation" and "Unable to access {source}" are the language.
 
 ---
 
-## Depth Requirements
+## Entry Template and Category
 
-<depth_requirements>
-
-Research entries MUST go beyond surface-level feature lists. Each entry section has a minimum depth requirement.
-
-### Architecture Section — REQUIRED depth
-
-Do NOT write "uses a plugin-based architecture" without explaining what that means concretely. MUST include:
-
-- Core components and their relationships (with exact names from source)
-- Data flow or execution model
-- Key design decisions and their stated rationale (if documented)
-- Extension or integration points
-
-### Features Section — REQUIRED depth
-
-For each documented feature:
-
-1. State what it does (extracted from source)
-2. State HOW it does it — the mechanism, not just the outcome
-3. Include a concrete example if the source provides one
-4. Note any configuration or constraints
-
-### Usage Examples Section — REQUIRED depth
-
-MUST include at least one complete, working example extracted verbatim or adapted minimally from official documentation. Examples invented without a source basis are FORBIDDEN.
-
-For installation commands: verify the exact command from official docs. Do NOT construct install commands from assumed package names.
-
-### Limitations and Caveats Section
-
-REQUIRED — not optional. Every tool has limitations. If primary sources document none, write: "No limitations documented in reviewed sources (confidence: low — absence of documented limitations does not confirm absence of limitations)."
-
-</depth_requirements>
-
----
-
-## Category List
-
-<categories>
-
-Select the most appropriate category for the resource. Create the directory under `./research/` if it does not exist.
-
-- research-agent-patterns -- multi-agent orchestration
-- skill-generation-tools -- creates AI skills/prompts
-- prompt-engineering -- prompt optimization/testing
-- context-management -- memory, RAG, context window
-- mcp-ecosystem -- MCP server or integration
-- agent-frameworks -- agent SDK or framework
-- evaluation-testing -- agent evaluation/benchmarking
-- developer-tools -- developer productivity tool
-- async-libraries -- async/concurrency library
-- agent-infrastructure -- infrastructure for agents at scale
-- api-frameworks -- API/web framework
-- ai-observability -- LLM observability/debugging
-- code-auditing -- code security/auditing
-- coding-agents -- autonomous coding agent
-- data-infrastructure -- real-time data platform
-- ml-infrastructure -- ML compute/model serving
-- python-runtimes -- alternative Python runtime
-- rust-python-bindings -- Rust-Python bindings
-- task-management -- task management for dev
-- documentation-tools -- documentation tooling
-- llm-infrastructure -- LLM infra/serving
-- low-code-platforms -- low-code/no-code platform
-- ai-design-tools -- AI design tools
-- ai-research-tools -- AI research tools
-- ai-writing-tools -- AI writing tools
-
-</categories>
-
----
-
-## Entry Template
-
-Follow the entry template in [entry-template.md](./../skills/research-curator/references/entry-template.md).
+Follow the entry template, and select the category with the flowchart, in [entry-template.md](./../skills/research-curator/references/entry-template.md). Create the category directory under `./research/` if it does not exist.
 
 Entry files go at `./research/{category}/{resource-name}.md`.
-
-All sections in the template MUST be complete with real data gathered from primary sources. Placeholders, "TBD", and bare "N/A" are FORBIDDEN. If data is genuinely unavailable, write what was searched, what was found, and why the data is absent.
 
 ---
 
@@ -430,12 +187,7 @@ flowchart TD
 1. READ the existing entry file first.
 2. Re-gather fresh data for versions and features from primary sources.
 3. Re-extract passages. Note where data has changed vs. the existing entry.
-4. Run the Doc-Sufficiency Check on the re-extracted passages (same three binary questions):
-   - Q1: Do any extracts name at least 2 specific component, module, or class names (not generic descriptions like "has a plugin system")?
-   - Q2: Do any extracts describe how data or control flows between at least 2 named components (not generic statements like "processes data")?
-   - Q3: Do any extracts name an extension point, plugin interface, hook system, or registration mechanism with its concrete API?
-   If ANY answer is NO: record working note "Architecture depth requirements unsatisfied — triggering code analysis" and proceed to Phase 1b before updating sections.
-   If ALL answers are YES: record working note "Architecture depth requirements satisfied from docs" and skip Phase 1b.
+4. Run the Doc-Sufficiency Check from [Extraction Methodology](./../skills/research-curator/references/extraction-methodology.md) on the re-extracted passages. Any NO: proceed to Phase 1b before updating sections. All YES: skip Phase 1b.
 5. (Conditional) Run Phase 1b code analysis on the worktree if the doc-sufficiency check failed. Merge the resulting code extracts with the re-extracted passages before updating sections.
 6. Update sections where source data has changed. Preserve sections where source data is unchanged.
 7. Update Freshness Tracking with today's date and new confidence assessments — in frontmatter
@@ -467,7 +219,7 @@ When a primary source cannot be fetched:
 4. Document the inaccessibility in the entry's References section with the exact error.
 5. If fallback sources exist (e.g., GitHub README when docs site is down), fetch those and note the fallback in the entry.
 
-"Not mentioned in the sources I could access" is NOT the same as "doesn't exist." Use the precise language from the Fidelity Rules.
+"Not mentioned in the sources I could access" is NOT the same as "doesn't exist." Use the precise Rule 3 language.
 
 </inaccessibility_handling>
 

--- a/.claude/agents/research-insight-extractor.md
+++ b/.claude/agents/research-insight-extractor.md
@@ -54,20 +54,23 @@ When the research entry describes an external tool's pattern, map it to the clos
 
 | Pattern domain | Look for local system at |
 |---|---|
-| Agent orchestration, task dispatch, concurrency | `.claude/skills/implement-feature/SKILL.md` |
-| Task state, status tracking, retry | `.claude/skills/implementation-manager/` scripts and `SKILL.md` |
-| Task hooks, lifecycle events | `.claude/skills/start-task/SKILL.md`, `task_status_hook.py` |
-| Skill structure, frontmatter, validation | `.claude/skills/research-curator/`, `plugin-creator/skill-creator/SKILL.md` |
+| Agent orchestration, task dispatch, concurrency | `plugins/development-harness/skills/implement-feature/SKILL.md` |
+| Task state, status tracking, retry | `plugins/development-harness/skills/implementation-manager/` scripts and `SKILL.md` |
+| Task hooks, lifecycle events | `plugins/development-harness/skills/start-task/SKILL.md`, `plugins/development-harness/skills/implementation-manager/scripts/task_status_hook.py` |
+| Skill structure, frontmatter, validation | `.claude/skills/research-curator/`, `plugins/plugin-creator/skills/skill-creator/SKILL.md` |
 | Research workflows | `.claude/agents/research-curator.md`, `.claude/skills/research-curator/SKILL.md` |
-| Backlog, issue management | `.claude/skills/backlog/SKILL.md` |
-| Agent creation, agent format | `.claude/agents/`, `plugin-creator/agent-creator/SKILL.md` |
+| Backlog, issue management | `plugins/development-harness/skills/work-backlog-item/SKILL.md` |
+| Agent creation, agent format | `.claude/agents/`, `plugins/plugin-creator/skills/agent-creator/SKILL.md` |
 | Multi-agent fan-out, parallel work | `plugins/agent-orchestration/skills/parallel-work/SKILL.md` |
-| Code review, quality gates | `.claude/skills/complete-implementation/SKILL.md` |
-| Context management, memory | CLAUDE.md, `.claude/rules/` |
-| MCP tools, server integration | `.claude/skills/fastmcp-creator/SKILL.md` |
-| Testing, validation | `python3-development:fastmcp-python-tests` SKILL.md |
+| Code review, quality gates | `plugins/development-harness/skills/complete-implementation/SKILL.md` |
+| Context management, memory | `.claude/CLAUDE.md`, `AGENTS.md`, `rules/` |
+| MCP tools, server integration | `plugins/fastmcp-creator/skills/fastmcp-creator/SKILL.md` |
+| Testing, validation | `plugins/fastmcp-creator/skills/fastmcp-python-tests/SKILL.md` |
 
-If the pattern does not map to any listed system, search with `Glob` for relevant files before concluding there is no match.
+This table is a starting point that drifts as skills move between plugins. Read the path before
+using it; when it does not exist, `Glob` for the skill directory by name and use what you find
+rather than treating the pattern as unmapped. If the pattern maps to no local system at all,
+`Glob` for relevant files before concluding there is no match.
 
 </system_map>
 

--- a/.claude/skills/research-curator/references/cross-reference-format.md
+++ b/.claude/skills/research-curator/references/cross-reference-format.md
@@ -1,0 +1,64 @@
+# Cross-Reference Format
+
+The canonical shape of a research entry's `## Cross-References` section. Every producer of
+cross-reference rows — `@research-cross-referencer` writing forward links, `@research-backlink-detector`
+writing reciprocal ones, and anyone adding a row by hand — writes rows in exactly this form, so the
+graph stays parseable by `backlink_lib.py` and symmetric under
+`validate_research.py check-backlinks`.
+
+---
+
+## Table
+
+```markdown
+---
+
+## Cross-References
+
+| Entry | Category | Relationship |
+|-------|----------|--------------|
+| [Resource Name](../other-category/filename.md) | other-category | {specific one-phrase relationship} |
+| [Resource Name](./same-category-file.md) | same-category | {specific one-phrase relationship} |
+```
+
+Column order and header text are fixed. Do not add, rename, or reorder columns.
+
+---
+
+## Placement
+
+The section goes at the end of the entry, anchored to whichever heading the entry actually has:
+
+- Entry has a body `## Freshness Tracking` heading (legacy text-header entry) → append after `## Freshness Tracking`.
+- Entry has no body Freshness Tracking heading (freshness lives in frontmatter) → append after `## References`.
+
+If a `## Cross-References` section already exists, replace it — never append a second one.
+
+---
+
+## Link Paths
+
+Relative paths are computed from the directory of the entry the row is being written **into**, not from the entry the row points at:
+
+- Forward row in entry A citing entry B: path is relative to A's directory.
+- Backlink row written into cited entry B pointing at source entry A: path is relative to B's directory.
+
+Within a category: `./other-entry.md`. Across categories: `../other-category/filename.md`. Use `pathlib.Path` to compute the relative path rather than assembling it by hand.
+
+Every path must resolve to a real file. Rows pointing at paths that do not exist on disk are defects — `validate_research.py check-backlinks` reports them, and `@research-backlink-detector` skips them with reason `path not found`.
+
+---
+
+## Relationship Phrase
+
+The **Relationship** column names the specific conceptual link between the two entries. A generic label — "related tool", "similar project", "see also" — fails this bar.
+
+Good examples:
+
+- "alternative MCP server transport approach"
+- "provides the embedding layer this tool queries"
+- "shares async task execution model"
+- "complements this tool's data collection with analysis"
+- "overlapping use case: structured agent output validation"
+
+Backlink rows do not restate the forward phrase verbatim — they carry its inverse, produced by `transform_to_backlink_description()` in [backlink_lib.py](./../scripts/backlink_lib.py), which is the single source of truth for that transform.

--- a/.claude/skills/research-curator/references/entry-quality-standards.md
+++ b/.claude/skills/research-curator/references/entry-quality-standards.md
@@ -1,0 +1,122 @@
+# Research Entry Quality Standards
+
+The content contract every research entry under `./research/` must satisfy, whoever writes it.
+
+Two halves, always consulted together:
+
+- **Fidelity Rules** govern each individual claim — where it came from, how precisely it is stated, and how confident the entry is in it.
+- **Depth Requirements** govern each section's coverage — how much a section must say before it counts as written.
+
+Reviewing a finished entry rather than writing one? Use [Entry Review Rubric](./entry-review-rubric.md), which turns both halves into discrete checks.
+
+---
+
+## Fidelity Rules
+
+<fidelity_rules>
+
+### Rule 1: Read Before Writing
+
+NEVER describe a resource based on its name, URL path, or domain alone. ALWAYS fetch and read primary sources before writing any section.
+
+If a source cannot be accessed: write "Unable to access [source]: [reason]" in the entry's References section. Do NOT infer content.
+
+### Rule 2: Preserve Counts and Specifics
+
+Write exact numbers as found in primary sources when the number describes what the resource
+does or how well it does it. NEVER substitute vague quantifiers for a capability figure.
+Popularity metrics (stars, downloads, forks) are out of scope entirely — see Rule 2a.
+
+| Source Says | Write | NEVER Write |
+|-------------|-------|-------------|
+| "supports 12 languages" | "supports 12 languages" | "many languages" |
+| "v0.8.2, released 2025-11-03" | "v0.8.2 (released 2025-11-03)" | "recent release" |
+| "benchmark: 45ms p99 latency" | "45ms p99 latency" | "low latency" |
+
+### Rule 2a: No Popularity Statistics
+
+Do NOT gather or write star counts, download counts, fork counts, or contributor counts.
+These describe how popular a resource is, not what it does, how it does it, or why it's
+valuable — they don't inform the review or utility judgments this entry exists to support,
+and a reader can query them programmatically at any time via `gh api repos/{owner}/{repo}`
+if genuinely needed. There is no "Key Statistics" section in the entry template; do not
+add one, and do not fold this data into another section.
+
+This rule binds gathering as well as writing: it applies whether the repository is in the
+session's authorized GitHub scope or out of it, and no fallback source (web search, package
+registry, a badge in the README) makes the data in scope.
+
+### Rule 3: Distinguish Absence from Nonexistence
+
+Use precise language when information is not found in sources.
+
+| Situation | Write | NEVER Write |
+|-----------|-------|-------------|
+| Searched but not in source | "Not mentioned in documentation" | "Doesn't support X" |
+| Source inaccessible | "Unable to access [source]" | "Not available" |
+| Source doesn't cover topic | "Outside the scope of reviewed sources" | "Not supported" |
+| Contradictory sources | "Source A states X; Source B states Y" | "The answer is X" |
+
+### Rule 4: State Confidence Explicitly
+
+Each major section of the entry MUST have a confidence level. Record this in the entry's Freshness Tracking section as a confidence map.
+
+**Confidence levels**:
+
+- `high` -- full primary source read, official documentation, recent and dated
+- `medium` -- partial read, informal source, or single source with no corroboration
+- `low` -- inferred, dated source (>12 months), or source conflict
+
+**Factors that reduce confidence**: source truncated, source is informal (blog post vs official docs), sources contradict each other, content required interpretation rather than extraction.
+
+**Factors that increase confidence**: full read of official documentation, multiple sources agree, content is structured/machine-readable (API spec, package manifest), source is dated and recent.
+
+Confidence qualifiers for code-derived claims (`(code-read)`, `(doc + code-read)`) are defined in [Entry Template](./entry-template.md).
+
+SOURCE: Confidence scoring methodology from [fidelity-rules.md](./../../../../plugins/summarizer/skills/summarizer/references/fidelity-rules.md) Rule 6 (accessed 2026-03-06).
+
+</fidelity_rules>
+
+---
+
+## Depth Requirements
+
+<depth_requirements>
+
+Research entries MUST go beyond surface-level feature lists. Each entry section has a minimum depth requirement.
+
+### Architecture Section — REQUIRED depth
+
+Do NOT write "uses a plugin-based architecture" without explaining what that means concretely. MUST include:
+
+- Core components and their relationships (with exact names from source)
+- Data flow or execution model
+- Key design decisions and their stated rationale (if documented)
+- Extension or integration points
+
+### Features Section — REQUIRED depth
+
+For each documented feature:
+
+1. State what it does (extracted from source)
+2. State HOW it does it — the mechanism, not just the outcome
+3. Include a concrete example if the source provides one
+4. Note any configuration or constraints
+
+### Usage Examples Section — REQUIRED depth
+
+MUST include at least one complete, working example extracted verbatim or adapted minimally from official documentation. Examples invented without a source basis are FORBIDDEN.
+
+For installation commands: verify the exact command from official docs. Do NOT construct install commands from assumed package names.
+
+### Limitations and Caveats Section
+
+REQUIRED — not optional. Every tool has limitations. If primary sources document none, write: "No limitations documented in reviewed sources (confidence: low — absence of documented limitations does not confirm absence of limitations)."
+
+</depth_requirements>
+
+---
+
+## Completeness
+
+Every section of [Entry Template](./entry-template.md) MUST be complete with real data gathered from primary sources. Placeholders, "TBD", and bare "N/A" are FORBIDDEN. When data is genuinely unavailable, write what was searched, what was found, and why the data is absent — using the Rule 3 language above.

--- a/.claude/skills/research-curator/references/entry-review-rubric.md
+++ b/.claude/skills/research-curator/references/entry-review-rubric.md
@@ -1,0 +1,134 @@
+# Research Entry Review Rubric
+
+How to review a finished research entry and the analysis files produced from it.
+
+Writing an entry rather than reviewing one? Use [Entry Quality Standards](./entry-quality-standards.md) and [Extraction Methodology](./extraction-methodology.md) instead — this rubric is the audit that runs afterwards.
+
+**Review scope** — every file the entry's creation touched:
+
+- The entry: `./research/{category}/{name}.md`
+- Improvement proposals, when present: `./research/insights/{YYYY-MM-DD}-{name}-improvements.md`
+- Utilization proposals, when present: `./research/insights/{YYYY-MM-DD}-{name}-utilization.md`
+- Cited entries, when the entry added cross-references to them
+
+**Completion criterion**: every gate below has been run and its result recorded. A gate you skipped is a gate that FAILED — record it as `NOT RUN` with the reason, never as a pass.
+
+**Defect** = any finding under any gate. Record every defect as `{file}:{line} — {gate} — {exact quoted text} — {required correction}`. Quote the offending text verbatim; paraphrase loses the reviewer's evidence.
+
+---
+
+## Gate 1 — Mechanical Checks
+
+Run all three commands. Report their output as **exact counts per severity and the verbatim issue lines** — "mostly clean", "a few warnings", and "passes validation" are not review output.
+
+```bash
+uv run --script .claude/skills/research-curator/scripts/fix_research_formatting.py --check ./research/{category}/{name}.md
+uv run --script .claude/skills/research-curator/scripts/validate_research.py main --json ./research/{category}/{name}.md
+uv run --script .claude/skills/research-curator/scripts/validate_research.py check-backlinks ./research
+```
+
+| Command | What a defect looks like | Record |
+|---|---|---|
+| `fix_research_formatting.py --check` | Non-zero exit — the file needs formatting fixes | Every path the tool named, and the fix it wanted. `--check` does not write; drop `--check` only when this review is also applying fixes |
+| `validate_research.py main --json` | Any issue in the JSON `entries[].issues[]` array | `errors: N, warnings: N, info: N` from `summary`, then every issue's `check`, `severity`, `message`, and `line`, quoted |
+| `validate_research.py check-backlinks ./research` | Any asymmetric cross-reference involving this entry | Each asymmetric pair by both paths. Run without `--fix` to review; `--fix` repairs but hides what was wrong |
+
+**Cross-reference reciprocity** is measured by `check-backlinks`, not by eye. An entry that cites B while B does not cite back is a defect against this entry even though the missing row lives in B. Row format: [Cross-Reference Format](./cross-reference-format.md).
+
+---
+
+## Gate 2 — Fidelity Rules
+
+Each rule in [Entry Quality Standards](./entry-quality-standards.md) is a separate check with its own verdict. Run all five; one rule's pass says nothing about another's.
+
+| Check | Question | Defect |
+|---|---|---|
+| **Rule 1 — Read Before Writing** | Does every section's content trace to a source listed in References, and was that source actually reachable? | A claim whose only possible basis is the resource's name, URL path, or domain. An inaccessible source whose absence is not stated in References |
+| **Rule 2 — Preserve Counts** | Are capability figures written as the exact number the source gives? | A vague quantifier ("many languages", "recent release", "low latency") standing where the source has a figure |
+| **Rule 2a — No Popularity Statistics** | Is the entry free of star, download, fork, and contributor counts? | Any such figure anywhere in the entry, including inside a badge, a quoted README passage, or a "Key Statistics" section that should not exist |
+| **Rule 3 — Absence vs Nonexistence** | Where information was not found, does the entry say it was not found? | "Doesn't support X" / "Not available" / "Not supported" where the honest statement is "Not mentioned in documentation" or "Unable to access {source}" |
+| **Rule 4 — Explicit Confidence** | Does every major section carry a confidence level in the confidence map? | A section missing from the map. A `high` on a section whose sources are informal, partial, contradictory, or code-read |
+
+---
+
+## Gate 3 — Depth
+
+Score each section against its bar in [Entry Quality Standards](./entry-quality-standards.md#depth-requirements). Present-but-thin is a defect; the section existing is not the bar.
+
+| Section | Passes when | Defect |
+|---|---|---|
+| **Technical Architecture** | Names components with their exact source names, describes data flow or execution model, and names extension or integration points | "Uses a plugin-based architecture" with no component named and no mechanism given |
+| **Key Features** | Each feature states what it does AND the mechanism by which it does it | A feature list that is a list of outcomes with no mechanism |
+| **Installation & Usage** | At least one complete example taken verbatim or near-verbatim from official docs; install command verified against official docs | An install command assembled from a guessed package name. A usage example with no source behind it |
+| **Limitations and Caveats** | Present, with either documented limitations or the explicit low-confidence absence statement | Section missing, empty, or filled with "N/A" |
+
+---
+
+## Gate 4 — Repo Claims Verified Against the Repo
+
+Every statement an entry or an analysis file makes about **this repository** is a claim to verify against the actual files, not a claim to accept. This gate covers the entry's "Relevance to Claude Code Development" section and every proposal in the `-improvements.md` and `-utilization.md` files.
+
+For each repo claim, in order:
+
+1. **Path exists** — read the path the claim names. A proposal resting on a path that is not in the repo is a defect, full stop. Resolve it yourself; do not assume a near-miss was a typo.
+2. **Path is described correctly** — the file's real contents match what the claim says about them. A proposal that names a real path but misdescribes what lives there is a defect of the same severity as an invented path.
+3. **Gap is real** — where a proposal says the local system lacks a capability, the file confirms the absence. A capability the file already implements makes the proposal a defect, not a low-confidence proposal.
+4. **Measurable signal is runnable** — where a proposal names a command or an observable field as its completion signal, that command runs and that field is reachable.
+
+Record each verified claim with the path you read. A gate 4 pass asserts you opened the files; it cannot be reached by reading the proposal alone.
+
+---
+
+## Gate 5 — Did the Analysis Engage This Repo?
+
+Judgment check, applied to the entry's "Relevance to Claude Code Development" section and to both analysis files.
+
+Ask: **could this text have been written about any Python repository without opening this one?**
+
+- **Passes** when the analysis names specific files, skills, agents, or workflows of this repo and says something about them that is true here and would be false elsewhere.
+- **FAILS** when the analysis would survive a find-and-replace of this repo's name — generic advice ("could improve code quality", "useful for agent workflows", "fits well with this project's architecture") dressed as repo-specific findings.
+
+A gate 5 failure is a defect even when every individual sentence in gate 4 verified: correct-but-generic analysis is the failure mode this gate exists to catch.
+
+---
+
+## Gate 6 — Hallucination Triggers
+
+Scan the entry and both analysis files for each trigger. Quote every hit.
+
+| Trigger | Scan for | Defect unless | Required correction |
+|---|---|---|---|
+| **Speculation language** | "I think", "likely", "probably", "seems", "should be", "assume", "maybe", "might" | The phrase sits inside a verbatim quotation from a primary source, attributed as such | Replace with what the source states, with "Not mentioned in documentation" per Rule 3, or with the steps taken and what was observed |
+| **Causality without evidence** | "because", "due to", "caused by", "therefore", "this means", "as a result" | The sentence cites the specific observation behind it — a source passage, a file and line, a command's output | Rewrite as an observation alone, or as an explicit hypothesis plus the verification step that would settle it |
+| **Pseudo-quantification** | Scores and percentages — "8.5/10", "70% faster", "100% coverage" | The figure is quoted from a primary source with its method, or the entry states the method used to produce it | Replace with the measured evidence, or remove the figure |
+| **Completeness overclaims** | "all files checked", "comprehensive analysis", "fully resolved", "everything fixed", "every skill reviewed" | The text lists the concrete checks performed and their scope | List what was inspected and with what scope, or narrow the claim to what was actually covered |
+
+SOURCE: Triggers 1–4 adapted for research-entry content from the `hallucination-detector` plugin's `commands/hallucination-audit.md` (<https://github.com/bitflight-devops/hallucination-detector>, accessed 2026-09-13); also reachable in this repo as the `/hallucination-detector:hallucination-audit` command.
+
+---
+
+## Verdict
+
+Report in this form:
+
+```text
+REVIEW: ./research/{category}/{name}.md
+
+GATE 1 mechanical:    PASS | FAIL | NOT RUN ({reason})
+  fix_research_formatting --check: exit {N}
+  validate_research main --json:   errors {N}, warnings {N}, info {N}
+  check-backlinks:                 {N} asymmetric pairs
+GATE 2 fidelity:      PASS | FAIL — rules failed: {1|2|2a|3|4}
+GATE 3 depth:         PASS | FAIL — sections failed: {names}
+GATE 4 repo claims:   PASS | FAIL — {N} claims verified, {N} defective
+GATE 5 engagement:    PASS | FAIL
+GATE 6 triggers:      PASS | FAIL — triggers hit: {names}
+
+DEFECTS: {N}
+1. {file}:{line} — GATE {N} — "{exact quoted text}" — {required correction}
+2. ...
+
+VERDICT: APPROVE | REQUEST CHANGES
+```
+
+`APPROVE` requires every gate at PASS and `DEFECTS: 0`. Any gate at FAIL or NOT RUN, or any defect recorded, is `REQUEST CHANGES` — a defect count above zero and an `APPROVE` verdict cannot both be true.

--- a/.claude/skills/research-curator/references/entry-template.md
+++ b/.claude/skills/research-curator/references/entry-template.md
@@ -189,9 +189,11 @@ How the resource works internally. Include diagrams if helpful.
 > `Source: src/core/engine.py — class TaskEngine, src/core/graph.py — class DependencyGraph`
 
 > **Note**: The `## Cross-References` section is populated automatically by
-> `@research-cross-referencer` after entry creation. For manually created entries, add it
-> after the fact. This section is optional for entries created before 2026-03-12; the
-> validator emits a warning (not error) if absent on newer entries.
+> `@research-cross-referencer` after entry creation, and reciprocal rows by
+> `@research-backlink-detector`. For manually created entries, add it after the fact. This
+> section is optional for entries created before 2026-03-12; the validator emits a warning
+> (not error) if absent on newer entries. Row shape, placement anchor, relative-path rules and
+> the relationship-phrase bar: [Cross-Reference Format](./cross-reference-format.md).
 
 > **Note**: The frontmatter's `freshness_tracking.next_review` field is a suggestion, not a
 > gate. When a user or orchestrator explicitly requests re-research for this entry — via

--- a/.claude/skills/research-curator/references/extraction-methodology.md
+++ b/.claude/skills/research-curator/references/extraction-methodology.md
@@ -1,0 +1,146 @@
+# Extractive Research Methodology
+
+Extract before abstracting. Every claim in a research entry traces back to a passage pulled
+verbatim from a primary source, recorded before any prose is written. Writing a section from
+memory, from inference, or from a model's prior knowledge of the resource is FORBIDDEN.
+
+The phases run in order: Phase 1 → Doc-Sufficiency Check → (Phase 1b, conditional) → Phase 2.
+
+The content bar each written section must then clear is in [Entry Quality Standards](./entry-quality-standards.md).
+
+---
+
+## Phase 1: Extract Key Passages
+
+BEFORE writing any section of the entry, extract relevant quotes and data points from primary sources. Record each extract with its source.
+
+Use this format during extraction (internal working notes, not written to the entry file):
+
+```text
+EXTRACTED PASSAGES — {resource-name}
+
+1. "{exact quote or data point}"
+   Source: {URL or tool + section}
+   Relevance: {which entry section this feeds}
+
+2. "{exact quote or data point}"
+   Source: {URL or tool + section}
+   Relevance: {which entry section this feeds}
+```
+
+Apply this to EVERY section: features, architecture, installation steps, usage examples, limitations. Numbers, version strings, benchmark figures, and configuration values MUST be quoted verbatim from source — never paraphrased or estimated.
+
+**Relevance values**: Use the exact section names from [Entry Template](./entry-template.md) — Overview, Problem Addressed, Key Features, Technical Architecture, Installation & Usage, Relevance to Claude Code Development, References, Freshness Tracking. This enables the doc-sufficiency check after Phase 1 to filter extracts by section.
+
+---
+
+## Doc-Sufficiency Check
+
+Run immediately after Phase 1 completes. Record the result as a working note — do NOT write it to the entry file.
+
+1. Scan your Phase 1 extracts tagged with `Relevance: Technical Architecture` or `Relevance: Key Features`.
+2. Answer each question YES or NO:
+   - Q1: Do any extracts name at least 2 specific component, module, or class names (not generic descriptions like "has a plugin system")?
+   - Q2: Do any extracts describe how data or control flows between at least 2 named components (not generic statements like "processes data")?
+   - Q3: Do any extracts name an extension point, plugin interface, hook system, or registration mechanism with its concrete API?
+3. If ANY answer is NO: record working note "Architecture depth requirements unsatisfied — triggering code analysis" and proceed to Phase 1b.
+4. If ALL answers are YES: record working note "Architecture depth requirements satisfied from docs" and skip to Phase 2.
+
+`--rerun` runs this same check against the re-extracted passages, with the same two outcomes.
+
+---
+
+## Phase 1b: Code Analysis (conditional)
+
+This phase triggers ONLY when the doc-sufficiency check recorded "Architecture depth requirements unsatisfied — triggering code analysis". It reads source files from the shallow clone to extract architectural evidence that documentation did not provide.
+
+**Phase 1b Procedure** (when triggered):
+
+1. **Detect primary language**: Check for `pyproject.toml` (Python), `package.json`
+   (Node.js/TypeScript), `Cargo.toml` (Rust), `go.mod` (Go), `pom.xml` / `build.gradle`
+   (Java/Kotlin). If none found, count file extensions via Glob to determine the dominant
+   language.
+
+2. **Read files in tier order** — stop at 12 files total:
+
+   **Tier 1 — Entrypoints** (read these first):
+
+   - Python: `**/main.py`, `**/cli.py`, `**/app.py`, `**/__main__.py`, `**/server.py`, `**/wsgi.py`, `**/asgi.py`
+   - Node/TS: `**/index.ts`, `**/index.js`, `**/main.ts`, `**/main.js`, `**/app.ts`, `**/app.js`, `**/server.ts`, `**/server.js`
+   - Go: `**/main.go`, `**/cmd/**/main.go`
+   - Rust: `**/main.rs`, `**/lib.rs`
+   - Java/Kotlin: `**/Application.java`, `**/Main.java`, `**/App.kt`
+   - Ruby: `**/config.ru`, `**/Rakefile`, `**/bin/*`
+
+   **Tier 2 — Type/schema declarations** (read after Tier 1):
+
+   - Python: `**/models.py`, `**/schema.py`, `**/schemas.py`, `**/types.py`, `**/models/*.py`
+   - Node/TS: `**/types.ts`, `**/types.d.ts`, `**/schema.ts`, `**/models/*.ts`, `**/interfaces.ts`
+   - Go: `**/types.go`, `**/models.go`
+   - Rust: `**/types.rs`, `**/models.rs`, `**/schema.rs`
+   - Any language: `**/*.proto`, `**/openapi.yaml`, `**/openapi.yml`, `**/openapi.json`, `**/schema.graphql`, `**/schema.json`
+
+   **Tier 3 — Index/barrel files** (read last):
+
+   - Python: `**/__init__.py` (top-level package directories only — skip deeply nested), `**/api.py`, `**/routes.py`, `**/urls.py`
+   - Node/TS: `**/index.ts` (in subdirectories — barrel exports), `**/exports.ts`
+   - Go: `**/doc.go`
+   - Rust: `**/mod.rs`
+   - Any language: `**/plugin.py`, `**/plugins/*.py`, `**/extensions/*.ts`, `**/middleware/*.py`, files matching `**/register*`
+
+   **Exclusions** — never read:
+
+   - Test files: `**/test_*.py`, `**/*_test.go`, `**/*.test.ts`, `**/*.spec.ts`, `**/*_test.*`, `**/*.test.*`
+   - Dependency dirs: `**/node_modules/**`, `**/.venv/**`, `**/vendor/**`, `**/__pycache__/**`
+   - Build artifacts: `**/*.min.js`, `**/*.bundle.js`, `**/dist/**`, `**/build/**`, `**/target/**`
+   - Files over 500 lines: skip and note "Skipped {path}: {N} lines (over 500-line limit)"
+
+   **Selection within a tier**: Prefer files in `src/` over root. Prefer shorter paths over
+   deeper paths. Read each file fully (do not use line limits). Increment the file counter after
+   each Read. Stop when counter reaches 12 or all tiers are exhausted. Record how many candidate
+   files remain unread when budget is exhausted.
+
+3. **Extract architectural evidence** from each file read. Record extracts using this format:
+
+   ```text
+   N. "{exact code passage — class definition, function signature, import block, or schema}"
+      Source: {relative-path}:{start-end lines} — {exported name}
+      Relevance: Technical Architecture | Key Features
+      Confidence: code-read
+   ```
+
+   Focus extraction on:
+
+   - Class/struct definitions with their public methods (architecture)
+   - Function signatures that reveal data flow (architecture)
+   - Import statements that reveal component dependencies (architecture)
+   - Schema/model field definitions (architecture)
+   - Registration patterns — decorators, register() calls, plugin lists (extension points)
+   - Configuration handling that reveals supported options (features)
+
+4. **Merge code extracts with Phase 1 extracts**. Both sets feed into Phase 2 identically.
+   Code extracts are distinguished only by their `Confidence: code-read` tag.
+
+Entries carrying code-derived claims cite them inline and qualify their confidence — formats in [Entry Template](./entry-template.md).
+
+---
+
+## Phase 2: Write From Extracts
+
+Write each entry section by organizing the extracted passages for that section, then composing prose or structured content grounded in those extracts.
+
+REQUIRED verification step: Before finalizing a section, confirm that every factual claim in that section traces to at least one extracted passage. If a claim cannot be traced, either find a source passage or remove the claim.
+
+---
+
+## What Counts as a Claim Requiring a Source
+
+- Version numbers ("v2.3.1")
+- Performance figures ("processes 10k events/sec")
+- Feature descriptions ("supports async/await")
+- License type
+- Architectural assertions ("uses a DAG-based task graph")
+- Installation commands (verify against official docs, not inferred)
+- Compatibility statements ("requires Python 3.11+")
+
+SOURCE: "Extract before abstracting" methodology from [fidelity-rules.md](./../../../../plugins/summarizer/skills/summarizer/references/fidelity-rules.md) Rule 2 (accessed 2026-03-06). Quote-grounding technique from Anthropic prompt engineering documentation (<https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/long-context-tips>, accessed 2026-02-06).


### PR DESCRIPTION
## Why

`.claude/agents/research-curator.md` was 543 lines and was the only home for material that governs every research entry, not one agent's role. A Lapidary audit found the approved-goal G1 quote-grounding and confidence requirements, and the "no popularity statistics" non-goal, recoverable only indirectly from that agent file and never stated centrally. Nothing in the skill stated the per-section depth bar at all. And a review of #3510 had to invent a review rubric from scratch, because none existed.

## Layout

Four new references under `.claude/skills/research-curator/references/`:

| File | Owns | Consumer |
|---|---|---|
| `entry-quality-standards.md` | Fidelity Rules 1, 2, 2a, 3, 4 + Depth Requirements + the no-placeholders completeness bar | Anyone writing an entry |
| `extraction-methodology.md` | Phase 1 extraction, the Doc-Sufficiency Check, conditional Phase 1b code analysis, Phase 2, what counts as a claim requiring a source | The researching agent |
| `entry-review-rubric.md` | **New.** Six-gate audit of a finished entry | A reviewer |
| `cross-reference-format.md` | Canonical Cross-References table, placement anchors, relative-path rules, relationship-phrase bar | Both cross-reference agents and the template |

Fidelity and depth share one file because they are always consulted at the same moment — one governs each claim, the other each section's coverage — and one pointer is cheaper than two. Extraction is split out because it is a procedure rather than a contract, and its Phase 1b tier lists are reached only on the branch where docs were insufficient.

### The review rubric

Six gates, each with its own verdict, and a completion criterion that a skipped gate is recorded `NOT RUN`, never as a pass:

1. **Mechanical** — `fix_research_formatting.py --check`, `validate_research.py main --json`, `validate_research.py check-backlinks`. Output is exact per-severity counts plus every issue line verbatim; "mostly clean" is not review output. Cross-reference reciprocity is measured by `check-backlinks`, not by eye.
2. **Fidelity** — each of Rules 1, 2, 2a, 3, 4 as a discrete check with its own defect definition.
3. **Depth** — per-section, with present-but-thin called out as a defect.
4. **Repo claims** — every claim an entry's Relevance section or an insights/utilization file makes about *this* repository is verified against the actual file: path exists, path is described correctly, gap is real, measurable signal runs. A proposal resting on a nonexistent path, or misdescribing a real one, is a defect of equal severity.
5. **Engagement** — could this analysis have been written about any Python repo without opening this one? Correct-but-generic fails even when every gate 4 claim verified.
6. **Hallucination triggers** — speculation language, causality without a cited observation, pseudo-quantification, completeness overclaims. Adapted from `hallucination-detector`'s `commands/hallucination-audit.md`. Its fifth trigger (delegation micromanagement) is deliberately **not** included — it audits orchestration prompts, not entry content.

## Agent line counts

| Agent | Before | After |
|---|---|---|
| `research-curator.md` | 543 | 295 |
| `research-cross-referencer.md` | 133 | 111 |
| `research-backlink-detector.md` | 150 | 142 |
| `research-insight-extractor.md` | 269 | 272 |
| `research-context-agent.md` | 198 | 198 |
| `research-utilization-assessor.md` | 164 | 164 |

`research-insight-extractor` grew by 3 lines: its pattern-to-local-system table named seven paths that no longer exist (skills moved into `plugins/`), and the table had no instruction for what an agent should do when a mapped path is missing. Paths repaired and verified; recovery instruction added. Found by applying the new rubric's gate 4 to the repo's own files.

## Kept inline, deliberately

- **The four-step phase spine** in `research-curator.md` — phase order must survive a reference load that does not happen.
- **Rule 2a and Rule 3 one-liners** at the tool-selection point — a haiku agent decides whether to run `gh api .../stargazers` while reading the tools section, not while reading a reference file. The reference is authoritative for the rule and its rationale; the inline line is the gate where the behaviour fires.
- **Every agent's Boundaries block** — boundaries are stopping conditions, and a stopping condition behind a pointer is a stopping condition that may not be read.
- **Each agent's own output format** (improvement-proposal format, utilization-proposal format, return blocks) — required output belongs to the agent, and none of these were duplicated anywhere.

## Follow-ups blocked by locked files

Tracked as **#3515** (P2) and handed to the agent holding the file.

`.claude/skills/research-curator/SKILL.md` was held by another agent and could not be edited. It needs these pointers added to its **Reference Links** section (currently ends at `repo-access-procedure.md`):

```markdown
- [Entry Quality Standards](./references/entry-quality-standards.md) -- Fidelity Rules and per-section Depth Requirements every entry must satisfy
- [Extraction Methodology](./references/extraction-methodology.md) -- extraction phases, Doc-Sufficiency Check, and Phase 1b code analysis
- [Entry Review Rubric](./references/entry-review-rubric.md) -- six-gate audit of a finished entry and its insight/utilization files
- [Cross-Reference Format](./references/cross-reference-format.md) -- canonical Cross-References row shape, placement and path rules
```

And one more, in **Post-Actions** (line ~413), so the rubric is reachable at the point a finished entry exists: after the analysis-agent fan-out completes, review the entry and its insight/utilization files against `./references/entry-review-rubric.md`.

Without those, the rubric is reachable only from `entry-quality-standards.md`, which links it.

## Conservation

Every block removed from an agent file was verified present at its new location before deletion. The category list was confirmed byte-identical in set and order to the flowchart already in `entry-template.md` — no drift, straight duplication — and `entry-template.md` additionally carried the "create the directory if absent" instruction and a "None fit" branch the agent list lacked. No content was dropped.

All relative links in the six agent files and the skill's references resolve (verified programmatically, excluding template placeholders inside code fences). `prek` passes on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
